### PR TITLE
feat: Promise.allOrCancel() and fix instance all() parallelism

### DIFF
--- a/core/src/main/java/org/pragmatica/lang/Promise.java
+++ b/core/src/main/java/org/pragmatica/lang/Promise.java
@@ -601,9 +601,9 @@ public interface Promise<T> {
     /// @return Mapper2 for further transformation
     default <T1, T2> Mapper2<T1, T2> all(Fn1<Promise<T1>, T> fn1,
                                          Fn1<Promise<T2>, T> fn2) {
-        return () -> flatMap(v -> fn1.apply(v)
-                                     .flatMap(v1 -> fn2.apply(v)
-                                                       .map(v2 -> Tuple.tuple(v1, v2))));
+        return () -> flatMap(v -> Promise.all(fn1.apply(v),
+                                              fn2.apply(v))
+                                         .id());
     }
 
     /// **[Pure Transform]**
@@ -620,10 +620,10 @@ public interface Promise<T> {
     default <T1, T2, T3> Mapper3<T1, T2, T3> all(Fn1<Promise<T1>, T> fn1,
                                                  Fn1<Promise<T2>, T> fn2,
                                                  Fn1<Promise<T3>, T> fn3) {
-        return () -> flatMap(v -> fn1.apply(v)
-                                     .flatMap(v1 -> fn2.apply(v)
-                                                       .flatMap(v2 -> fn3.apply(v)
-                                                                         .map(v3 -> Tuple.tuple(v1, v2, v3)))));
+        return () -> flatMap(v -> Promise.all(fn1.apply(v),
+                                              fn2.apply(v),
+                                              fn3.apply(v))
+                                         .id());
     }
 
     /// **[Pure Transform]**
@@ -632,14 +632,11 @@ public interface Promise<T> {
                                                          Fn1<Promise<T2>, T> fn2,
                                                          Fn1<Promise<T3>, T> fn3,
                                                          Fn1<Promise<T4>, T> fn4) {
-        return () -> flatMap(v -> fn1.apply(v)
-                                     .flatMap(v1 -> fn2.apply(v)
-                                                       .flatMap(v2 -> fn3.apply(v)
-                                                                         .flatMap(v3 -> fn4.apply(v)
-                                                                                           .map(v4 -> Tuple.tuple(v1,
-                                                                                                                  v2,
-                                                                                                                  v3,
-                                                                                                                  v4))))));
+        return () -> flatMap(v -> Promise.all(fn1.apply(v),
+                                              fn2.apply(v),
+                                              fn3.apply(v),
+                                              fn4.apply(v))
+                                         .id());
     }
 
     /// **[Pure Transform]**
@@ -649,16 +646,12 @@ public interface Promise<T> {
                                                                  Fn1<Promise<T3>, T> fn3,
                                                                  Fn1<Promise<T4>, T> fn4,
                                                                  Fn1<Promise<T5>, T> fn5) {
-        return () -> flatMap(v -> fn1.apply(v)
-                                     .flatMap(v1 -> fn2.apply(v)
-                                                       .flatMap(v2 -> fn3.apply(v)
-                                                                         .flatMap(v3 -> fn4.apply(v)
-                                                                                           .flatMap(v4 -> fn5.apply(v)
-                                                                                                             .map(v5 -> Tuple.tuple(v1,
-                                                                                                                                    v2,
-                                                                                                                                    v3,
-                                                                                                                                    v4,
-                                                                                                                                    v5)))))));
+        return () -> flatMap(v -> Promise.all(fn1.apply(v),
+                                              fn2.apply(v),
+                                              fn3.apply(v),
+                                              fn4.apply(v),
+                                              fn5.apply(v))
+                                         .id());
     }
 
     /// **[Pure Transform]**
@@ -669,18 +662,13 @@ public interface Promise<T> {
                                                                          Fn1<Promise<T4>, T> fn4,
                                                                          Fn1<Promise<T5>, T> fn5,
                                                                          Fn1<Promise<T6>, T> fn6) {
-        return () -> flatMap(v -> fn1.apply(v)
-                                     .flatMap(v1 -> fn2.apply(v)
-                                                       .flatMap(v2 -> fn3.apply(v)
-                                                                         .flatMap(v3 -> fn4.apply(v)
-                                                                                           .flatMap(v4 -> fn5.apply(v)
-                                                                                                             .flatMap(v5 -> fn6.apply(v)
-                                                                                                                               .map(v6 -> Tuple.tuple(v1,
-                                                                                                                                                      v2,
-                                                                                                                                                      v3,
-                                                                                                                                                      v4,
-                                                                                                                                                      v5,
-                                                                                                                                                      v6))))))));
+        return () -> flatMap(v -> Promise.all(fn1.apply(v),
+                                              fn2.apply(v),
+                                              fn3.apply(v),
+                                              fn4.apply(v),
+                                              fn5.apply(v),
+                                              fn6.apply(v))
+                                         .id());
     }
 
     /// **[Pure Transform]**
@@ -692,20 +680,14 @@ public interface Promise<T> {
                                                                                  Fn1<Promise<T5>, T> fn5,
                                                                                  Fn1<Promise<T6>, T> fn6,
                                                                                  Fn1<Promise<T7>, T> fn7) {
-        return () -> flatMap(v -> fn1.apply(v)
-                                     .flatMap(v1 -> fn2.apply(v)
-                                                       .flatMap(v2 -> fn3.apply(v)
-                                                                         .flatMap(v3 -> fn4.apply(v)
-                                                                                           .flatMap(v4 -> fn5.apply(v)
-                                                                                                             .flatMap(v5 -> fn6.apply(v)
-                                                                                                                               .flatMap(v6 -> fn7.apply(v)
-                                                                                                                                                 .map(v7 -> Tuple.tuple(v1,
-                                                                                                                                                                        v2,
-                                                                                                                                                                        v3,
-                                                                                                                                                                        v4,
-                                                                                                                                                                        v5,
-                                                                                                                                                                        v6,
-                                                                                                                                                                        v7)))))))));
+        return () -> flatMap(v -> Promise.all(fn1.apply(v),
+                                              fn2.apply(v),
+                                              fn3.apply(v),
+                                              fn4.apply(v),
+                                              fn5.apply(v),
+                                              fn6.apply(v),
+                                              fn7.apply(v))
+                                         .id());
     }
 
     /// **[Pure Transform]**
@@ -718,22 +700,15 @@ public interface Promise<T> {
                                                                                          Fn1<Promise<T6>, T> fn6,
                                                                                          Fn1<Promise<T7>, T> fn7,
                                                                                          Fn1<Promise<T8>, T> fn8) {
-        return () -> flatMap(v -> fn1.apply(v)
-                                     .flatMap(v1 -> fn2.apply(v)
-                                                       .flatMap(v2 -> fn3.apply(v)
-                                                                         .flatMap(v3 -> fn4.apply(v)
-                                                                                           .flatMap(v4 -> fn5.apply(v)
-                                                                                                             .flatMap(v5 -> fn6.apply(v)
-                                                                                                                               .flatMap(v6 -> fn7.apply(v)
-                                                                                                                                                 .flatMap(v7 -> fn8.apply(v)
-                                                                                                                                                                   .map(v8 -> Tuple.tuple(v1,
-                                                                                                                                                                                          v2,
-                                                                                                                                                                                          v3,
-                                                                                                                                                                                          v4,
-                                                                                                                                                                                          v5,
-                                                                                                                                                                                          v6,
-                                                                                                                                                                                          v7,
-                                                                                                                                                                                          v8))))))))));
+        return () -> flatMap(v -> Promise.all(fn1.apply(v),
+                                              fn2.apply(v),
+                                              fn3.apply(v),
+                                              fn4.apply(v),
+                                              fn5.apply(v),
+                                              fn6.apply(v),
+                                              fn7.apply(v),
+                                              fn8.apply(v))
+                                         .id());
     }
 
     /// **[Pure Transform]**
@@ -747,24 +722,16 @@ public interface Promise<T> {
                                                                                                  Fn1<Promise<T7>, T> fn7,
                                                                                                  Fn1<Promise<T8>, T> fn8,
                                                                                                  Fn1<Promise<T9>, T> fn9) {
-        return () -> flatMap(v -> fn1.apply(v)
-                                     .flatMap(v1 -> fn2.apply(v)
-                                                       .flatMap(v2 -> fn3.apply(v)
-                                                                         .flatMap(v3 -> fn4.apply(v)
-                                                                                           .flatMap(v4 -> fn5.apply(v)
-                                                                                                             .flatMap(v5 -> fn6.apply(v)
-                                                                                                                               .flatMap(v6 -> fn7.apply(v)
-                                                                                                                                                 .flatMap(v7 -> fn8.apply(v)
-                                                                                                                                                                   .flatMap(v8 -> fn9.apply(v)
-                                                                                                                                                                                     .map(v9 -> Tuple.tuple(v1,
-                                                                                                                                                                                                            v2,
-                                                                                                                                                                                                            v3,
-                                                                                                                                                                                                            v4,
-                                                                                                                                                                                                            v5,
-                                                                                                                                                                                                            v6,
-                                                                                                                                                                                                            v7,
-                                                                                                                                                                                                            v8,
-                                                                                                                                                                                                            v9)))))))))));
+        return () -> flatMap(v -> Promise.all(fn1.apply(v),
+                                              fn2.apply(v),
+                                              fn3.apply(v),
+                                              fn4.apply(v),
+                                              fn5.apply(v),
+                                              fn6.apply(v),
+                                              fn7.apply(v),
+                                              fn8.apply(v),
+                                              fn9.apply(v))
+                                         .id());
     }
 
     /// **[Pure Transform]**
@@ -779,26 +746,17 @@ public interface Promise<T> {
                                                                                                             Fn1<Promise<T8>, T> fn8,
                                                                                                             Fn1<Promise<T9>, T> fn9,
                                                                                                             Fn1<Promise<T10>, T> fn10) {
-        return () -> flatMap(v -> fn1.apply(v)
-                                     .flatMap(v1 -> fn2.apply(v)
-                                                       .flatMap(v2 -> fn3.apply(v)
-                                                                         .flatMap(v3 -> fn4.apply(v)
-                                                                                           .flatMap(v4 -> fn5.apply(v)
-                                                                                                             .flatMap(v5 -> fn6.apply(v)
-                                                                                                                               .flatMap(v6 -> fn7.apply(v)
-                                                                                                                                                 .flatMap(v7 -> fn8.apply(v)
-                                                                                                                                                                   .flatMap(v8 -> fn9.apply(v)
-                                                                                                                                                                                     .flatMap(v9 -> fn10.apply(v)
-                                                                                                                                                                                                        .map(v10 -> Tuple.tuple(v1,
-                                                                                                                                                                                                                                v2,
-                                                                                                                                                                                                                                v3,
-                                                                                                                                                                                                                                v4,
-                                                                                                                                                                                                                                v5,
-                                                                                                                                                                                                                                v6,
-                                                                                                                                                                                                                                v7,
-                                                                                                                                                                                                                                v8,
-                                                                                                                                                                                                                                v9,
-                                                                                                                                                                                                                                v10))))))))))));
+        return () -> flatMap(v -> Promise.all(fn1.apply(v),
+                                              fn2.apply(v),
+                                              fn3.apply(v),
+                                              fn4.apply(v),
+                                              fn5.apply(v),
+                                              fn6.apply(v),
+                                              fn7.apply(v),
+                                              fn8.apply(v),
+                                              fn9.apply(v),
+                                              fn10.apply(v))
+                                         .id());
     }
 
     /// **[Pure Transform]**
@@ -814,28 +772,18 @@ public interface Promise<T> {
                                                                                                                       Fn1<Promise<T9>, T> fn9,
                                                                                                                       Fn1<Promise<T10>, T> fn10,
                                                                                                                       Fn1<Promise<T11>, T> fn11) {
-        return () -> flatMap(v -> fn1.apply(v)
-                                     .flatMap(v1 -> fn2.apply(v)
-                                                       .flatMap(v2 -> fn3.apply(v)
-                                                                         .flatMap(v3 -> fn4.apply(v)
-                                                                                           .flatMap(v4 -> fn5.apply(v)
-                                                                                                             .flatMap(v5 -> fn6.apply(v)
-                                                                                                                               .flatMap(v6 -> fn7.apply(v)
-                                                                                                                                                 .flatMap(v7 -> fn8.apply(v)
-                                                                                                                                                                   .flatMap(v8 -> fn9.apply(v)
-                                                                                                                                                                                     .flatMap(v9 -> fn10.apply(v)
-                                                                                                                                                                                                        .flatMap(v10 -> fn11.apply(v)
-                                                                                                                                                                                                                            .map(v11 -> Tuple.tuple(v1,
-                                                                                                                                                                                                                                                    v2,
-                                                                                                                                                                                                                                                    v3,
-                                                                                                                                                                                                                                                    v4,
-                                                                                                                                                                                                                                                    v5,
-                                                                                                                                                                                                                                                    v6,
-                                                                                                                                                                                                                                                    v7,
-                                                                                                                                                                                                                                                    v8,
-                                                                                                                                                                                                                                                    v9,
-                                                                                                                                                                                                                                                    v10,
-                                                                                                                                                                                                                                                    v11)))))))))))));
+        return () -> flatMap(v -> Promise.all(fn1.apply(v),
+                                              fn2.apply(v),
+                                              fn3.apply(v),
+                                              fn4.apply(v),
+                                              fn5.apply(v),
+                                              fn6.apply(v),
+                                              fn7.apply(v),
+                                              fn8.apply(v),
+                                              fn9.apply(v),
+                                              fn10.apply(v),
+                                              fn11.apply(v))
+                                         .id());
     }
 
     /// **[Pure Transform]**
@@ -853,30 +801,19 @@ public interface Promise<T> {
                                                                     Fn1<Promise<T10>, T> fn10,
                                                                     Fn1<Promise<T11>, T> fn11,
                                                                     Fn1<Promise<T12>, T> fn12) {
-        return () -> flatMap(v -> fn1.apply(v)
-                                     .flatMap(v1 -> fn2.apply(v)
-                                                       .flatMap(v2 -> fn3.apply(v)
-                                                                         .flatMap(v3 -> fn4.apply(v)
-                                                                                           .flatMap(v4 -> fn5.apply(v)
-                                                                                                             .flatMap(v5 -> fn6.apply(v)
-                                                                                                                               .flatMap(v6 -> fn7.apply(v)
-                                                                                                                                                 .flatMap(v7 -> fn8.apply(v)
-                                                                                                                                                                   .flatMap(v8 -> fn9.apply(v)
-                                                                                                                                                                                     .flatMap(v9 -> fn10.apply(v)
-                                                                                                                                                                                                        .flatMap(v10 -> fn11.apply(v)
-                                                                                                                                                                                                                            .flatMap(v11 -> fn12.apply(v)
-                                                                                                                                                                                                                                                .map(v12 -> Tuple.tuple(v1,
-                                                                                                                                                                                                                                                                        v2,
-                                                                                                                                                                                                                                                                        v3,
-                                                                                                                                                                                                                                                                        v4,
-                                                                                                                                                                                                                                                                        v5,
-                                                                                                                                                                                                                                                                        v6,
-                                                                                                                                                                                                                                                                        v7,
-                                                                                                                                                                                                                                                                        v8,
-                                                                                                                                                                                                                                                                        v9,
-                                                                                                                                                                                                                                                                        v10,
-                                                                                                                                                                                                                                                                        v11,
-                                                                                                                                                                                                                                                                        v12))))))))))))));
+        return () -> flatMap(v -> Promise.all(fn1.apply(v),
+                                              fn2.apply(v),
+                                              fn3.apply(v),
+                                              fn4.apply(v),
+                                              fn5.apply(v),
+                                              fn6.apply(v),
+                                              fn7.apply(v),
+                                              fn8.apply(v),
+                                              fn9.apply(v),
+                                              fn10.apply(v),
+                                              fn11.apply(v),
+                                              fn12.apply(v))
+                                         .id());
     }
 
     /// **[Pure Transform]**
@@ -895,32 +832,20 @@ public interface Promise<T> {
                                                                          Fn1<Promise<T11>, T> fn11,
                                                                          Fn1<Promise<T12>, T> fn12,
                                                                          Fn1<Promise<T13>, T> fn13) {
-        return () -> flatMap(v -> fn1.apply(v)
-                                     .flatMap(v1 -> fn2.apply(v)
-                                                       .flatMap(v2 -> fn3.apply(v)
-                                                                         .flatMap(v3 -> fn4.apply(v)
-                                                                                           .flatMap(v4 -> fn5.apply(v)
-                                                                                                             .flatMap(v5 -> fn6.apply(v)
-                                                                                                                               .flatMap(v6 -> fn7.apply(v)
-                                                                                                                                                 .flatMap(v7 -> fn8.apply(v)
-                                                                                                                                                                   .flatMap(v8 -> fn9.apply(v)
-                                                                                                                                                                                     .flatMap(v9 -> fn10.apply(v)
-                                                                                                                                                                                                        .flatMap(v10 -> fn11.apply(v)
-                                                                                                                                                                                                                            .flatMap(v11 -> fn12.apply(v)
-                                                                                                                                                                                                                                                .flatMap(v12 -> fn13.apply(v)
-                                                                                                                                                                                                                                                                    .map(v13 -> Tuple.tuple(v1,
-                                                                                                                                                                                                                                                                                            v2,
-                                                                                                                                                                                                                                                                                            v3,
-                                                                                                                                                                                                                                                                                            v4,
-                                                                                                                                                                                                                                                                                            v5,
-                                                                                                                                                                                                                                                                                            v6,
-                                                                                                                                                                                                                                                                                            v7,
-                                                                                                                                                                                                                                                                                            v8,
-                                                                                                                                                                                                                                                                                            v9,
-                                                                                                                                                                                                                                                                                            v10,
-                                                                                                                                                                                                                                                                                            v11,
-                                                                                                                                                                                                                                                                                            v12,
-                                                                                                                                                                                                                                                                                            v13)))))))))))))));
+        return () -> flatMap(v -> Promise.all(fn1.apply(v),
+                                              fn2.apply(v),
+                                              fn3.apply(v),
+                                              fn4.apply(v),
+                                              fn5.apply(v),
+                                              fn6.apply(v),
+                                              fn7.apply(v),
+                                              fn8.apply(v),
+                                              fn9.apply(v),
+                                              fn10.apply(v),
+                                              fn11.apply(v),
+                                              fn12.apply(v),
+                                              fn13.apply(v))
+                                         .id());
     }
 
     /// **[Pure Transform]**
@@ -940,34 +865,21 @@ public interface Promise<T> {
                                                                               Fn1<Promise<T12>, T> fn12,
                                                                               Fn1<Promise<T13>, T> fn13,
                                                                               Fn1<Promise<T14>, T> fn14) {
-        return () -> flatMap(v -> fn1.apply(v)
-                                     .flatMap(v1 -> fn2.apply(v)
-                                                       .flatMap(v2 -> fn3.apply(v)
-                                                                         .flatMap(v3 -> fn4.apply(v)
-                                                                                           .flatMap(v4 -> fn5.apply(v)
-                                                                                                             .flatMap(v5 -> fn6.apply(v)
-                                                                                                                               .flatMap(v6 -> fn7.apply(v)
-                                                                                                                                                 .flatMap(v7 -> fn8.apply(v)
-                                                                                                                                                                   .flatMap(v8 -> fn9.apply(v)
-                                                                                                                                                                                     .flatMap(v9 -> fn10.apply(v)
-                                                                                                                                                                                                        .flatMap(v10 -> fn11.apply(v)
-                                                                                                                                                                                                                            .flatMap(v11 -> fn12.apply(v)
-                                                                                                                                                                                                                                                .flatMap(v12 -> fn13.apply(v)
-                                                                                                                                                                                                                                                                    .flatMap(v13 -> fn14.apply(v)
-                                                                                                                                                                                                                                                                                        .map(v14 -> Tuple.tuple(v1,
-                                                                                                                                                                                                                                                                                                                v2,
-                                                                                                                                                                                                                                                                                                                v3,
-                                                                                                                                                                                                                                                                                                                v4,
-                                                                                                                                                                                                                                                                                                                v5,
-                                                                                                                                                                                                                                                                                                                v6,
-                                                                                                                                                                                                                                                                                                                v7,
-                                                                                                                                                                                                                                                                                                                v8,
-                                                                                                                                                                                                                                                                                                                v9,
-                                                                                                                                                                                                                                                                                                                v10,
-                                                                                                                                                                                                                                                                                                                v11,
-                                                                                                                                                                                                                                                                                                                v12,
-                                                                                                                                                                                                                                                                                                                v13,
-                                                                                                                                                                                                                                                                                                                v14))))))))))))))));
+        return () -> flatMap(v -> Promise.all(fn1.apply(v),
+                                              fn2.apply(v),
+                                              fn3.apply(v),
+                                              fn4.apply(v),
+                                              fn5.apply(v),
+                                              fn6.apply(v),
+                                              fn7.apply(v),
+                                              fn8.apply(v),
+                                              fn9.apply(v),
+                                              fn10.apply(v),
+                                              fn11.apply(v),
+                                              fn12.apply(v),
+                                              fn13.apply(v),
+                                              fn14.apply(v))
+                                         .id());
     }
 
     /// **[Pure Transform]**
@@ -988,36 +900,351 @@ public interface Promise<T> {
                                                                                    Fn1<Promise<T13>, T> fn13,
                                                                                    Fn1<Promise<T14>, T> fn14,
                                                                                    Fn1<Promise<T15>, T> fn15) {
+        return () -> flatMap(v -> Promise.all(fn1.apply(v),
+                                              fn2.apply(v),
+                                              fn3.apply(v),
+                                              fn4.apply(v),
+                                              fn5.apply(v),
+                                              fn6.apply(v),
+                                              fn7.apply(v),
+                                              fn8.apply(v),
+                                              fn9.apply(v),
+                                              fn10.apply(v),
+                                              fn11.apply(v),
+                                              fn12.apply(v),
+                                              fn13.apply(v),
+                                              fn14.apply(v),
+                                              fn15.apply(v))
+                                         .id());
+    }
+
+    //------------------------------------------------------------------------------------------------------------------
+    // Instance allOrCancel() methods - for-comprehension style composition with cancellation
+    //------------------------------------------------------------------------------------------------------------------
+    /// **[Pure Transform]**
+    /// Like instance [#all(Fn1)], but cancels remaining promises on first failure.
+    /// Single promise variant - no cancellation needed, behaves identically to [#all(Fn1)].
+    ///
+    /// @param fn1 Function that takes the current value and returns a Promise
+    /// @param <T1> Type of the result from fn1
+    ///
+    /// @return Mapper1 for further transformation
+    default <T1> Mapper1<T1> allOrCancel(Fn1<Promise<T1>, T> fn1) {
         return () -> flatMap(v -> fn1.apply(v)
-                                     .flatMap(v1 -> fn2.apply(v)
-                                                       .flatMap(v2 -> fn3.apply(v)
-                                                                         .flatMap(v3 -> fn4.apply(v)
-                                                                                           .flatMap(v4 -> fn5.apply(v)
-                                                                                                             .flatMap(v5 -> fn6.apply(v)
-                                                                                                                               .flatMap(v6 -> fn7.apply(v)
-                                                                                                                                                 .flatMap(v7 -> fn8.apply(v)
-                                                                                                                                                                   .flatMap(v8 -> fn9.apply(v)
-                                                                                                                                                                                     .flatMap(v9 -> fn10.apply(v)
-                                                                                                                                                                                                        .flatMap(v10 -> fn11.apply(v)
-                                                                                                                                                                                                                            .flatMap(v11 -> fn12.apply(v)
-                                                                                                                                                                                                                                                .flatMap(v12 -> fn13.apply(v)
-                                                                                                                                                                                                                                                                    .flatMap(v13 -> fn14.apply(v)
-                                                                                                                                                                                                                                                                                        .flatMap(v14 -> fn15.apply(v)
-                                                                                                                                                                                                                                                                                                            .map(v15 -> Tuple.tuple(v1,
-                                                                                                                                                                                                                                                                                                                                    v2,
-                                                                                                                                                                                                                                                                                                                                    v3,
-                                                                                                                                                                                                                                                                                                                                    v4,
-                                                                                                                                                                                                                                                                                                                                    v5,
-                                                                                                                                                                                                                                                                                                                                    v6,
-                                                                                                                                                                                                                                                                                                                                    v7,
-                                                                                                                                                                                                                                                                                                                                    v8,
-                                                                                                                                                                                                                                                                                                                                    v9,
-                                                                                                                                                                                                                                                                                                                                    v10,
-                                                                                                                                                                                                                                                                                                                                    v11,
-                                                                                                                                                                                                                                                                                                                                    v12,
-                                                                                                                                                                                                                                                                                                                                    v13,
-                                                                                                                                                                                                                                                                                                                                    v14,
-                                                                                                                                                                                                                                                                                                                                    v15)))))))))))))))));
+                                     .map(Tuple::tuple));
+    }
+
+    /// **[Pure Transform]**
+    /// Like instance [#all(Fn1, Fn1)], but cancels remaining promises on first failure.
+    /// All functions are executed in parallel; if any fails, remaining are cancelled.
+    default <T1, T2> Mapper2<T1, T2> allOrCancel(Fn1<Promise<T1>, T> fn1,
+                                                 Fn1<Promise<T2>, T> fn2) {
+        return () -> flatMap(v -> Promise.allOrCancel(fn1.apply(v),
+                                                      fn2.apply(v))
+                                         .id());
+    }
+
+    /// **[Pure Transform]**
+    /// Like instance [#all(Fn1, Fn1, Fn1)], but cancels remaining promises on first failure.
+    default <T1, T2, T3> Mapper3<T1, T2, T3> allOrCancel(Fn1<Promise<T1>, T> fn1,
+                                                         Fn1<Promise<T2>, T> fn2,
+                                                         Fn1<Promise<T3>, T> fn3) {
+        return () -> flatMap(v -> Promise.allOrCancel(fn1.apply(v),
+                                                      fn2.apply(v),
+                                                      fn3.apply(v))
+                                         .id());
+    }
+
+    /// **[Pure Transform]**
+    /// Like instance all(), but cancels remaining promises on first failure.
+    default <T1, T2, T3, T4> Mapper4<T1, T2, T3, T4> allOrCancel(Fn1<Promise<T1>, T> fn1,
+                                                                  Fn1<Promise<T2>, T> fn2,
+                                                                  Fn1<Promise<T3>, T> fn3,
+                                                                  Fn1<Promise<T4>, T> fn4) {
+        return () -> flatMap(v -> Promise.allOrCancel(fn1.apply(v),
+                                                      fn2.apply(v),
+                                                      fn3.apply(v),
+                                                      fn4.apply(v))
+                                         .id());
+    }
+
+    /// **[Pure Transform]**
+    /// Like instance all(), but cancels remaining promises on first failure.
+    default <T1, T2, T3, T4, T5> Mapper5<T1, T2, T3, T4, T5> allOrCancel(Fn1<Promise<T1>, T> fn1,
+                                                                          Fn1<Promise<T2>, T> fn2,
+                                                                          Fn1<Promise<T3>, T> fn3,
+                                                                          Fn1<Promise<T4>, T> fn4,
+                                                                          Fn1<Promise<T5>, T> fn5) {
+        return () -> flatMap(v -> Promise.allOrCancel(fn1.apply(v),
+                                                      fn2.apply(v),
+                                                      fn3.apply(v),
+                                                      fn4.apply(v),
+                                                      fn5.apply(v))
+                                         .id());
+    }
+
+    /// **[Pure Transform]**
+    /// Like instance all(), but cancels remaining promises on first failure.
+    default <T1, T2, T3, T4, T5, T6> Mapper6<T1, T2, T3, T4, T5, T6> allOrCancel(Fn1<Promise<T1>, T> fn1,
+                                                                                  Fn1<Promise<T2>, T> fn2,
+                                                                                  Fn1<Promise<T3>, T> fn3,
+                                                                                  Fn1<Promise<T4>, T> fn4,
+                                                                                  Fn1<Promise<T5>, T> fn5,
+                                                                                  Fn1<Promise<T6>, T> fn6) {
+        return () -> flatMap(v -> Promise.allOrCancel(fn1.apply(v),
+                                                      fn2.apply(v),
+                                                      fn3.apply(v),
+                                                      fn4.apply(v),
+                                                      fn5.apply(v),
+                                                      fn6.apply(v))
+                                         .id());
+    }
+
+    /// **[Pure Transform]**
+    /// Like instance all(), but cancels remaining promises on first failure.
+    default <T1, T2, T3, T4, T5, T6, T7> Mapper7<T1, T2, T3, T4, T5, T6, T7> allOrCancel(Fn1<Promise<T1>, T> fn1,
+                                                                                          Fn1<Promise<T2>, T> fn2,
+                                                                                          Fn1<Promise<T3>, T> fn3,
+                                                                                          Fn1<Promise<T4>, T> fn4,
+                                                                                          Fn1<Promise<T5>, T> fn5,
+                                                                                          Fn1<Promise<T6>, T> fn6,
+                                                                                          Fn1<Promise<T7>, T> fn7) {
+        return () -> flatMap(v -> Promise.allOrCancel(fn1.apply(v),
+                                                      fn2.apply(v),
+                                                      fn3.apply(v),
+                                                      fn4.apply(v),
+                                                      fn5.apply(v),
+                                                      fn6.apply(v),
+                                                      fn7.apply(v))
+                                         .id());
+    }
+
+    /// **[Pure Transform]**
+    /// Like instance all(), but cancels remaining promises on first failure.
+    default <T1, T2, T3, T4, T5, T6, T7, T8> Mapper8<T1, T2, T3, T4, T5, T6, T7, T8> allOrCancel(Fn1<Promise<T1>, T> fn1,
+                                                                                                  Fn1<Promise<T2>, T> fn2,
+                                                                                                  Fn1<Promise<T3>, T> fn3,
+                                                                                                  Fn1<Promise<T4>, T> fn4,
+                                                                                                  Fn1<Promise<T5>, T> fn5,
+                                                                                                  Fn1<Promise<T6>, T> fn6,
+                                                                                                  Fn1<Promise<T7>, T> fn7,
+                                                                                                  Fn1<Promise<T8>, T> fn8) {
+        return () -> flatMap(v -> Promise.allOrCancel(fn1.apply(v),
+                                                      fn2.apply(v),
+                                                      fn3.apply(v),
+                                                      fn4.apply(v),
+                                                      fn5.apply(v),
+                                                      fn6.apply(v),
+                                                      fn7.apply(v),
+                                                      fn8.apply(v))
+                                         .id());
+    }
+
+    /// **[Pure Transform]**
+    /// Like instance all(), but cancels remaining promises on first failure.
+    default <T1, T2, T3, T4, T5, T6, T7, T8, T9> Mapper9<T1, T2, T3, T4, T5, T6, T7, T8, T9> allOrCancel(Fn1<Promise<T1>, T> fn1,
+                                                                                                          Fn1<Promise<T2>, T> fn2,
+                                                                                                          Fn1<Promise<T3>, T> fn3,
+                                                                                                          Fn1<Promise<T4>, T> fn4,
+                                                                                                          Fn1<Promise<T5>, T> fn5,
+                                                                                                          Fn1<Promise<T6>, T> fn6,
+                                                                                                          Fn1<Promise<T7>, T> fn7,
+                                                                                                          Fn1<Promise<T8>, T> fn8,
+                                                                                                          Fn1<Promise<T9>, T> fn9) {
+        return () -> flatMap(v -> Promise.allOrCancel(fn1.apply(v),
+                                                      fn2.apply(v),
+                                                      fn3.apply(v),
+                                                      fn4.apply(v),
+                                                      fn5.apply(v),
+                                                      fn6.apply(v),
+                                                      fn7.apply(v),
+                                                      fn8.apply(v),
+                                                      fn9.apply(v))
+                                         .id());
+    }
+
+    /// **[Pure Transform]**
+    /// Like instance all(), but cancels remaining promises on first failure.
+    default <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> Mapper10<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> allOrCancel(Fn1<Promise<T1>, T> fn1,
+                                                                                                                     Fn1<Promise<T2>, T> fn2,
+                                                                                                                     Fn1<Promise<T3>, T> fn3,
+                                                                                                                     Fn1<Promise<T4>, T> fn4,
+                                                                                                                     Fn1<Promise<T5>, T> fn5,
+                                                                                                                     Fn1<Promise<T6>, T> fn6,
+                                                                                                                     Fn1<Promise<T7>, T> fn7,
+                                                                                                                     Fn1<Promise<T8>, T> fn8,
+                                                                                                                     Fn1<Promise<T9>, T> fn9,
+                                                                                                                     Fn1<Promise<T10>, T> fn10) {
+        return () -> flatMap(v -> Promise.allOrCancel(fn1.apply(v),
+                                                      fn2.apply(v),
+                                                      fn3.apply(v),
+                                                      fn4.apply(v),
+                                                      fn5.apply(v),
+                                                      fn6.apply(v),
+                                                      fn7.apply(v),
+                                                      fn8.apply(v),
+                                                      fn9.apply(v),
+                                                      fn10.apply(v))
+                                         .id());
+    }
+
+    /// **[Pure Transform]**
+    /// Like instance all(), but cancels remaining promises on first failure.
+    default <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> Mapper11<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> allOrCancel(Fn1<Promise<T1>, T> fn1,
+                                                                                                                               Fn1<Promise<T2>, T> fn2,
+                                                                                                                               Fn1<Promise<T3>, T> fn3,
+                                                                                                                               Fn1<Promise<T4>, T> fn4,
+                                                                                                                               Fn1<Promise<T5>, T> fn5,
+                                                                                                                               Fn1<Promise<T6>, T> fn6,
+                                                                                                                               Fn1<Promise<T7>, T> fn7,
+                                                                                                                               Fn1<Promise<T8>, T> fn8,
+                                                                                                                               Fn1<Promise<T9>, T> fn9,
+                                                                                                                               Fn1<Promise<T10>, T> fn10,
+                                                                                                                               Fn1<Promise<T11>, T> fn11) {
+        return () -> flatMap(v -> Promise.allOrCancel(fn1.apply(v),
+                                                      fn2.apply(v),
+                                                      fn3.apply(v),
+                                                      fn4.apply(v),
+                                                      fn5.apply(v),
+                                                      fn6.apply(v),
+                                                      fn7.apply(v),
+                                                      fn8.apply(v),
+                                                      fn9.apply(v),
+                                                      fn10.apply(v),
+                                                      fn11.apply(v))
+                                         .id());
+    }
+
+    /// **[Pure Transform]**
+    /// Like instance all(), but cancels remaining promises on first failure.
+    default <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>
+    Mapper12<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> allOrCancel(Fn1<Promise<T1>, T> fn1,
+                                                                             Fn1<Promise<T2>, T> fn2,
+                                                                             Fn1<Promise<T3>, T> fn3,
+                                                                             Fn1<Promise<T4>, T> fn4,
+                                                                             Fn1<Promise<T5>, T> fn5,
+                                                                             Fn1<Promise<T6>, T> fn6,
+                                                                             Fn1<Promise<T7>, T> fn7,
+                                                                             Fn1<Promise<T8>, T> fn8,
+                                                                             Fn1<Promise<T9>, T> fn9,
+                                                                             Fn1<Promise<T10>, T> fn10,
+                                                                             Fn1<Promise<T11>, T> fn11,
+                                                                             Fn1<Promise<T12>, T> fn12) {
+        return () -> flatMap(v -> Promise.allOrCancel(fn1.apply(v),
+                                                      fn2.apply(v),
+                                                      fn3.apply(v),
+                                                      fn4.apply(v),
+                                                      fn5.apply(v),
+                                                      fn6.apply(v),
+                                                      fn7.apply(v),
+                                                      fn8.apply(v),
+                                                      fn9.apply(v),
+                                                      fn10.apply(v),
+                                                      fn11.apply(v),
+                                                      fn12.apply(v))
+                                         .id());
+    }
+
+    /// **[Pure Transform]**
+    /// Like instance all(), but cancels remaining promises on first failure.
+    default <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>
+    Mapper13<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> allOrCancel(Fn1<Promise<T1>, T> fn1,
+                                                                                  Fn1<Promise<T2>, T> fn2,
+                                                                                  Fn1<Promise<T3>, T> fn3,
+                                                                                  Fn1<Promise<T4>, T> fn4,
+                                                                                  Fn1<Promise<T5>, T> fn5,
+                                                                                  Fn1<Promise<T6>, T> fn6,
+                                                                                  Fn1<Promise<T7>, T> fn7,
+                                                                                  Fn1<Promise<T8>, T> fn8,
+                                                                                  Fn1<Promise<T9>, T> fn9,
+                                                                                  Fn1<Promise<T10>, T> fn10,
+                                                                                  Fn1<Promise<T11>, T> fn11,
+                                                                                  Fn1<Promise<T12>, T> fn12,
+                                                                                  Fn1<Promise<T13>, T> fn13) {
+        return () -> flatMap(v -> Promise.allOrCancel(fn1.apply(v),
+                                                      fn2.apply(v),
+                                                      fn3.apply(v),
+                                                      fn4.apply(v),
+                                                      fn5.apply(v),
+                                                      fn6.apply(v),
+                                                      fn7.apply(v),
+                                                      fn8.apply(v),
+                                                      fn9.apply(v),
+                                                      fn10.apply(v),
+                                                      fn11.apply(v),
+                                                      fn12.apply(v),
+                                                      fn13.apply(v))
+                                         .id());
+    }
+
+    /// **[Pure Transform]**
+    /// Like instance all(), but cancels remaining promises on first failure.
+    default <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>
+    Mapper14<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> allOrCancel(Fn1<Promise<T1>, T> fn1,
+                                                                                       Fn1<Promise<T2>, T> fn2,
+                                                                                       Fn1<Promise<T3>, T> fn3,
+                                                                                       Fn1<Promise<T4>, T> fn4,
+                                                                                       Fn1<Promise<T5>, T> fn5,
+                                                                                       Fn1<Promise<T6>, T> fn6,
+                                                                                       Fn1<Promise<T7>, T> fn7,
+                                                                                       Fn1<Promise<T8>, T> fn8,
+                                                                                       Fn1<Promise<T9>, T> fn9,
+                                                                                       Fn1<Promise<T10>, T> fn10,
+                                                                                       Fn1<Promise<T11>, T> fn11,
+                                                                                       Fn1<Promise<T12>, T> fn12,
+                                                                                       Fn1<Promise<T13>, T> fn13,
+                                                                                       Fn1<Promise<T14>, T> fn14) {
+        return () -> flatMap(v -> Promise.allOrCancel(fn1.apply(v),
+                                                      fn2.apply(v),
+                                                      fn3.apply(v),
+                                                      fn4.apply(v),
+                                                      fn5.apply(v),
+                                                      fn6.apply(v),
+                                                      fn7.apply(v),
+                                                      fn8.apply(v),
+                                                      fn9.apply(v),
+                                                      fn10.apply(v),
+                                                      fn11.apply(v),
+                                                      fn12.apply(v),
+                                                      fn13.apply(v),
+                                                      fn14.apply(v))
+                                         .id());
+    }
+
+    /// **[Pure Transform]**
+    /// Like instance all(), but cancels remaining promises on first failure.
+    default <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>
+    Mapper15<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> allOrCancel(Fn1<Promise<T1>, T> fn1,
+                                                                                            Fn1<Promise<T2>, T> fn2,
+                                                                                            Fn1<Promise<T3>, T> fn3,
+                                                                                            Fn1<Promise<T4>, T> fn4,
+                                                                                            Fn1<Promise<T5>, T> fn5,
+                                                                                            Fn1<Promise<T6>, T> fn6,
+                                                                                            Fn1<Promise<T7>, T> fn7,
+                                                                                            Fn1<Promise<T8>, T> fn8,
+                                                                                            Fn1<Promise<T9>, T> fn9,
+                                                                                            Fn1<Promise<T10>, T> fn10,
+                                                                                            Fn1<Promise<T11>, T> fn11,
+                                                                                            Fn1<Promise<T12>, T> fn12,
+                                                                                            Fn1<Promise<T13>, T> fn13,
+                                                                                            Fn1<Promise<T14>, T> fn14,
+                                                                                            Fn1<Promise<T15>, T> fn15) {
+        return () -> flatMap(v -> Promise.allOrCancel(fn1.apply(v),
+                                                      fn2.apply(v),
+                                                      fn3.apply(v),
+                                                      fn4.apply(v),
+                                                      fn5.apply(v),
+                                                      fn6.apply(v),
+                                                      fn7.apply(v),
+                                                      fn8.apply(v),
+                                                      fn9.apply(v),
+                                                      fn10.apply(v),
+                                                      fn11.apply(v),
+                                                      fn12.apply(v),
+                                                      fn13.apply(v),
+                                                      fn14.apply(v),
+                                                      fn15.apply(v))
+                                         .id());
     }
 
     /// **[Factory]**
@@ -2044,6 +2271,493 @@ public interface Promise<T> {
                                  promise15);
     }
 
+    //------------------------------------------------------------------------------------------------------------------
+    // Static allOrCancel() methods - like all() but cancel remaining on first failure
+    //------------------------------------------------------------------------------------------------------------------
+    /// **[Factory]**
+    /// Like [#all(Promise)], but cancels remaining promises on first failure.
+    /// Single promise variant - no cancellation needed, delegates to [#all(Promise)].
+    ///
+    /// @param promise1 Input promise
+    ///
+    /// @return Promise instance, which will be resolved with all collected results.
+    static <T1> Mapper1<T1> allOrCancel(Promise<T1> promise1) {
+        return all(promise1);
+    }
+
+    /// **[Factory]**
+    /// Like [#all(Promise, Promise)], but cancels remaining promises on first failure.
+    /// The result promise is resolved with the first failure's cause.
+    @SuppressWarnings("unchecked")
+    static <T1, T2> Mapper2<T1, T2> allOrCancel(Promise<T1> promise1, Promise<T2> promise2) {
+        return () -> setupResultOrCancel(values -> Result.all((Result<T1>) values[0],
+                                                              (Result<T2>) values[1])
+                                                         .id(),
+                                         promise1,
+                                         promise2);
+    }
+
+    /// **[Factory]**
+    /// Like [#all(Promise, Promise, Promise)], but cancels remaining promises on first failure.
+    @SuppressWarnings("unchecked")
+    static <T1, T2, T3> Mapper3<T1, T2, T3> allOrCancel(Promise<T1> promise1, Promise<T2> promise2, Promise<T3> promise3) {
+        return () -> setupResultOrCancel(values -> Result.all((Result<T1>) values[0],
+                                                              (Result<T2>) values[1],
+                                                              (Result<T3>) values[2])
+                                                         .id(),
+                                         promise1,
+                                         promise2,
+                                         promise3);
+    }
+
+    /// **[Factory]**
+    /// Like static all(), but cancels remaining promises on first failure.
+    @SuppressWarnings("unchecked")
+    static <T1, T2, T3, T4> Mapper4<T1, T2, T3, T4> allOrCancel(Promise<T1> promise1,
+                                                                 Promise<T2> promise2,
+                                                                 Promise<T3> promise3,
+                                                                 Promise<T4> promise4) {
+        return () -> setupResultOrCancel(values -> Result.all((Result<T1>) values[0],
+                                                              (Result<T2>) values[1],
+                                                              (Result<T3>) values[2],
+                                                              (Result<T4>) values[3])
+                                                         .id(),
+                                         promise1,
+                                         promise2,
+                                         promise3,
+                                         promise4);
+    }
+
+    /// **[Factory]**
+    /// Like static all(), but cancels remaining promises on first failure.
+    @SuppressWarnings("unchecked")
+    static <T1, T2, T3, T4, T5> Mapper5<T1, T2, T3, T4, T5> allOrCancel(Promise<T1> promise1,
+                                                                         Promise<T2> promise2,
+                                                                         Promise<T3> promise3,
+                                                                         Promise<T4> promise4,
+                                                                         Promise<T5> promise5) {
+        return () -> setupResultOrCancel(values -> Result.all((Result<T1>) values[0],
+                                                              (Result<T2>) values[1],
+                                                              (Result<T3>) values[2],
+                                                              (Result<T4>) values[3],
+                                                              (Result<T5>) values[4])
+                                                         .id(),
+                                         promise1,
+                                         promise2,
+                                         promise3,
+                                         promise4,
+                                         promise5);
+    }
+
+    /// **[Factory]**
+    /// Like static all(), but cancels remaining promises on first failure.
+    @SuppressWarnings("unchecked")
+    static <T1, T2, T3, T4, T5, T6> Mapper6<T1, T2, T3, T4, T5, T6> allOrCancel(Promise<T1> promise1,
+                                                                                 Promise<T2> promise2,
+                                                                                 Promise<T3> promise3,
+                                                                                 Promise<T4> promise4,
+                                                                                 Promise<T5> promise5,
+                                                                                 Promise<T6> promise6) {
+        return () -> setupResultOrCancel(values -> Result.all((Result<T1>) values[0],
+                                                              (Result<T2>) values[1],
+                                                              (Result<T3>) values[2],
+                                                              (Result<T4>) values[3],
+                                                              (Result<T5>) values[4],
+                                                              (Result<T6>) values[5])
+                                                         .id(),
+                                         promise1,
+                                         promise2,
+                                         promise3,
+                                         promise4,
+                                         promise5,
+                                         promise6);
+    }
+
+    /// **[Factory]**
+    /// Like static all(), but cancels remaining promises on first failure.
+    @SuppressWarnings("unchecked")
+    static <T1, T2, T3, T4, T5, T6, T7> Mapper7<T1, T2, T3, T4, T5, T6, T7> allOrCancel(Promise<T1> promise1,
+                                                                                         Promise<T2> promise2,
+                                                                                         Promise<T3> promise3,
+                                                                                         Promise<T4> promise4,
+                                                                                         Promise<T5> promise5,
+                                                                                         Promise<T6> promise6,
+                                                                                         Promise<T7> promise7) {
+        return () -> setupResultOrCancel(values -> Result.all((Result<T1>) values[0],
+                                                              (Result<T2>) values[1],
+                                                              (Result<T3>) values[2],
+                                                              (Result<T4>) values[3],
+                                                              (Result<T5>) values[4],
+                                                              (Result<T6>) values[5],
+                                                              (Result<T7>) values[6])
+                                                         .id(),
+                                         promise1,
+                                         promise2,
+                                         promise3,
+                                         promise4,
+                                         promise5,
+                                         promise6,
+                                         promise7);
+    }
+
+    /// **[Factory]**
+    /// Like static all(), but cancels remaining promises on first failure.
+    @SuppressWarnings("unchecked")
+    static <T1, T2, T3, T4, T5, T6, T7, T8> Mapper8<T1, T2, T3, T4, T5, T6, T7, T8> allOrCancel(Promise<T1> promise1,
+                                                                                                 Promise<T2> promise2,
+                                                                                                 Promise<T3> promise3,
+                                                                                                 Promise<T4> promise4,
+                                                                                                 Promise<T5> promise5,
+                                                                                                 Promise<T6> promise6,
+                                                                                                 Promise<T7> promise7,
+                                                                                                 Promise<T8> promise8) {
+        return () -> setupResultOrCancel(values -> Result.all((Result<T1>) values[0],
+                                                              (Result<T2>) values[1],
+                                                              (Result<T3>) values[2],
+                                                              (Result<T4>) values[3],
+                                                              (Result<T5>) values[4],
+                                                              (Result<T6>) values[5],
+                                                              (Result<T7>) values[6],
+                                                              (Result<T8>) values[7])
+                                                         .id(),
+                                         promise1,
+                                         promise2,
+                                         promise3,
+                                         promise4,
+                                         promise5,
+                                         promise6,
+                                         promise7,
+                                         promise8);
+    }
+
+    /// **[Factory]**
+    /// Like static all(), but cancels remaining promises on first failure.
+    @SuppressWarnings("unchecked")
+    static <T1, T2, T3, T4, T5, T6, T7, T8, T9> Mapper9<T1, T2, T3, T4, T5, T6, T7, T8, T9> allOrCancel(Promise<T1> promise1,
+                                                                                                         Promise<T2> promise2,
+                                                                                                         Promise<T3> promise3,
+                                                                                                         Promise<T4> promise4,
+                                                                                                         Promise<T5> promise5,
+                                                                                                         Promise<T6> promise6,
+                                                                                                         Promise<T7> promise7,
+                                                                                                         Promise<T8> promise8,
+                                                                                                         Promise<T9> promise9) {
+        return () -> setupResultOrCancel(values -> Result.all((Result<T1>) values[0],
+                                                              (Result<T2>) values[1],
+                                                              (Result<T3>) values[2],
+                                                              (Result<T4>) values[3],
+                                                              (Result<T5>) values[4],
+                                                              (Result<T6>) values[5],
+                                                              (Result<T7>) values[6],
+                                                              (Result<T8>) values[7],
+                                                              (Result<T9>) values[8])
+                                                         .id(),
+                                         promise1,
+                                         promise2,
+                                         promise3,
+                                         promise4,
+                                         promise5,
+                                         promise6,
+                                         promise7,
+                                         promise8,
+                                         promise9);
+    }
+
+    /// **[Factory]**
+    /// Like static all(), but cancels remaining promises on first failure.
+    @SuppressWarnings("unchecked")
+    static <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> Mapper10<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> allOrCancel(Promise<T1> promise1,
+                                                                                                                    Promise<T2> promise2,
+                                                                                                                    Promise<T3> promise3,
+                                                                                                                    Promise<T4> promise4,
+                                                                                                                    Promise<T5> promise5,
+                                                                                                                    Promise<T6> promise6,
+                                                                                                                    Promise<T7> promise7,
+                                                                                                                    Promise<T8> promise8,
+                                                                                                                    Promise<T9> promise9,
+                                                                                                                    Promise<T10> promise10) {
+        return () -> setupResultOrCancel(values -> Result.all((Result<T1>) values[0],
+                                                              (Result<T2>) values[1],
+                                                              (Result<T3>) values[2],
+                                                              (Result<T4>) values[3],
+                                                              (Result<T5>) values[4],
+                                                              (Result<T6>) values[5],
+                                                              (Result<T7>) values[6],
+                                                              (Result<T8>) values[7],
+                                                              (Result<T9>) values[8],
+                                                              (Result<T10>) values[9])
+                                                         .id(),
+                                         promise1,
+                                         promise2,
+                                         promise3,
+                                         promise4,
+                                         promise5,
+                                         promise6,
+                                         promise7,
+                                         promise8,
+                                         promise9,
+                                         promise10);
+    }
+
+    /// **[Factory]**
+    /// Like static all(), but cancels remaining promises on first failure.
+    @SuppressWarnings("unchecked")
+    static <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> Mapper11<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> allOrCancel(Promise<T1> promise1,
+                                                                                                                              Promise<T2> promise2,
+                                                                                                                              Promise<T3> promise3,
+                                                                                                                              Promise<T4> promise4,
+                                                                                                                              Promise<T5> promise5,
+                                                                                                                              Promise<T6> promise6,
+                                                                                                                              Promise<T7> promise7,
+                                                                                                                              Promise<T8> promise8,
+                                                                                                                              Promise<T9> promise9,
+                                                                                                                              Promise<T10> promise10,
+                                                                                                                              Promise<T11> promise11) {
+        return () -> setupResultOrCancel(values -> Result.all((Result<T1>) values[0],
+                                                              (Result<T2>) values[1],
+                                                              (Result<T3>) values[2],
+                                                              (Result<T4>) values[3],
+                                                              (Result<T5>) values[4],
+                                                              (Result<T6>) values[5],
+                                                              (Result<T7>) values[6],
+                                                              (Result<T8>) values[7],
+                                                              (Result<T9>) values[8],
+                                                              (Result<T10>) values[9],
+                                                              (Result<T11>) values[10])
+                                                         .id(),
+                                         promise1,
+                                         promise2,
+                                         promise3,
+                                         promise4,
+                                         promise5,
+                                         promise6,
+                                         promise7,
+                                         promise8,
+                                         promise9,
+                                         promise10,
+                                         promise11);
+    }
+
+    /// **[Factory]**
+    /// Like static all(), but cancels remaining promises on first failure.
+    @SuppressWarnings("unchecked")
+    static <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>
+    Mapper12<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> allOrCancel(Promise<T1> promise1,
+                                                                             Promise<T2> promise2,
+                                                                             Promise<T3> promise3,
+                                                                             Promise<T4> promise4,
+                                                                             Promise<T5> promise5,
+                                                                             Promise<T6> promise6,
+                                                                             Promise<T7> promise7,
+                                                                             Promise<T8> promise8,
+                                                                             Promise<T9> promise9,
+                                                                             Promise<T10> promise10,
+                                                                             Promise<T11> promise11,
+                                                                             Promise<T12> promise12) {
+        return () -> setupResultOrCancel(values -> Result.all((Result<T1>) values[0],
+                                                              (Result<T2>) values[1],
+                                                              (Result<T3>) values[2],
+                                                              (Result<T4>) values[3],
+                                                              (Result<T5>) values[4],
+                                                              (Result<T6>) values[5],
+                                                              (Result<T7>) values[6],
+                                                              (Result<T8>) values[7],
+                                                              (Result<T9>) values[8],
+                                                              (Result<T10>) values[9],
+                                                              (Result<T11>) values[10],
+                                                              (Result<T12>) values[11])
+                                                         .id(),
+                                         promise1,
+                                         promise2,
+                                         promise3,
+                                         promise4,
+                                         promise5,
+                                         promise6,
+                                         promise7,
+                                         promise8,
+                                         promise9,
+                                         promise10,
+                                         promise11,
+                                         promise12);
+    }
+
+    /// **[Factory]**
+    /// Like static all(), but cancels remaining promises on first failure.
+    @SuppressWarnings("unchecked")
+    static <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>
+    Mapper13<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> allOrCancel(Promise<T1> promise1,
+                                                                                  Promise<T2> promise2,
+                                                                                  Promise<T3> promise3,
+                                                                                  Promise<T4> promise4,
+                                                                                  Promise<T5> promise5,
+                                                                                  Promise<T6> promise6,
+                                                                                  Promise<T7> promise7,
+                                                                                  Promise<T8> promise8,
+                                                                                  Promise<T9> promise9,
+                                                                                  Promise<T10> promise10,
+                                                                                  Promise<T11> promise11,
+                                                                                  Promise<T12> promise12,
+                                                                                  Promise<T13> promise13) {
+        return () -> setupResultOrCancel(values -> Result.all((Result<T1>) values[0],
+                                                              (Result<T2>) values[1],
+                                                              (Result<T3>) values[2],
+                                                              (Result<T4>) values[3],
+                                                              (Result<T5>) values[4],
+                                                              (Result<T6>) values[5],
+                                                              (Result<T7>) values[6],
+                                                              (Result<T8>) values[7],
+                                                              (Result<T9>) values[8],
+                                                              (Result<T10>) values[9],
+                                                              (Result<T11>) values[10],
+                                                              (Result<T12>) values[11],
+                                                              (Result<T13>) values[12])
+                                                         .id(),
+                                         promise1,
+                                         promise2,
+                                         promise3,
+                                         promise4,
+                                         promise5,
+                                         promise6,
+                                         promise7,
+                                         promise8,
+                                         promise9,
+                                         promise10,
+                                         promise11,
+                                         promise12,
+                                         promise13);
+    }
+
+    /// **[Factory]**
+    /// Like static all(), but cancels remaining promises on first failure.
+    @SuppressWarnings("unchecked")
+    static <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>
+    Mapper14<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> allOrCancel(Promise<T1> promise1,
+                                                                                       Promise<T2> promise2,
+                                                                                       Promise<T3> promise3,
+                                                                                       Promise<T4> promise4,
+                                                                                       Promise<T5> promise5,
+                                                                                       Promise<T6> promise6,
+                                                                                       Promise<T7> promise7,
+                                                                                       Promise<T8> promise8,
+                                                                                       Promise<T9> promise9,
+                                                                                       Promise<T10> promise10,
+                                                                                       Promise<T11> promise11,
+                                                                                       Promise<T12> promise12,
+                                                                                       Promise<T13> promise13,
+                                                                                       Promise<T14> promise14) {
+        return () -> setupResultOrCancel(values -> Result.all((Result<T1>) values[0],
+                                                              (Result<T2>) values[1],
+                                                              (Result<T3>) values[2],
+                                                              (Result<T4>) values[3],
+                                                              (Result<T5>) values[4],
+                                                              (Result<T6>) values[5],
+                                                              (Result<T7>) values[6],
+                                                              (Result<T8>) values[7],
+                                                              (Result<T9>) values[8],
+                                                              (Result<T10>) values[9],
+                                                              (Result<T11>) values[10],
+                                                              (Result<T12>) values[11],
+                                                              (Result<T13>) values[12],
+                                                              (Result<T14>) values[13])
+                                                         .id(),
+                                         promise1,
+                                         promise2,
+                                         promise3,
+                                         promise4,
+                                         promise5,
+                                         promise6,
+                                         promise7,
+                                         promise8,
+                                         promise9,
+                                         promise10,
+                                         promise11,
+                                         promise12,
+                                         promise13,
+                                         promise14);
+    }
+
+    /// **[Factory]**
+    /// Like static all(), but cancels remaining promises on first failure.
+    @SuppressWarnings("unchecked")
+    static <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>
+    Mapper15<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> allOrCancel(Promise<T1> promise1,
+                                                                                            Promise<T2> promise2,
+                                                                                            Promise<T3> promise3,
+                                                                                            Promise<T4> promise4,
+                                                                                            Promise<T5> promise5,
+                                                                                            Promise<T6> promise6,
+                                                                                            Promise<T7> promise7,
+                                                                                            Promise<T8> promise8,
+                                                                                            Promise<T9> promise9,
+                                                                                            Promise<T10> promise10,
+                                                                                            Promise<T11> promise11,
+                                                                                            Promise<T12> promise12,
+                                                                                            Promise<T13> promise13,
+                                                                                            Promise<T14> promise14,
+                                                                                            Promise<T15> promise15) {
+        return () -> setupResultOrCancel(values -> Result.all((Result<T1>) values[0],
+                                                              (Result<T2>) values[1],
+                                                              (Result<T3>) values[2],
+                                                              (Result<T4>) values[3],
+                                                              (Result<T5>) values[4],
+                                                              (Result<T6>) values[5],
+                                                              (Result<T7>) values[6],
+                                                              (Result<T8>) values[7],
+                                                              (Result<T9>) values[8],
+                                                              (Result<T10>) values[9],
+                                                              (Result<T11>) values[10],
+                                                              (Result<T12>) values[11],
+                                                              (Result<T13>) values[12],
+                                                              (Result<T14>) values[13],
+                                                              (Result<T15>) values[14])
+                                                         .id(),
+                                         promise1,
+                                         promise2,
+                                         promise3,
+                                         promise4,
+                                         promise5,
+                                         promise6,
+                                         promise7,
+                                         promise8,
+                                         promise9,
+                                         promise10,
+                                         promise11,
+                                         promise12,
+                                         promise13,
+                                         promise14,
+                                         promise15);
+    }
+
+    /// **[Factory]**
+    /// Like [#allOf(Collection)], but cancels remaining promises on first failure.
+    /// The result promise is resolved with the first failure's cause.
+    ///
+    /// @param promises Collection of promises to be resolved.
+    ///
+    /// @return Promise instance, which will be resolved with the list of results from resolved promises.
+    @SuppressWarnings("unchecked")
+    static <T> Promise<List<Result<T>>> allOfOrCancel(Collection<Promise<T>> promises) {
+        if (promises.isEmpty()) {
+            return Promise.success(List.of());
+        }
+        var promiseList = List.copyOf(promises);
+        var promise = Promise.promise();
+        var collector = ResultCollector.resultCollector(promiseList.size(),
+                                                        values -> promise.succeed(List.of(values)));
+        for (int i = 0; i < promiseList.size(); i++) {
+            final var index = i;
+            promiseList.get(index)
+                       .withResult(result -> collector.registerEvent(index, result))
+                       .withFailure(cause -> cancelAllOfOrCancel(cause, promise, promiseList));
+        }
+        return promise.map(list -> (List<Result<T>>) list);
+    }
+
+    private static <T> void cancelAllOfOrCancel(Cause cause, Promise<?> output, List<Promise<T>> promises) {
+        output.fail(cause);
+        promises.forEach(Promise::cancel);
+    }
+
     Promise<Unit> UNIT = Promise.resolved(unitResult());
 
     Result<?> OTHER_SUCCEEDED = new CoreError.Cancelled("Cancelled because other Promise instance succeeded").result();
@@ -2285,6 +2999,26 @@ public interface Promise<T> {
             p.withResult(result -> collector.registerEvent(index, result));
         }
         return promise;
+    }
+
+    private static <R> Promise<R> setupResultOrCancel(FnX<Result<R>> transformer, Promise<?>... promises) {
+        var promise = Promise.<R>promise();
+        var collector = resultCollector(promises.length,
+                                        values -> promise.resolve(transformer.apply(values)));
+        int count = 0;
+        for (var p : promises) {
+            final var index = count++;
+            p.withResult(result -> collector.registerEvent(index, result))
+             .withFailure(cause -> cancelAllUntyped(cause, promise, promises));
+        }
+        return promise;
+    }
+
+    private static void cancelAllUntyped(Cause cause, Promise<?> output, Promise<?>... promises) {
+        output.fail(cause);
+        for (var p : promises) {
+            p.cancel();
+        }
     }
 }
 

--- a/core/src/test/java/org/pragmatica/lang/PromiseAllOrCancelTest.java
+++ b/core/src/test/java/org/pragmatica/lang/PromiseAllOrCancelTest.java
@@ -1,0 +1,241 @@
+/*
+ *  Copyright (c) 2020-2025 Sergiy Yevtushenko.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package org.pragmatica.lang;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.pragmatica.lang.io.CoreError;
+
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.pragmatica.lang.io.TimeSpan.timeSpan;
+
+@Timeout(value = 30, unit = TimeUnit.SECONDS)
+public class PromiseAllOrCancelTest {
+    private static final Cause TEST_FAILURE = new CoreError.Fault("Test failure");
+
+    @Nested
+    class StaticAllOrCancel {
+
+        @Test
+        void allOrCancel_allSucceed_returnsAllValues_2args() {
+            var result = Promise.allOrCancel(Promise.success("a"), Promise.success(42))
+                                .map((s, i) -> s + i)
+                                .await();
+
+            result.onFailure(_ -> fail("Expected success"))
+                  .onSuccess(v -> assertEquals("a42", v));
+        }
+
+        @Test
+        void allOrCancel_allSucceed_returnsAllValues_3args() {
+            var result = Promise.allOrCancel(Promise.success("a"), Promise.success(42), Promise.success(true))
+                                .map((s, i, b) -> s + i + b)
+                                .await();
+
+            result.onFailure(_ -> fail("Expected success"))
+                  .onSuccess(v -> assertEquals("a42true", v));
+        }
+
+        @Test
+        void allOrCancel_firstFails_cancelsRemaining() throws InterruptedException {
+            var cancelled = new CountDownLatch(1);
+            var p2 = Promise.<Integer>promise()
+                            .onFailure(_ -> cancelled.countDown());
+
+            var output = Promise.allOrCancel(Promise.<String>failure(TEST_FAILURE), p2)
+                                .id();
+
+            output.await()
+                  .onSuccess(_ -> fail("Expected failure"))
+                  .onFailure(c -> assertEquals(TEST_FAILURE.message(), c.message()));
+
+            assertTrue(cancelled.await(2, TimeUnit.SECONDS), "Second promise should have been cancelled");
+        }
+
+        @Test
+        void allOrCancel_secondFails_cancelsRemaining() throws InterruptedException {
+            var cancelled = new CountDownLatch(1);
+            var p1 = Promise.<String>promise()
+                            .onFailure(_ -> cancelled.countDown());
+
+            var output = Promise.allOrCancel(p1, Promise.<Integer>failure(TEST_FAILURE))
+                                .id();
+
+            output.await()
+                  .onSuccess(_ -> fail("Expected failure"))
+                  .onFailure(c -> assertEquals(TEST_FAILURE.message(), c.message()));
+
+            assertTrue(cancelled.await(2, TimeUnit.SECONDS), "First promise should have been cancelled");
+        }
+
+        @Test
+        void allOrCancel_allFail_resolvesWithFirstFailure() {
+            var cause1 = new CoreError.Fault("First");
+            var cause2 = new CoreError.Fault("Second");
+
+            var output = Promise.allOrCancel(Promise.<String>failure(cause1), Promise.<Integer>failure(cause2))
+                                .id()
+                                .await();
+
+            output.onSuccess(_ -> fail("Expected failure"))
+                  .onFailure(c -> assertTrue(
+                          c.message().equals("First") || c.message().equals("Second"),
+                          "Should resolve with one of the failure causes"));
+        }
+
+        @Test
+        void allOrCancel_singlePromise_behavesLikeAll() {
+            var result = Promise.allOrCancel(Promise.success("hello"))
+                                .map(s -> s + " world")
+                                .await();
+
+            result.onFailure(_ -> fail("Expected success"))
+                  .onSuccess(v -> assertEquals("hello world", v));
+        }
+    }
+
+    @Nested
+    class AllOfOrCancel {
+
+        @Test
+        void allOfOrCancel_emptyCollection_returnsEmptyList() {
+            List<Promise<String>> empty = List.of();
+            var result = Promise.allOfOrCancel(empty).await();
+
+            result.onFailure(_ -> fail("Expected success"))
+                  .onSuccess(list -> assertTrue(list.isEmpty()));
+        }
+
+        @Test
+        void allOfOrCancel_allSucceed_returnsAllResults() {
+            var promises = List.of(Promise.success("a"), Promise.success("b"), Promise.success("c"));
+            var result = Promise.allOfOrCancel(promises).await();
+
+            result.onFailure(_ -> fail("Expected success"))
+                  .onSuccess(list -> assertEquals(3, list.size()));
+        }
+
+        @Test
+        void allOfOrCancel_oneFails_cancelsRemaining() throws InterruptedException {
+            var cancelled = new CountDownLatch(1);
+            var slow = Promise.<String>promise()
+                              .onFailure(_ -> cancelled.countDown());
+
+            var promises = List.of(slow, Promise.<String>failure(TEST_FAILURE));
+            var output = Promise.allOfOrCancel(promises);
+
+            output.await()
+                  .onSuccess(_ -> fail("Expected failure"))
+                  .onFailure(c -> assertEquals(TEST_FAILURE.message(), c.message()));
+
+            assertTrue(cancelled.await(2, TimeUnit.SECONDS), "Slow promise should have been cancelled");
+        }
+    }
+
+    @Nested
+    class InstanceAllOrCancel {
+
+        @Test
+        void instanceAllOrCancel_executesInParallel() {
+            var start = new AtomicLong();
+            var result = Promise.success("trigger")
+                                .allOrCancel(
+                                        _ -> delayedSuccess("a", 200),
+                                        _ -> delayedSuccess(42, 200))
+                                .map((s, i) -> s + i);
+
+            start.set(System.currentTimeMillis());
+            var awaited = result.await();
+            var elapsed = System.currentTimeMillis() - start.get();
+
+            awaited.onFailure(_ -> fail("Expected success"))
+                   .onSuccess(v -> assertEquals("a42", v));
+
+            assertTrue(elapsed < 600, "Two 200ms operations should run in parallel, took " + elapsed + "ms");
+        }
+
+        @Test
+        void instanceAllOrCancel_cancelsOnFailure() throws InterruptedException {
+            var cancelled = new CountDownLatch(1);
+
+            var result = Promise.success("trigger")
+                                .allOrCancel(
+                                        _ -> Promise.<String>failure(TEST_FAILURE),
+                                        _ -> Promise.<Integer>promise().onFailure(_ -> cancelled.countDown()))
+                                .id()
+                                .await();
+
+            result.onSuccess(_ -> fail("Expected failure"));
+
+            assertTrue(cancelled.await(2, TimeUnit.SECONDS), "Second promise should have been cancelled");
+        }
+    }
+
+    @Nested
+    class InstanceAllFixed {
+
+        @Test
+        void instanceAll_executesInParallel() {
+            var start = new AtomicLong();
+            var result = Promise.success("trigger")
+                                .all(_ -> delayedSuccess("a", 200),
+                                     _ -> delayedSuccess(42, 200))
+                                .map((s, i) -> s + i);
+
+            start.set(System.currentTimeMillis());
+            var awaited = result.await();
+            var elapsed = System.currentTimeMillis() - start.get();
+
+            awaited.onFailure(_ -> fail("Expected success"))
+                   .onSuccess(v -> assertEquals("a42", v));
+
+            assertTrue(elapsed < 600, "Two 200ms operations should run in parallel (instance all() fix), took " + elapsed + "ms");
+        }
+
+        @Test
+        void instanceAll_3args_executesInParallel() {
+            var start = new AtomicLong();
+            var result = Promise.success("trigger")
+                                .all(_ -> delayedSuccess("a", 150),
+                                     _ -> delayedSuccess(42, 150),
+                                     _ -> delayedSuccess(true, 150))
+                                .map((s, i, b) -> s + i + b);
+
+            start.set(System.currentTimeMillis());
+            var awaited = result.await();
+            var elapsed = System.currentTimeMillis() - start.get();
+
+            awaited.onFailure(_ -> fail("Expected success"))
+                   .onSuccess(v -> assertEquals("a42true", v));
+
+            assertTrue(elapsed < 500, "Three 150ms operations should run in parallel, took " + elapsed + "ms");
+        }
+    }
+
+    private static <T> Promise<T> delayedSuccess(T value, long delayMs) {
+        return Promise.promise(timeSpan(delayMs).millis(), promise -> promise.succeed(value));
+    }
+}


### PR DESCRIPTION
## Summary

- Add Promise.allOrCancel() -- like all() but cancels remaining promises on first failure
- Fix instance all() methods -- were sequential (nested flatMaps), now parallel via static all()
- Add allOfOrCancel(Collection) for homogeneous collections
- Add instance allOrCancel() methods (1-15 args) mirroring instance all()

## Problem

1. Promise.all() waits for ALL promises even when one has failed -- wastes resources
2. Instance all(fn1, fn2, ...) used nested flatMap chains -- sequential, not parallel

## Solution

allOrCancel short-circuits: first failure resolves output with that cause and cancels all input promises. Already-resolved promises ignore cancel (exactly-once).

Instance all() now delegates to static all() for true parallel execution.

## Test plan

- All succeed -- returns all values (2, 3+ args)
- First/second fails -- cancels remaining
- Concurrent failures -- first failure wins
- Empty collection -- empty list
- Instance methods execute in parallel, not sequential
- All existing core tests pass (no regressions)