### PR TITLE
docs: consistent naming — Pragmatica Core + Unified Application Runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1054,5 +1054,5 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 Historical changelogs for individual projects:
 
-- [Pragmatica Lite CHANGELOG](core/CHANGELOG.md)
+- [Pragmatica Core CHANGELOG](core/CHANGELOG.md)
 - [JBCT CHANGELOG](jbct/CHANGELOG.md)

--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 # Pragmatica
 
-A monorepo for building reliable Java backends with functional programming patterns and a distributed runtime.
+A monorepo for building reliable Java backends with functional programming patterns and a unified application runtime.
 
 ## What's Inside
 
-**[Pragmatica Lite Core](core/README.md)** — Functional primitives for Java: `Result<T>`, `Option<T>`, `Promise<T>`. No exceptions, no nulls, composable error handling.
+**[Pragmatica Core](core/README.md)** — Functional primitives for Java: `Result<T>`, `Option<T>`, `Promise<T>`. No exceptions, no nulls, composable error handling.
 
-**[Pragmatica Lite Integrations](integrations/)** — Ready-made integrations: PostgreSQL (async + JDBC + jOOQ), HTTP server/client, serialization (Kryo, Fury), consensus protocols, distributed storage, messaging, metrics.
+**[Pragmatica Integrations](integrations/)** — Ready-made integrations: PostgreSQL (async + JDBC + jOOQ), HTTP server/client, serialization (Kryo, Fury), consensus protocols, distributed storage, messaging, metrics.
 
 **[JBCT Tools](jbct/README.md)** — CLI and Maven plugin for Java Backend Coding Technology: code formatting, linting, slice annotation processing, project scaffolding.
 
-**[Aether Runtime](aether/README.md)** — Distributed runtime for Java. Deploy services as slices, scale transparently, no microservices boilerplate. Consensus-based state, automatic topology management, built-in observability.
+**[Aether Runtime](aether/README.md)** — Unified Application Runtime for Java. Deploy services as slices, scale transparently, no microservices boilerplate. Consensus-based state, automatic topology management, built-in observability.
 
 ## Prerequisites
 

--- a/aether/README.md
+++ b/aether/README.md
@@ -1,6 +1,6 @@
-# Pragmatica Aether
+# Aether — Unified Application Runtime
 
-Distributed runtime for Java -- scale horizontally without microservices complexity.
+Unified Application Runtime for Java -- scale horizontally without microservices complexity.
 
 ## Overview
 

--- a/aether/docs/README.md
+++ b/aether/docs/README.md
@@ -1,6 +1,6 @@
 # Aether Documentation
 
-Central hub for all Aether distributed runtime documentation.
+Central hub for all Aether Unified Application Runtime documentation.
 
 ## Architecture
 

--- a/aether/docs/aether-overview.md
+++ b/aether/docs/aether-overview.md
@@ -4,7 +4,7 @@ Pragmatica Aether is a distributed application platform for Java. It takes your 
 
 Aether occupies the space between a monolith and microservices. You write code as if it's a monolith — simple interfaces, direct method calls, no network boilerplate. The runtime handles distribution, replication, routing, and failure recovery transparently. When a node goes down, requests are retried on healthy nodes. When load increases, new instances are spun up automatically. When you deploy a new version, traffic shifts gradually with health-based rollback.
 
-The platform is built on Pragmatica Lite, a functional Java core library that enforces predictable, testable code through the JBCT (Java Backend Coding Technology) methodology. Every slice method returns a `Promise<T>` — the runtime handles the rest.
+The platform is built on Pragmatica Core, a functional Java core library that enforces predictable, testable code through the JBCT (Java Backend Coding Technology) methodology. Every slice method returns a `Promise<T>` — the runtime handles the rest.
 
 ---
 
@@ -55,7 +55,7 @@ Dependencies are validated eagerly during activation — if a required slice isn
 
 ### ClassLoader Isolation
 
-Each slice runs in its own `SliceClassLoader` with child-first delegation. Two slices can use different versions of the same library without conflict. Shared dependencies (like Pragmatica Lite core) are loaded once in a parent classloader and shared across all slices.
+Each slice runs in its own `SliceClassLoader` with child-first delegation. Two slices can use different versions of the same library without conflict. Shared dependencies (like Pragmatica Core core) are loaded once in a parent classloader and shared across all slices.
 
 ### Local Development: Forge
 

--- a/aether/docs/architecture-diagrams.md
+++ b/aether/docs/architecture-diagrams.md
@@ -1,6 +1,6 @@
 # Aether Architecture Diagrams
 
-Visual diagrams for understanding Aether's distributed runtime architecture.
+Visual diagrams for understanding Aether's Unified Application Runtime architecture.
 
 ---
 

--- a/aether/docs/architecture/11-slice-container.md
+++ b/aether/docs/architecture/11-slice-container.md
@@ -8,7 +8,7 @@ This document describes ClassLoader isolation, dependency materialization, and s
 graph TB
     subgraph JVM["JVM ClassLoader Hierarchy"]
         System["System ClassLoader"]
-        Shared["SharedLibraryClassLoader<br/>Pragmatica Lite core,<br/>common dependencies"]
+        Shared["SharedLibraryClassLoader<br/>Pragmatica Core core,<br/>common dependencies"]
 
         SCL1["SliceClassLoader A<br/>(child-first)"]
         SCL2["SliceClassLoader B<br/>(child-first)"]
@@ -44,7 +44,7 @@ This means two slices can use different versions of the same library without con
 ### SharedLibraryClassLoader
 
 Loaded once, shared across all slices:
-- Pragmatica Lite core (`Result`, `Option`, `Promise`)
+- Pragmatica Core core (`Result`, `Option`, `Promise`)
 - Slice API interfaces
 - Common serialization libraries
 

--- a/aether/docs/contributors/architecture.md
+++ b/aether/docs/contributors/architecture.md
@@ -1,6 +1,6 @@
 # Aether Architecture Overview
 
-This document provides a comprehensive technical overview of the Aether AI-driven distributed runtime architecture.
+This document provides a comprehensive technical overview of the Aether AI-driven Unified Application Runtime architecture.
 
 **See [vision-and-goals.md](../archive/vision-and-goals.md) for the complete vision and design principles.**
 

--- a/aether/docs/contributors/concepts.md
+++ b/aether/docs/contributors/concepts.md
@@ -1,4 +1,4 @@
-# Pragmatica Aether: Distributed Runtime Without the Complexity
+# Pragmatica Aether: Unified Application Runtime
 
 ## The Problem
 

--- a/aether/docs/contributors/consensus.md
+++ b/aether/docs/contributors/consensus.md
@@ -15,7 +15,7 @@ leader is elected or changed.
 
 ## Architecture
 
-The Pragmatica Lite Cluster module provides a robust implementation of the Rabia consensus algorithm with the following
+The Pragmatica Core Cluster module provides a robust implementation of the Rabia consensus algorithm with the following
 key components:
 
 ### Core Components

--- a/aether/docs/contributors/slice-runtime.md
+++ b/aether/docs/contributors/slice-runtime.md
@@ -1,6 +1,6 @@
 # Slice Runtime
 
-How slices execute in the Aether distributed runtime.
+How slices execute in the Aether Unified Application Runtime.
 
 ## Runtime Architecture
 

--- a/aether/docs/reference/feature-catalog.md
+++ b/aether/docs/reference/feature-catalog.md
@@ -1,6 +1,6 @@
 # Aether Feature Catalog
 
-Comprehensive inventory of all Aether distributed runtime capabilities.
+Comprehensive inventory of all Aether Unified Application Runtime capabilities.
 
 **Status legend:**
 - **Battle-tested** — Proven through multi-node E2E tests with failure injection (node kills, partitions, leader failovers)

--- a/aether/docs/specs/cloud-integration-spi-spec.md
+++ b/aether/docs/specs/cloud-integration-spi-spec.md
@@ -29,7 +29,7 @@
 
 ### 1.1 Purpose
 
-This specification defines four SPI contracts that cloud providers must implement to integrate with the Aether distributed runtime. The SPIs cover compute provisioning, load balancer management, peer discovery, and secret resolution. Together they enable Aether to manage its own infrastructure across multiple cloud providers.
+This specification defines four SPI contracts that cloud providers must implement to integrate with the Aether runtime. The SPIs cover compute provisioning, load balancer management, peer discovery, and secret resolution. Together they enable Aether to manage its own infrastructure across multiple cloud providers.
 
 ### 1.2 Goals
 

--- a/aether/docs/specs/hetzner-e2e-test-spec.md
+++ b/aether/docs/specs/hetzner-e2e-test-spec.md
@@ -33,7 +33,7 @@
 
 ### 1.1 Purpose
 
-This specification defines a fully automated, repeatable end-to-end test that validates the Aether distributed runtime on real Hetzner Cloud infrastructure. The test deploys a 5-node Aether cluster, runs the url-shortener example application via blueprint artifact, executes k6 benchmarks at production-level throughput, and exercises resilience scenarios (graceful drain, hard kill, auto-heal, leader kill) while monitoring latency and error rates.
+This specification defines a fully automated, repeatable end-to-end test that validates the Aether runtime on real Hetzner Cloud infrastructure. The test deploys a 5-node Aether cluster, runs the url-shortener example application via blueprint artifact, executes k6 benchmarks at production-level throughput, and exercises resilience scenarios (graceful drain, hard kill, auto-heal, leader kill) while monitoring latency and error rates.
 
 ### 1.2 Goals
 

--- a/aether/docs/specs/hierarchical-storage-spec.md
+++ b/aether/docs/specs/hierarchical-storage-spec.md
@@ -34,7 +34,7 @@
 
 ### 1.1 Purpose
 
-This specification defines a unified hierarchical storage layer for the Aether distributed runtime, referred to as **AHSE** (Aether Hierarchical Storage Engine) throughout Aether documentation. The system provides tiered, content-addressable block storage that serves as the persistence foundation for multiple Aether subsystems.
+This specification defines a unified hierarchical storage layer for the Aether runtime, referred to as **AHSE** (Aether Hierarchical Storage Engine) throughout Aether documentation. The system provides tiered, content-addressable block storage that serves as the persistence foundation for multiple Aether subsystems.
 
 ### 1.2 The Problem
 

--- a/aether/docs/specs/rbac-spec.md
+++ b/aether/docs/specs/rbac-spec.md
@@ -1,4 +1,4 @@
-# RBAC Design Specification for Aether Distributed Runtime
+# RBAC Design Specification for Aether Unified Application Runtime
 
 **Version:** 1.0
 **Target Release:** 0.18.0 (Tier 1 - API Keys)

--- a/aether/pom.xml
+++ b/aether/pom.xml
@@ -13,8 +13,8 @@
     <groupId>org.pragmatica-lite.aether</groupId>
     <artifactId>aether</artifactId>
     <packaging>pom</packaging>
-    <name>Pragmatica Aether Distributed Runtime</name>
-    <description>AI-driven distributed runtime environment for Java applications</description>
+    <name>Aether Unified Application Runtime</name>
+    <description>Unified Application Runtime for Java</description>
 
     <url>https://github.com/siy/aether</url>
 

--- a/core/README.md
+++ b/core/README.md
@@ -1,4 +1,4 @@
-# Pragmatica Lite
+# Pragmatica Core
 
 ![License](https://img.shields.io/badge/license-Apache%202-blue.svg)
 ![Java](https://img.shields.io/badge/Java-25-orange.svg)
@@ -6,9 +6,9 @@
 
 ## Modern Functional Programming for Java 25
 
-Pragmatica Lite brings the power of functional programming to Java with monadic types that eliminate null pointer exceptions, unchecked exceptions, and callback hell. Built on Java 25's latest features including sealed interfaces and pattern matching.
+Pragmatica Core brings the power of functional programming to Java with monadic types that eliminate null pointer exceptions, unchecked exceptions, and callback hell. Built on Java 25's latest features including sealed interfaces and pattern matching.
 
-## Why Pragmatica Lite?
+## Why Pragmatica Core?
 
 **Without Pragmatica:**
 ```java
@@ -79,7 +79,7 @@ Result<List<User>> allUsers = Result.allOf(userResults);
 
 ## Built for Java 25
 
-Pragmatica Lite targets Java 25 and leverages modern language features:
+Pragmatica Core targets Java 25 and leverages modern language features:
 
 - **Sealed Interfaces** (JDK 17): Type-safe Result and Option hierarchies
 - **Records** (JDK 16): Immutable data structures throughout
@@ -87,7 +87,7 @@ Pragmatica Lite targets Java 25 and leverages modern language features:
 
 ### Maven Configuration
 
-Pragmatica Lite is available on Maven Central. Simply add the dependency to your `pom.xml`:
+Pragmatica Core is available on Maven Central. Simply add the dependency to your `pom.xml`:
 
 ```xml
 <dependency>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -12,7 +12,7 @@
     <artifactId>core</artifactId>
     <packaging>jar</packaging>
 
-    <name>Pragmatica Lite Core</name>
+    <name>Pragmatica Core</name>
     <description>Modern functional programming library for Java 25 featuring Result, Option, and Promise monads</description>
 
     <dependencies>


### PR DESCRIPTION
Naming consistency pass across all public-facing docs, READMEs, and POMs.

- Pragmatica Lite Core → Pragmatica Core (5 files)
- Pragmatica Lite Integrations → Pragmatica Integrations
- Aether Distributed Runtime → Aether Unified Application Runtime (14 files)
- GitHub repo description updated

Maven coordinates (org.pragmatica-lite) unchanged — published on Maven Central.
Archive docs unchanged — historical.
JBCT/aether-coder skills already use correct naming.