### PR TITLE
feat: RateGuard resource type for per-route rate limiting

### DIFF
--- a/aether/node/src/main/java/org/pragmatica/aether/http/AppHttpServer.java
+++ b/aether/node/src/main/java/org/pragmatica/aether/http/AppHttpServer.java
@@ -1,5 +1,6 @@
 package org.pragmatica.aether.http;
 
+import org.pragmatica.aether.slice.RateGuardError;
 import org.pragmatica.aether.artifact.Artifact;
 import org.pragmatica.aether.artifact.Version;
 import org.pragmatica.aether.config.AppHttpConfig;
@@ -855,10 +856,28 @@ import static org.pragmatica.lang.Unit.unit;
     }
 
     private void handleLocalRouteFailure(ResponseWriter response, String path, String requestId, Cause cause) {
+        if (cause instanceof RateGuardError.LimitExceeded exceeded) {
+            sendRateLimitResponse(response, path, requestId, exceeded);
+            return;
+        }
         log.error("Failed to handle local route [{}]: {}", requestId, cause.message());
         sendProblem(response,
                     HttpStatus.INTERNAL_SERVER_ERROR,
                     "Request processing failed: " + cause.message(),
+                    path,
+                    requestId);
+    }
+
+    private void sendRateLimitResponse(ResponseWriter response, String path, String requestId,
+                                       RateGuardError.LimitExceeded exceeded) {
+        log.debug("Rate limit exceeded for [{}]: retry after {}ms", requestId, exceeded.retryAfterMs());
+        response.header("Retry-After", String.valueOf(exceeded.retryAfterSeconds()));
+        response.header("X-RateLimit-Limit", String.valueOf(exceeded.limit()));
+        response.header("X-RateLimit-Remaining", String.valueOf(exceeded.remaining()));
+        response.header("X-RateLimit-Reset", String.valueOf(exceeded.resetAtEpochSeconds()));
+        sendProblem(response,
+                    HttpStatus.TOO_MANY_REQUESTS,
+                    exceeded.message(),
                     path,
                     requestId);
     }

--- a/aether/node/src/main/java/org/pragmatica/aether/http/AppHttpServer.java
+++ b/aether/node/src/main/java/org/pragmatica/aether/http/AppHttpServer.java
@@ -856,16 +856,14 @@ import static org.pragmatica.lang.Unit.unit;
     }
 
     private void handleLocalRouteFailure(ResponseWriter response, String path, String requestId, Cause cause) {
-        if (cause instanceof RateGuardError.LimitExceeded exceeded) {
-            sendRateLimitResponse(response, path, requestId, exceeded);
-            return;
+        switch (cause) {
+            case RateGuardError.LimitExceeded exceeded -> sendRateLimitResponse(response, path, requestId, exceeded);
+            default -> {
+                log.error("Failed to handle local route [{}]: {}", requestId, cause.message());
+                sendProblem(response, HttpStatus.INTERNAL_SERVER_ERROR,
+                            "Request processing failed: " + cause.message(), path, requestId);
+            }
         }
-        log.error("Failed to handle local route [{}]: {}", requestId, cause.message());
-        sendProblem(response,
-                    HttpStatus.INTERNAL_SERVER_ERROR,
-                    "Request processing failed: " + cause.message(),
-                    path,
-                    requestId);
     }
 
     private void sendRateLimitResponse(ResponseWriter response, String path, String requestId,

--- a/aether/resource/interceptors/src/main/java/org/pragmatica/aether/resource/interceptor/DefaultRateGuard.java
+++ b/aether/resource/interceptors/src/main/java/org/pragmatica/aether/resource/interceptor/DefaultRateGuard.java
@@ -1,0 +1,38 @@
+package org.pragmatica.aether.resource.interceptor;
+
+import org.pragmatica.aether.slice.RateGuard;
+import org.pragmatica.aether.slice.RateGuardError;
+import org.pragmatica.lang.Promise;
+import org.pragmatica.lang.utils.RateLimiter;
+import org.pragmatica.lang.utils.RateLimiter.RateLimiterError;
+
+import java.util.function.Supplier;
+
+
+/// Local (per-node) RateGuard implementation backed by the core token bucket RateLimiter.
+///
+/// Enriches the core LimitExceeded error with HTTP-friendly metadata (limit, remaining, reset time).
+record DefaultRateGuard(RateLimiter limiter, int limit) implements RateGuard {
+    static DefaultRateGuard defaultRateGuard(RateGuardConfig config) {
+        var limiter = RateLimiter.builder()
+                                .rate(config.requestsPerSecond())
+                                .period(config.window())
+                                .burst(config.burst())
+                                .withDefaultTimeSource();
+        return new DefaultRateGuard(limiter, config.requestsPerSecond());
+    }
+
+    @Override public <T> Promise<T> guard(Supplier<Promise<T>> operation) {
+        return limiter.execute(operation)
+                      .mapError(this::enrichError);
+    }
+
+    private RateGuardError enrichError(org.pragmatica.lang.Cause cause) {
+        if (cause instanceof RateLimiterError.LimitExceeded exceeded) {
+            var retryAfterMs = exceeded.retryAfter().millis();
+            var resetAtMs = System.currentTimeMillis() + retryAfterMs;
+            return RateGuardError.LimitExceeded.limitExceeded(retryAfterMs, limit, 0, resetAtMs);
+        }
+        return RateGuardError.LimitExceeded.limitExceeded(1000, limit, 0, System.currentTimeMillis() + 1000);
+    }
+}

--- a/aether/resource/interceptors/src/main/java/org/pragmatica/aether/resource/interceptor/DefaultRateGuard.java
+++ b/aether/resource/interceptors/src/main/java/org/pragmatica/aether/resource/interceptor/DefaultRateGuard.java
@@ -2,6 +2,7 @@ package org.pragmatica.aether.resource.interceptor;
 
 import org.pragmatica.aether.slice.RateGuard;
 import org.pragmatica.aether.slice.RateGuardError;
+import org.pragmatica.lang.Cause;
 import org.pragmatica.lang.Promise;
 import org.pragmatica.lang.utils.RateLimiter;
 import org.pragmatica.lang.utils.RateLimiter.RateLimiterError;
@@ -13,6 +14,8 @@ import java.util.function.Supplier;
 ///
 /// Enriches the core LimitExceeded error with HTTP-friendly metadata (limit, remaining, reset time).
 record DefaultRateGuard(RateLimiter limiter, int limit) implements RateGuard {
+    private static final long DEFAULT_RETRY_AFTER_MS = 1000;
+
     static DefaultRateGuard defaultRateGuard(RateGuardConfig config) {
         var limiter = RateLimiter.builder()
                                 .rate(config.requestsPerSecond())
@@ -27,12 +30,17 @@ record DefaultRateGuard(RateLimiter limiter, int limit) implements RateGuard {
                       .mapError(this::enrichError);
     }
 
-    private RateGuardError enrichError(org.pragmatica.lang.Cause cause) {
-        if (cause instanceof RateLimiterError.LimitExceeded exceeded) {
-            var retryAfterMs = exceeded.retryAfter().millis();
-            var resetAtMs = System.currentTimeMillis() + retryAfterMs;
-            return RateGuardError.LimitExceeded.limitExceeded(retryAfterMs, limit, 0, resetAtMs);
-        }
-        return RateGuardError.LimitExceeded.limitExceeded(1000, limit, 0, System.currentTimeMillis() + 1000);
+    private RateGuardError enrichError(Cause cause) {
+        return switch (cause) {
+            case RateLimiterError.LimitExceeded exceeded -> toRateGuardError(exceeded);
+            default -> RateGuardError.LimitExceeded.limitExceeded(
+                    DEFAULT_RETRY_AFTER_MS, limit, 0, System.currentTimeMillis() + DEFAULT_RETRY_AFTER_MS);
+        };
+    }
+
+    private RateGuardError toRateGuardError(RateLimiterError.LimitExceeded exceeded) {
+        var retryAfterMs = exceeded.retryAfter().millis();
+        var resetAtMs = System.currentTimeMillis() + retryAfterMs;
+        return RateGuardError.LimitExceeded.limitExceeded(retryAfterMs, limit, 0, resetAtMs);
     }
 }

--- a/aether/resource/interceptors/src/main/java/org/pragmatica/aether/resource/interceptor/RateGuardConfig.java
+++ b/aether/resource/interceptors/src/main/java/org/pragmatica/aether/resource/interceptor/RateGuardConfig.java
@@ -1,0 +1,47 @@
+package org.pragmatica.aether.resource.interceptor;
+
+import org.pragmatica.lang.Result;
+import org.pragmatica.lang.Verify;
+import org.pragmatica.lang.io.TimeSpan;
+
+import static org.pragmatica.lang.Result.all;
+import static org.pragmatica.lang.Verify.ensure;
+import static org.pragmatica.lang.io.TimeSpan.timeSpan;
+
+
+/// Configuration for RateGuard resource.
+///
+/// Parsed from TOML config sections like:
+/// ```toml
+/// [rate-limit.orders]
+/// requests_per_second = 100
+/// burst = 20
+/// type = "local"
+/// ```
+///
+/// @param requestsPerSecond Base rate in requests per second
+/// @param burst             Additional burst capacity above the base rate
+/// @param type              Rate limiter type: "local" (per-node) or "distributed" (future, via DHT)
+public record RateGuardConfig(int requestsPerSecond, int burst, String type) {
+    public static Result<RateGuardConfig> rateGuardConfig(int requestsPerSecond, int burst) {
+        var validRate = ensure(requestsPerSecond, Verify.Is::positive);
+        var validBurst = ensure(burst, Verify.Is::nonNegative);
+        return all(validRate, validBurst).map((r, b) -> new RateGuardConfig(r, b, "local"));
+    }
+
+    public static Result<RateGuardConfig> rateGuardConfig(int requestsPerSecond, int burst, String type) {
+        var validRate = ensure(requestsPerSecond, Verify.Is::positive);
+        var validBurst = ensure(burst, Verify.Is::nonNegative);
+        var validType = ensure(type, Verify.Is::notBlank);
+        return all(validRate, validBurst, validType).map(RateGuardConfig::new);
+    }
+
+    public static Result<RateGuardConfig> rateGuardConfig() {
+        return rateGuardConfig(100, 20);
+    }
+
+    /// Convert to core RateLimiter parameters.
+    public TimeSpan window() {
+        return timeSpan(1).seconds();
+    }
+}

--- a/aether/resource/interceptors/src/main/java/org/pragmatica/aether/resource/interceptor/RateGuardConfig.java
+++ b/aether/resource/interceptors/src/main/java/org/pragmatica/aether/resource/interceptor/RateGuardConfig.java
@@ -24,9 +24,7 @@ import static org.pragmatica.lang.io.TimeSpan.timeSpan;
 /// @param type              Rate limiter type: "local" (per-node) or "distributed" (future, via DHT)
 public record RateGuardConfig(int requestsPerSecond, int burst, String type) {
     public static Result<RateGuardConfig> rateGuardConfig(int requestsPerSecond, int burst) {
-        var validRate = ensure(requestsPerSecond, Verify.Is::positive);
-        var validBurst = ensure(burst, Verify.Is::nonNegative);
-        return all(validRate, validBurst).map((r, b) -> new RateGuardConfig(r, b, "local"));
+        return rateGuardConfig(requestsPerSecond, burst, "local");
     }
 
     public static Result<RateGuardConfig> rateGuardConfig(int requestsPerSecond, int burst, String type) {

--- a/aether/resource/interceptors/src/main/java/org/pragmatica/aether/resource/interceptor/RateGuardFactory.java
+++ b/aether/resource/interceptors/src/main/java/org/pragmatica/aether/resource/interceptor/RateGuardFactory.java
@@ -1,0 +1,26 @@
+package org.pragmatica.aether.resource.interceptor;
+
+import org.pragmatica.aether.resource.ResourceFactory;
+import org.pragmatica.aether.slice.RateGuard;
+import org.pragmatica.lang.Promise;
+
+
+/// Factory that provisions a {@link RateGuard} from configuration.
+///
+/// Currently supports `type = "local"` (per-node token bucket).
+/// Distributed rate limiting (`type = "distributed"` via DHT) is planned for rc2 (#144).
+///
+/// Registered via META-INF/services/org.pragmatica.aether.resource.ResourceFactory
+public final class RateGuardFactory implements ResourceFactory<RateGuard, RateGuardConfig> {
+    @Override public Class<RateGuard> resourceType() {
+        return RateGuard.class;
+    }
+
+    @Override public Class<RateGuardConfig> configType() {
+        return RateGuardConfig.class;
+    }
+
+    @Override public Promise<RateGuard> provision(RateGuardConfig config) {
+        return Promise.success(DefaultRateGuard.defaultRateGuard(config));
+    }
+}

--- a/aether/resource/interceptors/src/main/resources/META-INF/services/org.pragmatica.aether.resource.ResourceFactory
+++ b/aether/resource/interceptors/src/main/resources/META-INF/services/org.pragmatica.aether.resource.ResourceFactory
@@ -4,3 +4,4 @@ org.pragmatica.aether.resource.interceptor.RateLimitInterceptorFactory
 org.pragmatica.aether.resource.interceptor.LoggingInterceptorFactory
 org.pragmatica.aether.resource.interceptor.MetricsInterceptorFactory
 org.pragmatica.aether.resource.interceptor.CacheInterceptorFactory
+org.pragmatica.aether.resource.interceptor.RateGuardFactory

--- a/aether/resource/interceptors/src/test/java/org/pragmatica/aether/resource/interceptor/RateGuardTest.java
+++ b/aether/resource/interceptors/src/test/java/org/pragmatica/aether/resource/interceptor/RateGuardTest.java
@@ -1,0 +1,94 @@
+package org.pragmatica.aether.resource.interceptor;
+
+import org.junit.jupiter.api.Test;
+import org.pragmatica.aether.slice.RateGuardError;
+import org.pragmatica.lang.Promise;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RateGuardTest {
+
+    @Test
+    void allows_requests_within_limit() {
+        var guard = DefaultRateGuard.defaultRateGuard(new RateGuardConfig(10, 0, "local"));
+        var result = guard.guard(() -> Promise.success("ok")).await();
+        assertThat(result.isSuccess()).isTrue();
+        assertThat(result.unwrap()).isEqualTo("ok");
+    }
+
+    @Test
+    void rejects_when_limit_exceeded() {
+        var guard = DefaultRateGuard.defaultRateGuard(new RateGuardConfig(1, 0, "local"));
+        // First request succeeds
+        guard.guard(() -> Promise.success("ok")).await();
+        // Second request should be rate limited
+        var result = guard.guard(() -> Promise.success("should fail")).await();
+        assertThat(result.isFailure()).isTrue();
+    }
+
+    @Test
+    void limit_exceeded_error_has_metadata() {
+        var guard = DefaultRateGuard.defaultRateGuard(new RateGuardConfig(1, 0, "local"));
+        guard.guard(() -> Promise.success("ok")).await();
+        var result = guard.guard(() -> Promise.success("fail")).await();
+        result.onFailure(cause -> {
+            assertThat(cause).isInstanceOf(RateGuardError.LimitExceeded.class);
+            var exceeded = (RateGuardError.LimitExceeded) cause;
+            assertThat(exceeded.limit()).isEqualTo(1);
+            assertThat(exceeded.remaining()).isEqualTo(0);
+            assertThat(exceeded.retryAfterMs()).isGreaterThan(0);
+            assertThat(exceeded.resetAtEpochMs()).isGreaterThan(System.currentTimeMillis() - 1000);
+            assertThat(exceeded.retryAfterSeconds()).isGreaterThanOrEqualTo(0);
+        });
+    }
+
+    @Test
+    void burst_allows_extra_requests() {
+        var guard = DefaultRateGuard.defaultRateGuard(new RateGuardConfig(1, 2, "local"));
+        // Rate=1 + burst=2 = 3 total permits
+        assertThat(guard.guard(() -> Promise.success(1)).await().isSuccess()).isTrue();
+        assertThat(guard.guard(() -> Promise.success(2)).await().isSuccess()).isTrue();
+        assertThat(guard.guard(() -> Promise.success(3)).await().isSuccess()).isTrue();
+        // 4th should fail
+        assertThat(guard.guard(() -> Promise.success(4)).await().isFailure()).isTrue();
+    }
+
+    @Test
+    void factory_provisions_from_config() {
+        var factory = new RateGuardFactory();
+        assertThat(factory.resourceType()).isEqualTo(org.pragmatica.aether.slice.RateGuard.class);
+        assertThat(factory.configType()).isEqualTo(RateGuardConfig.class);
+
+        var result = factory.provision(new RateGuardConfig(100, 20, "local")).await();
+        assertThat(result.isSuccess()).isTrue();
+    }
+
+    @Test
+    void config_validation_rejects_zero_rate() {
+        var result = RateGuardConfig.rateGuardConfig(0, 10);
+        assertThat(result.isFailure()).isTrue();
+    }
+
+    @Test
+    void config_validation_rejects_negative_burst() {
+        var result = RateGuardConfig.rateGuardConfig(100, -1);
+        assertThat(result.isFailure()).isTrue();
+    }
+
+    @Test
+    void config_defaults_are_reasonable() {
+        var result = RateGuardConfig.rateGuardConfig();
+        assertThat(result.isSuccess()).isTrue();
+        var config = result.unwrap();
+        assertThat(config.requestsPerSecond()).isEqualTo(100);
+        assertThat(config.burst()).isEqualTo(20);
+        assertThat(config.type()).isEqualTo("local");
+    }
+
+    @Test
+    void limit_exceeded_message_is_descriptive() {
+        var error = RateGuardError.LimitExceeded.limitExceeded(5000, 100, 0, System.currentTimeMillis() + 5000);
+        assertThat(error.message()).contains("Rate limit exceeded");
+        assertThat(error.message()).contains("5000ms");
+    }
+}

--- a/aether/resource/interceptors/src/test/java/org/pragmatica/aether/resource/interceptor/RateGuardTest.java
+++ b/aether/resource/interceptors/src/test/java/org/pragmatica/aether/resource/interceptor/RateGuardTest.java
@@ -1,94 +1,106 @@
 package org.pragmatica.aether.resource.interceptor;
 
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.pragmatica.aether.slice.RateGuardError;
+import org.pragmatica.lang.Cause;
 import org.pragmatica.lang.Promise;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.fail;
 
 class RateGuardTest {
 
-    @Test
-    void allows_requests_within_limit() {
-        var guard = DefaultRateGuard.defaultRateGuard(new RateGuardConfig(10, 0, "local"));
-        var result = guard.guard(() -> Promise.success("ok")).await();
-        assertThat(result.isSuccess()).isTrue();
-        assertThat(result.unwrap()).isEqualTo("ok");
+    @Nested
+    class Guard {
+        @Test
+        void guard_succeeds_withinLimit() {
+            var guard = DefaultRateGuard.defaultRateGuard(RateGuardConfig.rateGuardConfig(10, 0).unwrap());
+            var result = guard.guard(() -> Promise.success("ok")).await();
+            assertThat(result.isSuccess()).isTrue();
+            assertThat(result.unwrap()).isEqualTo("ok");
+        }
+
+        @Test
+        void guard_fails_whenLimitExceeded() {
+            var guard = DefaultRateGuard.defaultRateGuard(RateGuardConfig.rateGuardConfig(1, 0).unwrap());
+            guard.guard(() -> Promise.success("ok")).await()
+                 .onFailure(_ -> fail("First request should succeed"));
+            var result = guard.guard(() -> Promise.success("should fail")).await();
+            assertThat(result.isFailure()).isTrue();
+        }
+
+        @Test
+        void guard_returnsMetadata_whenLimitExceeded() {
+            var guard = DefaultRateGuard.defaultRateGuard(RateGuardConfig.rateGuardConfig(1, 0).unwrap());
+            guard.guard(() -> Promise.success("ok")).await();
+            var result = guard.guard(() -> Promise.success("fail")).await();
+            result.onSuccessRun(() -> fail("Expected failure"))
+                  .onFailure(RateGuardTest::assertLimitExceededMetadata);
+        }
+
+        @Test
+        void guard_succeeds_withBurstCapacity() {
+            var guard = DefaultRateGuard.defaultRateGuard(RateGuardConfig.rateGuardConfig(1, 2).unwrap());
+            assertThat(guard.guard(() -> Promise.success(1)).await().isSuccess()).isTrue();
+            assertThat(guard.guard(() -> Promise.success(2)).await().isSuccess()).isTrue();
+            assertThat(guard.guard(() -> Promise.success(3)).await().isSuccess()).isTrue();
+            assertThat(guard.guard(() -> Promise.success(4)).await().isFailure()).isTrue();
+        }
     }
 
-    @Test
-    void rejects_when_limit_exceeded() {
-        var guard = DefaultRateGuard.defaultRateGuard(new RateGuardConfig(1, 0, "local"));
-        // First request succeeds
-        guard.guard(() -> Promise.success("ok")).await();
-        // Second request should be rate limited
-        var result = guard.guard(() -> Promise.success("should fail")).await();
-        assertThat(result.isFailure()).isTrue();
+    @Nested
+    class Config {
+        @Test
+        void rateGuardConfig_fails_forZeroRate() {
+            assertThat(RateGuardConfig.rateGuardConfig(0, 10).isFailure()).isTrue();
+        }
+
+        @Test
+        void rateGuardConfig_fails_forNegativeBurst() {
+            assertThat(RateGuardConfig.rateGuardConfig(100, -1).isFailure()).isTrue();
+        }
+
+        @Test
+        void rateGuardConfig_succeeds_withDefaults() {
+            var result = RateGuardConfig.rateGuardConfig();
+            assertThat(result.isSuccess()).isTrue();
+            var config = result.unwrap();
+            assertThat(config.requestsPerSecond()).isEqualTo(100);
+            assertThat(config.burst()).isEqualTo(20);
+            assertThat(config.type()).isEqualTo("local");
+        }
     }
 
-    @Test
-    void limit_exceeded_error_has_metadata() {
-        var guard = DefaultRateGuard.defaultRateGuard(new RateGuardConfig(1, 0, "local"));
-        guard.guard(() -> Promise.success("ok")).await();
-        var result = guard.guard(() -> Promise.success("fail")).await();
-        result.onFailure(cause -> {
-            assertThat(cause).isInstanceOf(RateGuardError.LimitExceeded.class);
-            var exceeded = (RateGuardError.LimitExceeded) cause;
-            assertThat(exceeded.limit()).isEqualTo(1);
-            assertThat(exceeded.remaining()).isEqualTo(0);
-            assertThat(exceeded.retryAfterMs()).isGreaterThan(0);
-            assertThat(exceeded.resetAtEpochMs()).isGreaterThan(System.currentTimeMillis() - 1000);
-            assertThat(exceeded.retryAfterSeconds()).isGreaterThanOrEqualTo(0);
-        });
+    @Nested
+    class Factory {
+        @Test
+        void provision_succeeds_fromConfig() {
+            var factory = new RateGuardFactory();
+            assertThat(factory.resourceType()).isEqualTo(org.pragmatica.aether.slice.RateGuard.class);
+            assertThat(factory.configType()).isEqualTo(RateGuardConfig.class);
+            var result = factory.provision(RateGuardConfig.rateGuardConfig().unwrap()).await();
+            assertThat(result.isSuccess()).isTrue();
+        }
     }
 
-    @Test
-    void burst_allows_extra_requests() {
-        var guard = DefaultRateGuard.defaultRateGuard(new RateGuardConfig(1, 2, "local"));
-        // Rate=1 + burst=2 = 3 total permits
-        assertThat(guard.guard(() -> Promise.success(1)).await().isSuccess()).isTrue();
-        assertThat(guard.guard(() -> Promise.success(2)).await().isSuccess()).isTrue();
-        assertThat(guard.guard(() -> Promise.success(3)).await().isSuccess()).isTrue();
-        // 4th should fail
-        assertThat(guard.guard(() -> Promise.success(4)).await().isFailure()).isTrue();
+    @Nested
+    class LimitExceededError {
+        @Test
+        void limitExceeded_hasDescriptiveMessage() {
+            var error = RateGuardError.LimitExceeded.limitExceeded(5000, 100, 0, System.currentTimeMillis() + 5000);
+            assertThat(error.message()).contains("Rate limit exceeded");
+            assertThat(error.message()).contains("5000ms");
+        }
     }
 
-    @Test
-    void factory_provisions_from_config() {
-        var factory = new RateGuardFactory();
-        assertThat(factory.resourceType()).isEqualTo(org.pragmatica.aether.slice.RateGuard.class);
-        assertThat(factory.configType()).isEqualTo(RateGuardConfig.class);
-
-        var result = factory.provision(new RateGuardConfig(100, 20, "local")).await();
-        assertThat(result.isSuccess()).isTrue();
-    }
-
-    @Test
-    void config_validation_rejects_zero_rate() {
-        var result = RateGuardConfig.rateGuardConfig(0, 10);
-        assertThat(result.isFailure()).isTrue();
-    }
-
-    @Test
-    void config_validation_rejects_negative_burst() {
-        var result = RateGuardConfig.rateGuardConfig(100, -1);
-        assertThat(result.isFailure()).isTrue();
-    }
-
-    @Test
-    void config_defaults_are_reasonable() {
-        var result = RateGuardConfig.rateGuardConfig();
-        assertThat(result.isSuccess()).isTrue();
-        var config = result.unwrap();
-        assertThat(config.requestsPerSecond()).isEqualTo(100);
-        assertThat(config.burst()).isEqualTo(20);
-        assertThat(config.type()).isEqualTo("local");
-    }
-
-    @Test
-    void limit_exceeded_message_is_descriptive() {
-        var error = RateGuardError.LimitExceeded.limitExceeded(5000, 100, 0, System.currentTimeMillis() + 5000);
-        assertThat(error.message()).contains("Rate limit exceeded");
-        assertThat(error.message()).contains("5000ms");
+    private static void assertLimitExceededMetadata(Cause cause) {
+        assertThat(cause).isInstanceOf(RateGuardError.LimitExceeded.class);
+        var exceeded = (RateGuardError.LimitExceeded) cause;
+        assertThat(exceeded.limit()).isEqualTo(1);
+        assertThat(exceeded.remaining()).isEqualTo(0);
+        assertThat(exceeded.retryAfterMs()).isGreaterThan(0);
+        assertThat(exceeded.resetAtEpochMs()).isGreaterThan(System.currentTimeMillis() - 1000);
+        assertThat(exceeded.retryAfterSeconds()).isGreaterThanOrEqualTo(0);
     }
 }

--- a/aether/slice-api/src/main/java/org/pragmatica/aether/slice/RateGuard.java
+++ b/aether/slice-api/src/main/java/org/pragmatica/aether/slice/RateGuard.java
@@ -1,0 +1,41 @@
+package org.pragmatica.aether.slice;
+
+import org.pragmatica.lang.Promise;
+
+import java.util.function.Supplier;
+
+
+/// Resource type for rate-limiting slice method invocations.
+///
+/// Provisioned via `@ResourceQualifier(type = RateGuard.class, config = "rate-limit.xxx")`.
+/// Users create custom annotations per rate-limit policy:
+///
+/// ```java
+/// @ResourceQualifier(type = RateGuard.class, config = "rate-limit.orders")
+/// @Retention(RUNTIME) @Target(METHOD)
+/// public @interface OrdersRateLimit {}
+/// ```
+///
+/// Then annotate slice methods:
+///
+/// ```java
+/// @OrdersRateLimit
+/// Promise<OrderResult> processOrder(OrderRequest request);
+/// ```
+///
+/// The runtime wraps annotated method invocations: if the rate limit is exceeded,
+/// a `RateGuardError.LimitExceeded` is returned without invoking the method.
+/// HTTP servers translate this to 429 Too Many Requests with appropriate headers.
+///
+/// Configuration in `aether.toml`:
+/// ```toml
+/// [rate-limit.orders]
+/// requests_per_second = 100
+/// burst = 20
+/// type = "local"
+/// ```
+public interface RateGuard {
+    /// Guard an operation. Returns the result if within limits,
+    /// or RateGuardError.LimitExceeded if rate exceeded.
+    <T> Promise<T> guard(Supplier<Promise<T>> operation);
+}

--- a/aether/slice-api/src/main/java/org/pragmatica/aether/slice/RateGuardError.java
+++ b/aether/slice-api/src/main/java/org/pragmatica/aether/slice/RateGuardError.java
@@ -1,0 +1,31 @@
+package org.pragmatica.aether.slice;
+
+import org.pragmatica.lang.Cause;
+
+
+/// Error types for rate guard violations.
+public sealed interface RateGuardError extends Cause {
+    /// Rate limit exceeded. Contains metadata for HTTP 429 response headers.
+    record LimitExceeded(long retryAfterMs,
+                         long limit,
+                         long remaining,
+                         long resetAtEpochMs) implements RateGuardError {
+        public static LimitExceeded limitExceeded(long retryAfterMs, long limit, long remaining, long resetAtEpochMs) {
+            return new LimitExceeded(retryAfterMs, limit, remaining, resetAtEpochMs);
+        }
+
+        @Override public String message() {
+            return "Rate limit exceeded. Retry after " + retryAfterMs + "ms";
+        }
+
+        /// Retry-After header value in seconds (rounded up).
+        public long retryAfterSeconds() {
+            return (retryAfterMs + 999) / 1000;
+        }
+
+        /// X-RateLimit-Reset header value (Unix epoch seconds).
+        public long resetAtEpochSeconds() {
+            return resetAtEpochMs / 1000;
+        }
+    }
+}

--- a/jbct/slice-processor/src/main/java/org/pragmatica/jbct/slice/model/MethodModel.java
+++ b/jbct/slice-processor/src/main/java/org/pragmatica/jbct/slice/model/MethodModel.java
@@ -43,6 +43,7 @@ public record MethodModel(String name,
     private static final String STREAM_SUBSCRIBER_TYPE = "org.pragmatica.aether.slice.StreamSubscriber";
     private static final String PG_NOTIFICATION_SUBSCRIBER_TYPE = "org.pragmatica.aether.slice.PgNotificationSubscriber";
     private static final String CONFIGURATION_SECTION_TYPE = "org.pragmatica.aether.slice.annotation.ConfigurationSection";
+    private static final String RATE_GUARD_TYPE = "org.pragmatica.aether.slice.RateGuard";
     private static final String PRINCIPAL_TYPE = "org.pragmatica.aether.http.handler.security.Principal";
     private static final String SECURITY_CONTEXT_TYPE = "org.pragmatica.aether.http.handler.security.SecurityContext";
 
@@ -419,6 +420,7 @@ public record MethodModel(String name,
             case STREAM_SUBSCRIBER_TYPE -> "stream";
             case PG_NOTIFICATION_SUBSCRIBER_TYPE -> "pg-notification";
             case CONFIGURATION_SECTION_TYPE -> "config-update";
+            case RATE_GUARD_TYPE -> "rate-guard";
             default -> null;  // Not reactive — it's an interceptor
         };
     }


### PR DESCRIPTION
## Summary

Closes #77. Adds `RateGuard` as a new resource type following the `@ResourceQualifier` pattern. Users create custom method-level annotations to apply per-route rate limiting. HTTP servers translate `LimitExceeded` errors to 429 with full rate limit headers.

### Developer usage

```java
// Custom annotation per rate-limit policy
@ResourceQualifier(type = RateGuard.class, config = "rate-limit.orders")
@Retention(RUNTIME) @Target(METHOD)
public @interface OrdersRateLimit {}

// Apply to slice methods
@Slice
public interface OrderProcessor {
    @OrdersRateLimit
    Promise<OrderResult> processOrder(OrderRequest request);
}
```

```toml
# aether.toml
[rate-limit.orders]
requests_per_second = 100
burst = 20
type = "local"
```

### New files

| File | Description |
|------|-------------|
| `slice-api/RateGuard.java` | Resource interface |
| `slice-api/RateGuardError.java` | Sealed error with `LimitExceeded` (retryAfterMs, limit, remaining, resetAtEpochMs) |
| `interceptors/DefaultRateGuard.java` | Local token-bucket implementation wrapping core `RateLimiter` |
| `interceptors/RateGuardConfig.java` | Config record (requestsPerSecond, burst, type) |
| `interceptors/RateGuardFactory.java` | SPI ResourceFactory |
| `interceptors/RateGuardTest.java` | 9 tests |

### Modified files

| File | Change |
|------|--------|
| `MethodModel.java` | Add `RATE_GUARD_TYPE` → `"rate-guard"` reactive category |
| `AppHttpServer.java` | Map `RateGuardError.LimitExceeded` → 429 with Retry-After, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset headers |
| `META-INF/services/ResourceFactory` | Register `RateGuardFactory` |

### HTTP 429 response

```
HTTP/1.1 429 Too Many Requests
Retry-After: 5
X-RateLimit-Limit: 100
X-RateLimit-Remaining: 0
X-RateLimit-Reset: 1618884474
Content-Type: application/json

{"error": "Rate limit exceeded. Retry after 5000ms"}
```

### Design decisions

- **Per-node (local) rate limiting** for v1. Distributed via DHT is tracked as #144 (rc2).
- **General-purpose** — not ingress-specific. Guards any slice method invocation regardless of trigger.
- **`@ResourceQualifier` pattern** — same mechanism as `@Sql`, `@Http`, `@Notify`. Users create custom annotations per policy.
- **`type = "local"` config field** — placeholder for future `"distributed"` option.

## Test plan

- [x] 9 unit tests: within-limit, exceeded, burst, metadata fields, factory, config validation, defaults
- [x] Compilation verified across slice-api, interceptors, slice-processor, node
- [ ] Integration test: deploy slice with rate-limited method, verify 429 response

Closes #77