### PR TITLE
refactor: eliminate unsafe .unwrap() calls, use .expect() at boundaries (#160)

### DIFF
--- a/aether/aether-config/src/main/java/org/pragmatica/aether/config/ConfigLoader.java
+++ b/aether/aether-config/src/main/java/org/pragmatica/aether/config/ConfigLoader.java
@@ -742,27 +742,30 @@ public final class ConfigLoader {
         return parseDurationRaw(normalized);
     }
 
+    private static final Duration DEFAULT_DURATION = Duration.ofSeconds(1);
+
     private static Duration parseDurationMs(String normalized) {
-        return Number.parseLong(normalized.substring(0,
-                                                     normalized.length() - 2)).map(Duration::ofMillis)
-                               .unwrap();
+        return Number.parseLong(normalized.substring(0, normalized.length() - 2))
+                     .map(Duration::ofMillis)
+                     .or(DEFAULT_DURATION);
     }
 
     private static Duration parseDurationSeconds(String normalized) {
-        return Number.parseLong(normalized.substring(0,
-                                                     normalized.length() - 1)).map(Duration::ofSeconds)
-                               .unwrap();
+        return Number.parseLong(normalized.substring(0, normalized.length() - 1))
+                     .map(Duration::ofSeconds)
+                     .or(DEFAULT_DURATION);
     }
 
     private static Duration parseDurationMinutes(String normalized) {
-        return Number.parseLong(normalized.substring(0,
-                                                     normalized.length() - 1)).map(Duration::ofMinutes)
-                               .unwrap();
+        return Number.parseLong(normalized.substring(0, normalized.length() - 1))
+                     .map(Duration::ofMinutes)
+                     .or(DEFAULT_DURATION);
     }
 
     private static Duration parseDurationRaw(String normalized) {
-        return Number.parseLong(normalized).map(Duration::ofSeconds)
-                               .unwrap();
+        return Number.parseLong(normalized)
+                     .map(Duration::ofSeconds)
+                     .or(DEFAULT_DURATION);
     }
 
     public sealed interface ConfigError extends Cause {

--- a/aether/aether-dht/src/main/java/org/pragmatica/aether/dht/AetherMaps.java
+++ b/aether/aether-dht/src/main/java/org/pragmatica/aether/dht/AetherMaps.java
@@ -85,7 +85,8 @@ public interface AetherMaps {
     }
 
     private static EndpointKey deserializeEndpointKey(byte[] bytes) {
-        return EndpointKey.endpointKey(new String(bytes, StandardCharsets.UTF_8)).unwrap();
+        return EndpointKey.endpointKey(new String(bytes, StandardCharsets.UTF_8))
+                          .expect("DHT corruption: invalid EndpointKey bytes");
     }
 
     private static byte[] serializeEndpointValue(EndpointValue value) {
@@ -94,7 +95,8 @@ public interface AetherMaps {
     }
 
     private static EndpointValue deserializeEndpointValue(byte[] bytes) {
-        return new EndpointValue(NodeId.nodeId(new String(bytes, StandardCharsets.UTF_8)).unwrap());
+        return new EndpointValue(NodeId.nodeId(new String(bytes, StandardCharsets.UTF_8))
+                                       .expect("DHT corruption: invalid NodeId bytes for EndpointValue"));
     }
 
     private static byte[] serializeSliceNodeKey(SliceNodeKey key) {
@@ -102,7 +104,8 @@ public interface AetherMaps {
     }
 
     private static SliceNodeKey deserializeSliceNodeKey(byte[] bytes) {
-        return SliceNodeKey.sliceNodeKey(new String(bytes, StandardCharsets.UTF_8)).unwrap();
+        return SliceNodeKey.sliceNodeKey(new String(bytes, StandardCharsets.UTF_8))
+                           .expect("DHT corruption: invalid SliceNodeKey bytes");
     }
 
     private static byte[] serializeSliceNodeValue(SliceNodeValue value) {
@@ -125,7 +128,8 @@ public interface AetherMaps {
     }
 
     public static HttpNodeRouteKey deserializeHttpRouteKey(byte[] bytes) {
-        return HttpNodeRouteKey.httpNodeRouteKey(new String(bytes, StandardCharsets.UTF_8)).unwrap();
+        return HttpNodeRouteKey.httpNodeRouteKey(new String(bytes, StandardCharsets.UTF_8))
+                               .expect("DHT corruption: invalid HttpNodeRouteKey bytes");
     }
 
     public static byte[] serializeHttpRouteValue(HttpNodeRouteValue value) {

--- a/aether/aether-management-api/src/main/java/org/pragmatica/aether/management/route/RouteMatcher.java
+++ b/aether/aether-management-api/src/main/java/org/pragmatica/aether/management/route/RouteMatcher.java
@@ -48,7 +48,7 @@ public final class RouteMatcher {
     }
 
     private static RouteMatcher buildOrFail(ManagementRoute[] routes) {
-        return build(routes).unwrap();
+        return build(routes).expect("ManagementRoute enum contains ambiguous routes - coding bug");
     }
 
     public Result<MatchedRoute> match(HttpMethod method, String rawPath) {

--- a/aether/aether-setup/src/main/java/org/pragmatica/aether/setup/AetherUp.java
+++ b/aether/aether-setup/src/main/java/org/pragmatica/aether/setup/AetherUp.java
@@ -80,21 +80,24 @@ public final class AetherUp {
         var overrides = extractOverrides(options);
         var result = ConfigLoader.loadWithOverrides(configPath, overrides);
         result.onFailure(cause -> printErrorAndExit("Error loading configuration:", cause.message()));
-        return result.unwrap();
+        return result.expect("printErrorAndExit calls System.exit; unwrap unreachable on failure");
     }
 
     private static AetherConfig configFromDefaults(Map<String, String> options) {
         var envStr = options.getOrDefault("env", "docker");
-        var env = Environment.environment(envStr).onFailure(cause -> printErrorAndExit("Error:",
-                                                                                       cause.message()))
-                                         .unwrap();
+        var env = Environment.environment(envStr).onFailure(cause -> printErrorAndExit("Error:", cause.message()))
+                                                 .expect("printErrorAndExit calls System.exit; unwrap unreachable on failure");
         var builder = AetherConfig.builder().withEnvironment(env);
         withOverrides(builder, options);
         return builder.build();
     }
 
     private static void withOverrides(AetherConfig.Builder builder, Map<String, String> options) {
-        if (options.containsKey("nodes")) {builder.nodes(Number.parseInt(options.get("nodes")).unwrap());}
+        if (options.containsKey("nodes")) {
+            Number.parseInt(options.get("nodes"))
+                  .onFailure(cause -> printErrorAndExit("Invalid --nodes value:", cause.message()))
+                  .onSuccess(builder::nodes);
+        }
         if (options.containsKey("heap")) {builder.heap(options.get("heap"));}
         if (options.containsKey("tls")) {builder.tls(true);}
         if (options.containsKey("no-tls")) {builder.tls(false);}

--- a/aether/aether-setup/src/main/java/org/pragmatica/aether/setup/generators/DockerGenerator.java
+++ b/aether/aether-setup/src/main/java/org/pragmatica/aether/setup/generators/DockerGenerator.java
@@ -48,7 +48,7 @@ public final class DockerGenerator implements Generator {
     }
 
     @SuppressWarnings("JBCT-EX-01") private GeneratorOutput generateArtifacts(AetherConfig config, Path outputDir) throws Exception {
-        createDirectories(outputDir).unwrap();
+        createDirectories(outputDir).expect("create docker output directory");
         var generatedFiles = new ArrayList<Path>();
         writeFile(outputDir, "docker-compose.yml", generateDockerCompose(config), generatedFiles);
         writeFile(outputDir, ".env", generateEnvFile(config), generatedFiles);
@@ -60,13 +60,13 @@ public final class DockerGenerator implements Generator {
     }
 
     @SuppressWarnings("JBCT-EX-01") private void writeFile(Path dir, String name, String content, List<Path> files) throws Exception {
-        writeString(dir.resolve(name), content).unwrap();
+        writeString(dir.resolve(name), content).expect("write docker artifact: " + name);
         files.add(Path.of(name));
     }
 
     @SuppressWarnings("JBCT-EX-01") private Path writeScript(Path dir, String name, String content, List<Path> files) throws Exception {
         var path = dir.resolve(name);
-        writeString(path, content).unwrap();
+        writeString(path, content).expect("write docker script: " + name);
         makeExecutable(path);
         files.add(Path.of(name));
         return path;

--- a/aether/aether-setup/src/main/java/org/pragmatica/aether/setup/generators/KubernetesGenerator.java
+++ b/aether/aether-setup/src/main/java/org/pragmatica/aether/setup/generators/KubernetesGenerator.java
@@ -50,7 +50,7 @@ public final class KubernetesGenerator implements Generator {
 
     @SuppressWarnings("JBCT-EX-01") private GeneratorOutput generateManifests(AetherConfig config, Path outputDir) throws Exception {
         var manifestsDir = outputDir.resolve("manifests");
-        createDirectories(manifestsDir).unwrap();
+        createDirectories(manifestsDir).expect("create kubernetes manifests directory");
         var generatedFiles = new ArrayList<Path>();
         writeManifest(manifestsDir, "namespace.yaml", generateNamespace(config), generatedFiles);
         writeManifest(manifestsDir, "configmap.yaml", generateConfigMap(config), generatedFiles);
@@ -67,13 +67,13 @@ public final class KubernetesGenerator implements Generator {
                                                                String name,
                                                                String content,
                                                                List<Path> files) throws Exception {
-        writeString(dir.resolve(name), content).unwrap();
+        writeString(dir.resolve(name), content).expect("write kubernetes manifest: " + name);
         files.add(Path.of("manifests/" + name));
     }
 
     @SuppressWarnings("JBCT-EX-01") private void writeScript(Path dir, String name, String content, List<Path> files) throws Exception {
         var path = dir.resolve(name);
-        writeString(path, content).unwrap();
+        writeString(path, content).expect("write kubernetes script: " + name);
         makeExecutable(path);
         files.add(Path.of(name));
     }

--- a/aether/aether-setup/src/main/java/org/pragmatica/aether/setup/generators/LocalGenerator.java
+++ b/aether/aether-setup/src/main/java/org/pragmatica/aether/setup/generators/LocalGenerator.java
@@ -44,8 +44,8 @@ public final class LocalGenerator implements Generator {
     }
 
     @SuppressWarnings("JBCT-EX-01") private GeneratorOutput generateScripts(AetherConfig config, Path outputDir) throws Exception {
-        createDirectories(outputDir).unwrap();
-        createDirectories(outputDir.resolve("logs")).unwrap();
+        createDirectories(outputDir).expect("create local output directory");
+        createDirectories(outputDir.resolve("logs")).expect("create local logs directory");
         var generatedFiles = new ArrayList<Path>();
         var startPath = writeScript(outputDir, "start.sh", generateStartScript(config), generatedFiles);
         var stopPath = writeScript(outputDir, "stop.sh", generateStopScript(config), generatedFiles);
@@ -57,7 +57,7 @@ public final class LocalGenerator implements Generator {
 
     @SuppressWarnings("JBCT-EX-01") private Path writeScript(Path dir, String name, String content, List<Path> files) throws Exception {
         var path = dir.resolve(name);
-        writeString(path, content).unwrap();
+        writeString(path, content).expect("write local script: " + name);
         makeExecutable(path);
         files.add(Path.of(name));
         return path;

--- a/aether/node/src/main/java/org/pragmatica/aether/Main.java
+++ b/aether/node/src/main/java/org/pragmatica/aether/Main.java
@@ -83,7 +83,7 @@ import static org.pragmatica.net.tcp.NodeAddress.nodeAddress;
         var dhtConfig = parseDhtConfig(aetherConfig);
         logStartupInfo(nodeId, port, managementPort, peers, aetherConfig, sliceConfig);
         var coreMax = parseCoreMax(aetherConfig);
-        var tlsBundle = resolveTls(nodeId, peers, aetherConfig).unwrap();
+        var tlsBundle = resolveTls(nodeId, peers, aetherConfig).expect("Failed to resolve TLS configuration at node startup");
         var appHttpTls = aetherConfig.filter(AetherConfig::tlsEnabled).map(_ -> tlsBundle.tls());
         var config = AetherNodeConfig.builder().self(nodeId)
                                              .coreNodes(peers)
@@ -102,7 +102,7 @@ import static org.pragmatica.net.tcp.NodeAddress.nodeAddress;
                                              .backupConfig(resolveBackup(aetherConfig))
                                              .streaming(resolveStreaming(aetherConfig))
                                              .build();
-        var node = AetherNode.aetherNode(config).unwrap();
+        var node = AetherNode.aetherNode(config).expect("Failed to initialize Aether node at startup");
         registerShutdownHook(node);
         startNodeAndWait(node, nodeId);
     }
@@ -291,7 +291,9 @@ import static org.pragmatica.net.tcp.NodeAddress.nodeAddress;
                                       int selfPort,
                                       Map<String, String> labels,
                                       Option<AetherConfig> aetherConfig) {
-        var selfInfo = NodeInfo.nodeInfo(self, nodeAddress("localhost", selfPort).unwrap(), NodeRole.ACTIVE, labels);
+        var selfInfo = NodeInfo.nodeInfo(self,
+                                         nodeAddress("localhost", selfPort).expect("localhost is a valid node address"),
+                                         NodeRole.ACTIVE, labels);
         return findArg("--peers=").map(peersStr -> parsePeersFromString(peersStr, self, selfInfo))
                       .orElse(findEnv("CLUSTER_PEERS").map(peersStr -> parsePeersFromString(peersStr, self, selfInfo)))
                       .orElse(aetherConfig.map(this::generatePeersFromConfig))
@@ -314,8 +316,8 @@ import static org.pragmatica.net.tcp.NodeAddress.nodeAddress;
         var port = clusterPort + (env == Environment.LOCAL
                                   ? index
                                   : 0);
-        return NodeInfo.nodeInfo(NodeId.nodeId("node-" + index).unwrap(),
-                                 nodeAddress(host, port).unwrap());
+        return NodeInfo.nodeInfo(NodeId.nodeId("node-" + index).expect("generated node id must be valid"),
+                                 nodeAddress(host, port).expect("generated node address must be valid"));
     }
 
     private List<NodeInfo> parsePeersFromString(String peersStr, NodeId self, NodeInfo selfInfo) {
@@ -348,7 +350,7 @@ import static org.pragmatica.net.tcp.NodeAddress.nodeAddress;
     private Option<NodeInfo> parseHostPortPeer(String[] parts) {
         var host = parts[0];
         var port = Integer.parseInt(parts[1]);
-        var nodeId = NodeId.nodeId("node-" + host + "-" + port).unwrap();
+        var nodeId = NodeId.nodeId("node-" + host + "-" + port).expect("generated node id must be valid");
         return nodeAddress(host, port).map(addr -> NodeInfo.nodeInfo(nodeId, addr)).option();
     }
 

--- a/integrations/dht/src/main/java/org/pragmatica/dht/DHTNode.java
+++ b/integrations/dht/src/main/java/org/pragmatica/dht/DHTNode.java
@@ -70,7 +70,8 @@ public final class DHTNode {
                                   StorageEngine storage,
                                   ConsistentHashRing<NodeId> ring,
                                   DHTConfig config) {
-        var clock = HlcClock.hlcClock(nodeId.id()).unwrap();
+        var clock = HlcClock.hlcClock(nodeId.id())
+                            .expect("NodeId from validated source cannot produce invalid HlcClock");
         return new DHTNode(nodeId, storage, ring, config, clock);
     }
 

--- a/integrations/storage/src/main/java/org/pragmatica/storage/LocalDiskTier.java
+++ b/integrations/storage/src/main/java/org/pragmatica/storage/LocalDiskTier.java
@@ -43,7 +43,7 @@ public final class LocalDiskTier implements StorageTier {
 
     @Override
     public Promise<Option<byte[]>> get(BlockId id) {
-        return Promise.lift(READ_ERROR, () -> readBlock(id));
+        return Promise.lift(READ_ERROR, () -> readBlock(id)).flatMap(Promise::resolved);
     }
 
     @Override
@@ -52,7 +52,7 @@ public final class LocalDiskTier implements StorageTier {
             return StorageError.TierFull.tierFull(TierLevel.LOCAL_DISK, usedBytes.get(), maxBytes).promise();
         }
 
-        return Promise.lift(WRITE_ERROR, () -> writeBlock(id, content));
+        return Promise.lift(WRITE_ERROR, () -> writeBlock(id, content)).flatMap(Promise::resolved);
     }
 
     /// Atomic CAS capacity reservation — prevents TOCTOU race.
@@ -74,7 +74,7 @@ public final class LocalDiskTier implements StorageTier {
 
     @Override
     public Promise<Unit> delete(BlockId id) {
-        return Promise.lift(WRITE_ERROR, () -> deleteBlock(id));
+        return Promise.lift(WRITE_ERROR, () -> deleteBlock(id)).flatMap(Promise::resolved);
     }
 
     @Override
@@ -97,39 +97,40 @@ public final class LocalDiskTier implements StorageTier {
         return maxBytes;
     }
 
-    private Option<byte[]> readBlock(BlockId id) {
+    private Result<Option<byte[]>> readBlock(BlockId id) {
         var path = blockPath(id);
 
         return FileOps.exists(path)
-               ? some(FileOps.readBytes(path).unwrap())
-               : none();
+               ? FileOps.readBytes(path).map(Option::some)
+               : Result.success(none());
     }
 
-    private Unit writeBlock(BlockId id, byte[] content) {
+    private Result<Unit> writeBlock(BlockId id, byte[] content) {
         var path = blockPath(id);
-        FileOps.createDirectories(path.getParent()).unwrap();
+        return FileOps.createDirectories(path.getParent())
+                      .flatMap(_ -> existingSize(path))
+                      .flatMap(previousSize -> FileOps.writeBytes(path, content)
+                                                      .onSuccess(_ -> correctUsedBytes(previousSize)));
+    }
 
-        var previousSize = FileOps.exists(path) ? FileOps.size(path).unwrap() : 0L;
-        FileOps.writeBytes(path, content).unwrap();
+    private Result<Long> existingSize(Path path) {
+        return FileOps.exists(path) ? FileOps.size(path) : Result.success(0L);
+    }
 
+    private void correctUsedBytes(long previousSize) {
         // Capacity was pre-reserved for content.length. Correct for overwrites.
         if (previousSize > 0) {
             usedBytes.addAndGet(-previousSize);
         }
-
-        return unit();
     }
 
-    private Unit deleteBlock(BlockId id) {
+    private Result<Unit> deleteBlock(BlockId id) {
         var path = blockPath(id);
-
-        if (FileOps.exists(path)) {
-            var fileSize = FileOps.size(path).unwrap();
-            FileOps.delete(path).unwrap();
-            usedBytes.addAndGet(-fileSize);
+        if (!FileOps.exists(path)) {
+            return Result.success(unit());
         }
-
-        return unit();
+        return FileOps.size(path)
+                      .flatMap(fileSize -> FileOps.delete(path).onSuccess(_ -> usedBytes.addAndGet(-fileSize)));
     }
 
     private Path blockPath(BlockId id) {


### PR DESCRIPTION
## Summary

Addresses #160 by auditing every `.unwrap()` in production code (excluding parsers), classifying each into safe/unsafe categories, and eliminating or annotating the unsafe sites.

## Changes

**Unsafe unwraps eliminated (Category D):**

- **`LocalDiskTier.java`** (6 sites) — file I/O helpers refactored from throwing to `Result<T>`, composed via `Promise.lift(...).flatMap(Promise::resolved)` pattern. Preserves virtual-thread dispatch while surfacing real `FileError` causes.
- **`ConfigLoader.java`** duration parsing (4 sites) — `Number.parseLong(...).map(...).unwrap()` replaced with `.or(DEFAULT_DURATION)` fallback on malformed input.

**Boundary unwraps annotated (Category E) — `.unwrap()` → `.expect("reason")`:**

- `Main.java` (6 sites) — node startup, generated node ids/addresses, TLS resolution
- `AetherMaps.java` (4 sites) — DHT deserializers; corruption signal made explicit
- `DHTNode.java` (1 site) — HlcClock from validated NodeId
- `RouteMatcher.java` (1 site) — ManagementRoute enum validation (coding bug if fails)
- `AetherUp.java` (3 sites) — CLI config loading; `--nodes` input now properly validated via `onFailure(exit)`
- `DockerGenerator.java`, `KubernetesGenerator.java`, `LocalGenerator.java` (9 sites) — setup tool file writes; `.expect()` preserves `FileError` detail through the outer `Result.lift` wrapper

## Not changed (intentionally)

- **Category A (guarded)** ~18 sites — preceded by `isSuccess()` / `isPresent()` in the same block. Safe as-is.
- **Category B (static init with literals)** ~41 sites — e.g. `DEFAULT = factory("known-value").unwrap()`. Factories are no-op validators; safe.
- **Category C (error factory pattern)** ~14 sites — `return Error.error(...).unwrap()` returning the error itself; always succeeds.
- **Parsers** (3034 sites) — explicitly excluded per #160 scope (parser-combinator convention).

## Test plan

- [x] Full `mvn test` passes (132 modules, excluding `integrations/consensus` which has known pre-existing SSL test failures)
- [x] `.expect()` messages are descriptive enough to identify failure site from stack trace

Closes #160