### PR TITLE
feat: @NullReturn annotation for intentional-null methods

### DIFF
--- a/core/src/main/java/org/pragmatica/lang/Functions.java
+++ b/core/src/main/java/org/pragmatica/lang/Functions.java
@@ -506,7 +506,7 @@ public interface Functions {
     /// @param value Input value (ignored)
     ///
     /// @return null
-    @SuppressWarnings("JBCT-RET-03")
+    @NullReturn
     static <R, T1> R toNull(T1 value) {
         return null;
     }

--- a/core/src/main/java/org/pragmatica/lang/NullReturn.java
+++ b/core/src/main/java/org/pragmatica/lang/NullReturn.java
@@ -1,0 +1,34 @@
+package org.pragmatica.lang;
+
+import java.lang.annotation.*;
+
+/// Declares that a method intentionally returns `null` as part of its contract.
+///
+/// JBCT requires methods to use `Option<T>` for absent values rather than `null`.
+/// However, certain utility functions in functional contexts intentionally produce
+/// `null` — side-effect-only fold branches, JDK callback contracts (`Map.compute`,
+/// `Map.merge`, `computeIfPresent`) where `null` signals removal, and similar.
+///
+/// Use `@NullReturn` instead of `@SuppressWarnings("JBCT-RET-03")` to express this intent.
+/// Unlike `@SuppressWarnings`, which says "I know this is wrong, ignore it,"
+/// `@NullReturn` says "null is the correct return value for this method's contract."
+///
+/// Can be applied at method level or class level (covers all methods in the class).
+///
+/// Example:
+/// ```java
+/// // Side-effect fold branch — value is discarded
+/// @NullReturn
+/// static <R, T> R toNull(T value) { return null; }
+///
+/// // Map.computeIfPresent callback — null removes the entry
+/// @NullReturn
+/// private static StreamEntry removeIfStillIdle(StreamEntry current, ...) { ... }
+/// ```
+///
+/// @see org.pragmatica.lang.Option
+/// @see org.pragmatica.lang.Contract
+@Documented
+@Retention(RetentionPolicy.SOURCE)
+@Target({ElementType.METHOD, ElementType.TYPE})
+public @interface NullReturn {}

--- a/jbct/jbct-lint/src/main/java/org/pragmatica/jbct/lint/cst/SuppressionExtractor.java
+++ b/jbct/jbct-lint/src/main/java/org/pragmatica/jbct/lint/cst/SuppressionExtractor.java
@@ -9,13 +9,16 @@ import java.util.regex.Pattern;
 
 import static org.pragmatica.jbct.parser.CstNodes.*;
 
-/// Extracts @SuppressWarnings and @Contract annotations and determines which rules are suppressed at which locations.
+/// Extracts @SuppressWarnings, @Contract, @TerminalOperation, and @NullReturn annotations
+/// and determines which rules are suppressed at which locations.
 ///
 /// Supports both standard suppressions and JBCT rule IDs:
 /// - @SuppressWarnings("JBCT-RET-01") - single rule
 /// - @SuppressWarnings({"JBCT-RET-01", "JBCT-RET-02"}) - multiple rules
 /// - @SuppressWarnings("all") - suppresses all JBCT rules
 /// - @Contract - suppresses all JBCT rules (method signature dictated by external API contract)
+/// - @TerminalOperation - suppresses JBCT-PAT-03 (intentional blocking)
+/// - @NullReturn - suppresses JBCT-RET-03 (intentional null return)
 public final class SuppressionExtractor {
     private static final Pattern JBCT_RULE_PATTERN = Pattern.compile("JBCT-[A-Z]+-\\d+");
 
@@ -52,6 +55,10 @@ public final class SuppressionExtractor {
                                                                   "org.pragmatica.lang.TerminalOperation");
     private static final Set<String> TERMINAL_OP_SUPPRESSED = Set.of("JBCT-PAT-03");
 
+    private static final Set<String> NULL_RETURN_NAMES = Set.of("NullReturn",
+                                                                  "org.pragmatica.lang.NullReturn");
+    private static final Set<String> NULL_RETURN_SUPPRESSED = Set.of("JBCT-RET-03");
+
     /// Extract all suppressions from a CST.
     public static List<Suppression> extractSuppressions(CstNode root, String source) {
         var suppressions = new ArrayList<Suppression>();
@@ -72,6 +79,14 @@ public final class SuppressionExtractor {
             if (TERMINAL_OP_NAMES.contains(name)) {
                 findAnnotatedDeclaration(root, annotation)
                 .onPresent(scopeNode -> suppressions.add(Suppression.suppression(TERMINAL_OP_SUPPRESSED,
+                                                                                  startLine(scopeNode),
+                                                                                  endLine(scopeNode))));
+                continue;
+            }
+            // @NullReturn suppresses JBCT-RET-03 (intentional null return)
+            if (NULL_RETURN_NAMES.contains(name)) {
+                findAnnotatedDeclaration(root, annotation)
+                .onPresent(scopeNode -> suppressions.add(Suppression.suppression(NULL_RETURN_SUPPRESSED,
                                                                                   startLine(scopeNode),
                                                                                   endLine(scopeNode))));
                 continue;

--- a/jbct/jbct-lint/src/main/java/org/pragmatica/jbct/lint/cst/rules/CstNullReturnRule.java
+++ b/jbct/jbct-lint/src/main/java/org/pragmatica/jbct/lint/cst/rules/CstNullReturnRule.java
@@ -14,6 +14,8 @@ import static org.pragmatica.jbct.parser.CstNodes.*;
 /// JBCT-RET-03: Never return null.
 ///
 /// JBCT code never returns null. Use Option<T> for optional values.
+/// Annotate with @NullReturn if returning null is intentional (side-effect fold branches,
+/// JDK callback contracts like Map.computeIfPresent).
 public class CstNullReturnRule implements CstLintRule {
     private static final String RULE_ID = "JBCT-RET-03";
     private static final String DOC_LINK = "https://github.com/siy/coding-technology/blob/main/skills/jbct/fundamentals/four-return-kinds.md";
@@ -64,7 +66,8 @@ public class CstNullReturnRule implements CstLintRule {
                                      column,
                                      "Method '" + methodName + "' returns null; use Option<T> instead",
                                      "JBCT code never returns null. Use Option.none() for absent values, "
-                                     + "Option.some(value) for present values.")
+                                     + "Option.some(value) for present values. "
+                                     + "Annotate with @NullReturn if null return is intentional.")
                          .withExample("""
             // Before: returning null
             public User findUser(UserId id) {

--- a/jbct/jbct-lint/src/test/java/org/pragmatica/jbct/lint/cst/CstLinterTest.java
+++ b/jbct/jbct-lint/src/test/java/org/pragmatica/jbct/lint/cst/CstLinterTest.java
@@ -2176,6 +2176,64 @@ class CstLinterTest {
         }
     }
 
+    // ========== @NullReturn Annotation Support ==========
+    @Nested
+    @DisplayName("@NullReturn annotation suppresses JBCT-RET-03")
+    class NullReturnAnnotationTests {
+        @Test
+        void nullReturnOnMethod_suppressesNullWarning() {
+            var diagnostics = lint("""
+                package com.example.usecase.test;
+                public class Test {
+                    @NullReturn
+                    public <R> R toNull() {
+                        return null;
+                    }
+                }
+                """);
+            assertNoRule(diagnostics, "JBCT-RET-03");
+        }
+
+        @Test
+        void nullReturnOnClass_suppressesAllNullWarnings() {
+            var diagnostics = lint("""
+                package com.example.usecase.test;
+                @NullReturn
+                public class Test {
+                    public String findOne() { return null; }
+                    public String findTwo() { return null; }
+                }
+                """);
+            assertNoRule(diagnostics, "JBCT-RET-03");
+        }
+
+        @Test
+        void nullReturnScopeIsLimited_otherMethodsStillFlagged() {
+            var diagnostics = lint("""
+                package com.example.usecase.test;
+                public class Test {
+                    @NullReturn
+                    public String allowed() { return null; }
+
+                    public String notAllowed() { return null; }
+                }
+                """);
+            assertHasRule(diagnostics, "JBCT-RET-03");
+        }
+
+        @Test
+        void fullyQualifiedNullReturn_alsoWorks() {
+            var diagnostics = lint("""
+                package com.example.usecase.test;
+                public class Test {
+                    @org.pragmatica.lang.NullReturn
+                    public String allowed() { return null; }
+                }
+                """);
+            assertNoRule(diagnostics, "JBCT-RET-03");
+        }
+    }
+
     // ========== @Contract Annotation Support ==========
     @Nested
     @DisplayName("@Contract annotation suppresses JBCT-RET-01")


### PR DESCRIPTION
## Summary

Adds `@NullReturn` annotation analogous to existing `@Contract` (suppresses `JBCT-RET-01`) and `@TerminalOperation` (suppresses `JBCT-PAT-03`). Suppresses `JBCT-RET-03` for methods where returning `null` is the intended contract.

## Why

`core/Functions.java:509` was the only raw `@SuppressWarnings("JBCT-RET-03")` in core/. The pattern used by sibling annotations (`Contract`, `TerminalOperation`) declares semantic intent rather than silencing a warning. `@NullReturn` says "null is the correct return value for this contract" — used in side-effect fold branches, JDK callback contracts (`Map.computeIfPresent`, `Map.merge`), etc.

## Changes

- New: `core/.../NullReturn.java` — annotation, source-retention, method/type targets.
- `SuppressionExtractor` recognizes `@NullReturn` (FQ + simple name) → suppresses `JBCT-RET-03`.
- `CstNullReturnRule` error message and javadoc mention `@NullReturn`.
- 4 new tests in `CstLinterTest$NullReturnAnnotationTests` (method, class-level, scope-limit, fully-qualified).
- Migrated `Functions.toNull()` from `@SuppressWarnings("JBCT-RET-03")` to `@NullReturn`.

Other 21 occurrences of `@SuppressWarnings("JBCT-RET-03")` across the repo can migrate in follow-up PRs (out of scope here, several touch hot zones).

## Tests

`mvn -pl jbct/jbct-lint test` — 170 tests pass.