### PR TITLE
fix(postgres-async): tx-aware LISTEN/UNLISTEN ordering

### DIFF
--- a/integrations/db/postgres-async/src/main/java/org/pragmatica/postgres/PgConnection.java
+++ b/integrations/db/postgres-async/src/main/java/org/pragmatica/postgres/PgConnection.java
@@ -174,6 +174,52 @@ public class PgConnection implements Connection {
 
     private Columns currentColumns;
 
+    /// Outer-transaction depth: 0 = no tx, 1 = inside outer tx, >1 = nested savepoints.
+    /// PostgreSQL connections are single-threaded — no synchronization needed.
+    private int txDepth = 0;
+    /// Hooks fired once when the outer transaction commits (depth transitions 1 → 0 via COMMIT).
+    private final ArrayList<Runnable> onCommitHooks = new ArrayList<>();
+    /// Hooks fired once when the outer transaction rolls back (depth 1 → 0 via ROLLBACK).
+    private final ArrayList<Runnable> onRollbackHooks = new ArrayList<>();
+
+    boolean inTransaction() {
+        return txDepth > 0;
+    }
+
+    void enterTx() {
+        txDepth++;
+    }
+
+    /// Decrement tx depth. When the outer tx ends (depth reaches 0), fire either the
+    /// commit or rollback hooks (and discard the other side). Savepoint release/rollback
+    /// just decrements — hooks remain pending for the outer outcome. This means
+    /// subscribe/unlisten inside a rolled-back savepoint may leave inconsistent state;
+    /// see the javadoc on [#subscribe(String, Consumer)].
+    void exitTx(boolean committed) {
+        txDepth--;
+        if (txDepth > 0) {
+            return;
+        }
+        var fire = committed ? new ArrayList<>(onCommitHooks) : new ArrayList<>(onRollbackHooks);
+        onCommitHooks.clear();
+        onRollbackHooks.clear();
+        for (var hook : fire) {
+            try {
+                hook.run();
+            } catch (Throwable t) {
+                log.warn("Transaction {} hook threw", committed ? "commit" : "rollback", t);
+            }
+        }
+    }
+
+    void registerOnCommit(Runnable hook) {
+        onCommitHooks.add(hook);
+    }
+
+    void registerOnRollback(Runnable hook) {
+        onRollbackHooks.add(hook);
+    }
+
     PgConnection(ProtocolStream stream, DataConverter dataConverter, int maxStatements) {
         this.stream = stream;
         this.dataConverter = dataConverter;
@@ -316,31 +362,55 @@ public class PgConnection implements Connection {
     @Override
     public Promise<Transaction> begin() {
         return completeScript("BEGIN")
+            .withSuccess(_ -> enterTx())
             .map(_ -> new PgConnectionTransaction());
     }
 
+    /// Subscribe to NOTIFY messages on a channel.
+    ///
+    /// **Auto-commit (no active transaction):** LISTEN takes effect immediately.
+    /// The returned [Listening] removes the local handler and issues UNLISTEN.
+    ///
+    /// **Inside an explicit transaction:** PostgreSQL defers LISTEN until COMMIT
+    /// (and discards it on ROLLBACK). The local handler is registered immediately,
+    /// but a rollback hook is also registered: if the outer transaction rolls back,
+    /// the handler is removed (mirrors the server-side discard). Likewise, when
+    /// the returned [Listening] is invoked inside a transaction, UNLISTEN is queued
+    /// and the local handler is only removed if/when the outer transaction commits.
+    ///
+    /// **Limitation:** subscribe/unlisten inside a SAVEPOINT that is later rolled
+    /// back via `ROLLBACK TO SAVEPOINT` may leave the client and server states
+    /// inconsistent until the outer transaction completes. Outer COMMIT/ROLLBACK
+    /// always fires the registered hooks.
     public Promise<Listening> subscribe(String channel, Consumer<String> onNotification) {
-        // TODO: wait for commit before sending unlisten as otherwise it can be rolled back
         return validateChannelName(channel)
             .flatMap(_ -> completeScript("LISTEN " + channel))
-            .map(_ -> {
-                var unsubscribe = stream.subscribe(channel, onNotification);
-
-                return () -> completeScript("UNLISTEN " + channel).withSuccess(_ -> unsubscribe.run())
-                                                                  .mapToUnit();
-            });
+            .map(_ -> registerSubscription(channel, stream.subscribe(channel, onNotification)));
     }
 
     @Override
     public Promise<Listening> subscribe(String channel, NotificationHandler onNotification) {
         return validateChannelName(channel)
             .flatMap(_ -> completeScript("LISTEN " + channel))
-            .map(_ -> {
-                var unsubscribe = stream.subscribeWithDetails(channel, onNotification);
+            .map(_ -> registerSubscription(channel, stream.subscribeWithDetails(channel, onNotification)));
+    }
 
-                return () -> completeScript("UNLISTEN " + channel).withSuccess(_ -> unsubscribe.run())
-                                                                  .mapToUnit();
-            });
+    private Listening registerSubscription(String channel, Runnable unsubscribe) {
+        if (inTransaction()) {
+            registerOnRollback(unsubscribe);
+        }
+        return () -> doUnlisten(channel, unsubscribe);
+    }
+
+    private Promise<Unit> doUnlisten(String channel, Runnable unsubscribe) {
+        if (inTransaction()) {
+            return completeScript("UNLISTEN " + channel)
+                .withSuccess(_ -> registerOnCommit(unsubscribe))
+                .mapToUnit();
+        }
+        return completeScript("UNLISTEN " + channel)
+            .withSuccess(_ -> unsubscribe.run())
+            .mapToUnit();
     }
 
     private static Promise<Unit> validateChannelName(String channel) {
@@ -412,21 +482,36 @@ public class PgConnection implements Connection {
         public Promise<Transaction> begin() {
             int next = depth + 1;
             return completeScript("SAVEPOINT sp_" + next)
+                .withSuccess(_ -> enterTx())
                 .map(_ -> new PgConnectionTransaction(next));
         }
 
         @Override
         public Promise<Unit> commit() {
-            return depth == 0
-                ? PgConnection.this.completeScript("COMMIT").map(Unit::toUnit)
-                : PgConnection.this.completeScript("RELEASE SAVEPOINT sp_" + depth).map(Unit::toUnit);
+            if (depth == 0) {
+                // COMMIT: on server failure, the tx is automatically rolled back per PG semantics —
+                // fire rollback hooks. On wire/connection failure, also fire rollback hooks (best effort).
+                return PgConnection.this.completeScript("COMMIT")
+                                        .onResult(result -> exitTx(result.isSuccess()))
+                                        .map(Unit::toUnit);
+            }
+            return PgConnection.this.completeScript("RELEASE SAVEPOINT sp_" + depth)
+                                    .withSuccess(_ -> exitTx(true))
+                                    .map(Unit::toUnit);
         }
 
         @Override
         public Promise<Unit> rollback() {
-            return depth == 0
-                ? PgConnection.this.completeScript("ROLLBACK").map(Unit::toUnit)
-                : PgConnection.this.completeScript("ROLLBACK TO SAVEPOINT sp_" + depth).map(Unit::toUnit);
+            if (depth == 0) {
+                // ROLLBACK: fire rollback hooks regardless — on wire failure the connection is broken
+                // anyway, so unsubscribing local handlers is the right cleanup.
+                return PgConnection.this.completeScript("ROLLBACK")
+                                        .onResultRun(() -> exitTx(false))
+                                        .map(Unit::toUnit);
+            }
+            return PgConnection.this.completeScript("ROLLBACK TO SAVEPOINT sp_" + depth)
+                                    .withSuccess(_ -> exitTx(false))
+                                    .map(Unit::toUnit);
         }
 
         @Override

--- a/integrations/db/postgres-async/src/test/java/org/pragmatica/postgres/ListenNotifyTest.java
+++ b/integrations/db/postgres-async/src/test/java/org/pragmatica/postgres/ListenNotifyTest.java
@@ -2,6 +2,7 @@ package org.pragmatica.postgres;
 
 import org.pragmatica.postgres.net.Connectible;
 import org.pragmatica.postgres.net.Connection;
+import org.pragmatica.postgres.net.Listening;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
@@ -29,7 +30,8 @@ public class ListenNotifyTest {
 
     @BeforeEach
     public void setup() {
-        pool = dbr.pool();
+        // Build a fresh pool per test so the shared static container survives across tests.
+        pool = dbr.builder.maxConnections(5).pool();
     }
 
     @AfterEach
@@ -65,4 +67,99 @@ public class ListenNotifyTest {
         assertNull(result.poll(2, TimeUnit.SECONDS));
     }
 
+    @Test
+    public void subscribeInsideTxCommit_handlerStaysActiveAfterCommit() throws InterruptedException {
+        BlockingQueue<String> result = new LinkedBlockingQueue<>(5);
+        Connection conn = block(pool.getConnection());
+        Listening subscription = null;
+        try {
+            var tx = block(conn.begin());
+            subscription = block(tx.getConnection().subscribe("ch_tx_commit", (String payload) -> result.offer(payload)));
+            block(tx.commit());
+
+            TimeUnit.SECONDS.sleep(1);
+            block(pool.completeScript("notify ch_tx_commit, 'after-commit'"));
+
+            assertEquals("after-commit", result.poll(2, TimeUnit.SECONDS));
+        } finally {
+            if (subscription != null) {
+                block(subscription.unlisten());
+            }
+            block(conn.close());
+        }
+    }
+
+    @Test
+    public void subscribeInsideTxRollback_handlerRemovedAfterRollback() throws InterruptedException {
+        BlockingQueue<String> result = new LinkedBlockingQueue<>(5);
+        Connection conn = block(pool.getConnection());
+        try {
+            var tx = block(conn.begin());
+            // Construct the subscription inside the transaction. ROLLBACK must drop
+            // the local handler too — server-side LISTEN is also nullified.
+            block(tx.getConnection().subscribe("ch_tx_rollback", (String payload) -> result.offer(payload)));
+            block(tx.rollback());
+
+            TimeUnit.SECONDS.sleep(1);
+            block(pool.completeScript("notify ch_tx_rollback, 'should-not-fire'"));
+
+            // Handler was removed by the rollback hook — no notification should arrive.
+            assertNull(result.poll(1, TimeUnit.SECONDS));
+        } finally {
+            block(conn.close());
+        }
+    }
+
+    @Test
+    public void unlistenInsideTxCommit_handlerRemovedAfterCommit() throws InterruptedException {
+        BlockingQueue<String> result = new LinkedBlockingQueue<>(5);
+        Connection conn = block(pool.getConnection());
+        try {
+            var subscription = block(conn.subscribe("ch_unlisten_commit", (String payload) -> result.offer(payload)));
+            TimeUnit.SECONDS.sleep(1);
+
+            // Sanity check — subscription works before the transaction.
+            block(pool.completeScript("notify ch_unlisten_commit, 'baseline'"));
+            assertEquals("baseline", result.poll(2, TimeUnit.SECONDS));
+
+            var tx = block(conn.begin());
+            block(subscription.unlisten());
+            block(tx.commit());
+
+            TimeUnit.SECONDS.sleep(1);
+            block(pool.completeScript("notify ch_unlisten_commit, 'post-commit'"));
+
+            // After COMMIT both UNLISTEN and the deferred handler removal are applied.
+            assertNull(result.poll(1, TimeUnit.SECONDS));
+        } finally {
+            block(conn.close());
+        }
+    }
+
+    @Test
+    public void unlistenInsideTxRollback_handlerStillFiresAfterRollback() throws InterruptedException {
+        BlockingQueue<String> result = new LinkedBlockingQueue<>(5);
+        Connection conn = block(pool.getConnection());
+        Listening subscription = null;
+        try {
+            subscription = block(conn.subscribe("ch_unlisten_rollback", (String payload) -> result.offer(payload)));
+            TimeUnit.SECONDS.sleep(1);
+
+            var tx = block(conn.begin());
+            block(subscription.unlisten());
+            block(tx.rollback());
+
+            // ROLLBACK nullified UNLISTEN on the server, so server-side LISTEN remains.
+            // The fix keeps the client-side handler in place too — notifications must still flow.
+            TimeUnit.SECONDS.sleep(1);
+            block(pool.completeScript("notify ch_unlisten_rollback, 'after-rollback'"));
+
+            assertEquals("after-rollback", result.poll(2, TimeUnit.SECONDS));
+        } finally {
+            if (subscription != null) {
+                block(subscription.unlisten());
+            }
+            block(conn.close());
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Resolves the `TODO: wait for commit before sending unlisten as otherwise it can be rolled back` in `PgConnection.subscribe()`. The TODO is partially stale — auto-commit `subscribe()` already sequences correctly because `completeScript("LISTEN")` resolves only after the server's `CommandComplete`. But `subscribe`/`unlisten` invoked **inside an explicit transaction** had real bugs:

| Scenario | Before | After |
|---|---|---|
| `BEGIN; subscribe(ch); ROLLBACK;` | Server-side `LISTEN` is nullified by ROLLBACK; client-side handler still registered → silent leak | Rollback hook removes the local handler |
| Subscribe outside tx, then `BEGIN; unlisten(ch); ROLLBACK;` | UNLISTEN rolled back server-side → server keeps the LISTEN; client-side handler removed via `withSuccess` → notifications dropped silently | Client-side handler removed only on outer COMMIT (commit hook); rollback keeps it in place |
| `BEGIN; subscribe(ch); COMMIT;` | Worked by accident | Still works; rollback hook discarded on commit |

## Implementation (Option B from the design memo)

`PgConnection` gains `txDepth` plus `onCommitHooks`/`onRollbackHooks` lists. `PgConnectionTransaction.begin/commit/rollback` increment/decrement and fire hooks at the outer-tx boundary. `subscribe()` and the `Listening.unlisten()` lambda check `inTransaction()` at invocation time and register the appropriate hook.

- COMMIT failure path uses `onResult(result -> exitTx(result.isSuccess()))` — PG semantics: failed COMMIT means the tx was rolled back server-side, so rollback hooks fire.
- ROLLBACK uses `onResultRun(() -> exitTx(false))` — fires regardless of wire success (best-effort cleanup on broken connections).
- SAVEPOINT support is intentionally minimal: hooks are tracked at the outer-tx level only; `subscribe`/`unlisten` inside a rolled-back savepoint may leave inconsistent state until the outer tx ends. Documented in the `subscribe()` javadoc.

## Tests (Testcontainers, postgres:15-alpine, `@Tag("Slow")`)

5/5 pass:
- `shouldReceiveNotificationsOnListenedChannel` — original regression check
- `subscribeInsideTxCommit_handlerStaysActiveAfterCommit`
- `subscribeInsideTxRollback_handlerRemovedAfterRollback`
- `unlistenInsideTxCommit_handlerRemovedAfterCommit`
- `unlistenInsideTxRollback_handlerStillFiresAfterRollback`

Also fixed a pre-existing test-class lifecycle bug — `@AfterEach shutdown` was closing the **shared** static pool returned by `dbr.pool()`, so adding any second test broke the first. Refactored to per-test pool builds (matches `PreparedStatementsCacheTest` pattern).