### PR TITLE
feat(examples): notification-emailer slice demonstrating @Notify

### DIFF
--- a/examples/notification-hub/blueprint.toml
+++ b/examples/notification-hub/blueprint.toml
@@ -5,3 +5,7 @@ instances = 3
 [[slices]]
 artifact = "org.pragmatica.aether.example:notification-hub-notification-analytics:1.0.0-rc1"
 instances = 3
+
+[[slices]]
+artifact = "org.pragmatica.aether.example:notification-hub-notification-emailer:1.0.0-rc1"
+instances = 3

--- a/examples/notification-hub/notification-emailer/pom.xml
+++ b/examples/notification-hub/notification-emailer/pom.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.pragmatica.aether.example</groupId>
+        <artifactId>notification-hub</artifactId>
+        <version>1.0.0-rc1</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <groupId>org.pragmatica.aether.example</groupId>
+    <artifactId>notification-hub-notification-emailer</artifactId>
+    <name>Example Slice - Notification Emailer</name>
+    <description>Subscribes to notification stream events and sends email via the @Notify resource</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.pragmatica.aether.example</groupId>
+            <artifactId>notification-hub-notification-service</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.pragmatica-lite.aether</groupId>
+            <artifactId>resource-notification</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <!-- slice-api, slice-annotations, core inherited from parent with provided scope -->
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.pragmatica-lite</groupId>
+                            <artifactId>slice-processor</artifactId>
+                            <version>${project.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                    <compilerArgs>
+                        <arg>-Aslice.groupId=${project.groupId}</arg>
+                        <arg>-Aslice.artifactId=${project.artifactId}</arg>
+                    </compilerArgs>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.pragmatica-lite</groupId>
+                <artifactId>jbct-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>collect-deps</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>collect-slice-deps</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>package-slices</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>package-slices</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>install-slices</id>
+                        <phase>install</phase>
+                        <goals>
+                            <goal>install-slices</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>verify-slice</id>
+                        <goals>
+                            <goal>verify-slice</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/examples/notification-hub/notification-emailer/src/main/java/org/pragmatica/aether/example/notification/emailer/EmailerService.java
+++ b/examples/notification-hub/notification-emailer/src/main/java/org/pragmatica/aether/example/notification/emailer/EmailerService.java
@@ -1,0 +1,50 @@
+package org.pragmatica.aether.example.notification.emailer;
+
+import org.pragmatica.aether.example.notification.NotificationEvent;
+import org.pragmatica.aether.resource.notification.Notification;
+import org.pragmatica.aether.resource.notification.NotificationBody;
+import org.pragmatica.aether.resource.notification.NotificationSender;
+import org.pragmatica.aether.resource.notification.Notify;
+import org.pragmatica.aether.slice.annotation.Slice;
+import org.pragmatica.lang.Promise;
+import org.pragmatica.lang.Unit;
+import org.pragmatica.serialization.Codec;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.pragmatica.aether.example.notification.emailer.EmailerStatus.emailerStatus;
+
+
+@Slice public interface EmailerService {
+    @Codec record StatusRequest(){}
+
+    @NotificationConsumer Promise<Unit> processNotification(NotificationEvent event);
+    Promise<EmailerStatus> status(StatusRequest request);
+
+    static EmailerService emailerService(@Notify NotificationSender sender) {
+        return new emailerService(sender, new AtomicLong(), new AtomicLong());
+    }
+
+    record emailerService(NotificationSender sender, AtomicLong sentCount, AtomicLong failedCount) implements EmailerService {
+        private static final String FROM_ADDRESS = "notifications@notification-hub.example";
+
+        @Override public Promise<Unit> processNotification(NotificationEvent event) {
+            var email = Notification.Email.email(FROM_ADDRESS,
+                                                 List.of(recipientFor(event)),
+                                                 "Notification from " + event.senderId(),
+                                                 NotificationBody.Text.text(event.message()));
+            return sender.send(email).onSuccess(_ -> sentCount.incrementAndGet())
+                              .onFailure(_ -> failedCount.incrementAndGet())
+                              .mapToUnit();
+        }
+
+        @Override public Promise<EmailerStatus> status(StatusRequest request) {
+            return Promise.success(emailerStatus(sentCount.get(), failedCount.get()));
+        }
+
+        private static String recipientFor(NotificationEvent event) {
+            return event.channel() + "@notification-hub.example";
+        }
+    }
+}

--- a/examples/notification-hub/notification-emailer/src/main/java/org/pragmatica/aether/example/notification/emailer/EmailerStatus.java
+++ b/examples/notification-hub/notification-emailer/src/main/java/org/pragmatica/aether/example/notification/emailer/EmailerStatus.java
@@ -1,0 +1,10 @@
+package org.pragmatica.aether.example.notification.emailer;
+
+import org.pragmatica.serialization.Codec;
+
+
+@Codec public record EmailerStatus(long sent, long failed) {
+    public static EmailerStatus emailerStatus(long sent, long failed) {
+        return new EmailerStatus(sent, failed);
+    }
+}

--- a/examples/notification-hub/notification-emailer/src/main/java/org/pragmatica/aether/example/notification/emailer/NotificationConsumer.java
+++ b/examples/notification-hub/notification-emailer/src/main/java/org/pragmatica/aether/example/notification/emailer/NotificationConsumer.java
@@ -1,0 +1,12 @@
+package org.pragmatica.aether.example.notification.emailer;
+
+import org.pragmatica.aether.slice.StreamSubscriber;
+import org.pragmatica.aether.slice.annotation.ResourceQualifier;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+
+@ResourceQualifier(type = StreamSubscriber.class, config = "streams.notifications") @Retention(RetentionPolicy.RUNTIME) @Target(ElementType.METHOD) public@interface NotificationConsumer {}

--- a/examples/notification-hub/notification-emailer/src/main/resources/org/pragmatica/aether/example/notification/emailer/routes.toml
+++ b/examples/notification-hub/notification-emailer/src/main/resources/org/pragmatica/aether/example/notification/emailer/routes.toml
@@ -1,0 +1,4 @@
+prefix = "/api/v1/emailer"
+
+[routes]
+status = ["GET /", "public"]

--- a/examples/notification-hub/notification-emailer/src/main/resources/resources.toml
+++ b/examples/notification-hub/notification-emailer/src/main/resources/resources.toml
@@ -1,0 +1,26 @@
+[streams.notifications]
+partitions = 4
+retention = "time"
+retention-value = "5m"
+max-event-size = "64KB"
+
+# `@Notify NotificationSender` is provisioned from this section.
+# Backend can be "smtp" or "http". Below is a MailHog-friendly local SMTP setup;
+# real deployments would point at a production SMTP relay or vendor (SendGrid,
+# Mailgun, Postmark) via the [notification.http] backend.
+#
+# TODO(example-coverage): add a MailHog container to the parent example so
+# `./run-forge.sh` actually delivers and captures these emails.
+[notification]
+backend = "smtp"
+
+[notification.smtp]
+host = "localhost"
+port = 1025
+tls_mode = "NONE"
+username = ""
+password = ""
+pool_size = 2
+connect_timeout = "5s"
+command_timeout = "10s"
+helo_hostname = "notification-hub.example"

--- a/examples/notification-hub/pom.xml
+++ b/examples/notification-hub/pom.xml
@@ -26,6 +26,7 @@
     <modules>
         <module>notification-service</module>
         <module>notification-analytics</module>
+        <module>notification-emailer</module>
     </modules>
 
     <dependencies>


### PR DESCRIPTION
## Summary

Closes the example-coverage gap for the `@Notify NotificationSender` resource. Adds a third module to `examples/notification-hub` that subscribes to the same `streams.notifications` topic the existing publisher/analytics pair uses, and forwards each event to email via the injected `NotificationSender`.

## Context

Pre-investigation said both `@Notify` and pub-sub examples were missing. Re-checking the codebase showed pub-sub is already covered in 5 examples (`url-shortener`, `url-shortener-v2`, `pricing-engine`, `notification-hub`, `step-composition`). Only `@Notify` (SMTP/HTTP outbound notifications) had no example. This PR fills that gap.

## What's new

```
examples/notification-hub/notification-emailer/
├── pom.xml
├── src/main/java/.../emailer/
│   ├── EmailerService.java        # @Slice — subscribes + sends email
│   ├── EmailerStatus.java         # status response record
│   └── NotificationConsumer.java  # @StreamSubscriber qualifier
└── src/main/resources/
    ├── resources.toml             # streams.notifications + [notification] (SMTP backend)
    └── .../emailer/routes.toml    # GET /api/v1/emailer/ → status
```

Parent `pom.xml` adds the module; `blueprint.toml` deploys it alongside service + analytics.

## Wiring demonstrated

1. **Pub-sub consumer**: `@NotificationConsumer Promise<Unit> processNotification(NotificationEvent event)` — same pattern as existing analytics module, processes the same topic.
2. **`@Notify` resource injection**: `static EmailerService emailerService(@Notify NotificationSender sender)` — provisioned from the `[notification]` section of `resources.toml`. Backend swap (SMTP↔HTTP) requires no code change.

## Status / TODOs

- ✅ Compiles cleanly under the slice processor.
- ✅ `verify-slice` passes; manifest correctly lists the subscription + resource provision.
- ✅ Blueprint package + install succeed.
- 🚧 **TODO (option C from the design memo)**: bring up MailHog (or GreenMail) in `examples/notification-hub` so `./run-forge.sh` exercises publish → subscribe → send → receive end-to-end, with k6 verifying captured-inbox state. Tracked in inline `EmailerService` javadoc and `resources.toml` comment.

## Tests

`mvn -pl examples/notification-hub/notification-emailer install -am` — green. No unit tests added (slice example, no domain logic to assert beyond compile + slice-processor wiring).