### PR TITLE
fix(postgres-async): typed-get gaps for Boolean/UUID/byte[] and TypeToken array

### DIFF
--- a/integrations/db/postgres-async/src/main/java/org/pragmatica/postgres/PgRow.java
+++ b/integrations/db/postgres-async/src/main/java/org/pragmatica/postgres/PgRow.java
@@ -212,7 +212,6 @@ public class PgRow implements Row, KeyToValue {
         return getArray(getColumn(column).index(), arrayType);
     }
 
-    //TODO: does not work for known types, only for custom ones.
     @Override
     public <T> T get(int index, Class<T> type) {
         return dataConverter.toObject(columns[index].type(), data.getValue(index), type);
@@ -231,7 +230,6 @@ public class PgRow implements Row, KeyToValue {
         return get(getColumn(column).index());
     }
 
-    //TODO: arrays are not supported yet
     @SuppressWarnings("unchecked")
     @Override
     public <T> Result<T> get(String prefix, String key, TypeToken<T> typeToken) {
@@ -242,13 +240,17 @@ public class PgRow implements Row, KeyToValue {
             return new SqlError.ColumnNotFound("Unknown column '" + key + "'").result();
         }
 
-        if (typeToken.rawType().equals(Option.class)) {
+        var rawType = typeToken.rawType();
+
+        if (rawType.equals(Option.class)) {
             var value = typeToken.typeArgument(0)
                                  .map(cls -> get(column.index(), cls));
             return Result.success((T) option(value));
-        } else {
-            return Result.success(get(column.index(), (Class<T>) typeToken.rawType()));
         }
+        if (rawType.isArray()) {
+            return Result.success(getArray(column.index(), (Class<T>) rawType));
+        }
+        return Result.success(get(column.index(), (Class<T>) rawType));
     }
 
     private PgColumn getColumn(String name) {

--- a/integrations/db/postgres-async/src/main/java/org/pragmatica/postgres/conversion/DataConverter.java
+++ b/integrations/db/postgres-async/src/main/java/org/pragmatica/postgres/conversion/DataConverter.java
@@ -706,6 +706,11 @@ public class DataConverter {
         KNOWN_TYPES.put(double.class, NumericConversions::toDouble);
         KNOWN_TYPES.put(Double.class, NumericConversions::toDouble);
         KNOWN_TYPES.put(String.class, StringConversions::asString);
+        KNOWN_TYPES.put(boolean.class, BooleanConversions::toBoolean);
+        KNOWN_TYPES.put(Boolean.class, BooleanConversions::toBoolean);
+        KNOWN_TYPES.put(UUID.class, (oid, value) -> UUID.fromString(value));
+        // BYTEA in text format ("\x..."): strip the leading "\x" prefix before parsing hex.
+        KNOWN_TYPES.put(byte[].class, (oid, value) -> BlobConversions.toBytes(oid, value.substring(2)));
         KNOWN_TYPES.put(LocalDate.class, TemporalConversions::toLocalDate);
         KNOWN_TYPES.put(LocalTime.class, TemporalConversions::toLocalTime);
         KNOWN_TYPES.put(LocalDateTime.class, TemporalConversions::toLocalDateTime);

--- a/integrations/db/postgres-async/src/test/java/org/pragmatica/postgres/TypeConverterTest.java
+++ b/integrations/db/postgres-async/src/test/java/org/pragmatica/postgres/TypeConverterTest.java
@@ -238,4 +238,36 @@ public class TypeConverterTest {
         PgRow row = (PgRow) dbr.query("select $1::UUID as uuid", singletonList(uuid)).index(0);
         assertEquals(uuid, row.get("uuid"));
     }
+
+    @Test
+    public void shouldConvertViaTypedGet_Boolean() {
+        var row = dbr.query("select $1::BOOL as b", List.of(true)).index(0);
+        assertEquals(Boolean.TRUE, row.get(0, Boolean.class));
+        assertEquals(Boolean.TRUE, row.get("b", Boolean.class));
+    }
+
+    @Test
+    public void shouldConvertViaTypedGet_UUID() {
+        UUID uuid = UUID.randomUUID();
+        var row = dbr.query("select $1::UUID as id", singletonList(uuid)).index(0);
+        assertEquals(uuid, row.get(0, UUID.class));
+        assertEquals(uuid, row.get("id", UUID.class));
+    }
+
+    @Test
+    public void shouldConvertViaTypedGet_Bytes() {
+        var row = dbr.query("select '\\x4142'::BYTEA as data").index(0);
+        assertArrayEquals(new byte[]{0x41, 0x42}, row.get(0, byte[].class));
+        assertArrayEquals(new byte[]{0x41, 0x42}, row.get("data", byte[].class));
+    }
+
+    @Test
+    public void shouldResolveArrayViaTypeToken() {
+        var row = (PgRow) dbr.query("select '{1, 2, 3}'::INT4[] as nums").index(0);
+        var resolved = row.get("",
+                               "nums",
+                               new org.pragmatica.lang.type.TypeToken<Integer[]>() {});
+        var array = resolved.expect("INT4[] should resolve via TypeToken");
+        assertArrayEquals(new Integer[]{1, 2, 3}, array);
+    }
 }


### PR DESCRIPTION
## Summary

Closes two stale TODOs in `PgRow.java`:
- `:215` — "does not work for known types, only for custom ones"
- `:234` — "arrays are not supported yet"

## Gap 1 — `get(int, Class<T>)` missing common known types

`DataConverter.toObject(oid, value, type)` looks up the target class in `KNOWN_TYPES` before falling through to "Unknown conversion target". The map covered all numeric, string, and temporal types, but was missing **Boolean**, **boolean**, **UUID**, and **byte[]** — even though the OID-based fallback path (`type == null`) already converted those values correctly. Calling `row.get(0, Boolean.class)` threw "Unknown conversion target: java.lang.Boolean".

Fix: 4 entries added to the `KNOWN_TYPES` static block reusing existing `BooleanConversions::toBoolean`, `UUID::fromString`, and `BlobConversions.toBytes` (with the standard `\x` prefix strip).

## Gap 2 — `get(prefix, key, TypeToken<T>)` ignored arrays

The `TypeToken`-based dispatch handled `Option<T>` but fell through to `get(int, Class)` for everything else, which doesn't route arrays. Adding `Integer[]`-shaped TypeTokens silently produced "Unknown conversion target".

Fix: detect `rawType().isArray()` and dispatch to the existing `getArray(idx, arrayType)`.

## Tests

`TypeConverterTest` (testcontainers, postgres:15-alpine, `@Tag("Slow")`) — 40/40 pass:
- `shouldConvertViaTypedGet_Boolean` — `row.get(0, Boolean.class)` round-trip
- `shouldConvertViaTypedGet_UUID` — same for `UUID.class`
- `shouldConvertViaTypedGet_Bytes` — same for `byte[].class` against a `\x4142::BYTEA` literal
- `shouldResolveArrayViaTypeToken` — `INT4[]` resolved through `TypeToken<Integer[]>`

Stale TODO comments removed from both call sites.

## Out of scope (separate work)

- `NettyPgProtocolStream.java:72` — TLS config refactor (M, design discussion needed)
- `ArrayConversions.java:12` — internal `byte[] → PgValue(TEXT|BINARY)` format migration (L, larger refactor)