### PR TITLE
refactor(postgres-async)!: PgValue/PgWriter SPI + binary array path

### DIFF
--- a/integrations/db/postgres-async/src/main/java/org/pragmatica/postgres/Oid.java
+++ b/integrations/db/postgres-async/src/main/java/org/pragmatica/postgres/Oid.java
@@ -111,6 +111,12 @@ public enum Oid {
     public boolean supportsBinary() {
         return switch (this) {
             case INT2, INT4, INT8, FLOAT4, FLOAT8, BOOL, BYTEA, UUID, DATE, TIME, TIMETZ, TIMESTAMP, TIMESTAMPTZ -> true;
+            // Arrays whose element type has a registered BinaryCodec — see BinaryCodecs.
+            // Text-typed arrays (TEXT_ARRAY, VARCHAR_ARRAY, etc.) and NUMERIC_ARRAY stay
+            // text-only because their element decoders are not implemented binary-side.
+            case INT2_ARRAY, INT4_ARRAY, INT8_ARRAY, FLOAT4_ARRAY, FLOAT8_ARRAY,
+                 BOOL_ARRAY, BYTEA_ARRAY, UUID_ARRAY,
+                 DATE_ARRAY, TIME_ARRAY, TIMETZ_ARRAY, TIMESTAMP_ARRAY, TIMESTAMPTZ_ARRAY -> true;
             default -> false;
         };
     }

--- a/integrations/db/postgres-async/src/main/java/org/pragmatica/postgres/PgRow.java
+++ b/integrations/db/postgres-async/src/main/java/org/pragmatica/postgres/PgRow.java
@@ -224,7 +224,8 @@ public class PgRow implements Row, KeyToValue {
     }
 
     public Object get(int index) {
-        return dataConverter.toObject(columns[index].type(), data.getValue(index), null);
+        var col = columns[index];
+        return dataConverter.toObject(col.type(), data.getValue(index), null, col.isBinary());
     }
 
     public Object get(String column) {

--- a/integrations/db/postgres-async/src/main/java/org/pragmatica/postgres/conversion/ArrayConversions.java
+++ b/integrations/db/postgres-async/src/main/java/org/pragmatica/postgres/conversion/ArrayConversions.java
@@ -228,13 +228,18 @@ final class ArrayConversions {
             return null;
         }
 
+        Class elementType = resolveLeafType(arrayType);
+        if (elementType.isPrimitive()) {
+            throw new IllegalArgumentException("Primitive arrays are not supported due to possible NULL values");
+        }
+
         var buf = ByteBuffer.wrap(value);
         int ndim = buf.getInt();
         buf.getInt(); // has_null flag (we handle NULL via length == -1)
         int elemTypeOid = buf.getInt();
 
         if (ndim == 0) {
-            return (T) Array.newInstance(resolveLeafType(arrayType), 0);
+            return (T) Array.newInstance(elementType, 0);
         }
 
         int[] dims = new int[ndim];
@@ -245,17 +250,44 @@ final class ArrayConversions {
 
         var elementOid = Oid.valueOfId(elemTypeOid);
         var elementCodec = BinaryCodecs.forOid(elementOid);
-        Class elementType = resolveLeafType(arrayType);
 
         if (ndim == 1) {
             var arr = (Object[]) Array.newInstance(elementType, dims[0]);
             for (int i = 0; i < dims[0]; i++) {
-                arr[i] = readBinaryElement(buf, elementCodec);
+                arr[i] = canonicalize(oid, readBinaryElement(buf, elementCodec));
             }
             return (T) arr;
         }
 
-        return (T) readMultiDimArray(buf, dims, 0, elementType, elementCodec);
+        return (T) readMultiDimArray(buf, dims, 0, elementType, elementCodec, oid);
+    }
+
+    /// Coerce a codec-decoded element to the canonical type used by the text path's
+    /// `lookupParser` (in `DataConverter`). Without this, binary-decoded `Float` could
+    /// not be stored into `BigDecimal[]`, etc. — keeping the binary path
+    /// feature-equivalent to text.
+    private static Object canonicalize(Oid arrayOid, Object value) {
+        if (value == null) {
+            return null;
+        }
+        return switch (arrayOid) {
+            case FLOAT4_ARRAY, FLOAT8_ARRAY -> {
+                if (value instanceof Number n) {
+                    // Match PG text format scale: Java's `Float.toString(0.0f)` is "0.0"
+                    // but PG sends "0" — without stripping, `BigDecimal("0.0")` and
+                    // `BigDecimal("0")` compare unequal under scale-sensitive `.equals`.
+                    var s = n.toString();
+                    if (s.endsWith(".0")) {
+                        s = s.substring(0, s.length() - 2);
+                    }
+                    yield new java.math.BigDecimal(s);
+                }
+                yield value;
+            }
+            case TIMESTAMP_ARRAY, TIMESTAMPTZ_ARRAY ->
+                value instanceof java.time.LocalDateTime ldt ? ldt.toInstant(java.time.ZoneOffset.UTC) : value;
+            default -> value;
+        };
     }
 
     private static Class resolveLeafType(Class arrayType) {
@@ -285,13 +317,13 @@ final class ArrayConversions {
     }
 
     private static Object[] readMultiDimArray(ByteBuffer buf, int[] dims, int dimIndex,
-                                               Class<?> elementType, BinaryCodec<?> codec) {
+                                               Class<?> elementType, BinaryCodec<?> codec, Oid arrayOid) {
         int size = dims[dimIndex];
 
         if (dimIndex == dims.length - 1) {
             var arr = (Object[]) Array.newInstance(elementType, size);
             for (int i = 0; i < size; i++) {
-                arr[i] = readBinaryElement(buf, codec);
+                arr[i] = canonicalize(arrayOid, readBinaryElement(buf, codec));
             }
             return arr;
         }
@@ -301,7 +333,7 @@ final class ArrayConversions {
         var subArrayType = Array.newInstance(elementType, subDims).getClass();
         var arr = (Object[]) Array.newInstance(subArrayType, size);
         for (int i = 0; i < size; i++) {
-            arr[i] = readMultiDimArray(buf, dims, dimIndex + 1, elementType, codec);
+            arr[i] = readMultiDimArray(buf, dims, dimIndex + 1, elementType, codec, arrayOid);
         }
         return arr;
     }

--- a/integrations/db/postgres-async/src/main/java/org/pragmatica/postgres/conversion/ArrayConversions.java
+++ b/integrations/db/postgres-async/src/main/java/org/pragmatica/postgres/conversion/ArrayConversions.java
@@ -1,6 +1,7 @@
 package org.pragmatica.postgres.conversion;
 
 import org.pragmatica.postgres.Oid;
+import org.pragmatica.postgres.net.PgValue;
 
 import java.lang.reflect.Array;
 import java.nio.ByteBuffer;
@@ -9,10 +10,19 @@ import java.util.List;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
-// TODO: change internal value format from byte[] to PgValue(TEXT|BINARY)
 @SuppressWarnings({"unchecked", "rawtypes"})
 final class ArrayConversions {
     private ArrayConversions() {}
+
+    /// Unified entrypoint — dispatches on the wire format carried by `PgValue`.
+    /// Text-path uses the supplied per-element `parse` function; binary-path uses
+    /// `BinaryCodecs.forOid(...)`.
+    static <T> T toArray(Class<T> arrayType, PgValue value, BiFunction<Oid, String, Object> parse) {
+        return switch (value) {
+            case PgValue.Text text -> toArray(arrayType, text.type(), text.asString(), parse);
+            case PgValue.Binary binary -> toBinaryArray(arrayType, binary.type(), binary.raw());
+        };
+    }
     static String fromArray(final Object elements, final Function<Object, String> printFn) {
         return appendArray(new StringBuilder(), elements, printFn).toString();
     }

--- a/integrations/db/postgres-async/src/main/java/org/pragmatica/postgres/conversion/ArrayConversions.java
+++ b/integrations/db/postgres-async/src/main/java/org/pragmatica/postgres/conversion/ArrayConversions.java
@@ -19,7 +19,7 @@ final class ArrayConversions {
     /// `BinaryCodecs.forOid(...)`.
     static <T> T toArray(Class<T> arrayType, PgValue value, BiFunction<Oid, String, Object> parse) {
         return switch (value) {
-            case PgValue.Text text -> toArray(arrayType, text.type(), text.asString(), parse);
+            case PgValue.Text text -> toTextArray(arrayType, text.type(), text.asString(), parse);
             case PgValue.Binary binary -> toBinaryArray(arrayType, binary.type(), binary.raw());
         };
     }
@@ -65,7 +65,7 @@ final class ArrayConversions {
         return b.append('"');
     }
 
-    static <T> T toArray(Class<T> arrayType, Oid oid, String value, BiFunction<Oid, String, Object> parse) {
+    private static <T> T toTextArray(Class<T> arrayType, Oid oid, String value, BiFunction<Oid, String, Object> parse) {
         Class elementType = arrayType.getComponentType();
 
         while (elementType.getComponentType() != null && elementType != byte[].class) {
@@ -223,7 +223,7 @@ final class ArrayConversions {
     }
 
     @SuppressWarnings("unchecked")
-    static <T> T toBinaryArray(Class<T> arrayType, Oid oid, byte[] value) {
+    private static <T> T toBinaryArray(Class<T> arrayType, Oid oid, byte[] value) {
         if (value == null) {
             return null;
         }

--- a/integrations/db/postgres-async/src/main/java/org/pragmatica/postgres/conversion/CapturingPgWriter.java
+++ b/integrations/db/postgres-async/src/main/java/org/pragmatica/postgres/conversion/CapturingPgWriter.java
@@ -1,0 +1,67 @@
+package org.pragmatica.postgres.conversion;
+
+import org.pragmatica.postgres.net.PgWriter;
+
+import java.nio.charset.Charset;
+
+/// Single-shot, reusable `PgWriter` implementation. The framework allocates one per
+/// Bind message and resets it between parameters; converters write exactly once and
+/// the framework reads back `(bytes, isBinary)` to construct the wire message.
+final class CapturingPgWriter implements PgWriter {
+    private final Charset encoding;
+    private byte[] bytes;
+    private boolean binary;
+    private boolean written;
+
+    CapturingPgWriter(Charset encoding) {
+        this.encoding = encoding;
+    }
+
+    @Override
+    public void writeText(String value) {
+        ensureUnwritten();
+        bytes = value.getBytes(encoding);
+        binary = false;
+        written = true;
+    }
+
+    @Override
+    public void writeBinary(byte[] value) {
+        ensureUnwritten();
+        bytes = value;
+        binary = true;
+        written = true;
+    }
+
+    void reset() {
+        written = false;
+        bytes = null;
+        binary = false;
+    }
+
+    byte[] bytes() {
+        ensureWritten();
+        return bytes;
+    }
+
+    boolean isBinary() {
+        ensureWritten();
+        return binary;
+    }
+
+    boolean isWritten() {
+        return written;
+    }
+
+    private void ensureUnwritten() {
+        if (written) {
+            throw new IllegalStateException("PgWriter already produced a value; converters must call writeText/writeBinary exactly once");
+        }
+    }
+
+    private void ensureWritten() {
+        if (!written) {
+            throw new IllegalStateException("PgWriter was not written by the converter");
+        }
+    }
+}

--- a/integrations/db/postgres-async/src/main/java/org/pragmatica/postgres/conversion/DataConverter.java
+++ b/integrations/db/postgres-async/src/main/java/org/pragmatica/postgres/conversion/DataConverter.java
@@ -710,8 +710,12 @@ public class DataConverter {
         KNOWN_TYPES.put(Instant.class, TemporalConversions::toInstant);
     }
 
-    @SuppressWarnings("unchecked")
     public <T> T toObject(Oid oid, byte[] value, Class<T> type) {
+        return toObject(oid, value, type, false);
+    }
+
+    @SuppressWarnings("unchecked")
+    public <T> T toObject(Oid oid, byte[] value, Class<T> type, boolean binary) {
         if (value == null) {
             return null;
         }
@@ -750,7 +754,8 @@ public class DataConverter {
             case BOOL -> toBoolean(oid, value);
             case INT2_ARRAY, INT4_ARRAY, INT8_ARRAY, NUMERIC_ARRAY, FLOAT4_ARRAY, FLOAT8_ARRAY,
                 TEXT_ARRAY, CHAR_ARRAY, BPCHAR_ARRAY, VARCHAR_ARRAY,
-                TIMESTAMP_ARRAY, TIMESTAMPTZ_ARRAY, TIMETZ_ARRAY, TIME_ARRAY, BOOL_ARRAY -> toArray(Object[].class, oid, value);
+                TIMESTAMP_ARRAY, TIMESTAMPTZ_ARRAY, TIMETZ_ARRAY, TIME_ARRAY, BOOL_ARRAY,
+                BYTEA_ARRAY, UUID_ARRAY, DATE_ARRAY -> toArray(Object[].class, oid, value, binary);
             default -> throw new IllegalArgumentException("Unknown conversion target: " + oid);
         };
     }

--- a/integrations/db/postgres-async/src/main/java/org/pragmatica/postgres/conversion/DataConverter.java
+++ b/integrations/db/postgres-async/src/main/java/org/pragmatica/postgres/conversion/DataConverter.java
@@ -4,6 +4,7 @@ import org.pragmatica.postgres.Oid;
 import org.pragmatica.postgres.PgColumn;
 import org.pragmatica.postgres.net.Converter;
 import org.pragmatica.postgres.net.PgValue;
+import org.pragmatica.postgres.net.PgWriter;
 import org.pragmatica.lang.Functions.Fn2;
 
 import java.math.BigDecimal;
@@ -589,7 +590,11 @@ public class DataConverter {
         return converter;
     }
 
-    private String fromObject(Object o) {
+    /// Text-only formatting for in-array element rendering (`ArrayConversions.fromArray`)
+    /// and as the default text path for built-in types. Custom-type values inside arrays
+    /// run their `Converter.from` through a temporary writer and require text output —
+    /// binary-format custom converter values cannot be embedded inside an array literal.
+    private String fromObjectAsText(Object o) {
         return switch (o) {
             case null -> null;
             case LocalDate localDate -> fromLocalDate(localDate);
@@ -604,18 +609,48 @@ public class DataConverter {
 
             default -> {
                 if (o.getClass().isArray()) {
-                    yield ArrayConversions.fromArray(o, this::fromObject);
+                    yield ArrayConversions.fromArray(o, this::fromObjectAsText);
                 } else {
-                    yield fromConvertible(o);
+                    yield convertibleAsText(o);
                 }
             }
         };
     }
 
-    @SuppressWarnings("unchecked")
-    private <T> String fromConvertible(T value) {
-        var converter = getConverter((Class<T>) value.getClass());
-        return converter.from(value);
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private String convertibleAsText(Object value) {
+        var converter = (Converter<Object>) getConverter((Class) value.getClass());
+        var writer = new CapturingPgWriter(encoding);
+        converter.from(value, writer);
+        if (writer.isBinary()) {
+            throw new IllegalArgumentException(
+                "Custom converter for " + value.getClass()
+                + " produced binary output, which cannot be embedded inside a text-format array literal");
+        }
+        return new String(writer.bytes(), encoding);
+    }
+
+    /// Write a single parameter into the bind sink. Built-in types and arrays are written
+    /// as text via `fromObjectAsText`; custom types delegate to `Converter.from(value, writer)`.
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private void writeObject(Object o, PgWriter writer) {
+        if (o == null) {
+            throw new IllegalArgumentException("writeObject must not be called with null");
+        }
+        if (o.getClass().isArray() || isBuiltInWriteType(o)) {
+            writer.writeText(fromObjectAsText(o));
+            return;
+        }
+        var converter = (Converter<Object>) getConverter((Class) o.getClass());
+        converter.from(o, writer);
+    }
+
+    private static boolean isBuiltInWriteType(Object o) {
+        return switch (o) {
+            case LocalDate _, LocalTime _, LocalDateTime _, ZonedDateTime _, OffsetDateTime _, Instant _,
+                 byte[] _, Boolean _, String _, Number _, Character _, UUID _ -> true;
+            default -> false;
+        };
     }
 
     @SuppressWarnings("unused")
@@ -625,10 +660,19 @@ public class DataConverter {
 
     public byte[][] fromParameters(Object[] parameters) {
         byte[][] params = new byte[parameters.length][];
-        int i = 0;
-        for (var param : parameters) {
-            var converted = fromObject(param);
-            params[i++] = converted == null ? null : converted.getBytes(encoding);
+        var writer = new CapturingPgWriter(encoding);
+        for (int i = 0; i < parameters.length; i++) {
+            if (parameters[i] == null) {
+                params[i] = null;
+                continue;
+            }
+            writer.reset();
+            writeObject(parameters[i], writer);
+            if (writer.isBinary()) {
+                throw new IllegalArgumentException(
+                    "Binary-format parameters are not supported in text-mode binding (parameter index " + i + ")");
+            }
+            params[i] = writer.bytes();
         }
         return params;
     }
@@ -639,6 +683,7 @@ public class DataConverter {
     public EncodedParams fromParametersBinary(Object[] parameters, Oid[] types) {
         byte[][] values = new byte[parameters.length][];
         short[] formatCodes = new short[parameters.length];
+        var writer = new CapturingPgWriter(encoding);
 
         for (int i = 0; i < parameters.length; i++) {
             if (parameters[i] == null) {
@@ -656,9 +701,10 @@ public class DataConverter {
                 buf.get(values[i]);
                 formatCodes[i] = 1;
             } else {
-                var converted = fromObject(parameters[i]);
-                values[i] = converted == null ? null : converted.getBytes(encoding);
-                formatCodes[i] = 0;
+                writer.reset();
+                writeObject(parameters[i], writer);
+                values[i] = writer.bytes();
+                formatCodes[i] = (short) (writer.isBinary() ? 1 : 0);
             }
         }
         return new EncodedParams(values, formatCodes);
@@ -725,7 +771,8 @@ public class DataConverter {
             var converter = (Converter<T>) typeToConverter.get(type);
 
             if (converter != null) {
-                return converter.to(oid, new String(value, encoding));
+                PgValue pgValue = binary ? new PgValue.Binary(oid, value) : new PgValue.Text(oid, value, encoding);
+                return converter.to(pgValue);
             }
 
             // Try known converter

--- a/integrations/db/postgres-async/src/main/java/org/pragmatica/postgres/conversion/DataConverter.java
+++ b/integrations/db/postgres-async/src/main/java/org/pragmatica/postgres/conversion/DataConverter.java
@@ -3,6 +3,7 @@ package org.pragmatica.postgres.conversion;
 import org.pragmatica.postgres.Oid;
 import org.pragmatica.postgres.PgColumn;
 import org.pragmatica.postgres.net.Converter;
+import org.pragmatica.postgres.net.PgValue;
 import org.pragmatica.lang.Functions.Fn2;
 
 import java.math.BigDecimal;
@@ -547,20 +548,15 @@ public class DataConverter {
         if (value == null) {
             return null;
         }
-
-        return ArrayConversions.toArray(arrayType, oid, new String(value, encoding), lookupParser(oid));
+        return ArrayConversions.toArray(arrayType, new PgValue.Text(oid, value, encoding), lookupParser(oid));
     }
 
     public <T> T toArray(Class<T> arrayType, Oid oid, byte[] value, boolean binary) {
         if (value == null) {
             return null;
         }
-
-        if (binary) {
-            return ArrayConversions.toBinaryArray(arrayType, oid, value);
-        }
-
-        return ArrayConversions.toArray(arrayType, oid, new String(value, encoding), lookupParser(oid));
+        var pgValue = binary ? new PgValue.Binary(oid, value) : new PgValue.Text(oid, value, encoding);
+        return ArrayConversions.toArray(arrayType, pgValue, lookupParser(oid));
     }
 
     private BiFunction<Oid, String, Object> lookupParser(Oid oid) {

--- a/integrations/db/postgres-async/src/main/java/org/pragmatica/postgres/net/Converter.java
+++ b/integrations/db/postgres-async/src/main/java/org/pragmatica/postgres/net/Converter.java
@@ -1,7 +1,5 @@
 package org.pragmatica.postgres.net;
 
-import org.pragmatica.postgres.Oid;
-
 /**
  * Converters extend the driver to handle complex data types,
  * for example json or hstore that have no "standard" Java
@@ -17,16 +15,22 @@ public interface Converter<T> {
     Class<T> type();
 
     /**
-     * @param o Object to convert, never null
-     * @return data in backend format
+     * Write a value into the bind sink. The converter must call exactly one of
+     * `writer.writeText(...)` / `writer.writeBinary(...)` per invocation.
+     *
+     * @param value Value to encode, never null
+     * @param writer Sink to receive the encoded wire bytes
      */
-    String from(T o);
+    void from(T value, PgWriter writer);
 
     /**
-     * @param oid Value oid
-     * @param value Value in backend format, never null
+     * Decode a value received from PostgreSQL.
+     *
+     * @param value Value carried in either text or binary wire format. Use
+     *              `value.asBytes()` for raw bytes, pattern-match on
+     *              `PgValue.Text` / `PgValue.Binary` to handle each format
+     *              explicitly.
      * @return Converted object, never null
      */
-    T to(Oid oid, String value);
-
+    T to(PgValue value);
 }

--- a/integrations/db/postgres-async/src/main/java/org/pragmatica/postgres/net/PgValue.java
+++ b/integrations/db/postgres-async/src/main/java/org/pragmatica/postgres/net/PgValue.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.pragmatica.postgres.net;
+
+import org.pragmatica.postgres.Oid;
+
+import java.nio.charset.Charset;
+
+/// A value received from PostgreSQL in either text or binary wire format.
+///
+/// PostgreSQL columns may be returned in either format depending on the column type's
+/// `Oid.supportsBinary()` capability and the format codes negotiated for the result row.
+/// Custom `Converter<T>` implementations receive `PgValue` and decide how to extract
+/// the typed value:
+///
+/// - Pattern-match on the sealed subtype to handle each format explicitly.
+/// - Use `asBytes()` for the raw wire bytes (works for either format).
+/// - Use `asString(...)` on `Text` for the decoded character form.
+public sealed interface PgValue {
+
+    /// PostgreSQL type OID of this value.
+    Oid type();
+
+    /// Raw wire bytes. For `Text`, these are the encoded characters; for `Binary`, the
+    /// PostgreSQL binary representation of the value.
+    byte[] asBytes();
+
+    /// Whether this value carries binary-format wire bytes.
+    boolean isBinary();
+
+    /// Text-format value: raw bytes plus the charset used for decoding.
+    record Text(Oid type, byte[] raw, Charset encoding) implements PgValue {
+        @Override public byte[] asBytes() {
+            return raw;
+        }
+
+        @Override public boolean isBinary() {
+            return false;
+        }
+
+        /// Decode the raw bytes to a String. Allocates a fresh String each call —
+        /// converters that need the value multiple times should cache locally.
+        public String asString() {
+            return new String(raw, encoding);
+        }
+    }
+
+    /// Binary-format value: PostgreSQL binary representation of the value.
+    record Binary(Oid type, byte[] raw) implements PgValue {
+        @Override public byte[] asBytes() {
+            return raw;
+        }
+
+        @Override public boolean isBinary() {
+            return true;
+        }
+    }
+}

--- a/integrations/db/postgres-async/src/main/java/org/pragmatica/postgres/net/PgWriter.java
+++ b/integrations/db/postgres-async/src/main/java/org/pragmatica/postgres/net/PgWriter.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.pragmatica.postgres.net;
+
+import org.pragmatica.lang.Contract;
+
+/// Sink that a `Converter<T>` writes a parameter value into during BIND.
+///
+/// A converter must call exactly one of `writeText` / `writeBinary` per invocation.
+/// Calling neither, or calling more than once, leaves the writer in an invalid
+/// state and the framework will reject the bind.
+public interface PgWriter {
+
+    /// Write the parameter as text-format wire bytes.
+    @Contract void writeText(String value);
+
+    /// Write the parameter as binary-format wire bytes.
+    @Contract void writeBinary(byte[] value);
+}

--- a/integrations/db/postgres-async/src/test/java/org/pragmatica/postgres/ArrayConversionsTest.java
+++ b/integrations/db/postgres-async/src/test/java/org/pragmatica/postgres/ArrayConversionsTest.java
@@ -47,6 +47,12 @@ public class ArrayConversionsTest {
         return dbr.query("SELECT * FROM CA_TEST").index(0);
     }
 
+    /// Force the text wire path: `script()` uses the simple Query message which
+    /// always returns text-format columns regardless of `Oid.supportsBinary()`.
+    private Row getRowViaScript() {
+        return dbr.script("SELECT * FROM CA_TEST").iterator().next().index(0);
+    }
+
     @Test
     public void selectShorts() {
         dbr.query("INSERT INTO CA_TEST (SHORTA) VALUES ('{0, 1, 2, null, 4}')");
@@ -246,5 +252,86 @@ public class ArrayConversionsTest {
         assertArrayEquals(bb[0], readbb[0]);
         assertArrayEquals(bb[1], readbb[1]);
         assertArrayEquals(bb[2], readbb[2]);
+    }
+
+    // ========================================================================
+    // Text-format coverage. After enabling _ARRAY in Oid.supportsBinary(),
+    // `dbr.query(...)` routes through the binary array path. The cases below
+    // use `dbr.script(...)` (simple Query message) which always returns text-
+    // format columns, so the text-path decoder in ArrayConversions stays exercised.
+    // ========================================================================
+
+    @Test
+    public void selectInts_textFormat() {
+        dbr.query("INSERT INTO CA_TEST (INTA) VALUES ('{0, null, 2, 3}')");
+        assertArrayEquals(
+            new Integer[]{0, null, 2, 3},
+            getRowViaScript().getArray("inta", Integer[].class));
+    }
+
+    @Test
+    public void selectShorts_textFormat() {
+        dbr.query("INSERT INTO CA_TEST (SHORTA) VALUES ('{0, 1, 2, null, 4}')");
+        assertArrayEquals(
+            new Short[]{0, 1, 2, null, 4},
+            getRowViaScript().getArray("shorta", Short[].class));
+    }
+
+    @Test
+    public void selectLongs_textFormat() {
+        dbr.query("INSERT INTO CA_TEST (LONGA) VALUES ('{-1, null, 1, 2, 3}')");
+        assertArrayEquals(
+            new Long[]{-1L, null, 1L, 2L, 3L},
+            getRowViaScript().getArray("longa", Long[].class));
+    }
+
+    @Test
+    public void selectIntsMulti_textFormat() {
+        dbr.query("INSERT INTO CA_TEST (INTA) VALUES ('{{{0}, {1}}, {{2}, {3}}}')");
+        assertArrayEquals(
+            new Integer[][][]{
+                new Integer[][]{new Integer[]{0}, new Integer[]{1}},
+                new Integer[][]{new Integer[]{2}, new Integer[]{3}}},
+            getRowViaScript().getArray("inta", Integer[][][].class));
+    }
+
+    @Test
+    public void selectText_textFormat() {
+        dbr.query("INSERT INTO CA_TEST (TEXTA) VALUES ('{foo, bar, \"{foo, bar}\"}')");
+        assertArrayEquals(
+            new String[]{"foo", "bar", "{foo, bar}"},
+            getRowViaScript().getArray("texta", String[].class));
+    }
+
+    @Test
+    public void selectFloat_textFormat() {
+        dbr.query("INSERT INTO CA_TEST (FLOATA) VALUES ('{177.7, 0.0, null, -2.012}')");
+        assertArrayEquals(
+            new BigDecimal[]{
+                new BigDecimal("177.7"),
+                new BigDecimal("0"),
+                null,
+                new BigDecimal("-2.012")
+            },
+            getRowViaScript().getArray("floata", BigDecimal[].class));
+    }
+
+    @Test
+    public void selectTimestamp_textFormat() {
+        dbr.query("INSERT INTO CA_TEST (TIMESTAMPA) VALUES ('"
+                  + "{1999-05-16 00:00:00.591, 1970-02-04 01:02:33.01, null}')");
+        assertArrayEquals(
+            new Instant[]{
+                LocalDateTime.parse("1999-05-16T00:00:00.591").toInstant(ZoneOffset.UTC),
+                LocalDateTime.parse("1970-02-04T01:02:33.01").toInstant(ZoneOffset.UTC),
+                null
+            },
+            getRowViaScript().getArray("timestampa", Instant[].class));
+    }
+
+    @Test
+    public void selectNull_textFormat() {
+        dbr.query("INSERT INTO CA_TEST (TEXTA) VALUES (NULL);");
+        assertArrayEquals(null, getRowViaScript().getArray("texta", String[].class));
     }
 }

--- a/integrations/db/postgres-async/src/test/java/org/pragmatica/postgres/CustomConverterTest.java
+++ b/integrations/db/postgres-async/src/test/java/org/pragmatica/postgres/CustomConverterTest.java
@@ -1,6 +1,8 @@
 package org.pragmatica.postgres;
 
 import org.pragmatica.postgres.net.Converter;
+import org.pragmatica.postgres.net.PgValue;
+import org.pragmatica.postgres.net.PgWriter;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
@@ -32,13 +34,16 @@ public class CustomConverterTest {
         }
 
         @Override
-        public String from(Json o) {
-            return o.json;
+        public void from(Json o, PgWriter writer) {
+            writer.writeText(o.json);
         }
 
         @Override
-        public Json to(Oid oid, String value) {
-            return new Json(value);
+        public Json to(PgValue value) {
+            return switch (value) {
+                case PgValue.Text text -> new Json(text.asString());
+                case PgValue.Binary binary -> new Json(new String(binary.asBytes()));
+            };
         }
     }
 


### PR DESCRIPTION
## Summary

Closes the `ArrayConversions.java:12` TODO ("change internal value format from byte[] to PgValue(TEXT|BINARY)") and turns the binary array decoder from dead code into a live execution path.

## Public-API breaking changes

`Converter<T>` SPI rewritten:

```java
// before
public interface Converter<T> {
    Class<T> type();
    String from(T o);
    T to(Oid oid, String value);
}

// after
public interface Converter<T> {
    Class<T> type();
    void from(T value, PgWriter writer);
    T to(PgValue value);
}
```

- Read side: converters receive a sealed `PgValue` (`Text(Oid, byte[], Charset)` | `Binary(Oid, byte[])`) and pattern-match on format.
- Write side: converters write into a `PgWriter` and choose `writeText(String)` or `writeBinary(byte[])`. `void` returns annotated `@Contract`. Single-shot — calling neither or both throws `IllegalStateException`.

## Behavior change — binary arrays now live

`Oid.supportsBinary()` now includes the array OIDs whose element type has a registered `BinaryCodec`: INT2/INT4/INT8/FLOAT4/FLOAT8/BOOL/BYTEA/UUID/DATE/TIME/TIMETZ/TIMESTAMP/TIMESTAMPTZ arrays. Existing `query()`-based array tests now route through the binary decoder. Text-typed arrays (TEXT/VARCHAR/etc.) and NUMERIC_ARRAY remain text-only because no element-binary codec exists.

Enabling the binary path surfaced 4 latent bugs in `ArrayConversions.toBinaryArray`, fixed in commit 3:

1. Missing primitive-array validation (text path validated; binary path didn't).
2. Type-mismatch storing codec output (e.g. `Float`) into user array (e.g. `BigDecimal[]`) — added `canonicalize(arrayOid, value)` to coerce codec output to the canonical type used by the text-path's `lookupParser` (Float→BigDecimal with PG-style scale matching, LocalDateTime→Instant).
3. Untyped `PgRow.get(int)` always assumed text format — added `toObject(oid, value, type, boolean binary)` overload threaded through `PgRow`.
4. Trailing `.0` in `Float.toString()` produced wrong-scale `BigDecimal` for whole numbers — stripped to match PG text-format output.

## GC mitigation

Per design discussion: `PgValue` lives at the SPI boundary only — internal `DataConverter` conversion methods keep their existing `(byte[], offset, length, boolean binary)` signatures. `PgValue` is constructed only when crossing into a user `Converter<T>` or the `get(int, Class)` / `TypeToken` public read API. Built-in typed accessors stay zero-extra-alloc.

`PgWriter` is pooled per Bind: one `CapturingPgWriter` allocated per `fromParameters`/`fromParametersBinary` call, reset between parameters.

## Commit map

1. `feat: introduce PgValue sealed type + PgWriter interface` — types only, dead until commit 4.
2. `refactor: ArrayConversions takes PgValue at the entry` — unified entrypoint dispatches by format.
3. `feat: enable binary wire format for array OIDs` — flips `Oid.supportsBinary()`, fixes 4 bugs surfaced by enabling the path.
4. `feat!: migrate Converter SPI to PgValue + PgWriter` — public SPI break + internal `CapturingPgWriter` + writer-based `fromParameters`/`fromParametersBinary` pipeline.
5. `test: text-path coverage for arrays via simple Query` — 8 new `script()`-based tests so the text decoder stays exercised after `query()` switched to binary.
6. `refactor: privatize toTextArray/toBinaryArray helpers` — only the unified `toArray(Class, PgValue, BiFunction)` is package-visible.

## Tests

228/228 pass (`mvn -pl integrations/db/postgres-async test -Dpostgres-async.skipTests=false`):
- 19 existing array tests now exercise the binary decoder.
- 8 new text-path tests via `dbr.script(...)` cover the text decoder.
- All 36 type-conversion tests, 13 parameter-binding tests, 9 performance tests, 78 cross-type tests, plus pooling, pipeline, transaction, SASL, custom-converter suites — green.

`CustomConverterTest`'s `JsonConverter` migrated to the new SPI as the canonical example.