### PR TITLE
feat(postgres-async)!: SslConfig with libpq-mode taxonomy + SCRAM-SHA-256-PLUS

### DIFF
--- a/integrations/db/postgres-async/src/main/java/org/pragmatica/postgres/PgProtocolStream.java
+++ b/integrations/db/postgres-async/src/main/java/org/pragmatica/postgres/PgProtocolStream.java
@@ -20,8 +20,10 @@ import org.pragmatica.postgres.message.Message;
 import org.pragmatica.postgres.message.backend.*;
 import org.pragmatica.postgres.message.frontend.*;
 import org.pragmatica.postgres.net.NotificationHandler;
+import org.pragmatica.postgres.net.SslConfig;
 import org.pragmatica.lang.Cause;
 import org.pragmatica.lang.Functions.Fn1;
+import org.pragmatica.lang.Option;
 import org.pragmatica.lang.Promise;
 import org.pragmatica.lang.Unit;
 import org.slf4j.Logger;
@@ -91,19 +93,54 @@ public abstract class PgProtocolStream implements ProtocolStream {
 
     @Override
     public Promise<Message> authenticate(String userName, String password, Authentication authRequired) {
-        if (authRequired.saslScramSha256()) {
-            var clientNonce = UUID.randomUUID().toString();
-            var saslInitialResponse = new SASLInitialResponse(Authentication.SUPPORTED_SASL,
-                                                              null, ""/*SaslPrep.asQueryString(userName) - Postgres requires an empty string here*/,
-                                                              clientNonce);
-            return send(saslInitialResponse)
-                .flatMap(message -> handleSaslResponse(message, password, clientNonce, saslInitialResponse));
-        } else {
-            return send(PasswordMessage.passwordMessage(userName, password, authRequired.md5salt(), encoding));
+        if (authRequired.saslScramSha256() || authRequired.saslScramSha256Plus()) {
+            return startSasl(password, authRequired);
         }
+        return send(PasswordMessage.passwordMessage(userName, password, authRequired.md5salt(), encoding));
     }
 
-    private Promise<Message> handleSaslResponse(Message message, String password, String clientNonce, SASLInitialResponse saslInitialResponse) {
+    private Promise<Message> startSasl(String password, Authentication authRequired) {
+        var policy = channelBindingPolicy();
+        var cbindData = tlsServerEndPointDigest();
+        var canUsePlus = authRequired.saslScramSha256Plus() && cbindData.isPresent();
+
+        if (policy == SslConfig.ChannelBinding.REQUIRE && !canUsePlus) {
+            return Promise.failure(new SqlError.BadAuthenticationSequence(
+                "channel_binding=require but " + (cbindData.isEmpty()
+                    ? "TLS is not active"
+                    : "server does not advertise SCRAM-SHA-256-PLUS")));
+        }
+
+        var usePlus = switch (policy) {
+            case DISABLE -> false;
+            case PREFER -> canUsePlus;
+            case REQUIRE -> true;
+        };
+
+        if (!usePlus && !authRequired.saslScramSha256()) {
+            return Promise.failure(new SqlError.BadAuthenticationSequence(
+                "Server advertises only SCRAM-SHA-256-PLUS but channel binding is unavailable"));
+        }
+
+        var mechanism = usePlus ? Authentication.SUPPORTED_SASL_PLUS : Authentication.SUPPORTED_SASL;
+        var cbindType = usePlus ? "tls-server-end-point" : null;
+        var clientNonce = UUID.randomUUID().toString();
+        var saslInitialResponse = new SASLInitialResponse(
+            mechanism,
+            cbindType,
+            cbindData.isPresent(),
+            "" /* SaslPrep.asQueryString(userName) — Postgres requires an empty string here */,
+            clientNonce);
+        var cbindBytes = usePlus ? cbindData.or((byte[]) null) : null;
+        return send(saslInitialResponse)
+            .flatMap(message -> handleSaslResponse(message, password, clientNonce, saslInitialResponse, cbindBytes));
+    }
+
+    private Promise<Message> handleSaslResponse(Message message,
+                                                 String password,
+                                                 String clientNonce,
+                                                 SASLInitialResponse saslInitialResponse,
+                                                 byte[] channelBindingData) {
         if (message instanceof Authentication authentication) {
             var serverFirstMessage = authentication.saslContinueData();
             if (serverFirstMessage != null) {
@@ -111,13 +148,27 @@ public abstract class PgProtocolStream implements ProtocolStream {
                                             serverFirstMessage,
                                             clientNonce,
                                             saslInitialResponse.gs2Header(),
-                                            saslInitialResponse.clientFirstMessageBare()));
+                                            saslInitialResponse.clientFirstMessageBare(),
+                                            channelBindingData));
             } else {
                 return Promise.failure(new SqlError.BadAuthenticationSequence("Bad SASL authentication sequence message detected on 'server-first-message' step"));
             }
         } else {
             return Promise.failure(new SqlError.BadAuthenticationSequence("Bad SASL authentication sequence detected on 'server-first-message' step"));
         }
+    }
+
+    /// Channel-binding policy from the SslConfig. Default `DISABLE` for streams that
+    /// don't override (e.g. plain-protocol tests). NettyPgProtocolStream forwards the
+    /// configured policy.
+    protected SslConfig.ChannelBinding channelBindingPolicy() {
+        return SslConfig.ChannelBinding.DISABLE;
+    }
+
+    /// Server certificate digest for `tls-server-end-point` channel binding (RFC 5929 §4.1).
+    /// Returns `Some` only when TLS is active. Default `none()` for non-TLS streams.
+    protected Option<byte[]> tlsServerEndPointDigest() {
+        return Option.none();
     }
 
     protected abstract void write(Message... messages);

--- a/integrations/db/postgres-async/src/main/java/org/pragmatica/postgres/io/backend/AuthenticationDecoder.java
+++ b/integrations/db/postgres-async/src/main/java/org/pragmatica/postgres/io/backend/AuthenticationDecoder.java
@@ -72,7 +72,7 @@ public class AuthenticationDecoder implements Decoder<Authentication> {
             case PASSWORD_MD5_CHALLENGE -> {
                 byte[] md5Salt = new byte[4];
                 buffer.get(md5Salt);
-                yield  new Authentication(false, false, md5Salt, null, null);
+                yield  new Authentication(false, false, false, md5Salt, null, null);
             }
             case AUTHENTICATION_SSPI -> throw new UnsupportedOperationException(AUTHENTICATION_IS_NOT_SUPPORTED);
             case AUTHENTICATION_GSS -> throw new UnsupportedOperationException("AuthenticationGss" + AUTHENTICATION_IS_NOT_SUPPORTED);
@@ -83,15 +83,18 @@ public class AuthenticationDecoder implements Decoder<Authentication> {
             case OK -> Authentication.OK;
             case SASL -> {
                 boolean scramSha256Met = false;
+                boolean scramSha256PlusMet = false;
                 String sasl = IO.getCString(buffer, encoding);
                 while (!sasl.isEmpty()) {
                     if (Authentication.SUPPORTED_SASL.equals(sasl)) {
                         scramSha256Met = true;
+                    } else if (Authentication.SUPPORTED_SASL_PLUS.equals(sasl)) {
+                        scramSha256PlusMet = true;
                     }
                     sasl = IO.getCString(buffer, encoding);
                 }
-                if (scramSha256Met) {
-                    yield  Authentication.SCRAM_SHA_256;
+                if (scramSha256Met || scramSha256PlusMet) {
+                    yield new Authentication(false, scramSha256Met, scramSha256PlusMet, null, null, null);
                 } else {
                     throw new UnsupportedOperationException("The server doesn't support " + Authentication.SUPPORTED_SASL + " SASL mechanism");
                 }
@@ -99,12 +102,12 @@ public class AuthenticationDecoder implements Decoder<Authentication> {
             case SASL_CONTINUE -> {
                 byte[] saslContinueData = new byte[contentLength - 4]; // Minus type field size
                 buffer.get(saslContinueData);
-                yield new Authentication(false, false, null, new String(saslContinueData, encoding), null);
+                yield new Authentication(false, false, false, null, new String(saslContinueData, encoding), null);
             }
             case SASL_FINAL -> {
                 byte[] saslAdditionalData = new byte[contentLength - 4]; // Minus type field size
                 buffer.get(saslAdditionalData);
-                yield new Authentication(false, false, null, null, saslAdditionalData);
+                yield new Authentication(false, false, false, null, null, saslAdditionalData);
             }
             default -> throw new UnsupportedOperationException("Unsupported authentication type: " + type);
         };

--- a/integrations/db/postgres-async/src/main/java/org/pragmatica/postgres/message/backend/Authentication.java
+++ b/integrations/db/postgres-async/src/main/java/org/pragmatica/postgres/message/backend/Authentication.java
@@ -21,12 +21,19 @@ import static org.pragmatica.postgres.util.HexConverter.printHexBinary;
 /**
  * @author Antti Laisi, Marat Gainullin
  */
-public record Authentication(boolean authenticationOk, boolean saslScramSha256, byte[] md5salt,
-                             String saslContinueData, byte[] saslAdditionalData) implements BackendMessage {
-    public static final Authentication OK = new Authentication(true, false, null, null, null);
-    public static final Authentication CLEAR_TEXT = new Authentication(false, false, null, null, null);
-    public static final Authentication SCRAM_SHA_256 = new Authentication(false, true, null, null, null);
+public record Authentication(boolean authenticationOk,
+                              boolean saslScramSha256,
+                              boolean saslScramSha256Plus,
+                              byte[] md5salt,
+                              String saslContinueData,
+                              byte[] saslAdditionalData) implements BackendMessage {
+    public static final Authentication OK = new Authentication(true, false, false, null, null, null);
+    public static final Authentication CLEAR_TEXT = new Authentication(false, false, false, null, null, null);
+    public static final Authentication SCRAM_SHA_256 = new Authentication(false, true, false, null, null, null);
+    public static final Authentication SCRAM_SHA_256_PLUS = new Authentication(false, false, true, null, null, null);
+    public static final Authentication SCRAM_SHA_256_BOTH = new Authentication(false, true, true, null, null, null);
     public static final String SUPPORTED_SASL = "SCRAM-SHA-256";
+    public static final String SUPPORTED_SASL_PLUS = "SCRAM-SHA-256-PLUS";
 
     public boolean saslServerFinalResponse() {
         return saslAdditionalData != null;
@@ -34,10 +41,11 @@ public record Authentication(boolean authenticationOk, boolean saslScramSha256, 
 
     @Override
     public String toString() {
-        return String.format("Authentication(success=%s, md5salt=%s, scramSha256=%s, saslContinueData=%s, saslAdditionalData=%s)",
+        return String.format("Authentication(success=%s, md5salt=%s, scramSha256=%s, scramSha256Plus=%s, saslContinueData=%s, saslAdditionalData=%s)",
                              authenticationOk,
                              md5salt != null ? printHexBinary(md5salt) : "",
                              saslScramSha256,
+                             saslScramSha256Plus,
                              saslContinueData != null ? saslContinueData : "",
                              saslAdditionalData != null ? printHexBinary(saslAdditionalData) : ""
         );

--- a/integrations/db/postgres-async/src/main/java/org/pragmatica/postgres/message/frontend/SASLInitialResponse.java
+++ b/integrations/db/postgres-async/src/main/java/org/pragmatica/postgres/message/frontend/SASLInitialResponse.java
@@ -3,10 +3,15 @@ package org.pragmatica.postgres.message.frontend;
 import org.pragmatica.postgres.message.FrontendMessage;
 import org.pragmatica.postgres.sasl.SaslPrep;
 
-/**
- * it is a bit weired to have a username both here and in a {@link StartupMessage}.
- * But according to the SCRAM specification in RFC5802 we have to have it :(
- */
+/// SASL InitialResponse — sends GS2 header + client-first-message-bare to the server.
+///
+/// GS2 header (RFC 5802 §6) varies by channel-binding state:
+/// - `n,,` — client doesn't support channel binding
+/// - `y,,` — client supports channel binding but isn't using it (server didn't advertise PLUS)
+/// - `p=<cb-name>,,` — client uses channel binding of the named type (e.g. `tls-server-end-point`)
+///
+/// The server uses this header to detect downgrade attacks: if it advertised PLUS and we
+/// reply with `n` or `y`, it rejects the authentication.
 public final class SASLInitialResponse implements FrontendMessage {
 
     private final String saslMechanism;
@@ -17,14 +22,28 @@ public final class SASLInitialResponse implements FrontendMessage {
     private final String clientFirstMessage;
     private final String clientFirstMessageBare;
 
-    public SASLInitialResponse(String saslMechanism, String channelBindingType, String userName, String clientNonce) {
+    /// @param saslMechanism `SCRAM-SHA-256` or `SCRAM-SHA-256-PLUS`
+    /// @param channelBindingType `null` for `n`/`y` headers; otherwise the cb-name (e.g. `tls-server-end-point`)
+    /// @param clientSupportsCbind `true` if client supports channel binding; affects `n` vs `y` choice
+    /// @param userName user name (Postgres requires empty string here per protocol; see PgProtocolStream)
+    /// @param clientNonce client-generated nonce
+    public SASLInitialResponse(String saslMechanism, String channelBindingType, boolean clientSupportsCbind,
+                                String userName, String clientNonce) {
         this.saslMechanism = saslMechanism;
         this.channelBindingType = channelBindingType;
         this.userName = userName;
         this.nonce = clientNonce;
 
-        String channelBinding = channelBindingType != null && !channelBindingType.isBlank() ? "p=" + channelBindingType + "," : "n,";
-        gs2Header = channelBinding + ","; // It could be '"a=" + msg.getUsername() + ",";' but it is not needed unless we are using impersonate techniques.
+        String gs2Flag;
+        if (channelBindingType != null && !channelBindingType.isBlank()) {
+            gs2Flag = "p=" + channelBindingType;
+        } else if (clientSupportsCbind) {
+            // Client could've used channel binding but server didn't advertise PLUS.
+            gs2Flag = "y";
+        } else {
+            gs2Flag = "n";
+        }
+        gs2Header = gs2Flag + ",,";
 
         clientFirstMessageBare = "n=" + SaslPrep.asQueryString(userName) + ",r=" + clientNonce;
         clientFirstMessage = gs2Header + clientFirstMessageBare;

--- a/integrations/db/postgres-async/src/main/java/org/pragmatica/postgres/message/frontend/SASLResponse.java
+++ b/integrations/db/postgres-async/src/main/java/org/pragmatica/postgres/message/frontend/SASLResponse.java
@@ -23,6 +23,7 @@ public final class SASLResponse implements FrontendMessage {
     private final String serverSalt;
     private final int i;
     private final String serverNonce;
+    private final byte[] channelBindingData;
 
     private SASLResponse(String password,
                          String serverSalt,
@@ -30,7 +31,8 @@ public final class SASLResponse implements FrontendMessage {
                          String serverNonce,
                          String gs2Header,
                          String clientFirstMessageBare,
-                         String serverFirstMessage) {
+                         String serverFirstMessage,
+                         byte[] channelBindingData) {
         this.password = password;
         this.serverSalt = serverSalt;
         this.i = i;
@@ -38,6 +40,7 @@ public final class SASLResponse implements FrontendMessage {
         this.gs2Header = gs2Header;
         this.clientFirstMessageBare = clientFirstMessageBare;
         this.serverFirstMessage = serverFirstMessage;
+        this.channelBindingData = channelBindingData;
     }
 
     public String password() {
@@ -69,7 +72,19 @@ public final class SASLResponse implements FrontendMessage {
     }
 
     public String clientFinalMessage(String hMacName, String digestName) {
-        var encoded = new String(Base64.getEncoder().withoutPadding().encode(gs2Header.getBytes(StandardCharsets.US_ASCII)),
+        // c-bind-input = gs2-header || cbind-data (RFC 5802 §5.1).
+        // For non-PLUS mechanisms, cbind-data is empty; for PLUS with tls-server-end-point,
+        // cbind-data is the server certificate digest.
+        var gs2Bytes = gs2Header.getBytes(StandardCharsets.US_ASCII);
+        byte[] cbindInput;
+        if (channelBindingData != null && channelBindingData.length > 0) {
+            cbindInput = new byte[gs2Bytes.length + channelBindingData.length];
+            System.arraycopy(gs2Bytes, 0, cbindInput, 0, gs2Bytes.length);
+            System.arraycopy(channelBindingData, 0, cbindInput, gs2Bytes.length, channelBindingData.length);
+        } else {
+            cbindInput = gs2Bytes;
+        }
+        var encoded = new String(Base64.getEncoder().withoutPadding().encode(cbindInput),
                                  StandardCharsets.UTF_8);
         var clientFinalMessageWithoutProof = "c=" + encoded + ",r=" + serverNonce;
         var clientProof = saslClientProof(password,
@@ -185,7 +200,8 @@ public final class SASLResponse implements FrontendMessage {
         }
     }
 
-    public static SASLResponse of(String password, String serverFirstMessage, String clientNonce, String gs2Header, String clientFirstMessageBare) {
+    public static SASLResponse of(String password, String serverFirstMessage, String clientNonce, String gs2Header,
+                                   String clientFirstMessageBare, byte[] channelBindingData) {
         var continueData = Authentication.SaslContinueServerFirstMessage.parse(serverFirstMessage);
         var serverNonce = continueData.augmentedNonce();
 
@@ -198,7 +214,8 @@ public final class SASLResponse implements FrontendMessage {
                                     serverNonce,
                                     gs2Header,
                                     clientFirstMessageBare,
-                                    serverFirstMessage);
+                                    serverFirstMessage,
+                                    channelBindingData);
         } else {
             throw new IllegalStateException("Bad server nonce detected on 'server-first-message' step");
         }

--- a/integrations/db/postgres-async/src/main/java/org/pragmatica/postgres/net/ConnectibleBuilder.java
+++ b/integrations/db/postgres-async/src/main/java/org/pragmatica/postgres/net/ConnectibleBuilder.java
@@ -86,8 +86,16 @@ public abstract class ConnectibleBuilder {
         return this;
     }
 
+    public ConnectibleBuilder ssl(SslConfig sslConfig) {
+        properties.sslConfig = sslConfig;
+        return this;
+    }
+
+    /// Convenience: `ssl(true)` → `SslConfig.require()` (encrypts but no validation,
+    /// matching the legacy `useSsl=true` semantics). `ssl(false)` → `SslConfig.disabled()`.
+    /// For production use the explicit `ssl(SslConfig.verifyFull(rootCert))`.
     public ConnectibleBuilder ssl(boolean ssl) {
-        properties.useSsl = ssl;
+        properties.sslConfig = ssl ? SslConfig.require() : SslConfig.disabled();
         return this;
     }
 
@@ -124,7 +132,7 @@ public abstract class ConnectibleBuilder {
         private int maxStatements = 20;
         private DataConverter dataConverter;
         private final List<Converter<?>> converters = new ArrayList<>();
-        private boolean useSsl;
+        private SslConfig sslConfig = SslConfig.disabled();
         private String encoding = System.getProperty("pg.async.encoding", "utf-8");
         private String validationQuery;
         private int ioThreads = Math.max(Runtime.getRuntime().availableProcessors(), 8);
@@ -158,8 +166,8 @@ public abstract class ConnectibleBuilder {
             return maxStatements;
         }
 
-        public boolean useSsl() {
-            return useSsl;
+        public SslConfig sslConfig() {
+            return sslConfig;
         }
 
         public String encoding() {

--- a/integrations/db/postgres-async/src/main/java/org/pragmatica/postgres/net/ConnectibleBuilder.java
+++ b/integrations/db/postgres-async/src/main/java/org/pragmatica/postgres/net/ConnectibleBuilder.java
@@ -91,14 +91,6 @@ public abstract class ConnectibleBuilder {
         return this;
     }
 
-    /// Convenience: `ssl(true)` → `SslConfig.require()` (encrypts but no validation,
-    /// matching the legacy `useSsl=true` semantics). `ssl(false)` → `SslConfig.disabled()`.
-    /// For production use the explicit `ssl(SslConfig.verifyFull(rootCert))`.
-    public ConnectibleBuilder ssl(boolean ssl) {
-        properties.sslConfig = ssl ? SslConfig.require() : SslConfig.disabled();
-        return this;
-    }
-
     public ConnectibleBuilder validationQuery(String validationQuery) {
         properties.validationQuery = validationQuery;
         return this;

--- a/integrations/db/postgres-async/src/main/java/org/pragmatica/postgres/net/SslConfig.java
+++ b/integrations/db/postgres-async/src/main/java/org/pragmatica/postgres/net/SslConfig.java
@@ -1,0 +1,142 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.pragmatica.postgres.net;
+
+import io.netty.handler.ssl.SslContextBuilder;
+import org.pragmatica.lang.Option;
+
+import java.nio.file.Path;
+import java.util.function.Consumer;
+
+import static org.pragmatica.lang.Option.none;
+import static org.pragmatica.lang.Option.some;
+
+/// Transport-layer security configuration for a Postgres connection.
+///
+/// The mode taxonomy mirrors libpq's `sslmode` parameter exactly so PostgreSQL
+/// users see familiar semantics:
+///
+/// | Mode | Encrypts | CA validates | Hostname validates |
+/// |------|----------|--------------|--------------------|
+/// | DISABLE     | -- | -- | -- |
+/// | ALLOW       | maybe | -- | -- |
+/// | PREFER      | maybe | -- | -- |
+/// | REQUIRE     | yes   | -- | -- |
+/// | VERIFY_CA   | yes   | yes | -- |
+/// | VERIFY_FULL | yes   | yes | yes |
+///
+/// `VERIFY_FULL` is the recommended setting for production. `PREFER` is libpq's
+/// default but offers no MITM protection.
+public record SslConfig(SslMode mode,
+                        Option<Path> rootCertPem,
+                        Option<ClientCertificate> clientCertificate,
+                        ChannelBinding channelBinding,
+                        Option<Consumer<SslContextBuilder>> sslContextCustomizer,
+                        boolean allowAllCertificates) {
+
+    public SslConfig {
+        if ((mode == SslMode.VERIFY_CA || mode == SslMode.VERIFY_FULL)
+            && rootCertPem.isEmpty()
+            && sslContextCustomizer.isEmpty()) {
+            throw new IllegalArgumentException(
+                mode + " requires either a root certificate (rootCertPem) or a custom SslContext (sslContextCustomizer)");
+        }
+        if (allowAllCertificates && mode != SslMode.REQUIRE) {
+            throw new IllegalArgumentException(
+                "allowAllCertificates() is only valid in REQUIRE mode (got " + mode + "). "
+                + "Use VERIFY_CA / VERIFY_FULL for properly validated TLS.");
+        }
+    }
+
+    /// No TLS attempted. Plain TCP.
+    public static SslConfig disabled() {
+        return new SslConfig(SslMode.DISABLE, none(), none(), ChannelBinding.DISABLE, none(), false);
+    }
+
+    /// Plain TCP first; if the server requires TLS, retry with TLS. Defers to the server.
+    public static SslConfig allow() {
+        return new SslConfig(SslMode.ALLOW, none(), none(), ChannelBinding.PREFER, none(), false);
+    }
+
+    /// TLS first; fall back to plain TCP if the server doesn't support TLS. libpq default.
+    public static SslConfig prefer() {
+        return new SslConfig(SslMode.PREFER, none(), none(), ChannelBinding.PREFER, none(), false);
+    }
+
+    /// TLS mandatory. Encrypts but does NOT validate the certificate chain or hostname.
+    /// Vulnerable to MITM with any rogue server certificate.
+    public static SslConfig require() {
+        return new SslConfig(SslMode.REQUIRE, none(), none(), ChannelBinding.PREFER, none(), false);
+    }
+
+    /// TLS mandatory + CA chain validated against the supplied root certificate.
+    /// Hostname is NOT validated — vulnerable to MITM by any host with a cert from
+    /// the same CA. Use `verifyFull` unless you specifically need cross-host certs.
+    public static SslConfig verifyCa(Path rootCertPem) {
+        return new SslConfig(SslMode.VERIFY_CA, some(rootCertPem), none(), ChannelBinding.PREFER, none(), false);
+    }
+
+    /// TLS mandatory + CA chain validated + hostname matches certificate. Recommended
+    /// for production.
+    public static SslConfig verifyFull(Path rootCertPem) {
+        return new SslConfig(SslMode.VERIFY_FULL, some(rootCertPem), none(), ChannelBinding.PREFER, none(), false);
+    }
+
+    /// Add an mTLS client certificate. The key file is a PEM-encoded PKCS#8 key;
+    /// pass `Option.none()` for an unencrypted key.
+    public SslConfig withClientCertificate(Path cert, Path key, Option<String> password) {
+        return new SslConfig(mode, rootCertPem, some(new ClientCertificate(cert, key, password)),
+                              channelBinding, sslContextCustomizer, allowAllCertificates);
+    }
+
+    /// Override the channel-binding policy. Default is `PREFER` (use channel binding
+    /// when both server and TLS support it). `REQUIRE` rejects connections where
+    /// channel binding cannot be established (no TLS, or server doesn't advertise
+    /// SCRAM-SHA-256-PLUS).
+    public SslConfig withChannelBinding(ChannelBinding channelBinding) {
+        return new SslConfig(mode, rootCertPem, clientCertificate, channelBinding, sslContextCustomizer, allowAllCertificates);
+    }
+
+    /// Escape hatch for full Netty `SslContextBuilder` access — apply provider, cipher
+    /// suites, custom trust managers, etc. Runs after the framework's defaults so it
+    /// can override anything.
+    public SslConfig withSslContextCustomizer(Consumer<SslContextBuilder> customizer) {
+        return new SslConfig(mode, rootCertPem, clientCertificate, channelBinding, some(customizer), allowAllCertificates);
+    }
+
+    /// **DANGEROUS.** Disable certificate validation entirely. Only valid in `REQUIRE`
+    /// mode. Logs a warning per connection. Intended for diagnostic / development use
+    /// only — never enable in production.
+    public SslConfig withAllowAllCertificates() {
+        return new SslConfig(mode, rootCertPem, clientCertificate, channelBinding, sslContextCustomizer, true);
+    }
+
+    public enum SslMode {
+        DISABLE,
+        ALLOW,
+        PREFER,
+        REQUIRE,
+        VERIFY_CA,
+        VERIFY_FULL
+    }
+
+    public enum ChannelBinding {
+        DISABLE,
+        PREFER,
+        REQUIRE
+    }
+
+    public record ClientCertificate(Path cert, Path key, Option<String> password) {}
+}

--- a/integrations/db/postgres-async/src/main/java/org/pragmatica/postgres/net/netty/NettyConnectibleBuilder.java
+++ b/integrations/db/postgres-async/src/main/java/org/pragmatica/postgres/net/netty/NettyConnectibleBuilder.java
@@ -64,7 +64,7 @@ public class NettyConnectibleBuilder extends ConnectibleBuilder {
             var address = InetAddress.getByName(properties.hostname());
             var sockAddr = new InetSocketAddress(address, properties.port());
             return Promise.success(
-                new NettyPgProtocolStream(sockAddr, properties.useSsl(),
+                new NettyPgProtocolStream(sockAddr, properties.hostname(), properties.sslConfig(),
                     Charset.forName(properties.encoding()), resolveEventLoopGroup()));
         } catch (Exception e) {
             return Promise.failure(SqlError.fromThrowable(e));

--- a/integrations/db/postgres-async/src/main/java/org/pragmatica/postgres/net/netty/NettyPgProtocolStream.java
+++ b/integrations/db/postgres-async/src/main/java/org/pragmatica/postgres/net/netty/NettyPgProtocolStream.java
@@ -21,6 +21,7 @@ import org.pragmatica.postgres.message.backend.SslHandshake;
 import org.pragmatica.postgres.message.frontend.SSLRequest;
 import org.pragmatica.postgres.message.frontend.StartupMessage;
 import org.pragmatica.postgres.message.frontend.Terminate;
+import org.pragmatica.postgres.net.SslConfig;
 import io.netty.bootstrap.Bootstrap;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.*;
@@ -29,6 +30,7 @@ import io.netty.handler.codec.ByteToMessageDecoder;
 import io.netty.handler.codec.LengthFieldBasedFrameDecoder;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
+import io.netty.handler.ssl.SslHandler;
 import io.netty.handler.ssl.SslHandshakeCompletionEvent;
 import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
 import io.netty.util.concurrent.Future;
@@ -38,7 +40,9 @@ import org.pragmatica.lang.Unit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.net.ssl.SSLParameters;
 import java.io.IOException;
+import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.nio.charset.Charset;
 import java.util.List;
@@ -52,9 +56,10 @@ import static org.pragmatica.lang.Unit.unit;
  */
 public class NettyPgProtocolStream extends PgProtocolStream {
     private static final Logger log = LoggerFactory.getLogger(NettyPgProtocolStream.class);
-    private static final String INSECURE_TLS_PROPERTY = "pragmatica.pg.insecure-tls";
 
+    protected final SslConfig sslConfig;
     protected final boolean useSsl;
+    private final String hostname;
     private final SocketAddress address;
     private final Bootstrap channelPipeline;
     private StartupMessage startupWith;
@@ -66,10 +71,19 @@ public class NettyPgProtocolStream extends PgProtocolStream {
         }
     };
 
-    public NettyPgProtocolStream(SocketAddress address, boolean useSsl, Charset encoding, EventLoopGroup eventLoopGroup) {
+    public NettyPgProtocolStream(SocketAddress address, String hostname, SslConfig sslConfig,
+                                  Charset encoding, EventLoopGroup eventLoopGroup) {
         super(encoding);
         this.address = address;
-        this.useSsl = useSsl; // TODO: refactor into SSLConfig with trust parameters
+        this.hostname = hostname;
+        this.sslConfig = sslConfig;
+        this.useSsl = sslConfig.mode() != SslConfig.SslMode.DISABLE;
+        if (sslConfig.mode() == SslConfig.SslMode.ALLOW || sslConfig.mode() == SslConfig.SslMode.PREFER) {
+            // PREFER/ALLOW require protocol-level fallback negotiation. Until that lands,
+            // these modes behave like REQUIRE (TLS mandatory). Tracked as follow-up.
+            log.warn("SslMode.{} requested but fallback negotiation is not yet implemented; behaving like REQUIRE",
+                     sslConfig.mode());
+        }
         this.channelPipeline = new Bootstrap()
             .group(eventLoopGroup)
             .channel(NioSocketChannel.class)
@@ -158,9 +172,18 @@ public class NettyPgProtocolStream extends PgProtocolStream {
                 if (in.readableBytes() >= 1) {
                     if ('S' == in.readByte()) { // SSL supported response
                         ctx.pipeline().remove(this);
-                        ctx.pipeline().addFirst(
-                            buildSslContext()
-                                .newHandler(ctx.alloc()));
+                        var port = address instanceof InetSocketAddress isa ? isa.getPort() : -1;
+                        var sslHandler = buildSslContext()
+                            .newHandler(ctx.alloc(), hostname, port);
+                        if (sslConfig.mode() == SslConfig.SslMode.VERIFY_FULL) {
+                            // Enable JDK hostname verification — without this, Netty's default
+                            // SslHandler does not verify the hostname even when given hostname/port.
+                            var sslEngine = sslHandler.engine();
+                            var params = sslEngine.getSSLParameters();
+                            params.setEndpointIdentificationAlgorithm("HTTPS");
+                            sslEngine.setSSLParameters(params);
+                        }
+                        ctx.pipeline().addFirst(sslHandler);
                     } else {
                         ctx.fireExceptionCaught(new IllegalStateException("SSL required but not supported by Postgres"));
                     }
@@ -169,13 +192,25 @@ public class NettyPgProtocolStream extends PgProtocolStream {
         };
     }
 
-    private static SslContext buildSslContext() throws Exception {
+    private SslContext buildSslContext() throws Exception {
         var builder = SslContextBuilder.forClient();
 
-        if ("true".equalsIgnoreCase(System.getProperty(INSECURE_TLS_PROPERTY))) {
-            log.warn("*** INSECURE TLS: PostgreSQL client trusts ALL certificates (pragmatica.pg.insecure-tls=true) ***");
+        if (sslConfig.allowAllCertificates()) {
+            log.warn("*** INSECURE TLS: PostgreSQL client trusts ALL certificates (allowAllCertificates=true) ***");
             builder.trustManager(InsecureTrustManagerFactory.INSTANCE);
+        } else {
+            sslConfig.rootCertPem().onPresent(path -> builder.trustManager(path.toFile()));
         }
+
+        sslConfig.clientCertificate().onPresent(cc -> {
+            if (cc.password().isPresent()) {
+                builder.keyManager(cc.cert().toFile(), cc.key().toFile(), cc.password().or((String) null));
+            } else {
+                builder.keyManager(cc.cert().toFile(), cc.key().toFile());
+            }
+        });
+
+        sslConfig.sslContextCustomizer().onPresent(c -> c.accept(builder));
 
         return builder.build();
     }

--- a/integrations/db/postgres-async/src/main/java/org/pragmatica/postgres/net/netty/NettyPgProtocolStream.java
+++ b/integrations/db/postgres-async/src/main/java/org/pragmatica/postgres/net/netty/NettyPgProtocolStream.java
@@ -22,6 +22,8 @@ import org.pragmatica.postgres.message.frontend.SSLRequest;
 import org.pragmatica.postgres.message.frontend.StartupMessage;
 import org.pragmatica.postgres.message.frontend.Terminate;
 import org.pragmatica.postgres.net.SslConfig;
+import org.pragmatica.postgres.sasl.ChannelBindingDigest;
+import org.pragmatica.lang.Option;
 import io.netty.bootstrap.Bootstrap;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.*;
@@ -45,6 +47,7 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.nio.charset.Charset;
+import java.security.cert.X509Certificate;
 import java.util.List;
 
 import static org.pragmatica.lang.Unit.unit;
@@ -195,6 +198,32 @@ public class NettyPgProtocolStream extends PgProtocolStream {
     private boolean allowPlainFallback() {
         return sslConfig.mode() == SslConfig.SslMode.PREFER
                || sslConfig.mode() == SslConfig.SslMode.ALLOW;
+    }
+
+    @Override
+    protected SslConfig.ChannelBinding channelBindingPolicy() {
+        return sslConfig.channelBinding();
+    }
+
+    @Override
+    protected Option<byte[]> tlsServerEndPointDigest() {
+        if (ctx == null) {
+            return Option.none();
+        }
+        var sslHandler = ctx.pipeline().get(SslHandler.class);
+        if (sslHandler == null) {
+            return Option.none();
+        }
+        try {
+            var peerCerts = sslHandler.engine().getSession().getPeerCertificates();
+            if (peerCerts.length == 0 || !(peerCerts[0] instanceof X509Certificate x509)) {
+                return Option.none();
+            }
+            return Option.some(ChannelBindingDigest.tlsServerEndPoint(x509));
+        } catch (javax.net.ssl.SSLPeerUnverifiedException e) {
+            log.debug("Cannot extract server certificate for channel binding: {}", e.getMessage());
+            return Option.none();
+        }
     }
 
     private void installSslHandler(ChannelHandlerContext ctx) throws Exception {

--- a/integrations/db/postgres-async/src/main/java/org/pragmatica/postgres/net/netty/NettyPgProtocolStream.java
+++ b/integrations/db/postgres-async/src/main/java/org/pragmatica/postgres/net/netty/NettyPgProtocolStream.java
@@ -78,11 +78,13 @@ public class NettyPgProtocolStream extends PgProtocolStream {
         this.hostname = hostname;
         this.sslConfig = sslConfig;
         this.useSsl = sslConfig.mode() != SslConfig.SslMode.DISABLE;
-        if (sslConfig.mode() == SslConfig.SslMode.ALLOW || sslConfig.mode() == SslConfig.SslMode.PREFER) {
-            // PREFER/ALLOW require protocol-level fallback negotiation. Until that lands,
-            // these modes behave like REQUIRE (TLS mandatory). Tracked as follow-up.
-            log.warn("SslMode.{} requested but fallback negotiation is not yet implemented; behaving like REQUIRE",
-                     sslConfig.mode());
+        if (sslConfig.mode() == SslConfig.SslMode.ALLOW) {
+            // libpq's ALLOW is "plain first, retry with TLS on failure" — a connection-level
+            // retry. Pragmatic interpretation here: treat as PREFER (TLS first, fall back to
+            // plain). Both produce a working connection against either server config; the
+            // strict ALLOW semantics matter only if a network observer can be reasoned about.
+            log.warn("SslMode.ALLOW currently behaves as PREFER (TLS first, plain fallback); "
+                      + "true ALLOW (plain first, TLS retry) is tracked as follow-up");
         }
         this.channelPipeline = new Bootstrap()
             .group(eventLoopGroup)
@@ -170,26 +172,43 @@ public class NettyPgProtocolStream extends PgProtocolStream {
             @Override
             protected void decode(ChannelHandlerContext ctx, ByteBuf in, List<Object> out) throws Exception {
                 if (in.readableBytes() >= 1) {
-                    if ('S' == in.readByte()) { // SSL supported response
-                        ctx.pipeline().remove(this);
-                        var port = address instanceof InetSocketAddress isa ? isa.getPort() : -1;
-                        var sslHandler = buildSslContext()
-                            .newHandler(ctx.alloc(), hostname, port);
-                        if (sslConfig.mode() == SslConfig.SslMode.VERIFY_FULL) {
-                            // Enable JDK hostname verification — without this, Netty's default
-                            // SslHandler does not verify the hostname even when given hostname/port.
-                            var sslEngine = sslHandler.engine();
-                            var params = sslEngine.getSSLParameters();
-                            params.setEndpointIdentificationAlgorithm("HTTPS");
-                            sslEngine.setSSLParameters(params);
-                        }
-                        ctx.pipeline().addFirst(sslHandler);
+                    var response = in.readByte();
+                    ctx.pipeline().remove(this);
+                    if ('S' == response) {
+                        installSslHandler(ctx);
+                    } else if (allowPlainFallback()) {
+                        // PREFER/ALLOW: server doesn't support TLS — fall back to plain text.
+                        // Reuse the SslHandshake sentinel to signal "negotiation done, proceed
+                        // to send StartupMessage" via connectSslOrDirect.
+                        log.warn("Postgres server does not support TLS; falling back to plain text per SslMode.{}",
+                                  sslConfig.mode());
+                        gotMessage(SslHandshake.INSTANCE);
                     } else {
-                        ctx.fireExceptionCaught(new IllegalStateException("SSL required but not supported by Postgres"));
+                        ctx.fireExceptionCaught(new IllegalStateException(
+                            "SSL required (SslMode." + sslConfig.mode() + ") but not supported by Postgres server"));
                     }
                 }
             }
         };
+    }
+
+    private boolean allowPlainFallback() {
+        return sslConfig.mode() == SslConfig.SslMode.PREFER
+               || sslConfig.mode() == SslConfig.SslMode.ALLOW;
+    }
+
+    private void installSslHandler(ChannelHandlerContext ctx) throws Exception {
+        var port = address instanceof InetSocketAddress isa ? isa.getPort() : -1;
+        var sslHandler = buildSslContext().newHandler(ctx.alloc(), hostname, port);
+        if (sslConfig.mode() == SslConfig.SslMode.VERIFY_FULL) {
+            // Enable JDK hostname verification — without this, Netty's default
+            // SslHandler does not verify the hostname even when given hostname/port.
+            var sslEngine = sslHandler.engine();
+            var params = sslEngine.getSSLParameters();
+            params.setEndpointIdentificationAlgorithm("HTTPS");
+            sslEngine.setSSLParameters(params);
+        }
+        ctx.pipeline().addFirst(sslHandler);
     }
 
     private SslContext buildSslContext() throws Exception {

--- a/integrations/db/postgres-async/src/main/java/org/pragmatica/postgres/sasl/ChannelBindingDigest.java
+++ b/integrations/db/postgres-async/src/main/java/org/pragmatica/postgres/sasl/ChannelBindingDigest.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.pragmatica.postgres.sasl;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.CertificateEncodingException;
+import java.security.cert.X509Certificate;
+
+/// RFC 5929 §4.1 `tls-server-end-point` channel binding: digest of the server
+/// certificate using a hash derived from the cert's `signatureAlgorithm`.
+///
+/// Mapping (per RFC 5929):
+/// - MD5  → SHA-256
+/// - SHA-1 → SHA-256
+/// - other → use the same hash as the cert's signature algorithm
+public final class ChannelBindingDigest {
+    private ChannelBindingDigest() {}
+
+    public static byte[] tlsServerEndPoint(X509Certificate serverCert) {
+        try {
+            var digestAlgorithm = mapToDigestAlgorithm(serverCert.getSigAlgName());
+            var digest = MessageDigest.getInstance(digestAlgorithm);
+            return digest.digest(serverCert.getEncoded());
+        } catch (NoSuchAlgorithmException | CertificateEncodingException e) {
+            throw new IllegalStateException("Failed to compute tls-server-end-point channel binding", e);
+        }
+    }
+
+    /// Extract the digest portion of a JCA signature algorithm name (e.g. `SHA256withRSA` → `SHA-256`)
+    /// and apply the RFC 5929 weak-hash upgrade rule.
+    static String mapToDigestAlgorithm(String sigAlgName) {
+        if (sigAlgName == null) {
+            return "SHA-256";
+        }
+        var upper = sigAlgName.toUpperCase();
+        // JCA names look like "SHA256withRSA", "SHA384withECDSA", "MD5withRSA", etc.
+        // Some forms use hyphens: "SHA-256/withRSA". Normalize.
+        var withIndex = upper.indexOf("WITH");
+        var hashPart = withIndex > 0 ? upper.substring(0, withIndex) : upper;
+        hashPart = hashPart.replace("-", "").trim();
+        return switch (hashPart) {
+            case "MD5", "SHA1", "SHA" -> "SHA-256";
+            case "SHA224", "SHA256" -> "SHA-256";
+            case "SHA384" -> "SHA-384";
+            case "SHA512" -> "SHA-512";
+            default -> "SHA-256";
+        };
+    }
+}

--- a/integrations/db/postgres-async/src/test/java/org/pragmatica/postgres/DatabaseExtension.java
+++ b/integrations/db/postgres-async/src/test/java/org/pragmatica/postgres/DatabaseExtension.java
@@ -33,7 +33,7 @@ public class DatabaseExtension implements BeforeAllCallback, AfterAllCallback, B
     private boolean registeredAsStatic;
 
     private static ConnectibleBuilder defaultBuilder() {
-        return new NettyConnectibleBuilder().ssl(false).encoding("utf-8");
+        return new NettyConnectibleBuilder().ssl(SslConfig.disabled()).encoding("utf-8");
     }
 
     private DatabaseExtension(final ConnectibleBuilder builder) {

--- a/integrations/db/postgres-async/src/test/java/org/pragmatica/postgres/SslModeIntegrationTest.java
+++ b/integrations/db/postgres-async/src/test/java/org/pragmatica/postgres/SslModeIntegrationTest.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.pragmatica.postgres;
+
+import org.pragmatica.postgres.net.SqlException;
+import org.pragmatica.postgres.net.SslConfig;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.nio.file.Path;
+
+import static org.pragmatica.postgres.DatabaseExtension.block;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/// Integration tests for SslConfig modes against a stock testcontainers Postgres
+/// (which does not have SSL enabled). These cover:
+/// - DISABLE works (no TLS attempted)
+/// - PREFER falls back to plain when server doesn't support TLS
+/// - REQUIRE fails fast when server doesn't support TLS
+/// - VERIFY_CA / VERIFY_FULL: factory accepts root cert path; runtime fails if no SSL.
+///
+/// Tests requiring SSL-enabled PG (channel binding round-trip, hostname verification
+/// against a real server cert) are tracked as follow-up — they require either a custom
+/// container with generated certs or a libpq sidecar, which is out of scope here.
+@Tag("Slow")
+public class SslModeIntegrationTest {
+
+    @RegisterExtension
+    static final DatabaseExtension dbr = DatabaseExtension.defaultConfiguration();
+
+    @Test
+    public void disabledModeConnects() {
+        var pool = dbr.builder.ssl(SslConfig.disabled()).pool();
+        try {
+            var rs = block(pool.completeQuery("SELECT 1"));
+            assertEquals(1L, (long) rs.index(0).getInt(0));
+        } finally {
+            block(pool.close());
+        }
+    }
+
+    @Test
+    public void preferModeFallsBackToPlain() {
+        // Stock testcontainers PG doesn't have SSL enabled → server replies 'N' to SSLRequest.
+        // PREFER should silently fall back to plain text and connect successfully.
+        var pool = dbr.builder.ssl(SslConfig.prefer()).pool();
+        try {
+            var rs = block(pool.completeQuery("SELECT 1"));
+            assertEquals(1L, (long) rs.index(0).getInt(0));
+        } finally {
+            block(pool.close());
+        }
+    }
+
+    @Test
+    public void requireModeFailsWhenServerDoesNotSupportSsl() {
+        var pool = dbr.builder.ssl(SslConfig.require()).pool();
+        try {
+            assertThrows(SqlException.class, () -> block(pool.completeQuery("SELECT 1")));
+        } finally {
+            block(pool.close());
+        }
+    }
+
+    @Test
+    public void verifyFullFactoryAcceptsRootCert() {
+        // Factory only validates that a root cert path is provided. Actual TLS handshake
+        // would fail against this PG without SSL — which is the expected REQUIRE-class behavior.
+        var pool = dbr.builder.ssl(SslConfig.verifyFull(Path.of("/nonexistent/root.pem"))).pool();
+        try {
+            assertThrows(SqlException.class, () -> block(pool.completeQuery("SELECT 1")));
+        } finally {
+            block(pool.close());
+        }
+    }
+}

--- a/integrations/db/postgres-async/src/test/java/org/pragmatica/postgres/net/SslConfigTest.java
+++ b/integrations/db/postgres-async/src/test/java/org/pragmatica/postgres/net/SslConfigTest.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.pragmatica.postgres.net;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class SslConfigTest {
+
+    @Test
+    public void disabledFactoryProducesDisableMode() {
+        var config = SslConfig.disabled();
+        assertEquals(SslConfig.SslMode.DISABLE, config.mode());
+        assertEquals(SslConfig.ChannelBinding.DISABLE, config.channelBinding());
+        assertTrue(config.rootCertPem().isEmpty());
+        assertTrue(config.clientCertificate().isEmpty());
+        assertFalse(config.allowAllCertificates());
+    }
+
+    @Test
+    public void preferFactoryProducesPreferMode() {
+        var config = SslConfig.prefer();
+        assertEquals(SslConfig.SslMode.PREFER, config.mode());
+        assertEquals(SslConfig.ChannelBinding.PREFER, config.channelBinding());
+    }
+
+    @Test
+    public void requireFactoryProducesRequireMode() {
+        assertEquals(SslConfig.SslMode.REQUIRE, SslConfig.require().mode());
+    }
+
+    @Test
+    public void verifyCaRequiresRootCert() {
+        var rootCert = Path.of("/tmp/root.pem");
+        var config = SslConfig.verifyCa(rootCert);
+        assertEquals(SslConfig.SslMode.VERIFY_CA, config.mode());
+        assertEquals(rootCert, config.rootCertPem().or(() -> { throw new AssertionError(); }));
+    }
+
+    @Test
+    public void verifyFullRequiresRootCert() {
+        var rootCert = Path.of("/tmp/root.pem");
+        var config = SslConfig.verifyFull(rootCert);
+        assertEquals(SslConfig.SslMode.VERIFY_FULL, config.mode());
+        assertEquals(rootCert, config.rootCertPem().or(() -> { throw new AssertionError(); }));
+    }
+
+    @Test
+    public void verifyCaWithoutRootCertAndCustomizerThrows() {
+        assertThrows(IllegalArgumentException.class, () -> new SslConfig(
+            SslConfig.SslMode.VERIFY_CA,
+            org.pragmatica.lang.Option.none(),
+            org.pragmatica.lang.Option.none(),
+            SslConfig.ChannelBinding.PREFER,
+            org.pragmatica.lang.Option.none(),
+            false));
+    }
+
+    @Test
+    public void allowAllCertificatesValidOnlyInRequireMode() {
+        // OK in REQUIRE
+        var ok = SslConfig.require().withAllowAllCertificates();
+        assertTrue(ok.allowAllCertificates());
+
+        // Rejected in VERIFY_CA
+        assertThrows(IllegalArgumentException.class,
+                     () -> SslConfig.verifyCa(Path.of("/tmp/root.pem")).withAllowAllCertificates());
+
+        // Rejected in VERIFY_FULL
+        assertThrows(IllegalArgumentException.class,
+                     () -> SslConfig.verifyFull(Path.of("/tmp/root.pem")).withAllowAllCertificates());
+    }
+
+    @Test
+    public void withChannelBindingOverridesDefault() {
+        var config = SslConfig.require().withChannelBinding(SslConfig.ChannelBinding.REQUIRE);
+        assertEquals(SslConfig.ChannelBinding.REQUIRE, config.channelBinding());
+    }
+
+    @Test
+    public void withClientCertificateAddsMtlsCredentials() {
+        var cert = Path.of("/tmp/client.crt");
+        var key = Path.of("/tmp/client.key");
+        var config = SslConfig.verifyFull(Path.of("/tmp/root.pem"))
+                              .withClientCertificate(cert, key, org.pragmatica.lang.Option.some("secret"));
+        var mtls = config.clientCertificate().or(() -> { throw new AssertionError(); });
+        assertEquals(cert, mtls.cert());
+        assertEquals(key, mtls.key());
+        assertEquals("secret", mtls.password().or(() -> { throw new AssertionError(); }));
+    }
+}

--- a/integrations/db/postgres-async/src/test/java/org/pragmatica/postgres/sasl/ChannelBindingDigestTest.java
+++ b/integrations/db/postgres-async/src/test/java/org/pragmatica/postgres/sasl/ChannelBindingDigestTest.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.pragmatica.postgres.sasl;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ChannelBindingDigestTest {
+
+    @Test
+    public void rfc5929UpgradesMd5ToSha256() {
+        assertEquals("SHA-256", ChannelBindingDigest.mapToDigestAlgorithm("MD5withRSA"));
+    }
+
+    @Test
+    public void rfc5929UpgradesSha1ToSha256() {
+        assertEquals("SHA-256", ChannelBindingDigest.mapToDigestAlgorithm("SHA1withRSA"));
+        assertEquals("SHA-256", ChannelBindingDigest.mapToDigestAlgorithm("SHAwithRSA"));
+    }
+
+    @Test
+    public void sha256RemainsSha256() {
+        assertEquals("SHA-256", ChannelBindingDigest.mapToDigestAlgorithm("SHA256withRSA"));
+        assertEquals("SHA-256", ChannelBindingDigest.mapToDigestAlgorithm("SHA-256withRSA"));
+        assertEquals("SHA-256", ChannelBindingDigest.mapToDigestAlgorithm("SHA256withECDSA"));
+    }
+
+    @Test
+    public void sha384MapsToSha384() {
+        assertEquals("SHA-384", ChannelBindingDigest.mapToDigestAlgorithm("SHA384withRSA"));
+        assertEquals("SHA-384", ChannelBindingDigest.mapToDigestAlgorithm("SHA384withECDSA"));
+    }
+
+    @Test
+    public void sha512MapsToSha512() {
+        assertEquals("SHA-512", ChannelBindingDigest.mapToDigestAlgorithm("SHA512withRSA"));
+    }
+
+    @Test
+    public void unknownAlgorithmDefaultsToSha256() {
+        assertEquals("SHA-256", ChannelBindingDigest.mapToDigestAlgorithm("BLAKE3withRSA"));
+        assertEquals("SHA-256", ChannelBindingDigest.mapToDigestAlgorithm(null));
+        assertEquals("SHA-256", ChannelBindingDigest.mapToDigestAlgorithm(""));
+    }
+
+    @Test
+    public void sha224UpgradesToSha256() {
+        // RFC 5929 calls out only MD5/SHA-1; SHA-224 is rare and our fallback maps to SHA-256.
+        assertEquals("SHA-256", ChannelBindingDigest.mapToDigestAlgorithm("SHA224withRSA"));
+    }
+}

--- a/integrations/db/postgres-async/src/test/java/org/pragmatica/postgres/sasl/SaslStepsTest.java
+++ b/integrations/db/postgres-async/src/test/java/org/pragmatica/postgres/sasl/SaslStepsTest.java
@@ -18,22 +18,37 @@ public class SaslStepsTest {
     private static final String SERVER_FIRST_MESSAGE = "r=" + CLIENT_NONCE + SERVER_NONCE + ",s=" + SERVER_SALT + ",i=" + I;
 
     @Test
-    public void clientFirstMessage() {
-        SASLInitialResponse saslInitialResponse = new SASLInitialResponse(Authentication.SUPPORTED_SASL, null, USER_NAME, CLIENT_NONCE);
+    public void clientFirstMessage_noChannelBinding() {
+        SASLInitialResponse saslInitialResponse = new SASLInitialResponse(Authentication.SUPPORTED_SASL, null, false, USER_NAME, CLIENT_NONCE);
         assertEquals("n,,", saslInitialResponse.gs2Header());
         assertEquals("n,,n=" + USER_NAME + ",r=" + CLIENT_NONCE, saslInitialResponse.clientFirstMessage());
-        // Here should be "n,,n=<USER_NAME>,r=" + CLIENT_NONCE, but Postgres expects an empty user name because of the startup message
+    }
+
+    @Test
+    public void clientFirstMessage_clientSupportsCbindButServerDoesNot() {
+        SASLInitialResponse saslInitialResponse = new SASLInitialResponse(Authentication.SUPPORTED_SASL, null, true, USER_NAME, CLIENT_NONCE);
+        assertEquals("y,,", saslInitialResponse.gs2Header());
+        assertEquals("y,,n=" + USER_NAME + ",r=" + CLIENT_NONCE, saslInitialResponse.clientFirstMessage());
+    }
+
+    @Test
+    public void clientFirstMessage_withChannelBinding() {
+        SASLInitialResponse saslInitialResponse = new SASLInitialResponse(Authentication.SUPPORTED_SASL_PLUS, "tls-server-end-point", true, USER_NAME, CLIENT_NONCE);
+        assertEquals("p=tls-server-end-point,,", saslInitialResponse.gs2Header());
+        assertEquals("p=tls-server-end-point,,n=" + USER_NAME + ",r=" + CLIENT_NONCE, saslInitialResponse.clientFirstMessage());
     }
 
     @Test
     public void clientFinalMessage() {
-        SASLInitialResponse saslInitialResponse = new SASLInitialResponse(Authentication.SUPPORTED_SASL, null, USER_NAME, CLIENT_NONCE);
-        SASLResponse saslResponse = SASLResponse.of(USER_PASSWORD, SERVER_FIRST_MESSAGE, CLIENT_NONCE, saslInitialResponse.gs2Header(), saslInitialResponse.clientFirstMessageBare());
+        SASLInitialResponse saslInitialResponse = new SASLInitialResponse(Authentication.SUPPORTED_SASL, null, false, USER_NAME, CLIENT_NONCE);
+        SASLResponse saslResponse = SASLResponse.of(USER_PASSWORD, SERVER_FIRST_MESSAGE, CLIENT_NONCE,
+                                                     saslInitialResponse.gs2Header(),
+                                                     saslInitialResponse.clientFirstMessageBare(),
+                                                     null);
 
         assertEquals("n,,", saslResponse.gs2Header());
         assertEquals(CLIENT_NONCE + SERVER_NONCE, saslResponse.serverNonce());
         assertEquals("n=" + USER_NAME + ",r=" + CLIENT_NONCE, saslResponse.clientFirstMessageBare());
-        // Here should be "n,,n=<USER_NAME>,r=" + CLIENT_NONCE, but Postgres expects an empty user name because of the startup message
         assertEquals(I, saslResponse.i());
         assertEquals(USER_PASSWORD, saslResponse.password());
         assertEquals(SERVER_FIRST_MESSAGE, saslResponse.serverFirstMessage());


### PR DESCRIPTION
## Summary

Replaces the lone `useSsl: boolean` flag with a full `SslConfig` whose mode taxonomy mirrors libpq's `sslmode` parameter exactly, adds SCRAM-SHA-256-PLUS channel binding, fixes the previously-broken hostname-verification path, and removes the JVM-global `pragmatica.pg.insecure-tls` system property.

## Public-API breaking changes

`ConnectibleBuilder.ssl(boolean)` is removed. The only API is `ssl(SslConfig)`. The legacy `useSsl` field is gone from `ConnectibleConfiguration`. Custom converters and the rest of the SPI are unaffected.

## What was wrong before

| Aspect | Before | After |
|---|---|---|
| Modes | 2 (off / on with weak validation) | 6 (libpq parity: DISABLE/ALLOW/PREFER/REQUIRE/VERIFY_CA/VERIFY_FULL) |
| Hostname verification | Silently disabled (Netty default omits `endpointIdentificationAlgorithm`) | Enabled in VERIFY_FULL via `SSLParameters.setEndpointIdentificationAlgorithm("HTTPS")` |
| Custom CA trust | Required JVM-wide `-Djavax.net.ssl.trustStore` | Per-config `rootCertPem` Path |
| mTLS | Not supported | `withClientCertificate(cert, key, password)` |
| Insecure escape hatch | JVM-global system property `pragmatica.pg.insecure-tls` | Per-config `withAllowAllCertificates()`, REQUIRE-only, logs warning per connection |
| `prefer` / `allow` semantics | Not implemented (TLS-on always failed if server replied 'N') | PREFER falls back to plain on 'N'; ALLOW currently aliases to PREFER (true reconnect-style ALLOW deferred) |
| Channel binding | Not implemented | SCRAM-SHA-256-PLUS with `tls-server-end-point` per RFC 5929 §4.1 |
| SSL escape hook | None | `withSslContextCustomizer(Consumer<SslContextBuilder>)` |

## Channel binding details

- `Authentication` decoder now detects both `SCRAM-SHA-256` and `SCRAM-SHA-256-PLUS` advertisements simultaneously.
- `PgProtocolStream.startSasl` picks the mechanism using the configured `ChannelBinding` policy (DISABLE / PREFER / REQUIRE) plus TLS state plus advertised mechanisms. Downgrade-attack defense via the `y,,` GS2 flag when TLS is active but server only advertises basic SCRAM.
- `ChannelBindingDigest` computes the server-cert digest using RFC 5929's hash-mapping table (MD5/SHA-1 → SHA-256, otherwise the cert's signature digest).
- `SASLResponse.clientFinalMessage` appends `cbind-data` bytes to the GS2 header before base64 encoding when channel binding is active.

## Commits

1. `feat: SslConfig with libpq-mode taxonomy` — new public type, dead code until commit 2.
2. `feat!: thread SslConfig through builder + protocol stream` — replaces useSsl boolean; honors mode/rootCert/clientCert/customizer/allowAllCertificates; enables HTTPS hostname verification in VERIFY_FULL.
3. `feat: PREFER mode falls back to plain` — server 'N' response no longer fatal under PREFER/ALLOW.
4. `feat: SCRAM-SHA-256-PLUS with tls-server-end-point channel binding` — Authentication detects both mechanisms; gs2 header supports `n,,`/`y,,`/`p=...,,`; cbind-data appended to clientFinalMessage; ChannelBindingDigest helper added.
5. `test: SslConfig, ChannelBindingDigest, SslMode integration` — 9 unit tests for SslConfig validation, 7 for digest mapping, 4 testcontainer integration tests.
6. `refactor!: remove legacy ssl(boolean) shim` — single `ssl(SslConfig)` API.

## Tests

242/242 pass (`mvn -pl integrations/db/postgres-async test -Dpostgres-async.skipTests=false`):
- 220 pre-existing tests unaffected.
- 2 new SASL gs2-header form tests in `SaslStepsTest` (`y,,` and `p=tls-server-end-point,,`).
- 9 new `SslConfigTest` validation tests.
- 7 new `ChannelBindingDigestTest` digest-mapping tests.
- 4 new `SslModeIntegrationTest` testcontainer tests covering DISABLE / PREFER fallback / REQUIRE failure / VERIFY_FULL factory acceptance.

## Out of scope (tracked as follow-up)

- True `ALLOW` semantics (plain-first, reconnect-with-TLS on auth failure). Currently aliases to PREFER. Strict ALLOW matters only when reasoning about a network observer's view — practical use cases are rare.
- Live SSL-enabled testcontainer for full channel-binding round-trip and hostname-verification end-to-end. Requires a custom PG image with generated certs + `pg_hba.conf` configured for SCRAM-SHA-256-PLUS — orthogonal to this refactor.