### PR TITLE
feat(jbct-lint): JBCT-VO-02 recognizes parse + construct factory pattern

### DIFF
--- a/aether/aether-config/src/main/java/org/pragmatica/aether/config/AetherConfig.java
+++ b/aether/aether-config/src/main/java/org/pragmatica/aether/config/AetherConfig.java
@@ -85,7 +85,7 @@ public record AetherConfig(ClusterConfig cluster,
         return cluster.tls();
     }
 
-    @SuppressWarnings("JBCT-VO-02") public AetherConfig withStorage(Map<String, StorageConfig> storage) {
+    public AetherConfig withStorage(Map<String, StorageConfig> storage) {
         return new AetherConfig(cluster,
                                 node,
                                 tls,
@@ -103,7 +103,7 @@ public record AetherConfig(ClusterConfig cluster,
                                 streaming);
     }
 
-    @SuppressWarnings("JBCT-VO-02") public AetherConfig withEndpoints(Map<String, EndpointConfig> endpoints) {
+    public AetherConfig withEndpoints(Map<String, EndpointConfig> endpoints) {
         return new AetherConfig(cluster,
                                 node,
                                 tls,
@@ -121,7 +121,7 @@ public record AetherConfig(ClusterConfig cluster,
                                 streaming);
     }
 
-    @SuppressWarnings("JBCT-VO-02") public AetherConfig withCloud(CloudConfig cloud) {
+    public AetherConfig withCloud(CloudConfig cloud) {
         return new AetherConfig(cluster,
                                 node,
                                 tls,
@@ -139,7 +139,7 @@ public record AetherConfig(ClusterConfig cluster,
                                 streaming);
     }
 
-    @SuppressWarnings("JBCT-VO-02") public AetherConfig withStreaming(StreamingConfig streaming) {
+    public AetherConfig withStreaming(StreamingConfig streaming) {
         return new AetherConfig(cluster,
                                 node,
                                 tls,

--- a/aether/aether-config/src/main/java/org/pragmatica/aether/config/WorkerConfig.java
+++ b/aether/aether-config/src/main/java/org/pragmatica/aether/config/WorkerConfig.java
@@ -184,7 +184,7 @@ import static org.pragmatica.lang.io.TimeSpan.timeSpan;
 
         public static final int DEFAULT_MAX_PIGGYBACK = 8;
 
-        @SuppressWarnings("JBCT-VO-02") private static final SwimSettings DEFAULT = new SwimSettings(DEFAULT_PERIOD,
+        private static final SwimSettings DEFAULT = new SwimSettings(DEFAULT_PERIOD,
                                                                                                      DEFAULT_PROBE_TIMEOUT,
                                                                                                      DEFAULT_INDIRECT_PROBES,
                                                                                                      DEFAULT_SUSPECT_TIMEOUT,

--- a/aether/aether-control/src/main/java/org/pragmatica/aether/controller/ControllerConfig.java
+++ b/aether/aether-control/src/main/java/org/pragmatica/aether/controller/ControllerConfig.java
@@ -10,13 +10,34 @@ import org.pragmatica.lang.Result;
 import org.pragmatica.lang.utils.Causes;
 
 
-@SuppressWarnings("JBCT-VO-02") public record ControllerConfig(double cpuScaleUpThreshold,
-                                                               double cpuScaleDownThreshold,
-                                                               double callRateScaleUpThreshold,
-                                                               long evaluationIntervalMs,
-                                                               long warmUpPeriodMs,
-                                                               long sliceCooldownMs,
-                                                               ScalingConfig scalingConfig) {
+/// Configuration for the cluster controller.
+///
+///
+/// Controls thresholds for automatic scaling decisions.
+///
+///
+/// **Note on evaluationIntervalMs:** Both ControllerConfig and ScalingConfig have
+/// an evaluationIntervalMs field. They serve different purposes:
+///
+///   - `ControllerConfig.evaluationIntervalMs` - Controls the scheduler interval for the control loop
+///   - `ScalingConfig.evaluationIntervalMs` - Used for window timing calculations (how long until window is full)
+///
+///
+/// @param cpuScaleUpThreshold CPU usage above which to scale up (0.0-1.0)
+/// @param cpuScaleDownThreshold CPU usage below which to scale down (0.0-1.0)
+/// @param callRateScaleUpThreshold call rate above which to scale up (must be positive)
+/// @param evaluationIntervalMs interval between controller evaluations in milliseconds (must be positive)
+/// @param warmUpPeriodMs time after ControlLoop activation during which scaling is blocked (must be non-negative)
+/// @param sliceCooldownMs time after slice reaches ACTIVE during which scaling is blocked (must be non-negative)
+/// @param scalingConfig configuration for the Lizard Brain relative change scaling algorithm
+// Record copy methods (with*) and DEFAULT constant use new internally — validated by factory
+public record ControllerConfig(double cpuScaleUpThreshold,
+                               double cpuScaleDownThreshold,
+                               double callRateScaleUpThreshold,
+                               long evaluationIntervalMs,
+                               long warmUpPeriodMs,
+                               long sliceCooldownMs,
+                               ScalingConfig scalingConfig) {
     private static final Fn1<Cause, String> INVALID_THRESHOLD = Causes.forOneValue("Invalid threshold: %s (must be between 0.0 and 1.0)");
 
     private static final Fn1<Cause, String> INVALID_POSITIVE = Causes.forOneValue("Invalid value: %s (must be positive)");

--- a/aether/aether-control/src/main/java/org/pragmatica/aether/controller/MetricWindow.java
+++ b/aether/aether-control/src/main/java/org/pragmatica/aether/controller/MetricWindow.java
@@ -44,7 +44,7 @@ public record MetricWindow(double[] valuesInternal, int head, int count, double 
               : 1.0;
     }
 
-    @SuppressWarnings("JBCT-VO-02") public MetricWindow record(double value) {
+    public MetricWindow record(double value) {
         var newValues = valuesInternal.clone();
         var windowSize = newValues.length;
         var newRecordCount = recordCount + 1;

--- a/aether/aether-control/src/main/java/org/pragmatica/aether/controller/ScalingConfig.java
+++ b/aether/aether-control/src/main/java/org/pragmatica/aether/controller/ScalingConfig.java
@@ -32,7 +32,7 @@ public record ScalingConfig(int windowSize,
 
     @Deprecated static final double ERROR_RATE_BLOCK_THRESHOLD = DEFAULT_ERROR_RATE_BLOCK_THRESHOLD;
 
-    @SuppressWarnings("JBCT-VO-02") public static ScalingConfig productionDefaults() {
+    public static ScalingConfig productionDefaults() {
         var weights = new EnumMap<ScalingMetric, Double>(ScalingMetric.class);
         weights.put(ScalingMetric.CPU, 0.4);
         weights.put(ScalingMetric.ACTIVE_INVOCATIONS, 0.4);
@@ -46,7 +46,7 @@ public record ScalingConfig(int windowSize,
                                  DEFAULT_ERROR_RATE_BLOCK_THRESHOLD);
     }
 
-    @SuppressWarnings("JBCT-VO-02") public static ScalingConfig forgeDefaults() {
+    public static ScalingConfig forgeDefaults() {
         var weights = new EnumMap<ScalingMetric, Double>(ScalingMetric.class);
         weights.put(ScalingMetric.CPU, 0.0);
         weights.put(ScalingMetric.ACTIVE_INVOCATIONS, 0.6);

--- a/aether/aether-invoke/src/main/java/org/pragmatica/aether/update/AbTestDeployment.java
+++ b/aether/aether-invoke/src/main/java/org/pragmatica/aether/update/AbTestDeployment.java
@@ -29,7 +29,7 @@ public record AbTestDeployment(String testId,
                                long updatedAt) {
     private static final Fn1<Cause, String> INVALID_TRANSITION = Causes.forOneValue("Invalid A/B test state transition: %s");
 
-    @SuppressWarnings("JBCT-VO-02") public static AbTestDeployment abTestDeployment(String testId,
+    public static AbTestDeployment abTestDeployment(String testId,
                                                                                     ArtifactBase artifactBase,
                                                                                     Version baselineVersion,
                                                                                     Map<String, Version> variantVersions,
@@ -48,7 +48,7 @@ public record AbTestDeployment(String testId,
                                     now);
     }
 
-    @SuppressWarnings("JBCT-VO-02") public Result<AbTestDeployment> transitionTo(AbTestState newState) {
+    public Result<AbTestDeployment> transitionTo(AbTestState newState) {
         if (!state.validTransitions().contains(newState)) {return INVALID_TRANSITION.apply(state + " -> " + newState)
                                                                                           .result();}
         return Result.success(new AbTestDeployment(testId,
@@ -64,7 +64,7 @@ public record AbTestDeployment(String testId,
                                                    System.currentTimeMillis()));
     }
 
-    @SuppressWarnings("JBCT-VO-02") public AbTestDeployment withRouting(VersionRouting newRouting) {
+    public AbTestDeployment withRouting(VersionRouting newRouting) {
         return new AbTestDeployment(testId,
                                     artifactBase,
                                     baselineVersion,
@@ -78,7 +78,7 @@ public record AbTestDeployment(String testId,
                                     System.currentTimeMillis());
     }
 
-    @SuppressWarnings("JBCT-VO-02") public AbTestDeployment withBlueprintContext(String newBlueprintId,
+    public AbTestDeployment withBlueprintContext(String newBlueprintId,
                                                                                  List<ArtifactBase> newArtifacts) {
         return new AbTestDeployment(testId,
                                     artifactBase,

--- a/aether/aether-invoke/src/main/java/org/pragmatica/aether/update/AbTestManager.java
+++ b/aether/aether-invoke/src/main/java/org/pragmatica/aether/update/AbTestManager.java
@@ -326,7 +326,7 @@ public interface AbTestManager extends DelegatedComponent {
                 if (restoredCount > 0) {log.info("Restored {} A/B tests from KV-Store", restoredCount);}
             }
 
-            @SuppressWarnings({"JBCT-VO-02", "JBCT-RET-01"}) private void restoreTest(AbTestValue atv) {
+            @SuppressWarnings("JBCT-RET-01") private void restoreTest(AbTestValue atv) {
                 var state = AbTestState.valueOf(atv.state());
                 var routing = new VersionRouting(atv.newWeight(), atv.oldWeight());
                 var variantVersions = deserializeVariantVersions(atv.variantVersionsJson());
@@ -433,7 +433,7 @@ public interface AbTestManager extends DelegatedComponent {
         return new long[]{a[0] + b[0], a[1] + b[1], a[2] + b[2], Math.max(a[3], b[3])};
     }
 
-    @SuppressWarnings("JBCT-VO-02") private static Map<String, Version> deserializeVariantVersions(String json) {
+    private static Map<String, Version> deserializeVariantVersions(String json) {
         if (json.isEmpty()) {return Map.of();}
         var result = new HashMap<String, Version>();
         for (var entry : json.split(",")) {
@@ -447,7 +447,7 @@ public interface AbTestManager extends DelegatedComponent {
         return Map.copyOf(result);
     }
 
-    @SuppressWarnings("JBCT-VO-02") private static SplitRule deserializeSplitRule(String json) {
+    private static SplitRule deserializeSplitRule(String json) {
         if (json.isEmpty()) {return SplitRule.HeaderHashSplit.headerHashSplit("X-Request-Id", 2);}
         if (json.startsWith("header-hash:")) {return parseHeaderHashSplit(json);}
         if (json.startsWith("cookie-hash:")) {return parseCookieHashSplit(json);}

--- a/aether/aether-invoke/src/main/java/org/pragmatica/aether/update/AbTestMetrics.java
+++ b/aether/aether-invoke/src/main/java/org/pragmatica/aether/update/AbTestMetrics.java
@@ -17,7 +17,7 @@ public record AbTestMetrics(String testId, Map<String, VariantMetrics> variantMe
                                  double errorRate,
                                  long p99LatencyMs,
                                  long avgLatencyMs) {
-        @SuppressWarnings("JBCT-VO-02") public static VariantMetrics variantMetrics(String variant,
+        public static VariantMetrics variantMetrics(String variant,
                                                                                     Version version,
                                                                                     long requestCount,
                                                                                     long errorCount,

--- a/aether/aether-invoke/src/main/java/org/pragmatica/aether/update/CanaryAnalysisConfig.java
+++ b/aether/aether-invoke/src/main/java/org/pragmatica/aether/update/CanaryAnalysisConfig.java
@@ -11,7 +11,7 @@ public record CanaryAnalysisConfig(ComparisonMode mode, int relativeThresholdPer
         RELATIVE_AND_ABSOLUTE
     }
 
-    @SuppressWarnings("JBCT-VO-02") public static final CanaryAnalysisConfig DEFAULT = new CanaryAnalysisConfig(ComparisonMode.ABSOLUTE_ONLY,
+    public static final CanaryAnalysisConfig DEFAULT = new CanaryAnalysisConfig(ComparisonMode.ABSOLUTE_ONLY,
                                                                                                                 0);
 
     public static CanaryAnalysisConfig canaryAnalysisConfig(ComparisonMode mode, int relativeThresholdPercent) {

--- a/aether/aether-invoke/src/main/java/org/pragmatica/aether/update/CanaryHealthComparison.java
+++ b/aether/aether-invoke/src/main/java/org/pragmatica/aether/update/CanaryHealthComparison.java
@@ -33,7 +33,7 @@ public record CanaryHealthComparison(String canaryId,
             return requestCount >= MIN_REQUESTS;
         }
 
-        @SuppressWarnings("JBCT-VO-02") public static VersionMetrics versionMetrics(Version version,
+        public static VersionMetrics versionMetrics(Version version,
                                                                                     long requestCount,
                                                                                     long errorCount,
                                                                                     double errorRate,

--- a/aether/aether-invoke/src/main/java/org/pragmatica/aether/update/CanaryStage.java
+++ b/aether/aether-invoke/src/main/java/org/pragmatica/aether/update/CanaryStage.java
@@ -22,11 +22,11 @@ public record CanaryStage(int trafficPercent, int observationMinutes) {
         return Result.success(new CanaryStage(trafficPercent, observationMinutes));
     }
 
-    @SuppressWarnings("JBCT-VO-02") public VersionRouting toRouting() {
+    public VersionRouting toRouting() {
         return new VersionRouting(trafficPercent, 100 - trafficPercent);
     }
 
-    @SuppressWarnings("JBCT-VO-02") public static List<CanaryStage> defaultStages() {
+    public static List<CanaryStage> defaultStages() {
         return List.of(new CanaryStage(1, 5),
                        new CanaryStage(5, 5),
                        new CanaryStage(25, 10),

--- a/aether/aether-invoke/src/main/java/org/pragmatica/aether/update/Deployment.java
+++ b/aether/aether-invoke/src/main/java/org/pragmatica/aether/update/Deployment.java
@@ -30,7 +30,7 @@ public record Deployment(String deploymentId,
                          long updatedAt) {
     private static final Fn1<Cause, String> INVALID_TRANSITION = Causes.forOneValue("Invalid deployment state transition: %s");
 
-    @SuppressWarnings("JBCT-VO-02") public static Deployment deployment(String deploymentId,
+    public static Deployment deployment(String deploymentId,
                                                                         String blueprintId,
                                                                         Version oldVersion,
                                                                         Version newVersion,
@@ -101,7 +101,7 @@ public record Deployment(String deploymentId,
         return System.currentTimeMillis() - updatedAt;
     }
 
-    @SuppressWarnings("JBCT-VO-02") private Result<Deployment> transitionTo(DeploymentState newState) {
+    private Result<Deployment> transitionTo(DeploymentState newState) {
         if (!state.validTransitions().contains(newState)) {return INVALID_TRANSITION.apply(state + " -> " + newState)
                                                                                           .result();}
         return Result.success(new Deployment(deploymentId,
@@ -120,7 +120,7 @@ public record Deployment(String deploymentId,
                                              System.currentTimeMillis()));
     }
 
-    @SuppressWarnings("JBCT-VO-02") private Deployment withRouting(VersionRouting newRouting) {
+    private Deployment withRouting(VersionRouting newRouting) {
         return new Deployment(deploymentId,
                               blueprintId,
                               oldVersion,

--- a/aether/aether-invoke/src/main/java/org/pragmatica/aether/update/DeploymentManagerImpl.java
+++ b/aether/aether-invoke/src/main/java/org/pragmatica/aether/update/DeploymentManagerImpl.java
@@ -393,7 +393,7 @@ final class DeploymentManagerImpl implements DeploymentManager {
         if (restoredCount > 0) {log.info("Restored {} deployments from KV-Store", restoredCount);}
     }
 
-    @SuppressWarnings({"JBCT-VO-02", "JBCT-RET-01"}) private void restoreDeployment(DeploymentValue dv) {
+    @SuppressWarnings("JBCT-RET-01") private void restoreDeployment(DeploymentValue dv) {
         var state = DeploymentState.valueOf(dv.state());
         if (state.isTerminal()) {return;}
         var strategy = DeploymentStrategy.valueOf(dv.strategy());

--- a/aether/aether-invoke/src/main/java/org/pragmatica/aether/update/HealthThresholds.java
+++ b/aether/aether-invoke/src/main/java/org/pragmatica/aether/update/HealthThresholds.java
@@ -14,11 +14,11 @@ public record HealthThresholds(double maxErrorRate, long maxLatencyMs, boolean r
 
     private static final Cause NEGATIVE_LATENCY = Causes.cause("Latency must be non-negative");
 
-    @SuppressWarnings("JBCT-VO-02") public static final HealthThresholds DEFAULT = new HealthThresholds(0.01, 500, false);
+    public static final HealthThresholds DEFAULT = new HealthThresholds(0.01, 500, false);
 
-    @SuppressWarnings("JBCT-VO-02") public static final HealthThresholds STRICT = new HealthThresholds(0.001, 200, false);
+    public static final HealthThresholds STRICT = new HealthThresholds(0.001, 200, false);
 
-    @SuppressWarnings("JBCT-VO-02") public static final HealthThresholds MANUAL_ONLY = new HealthThresholds(0.0, 0, true);
+    public static final HealthThresholds MANUAL_ONLY = new HealthThresholds(0.0, 0, true);
 
     public static Result<HealthThresholds> healthThresholds(double maxErrorRate,
                                                             long maxLatencyMs,
@@ -41,11 +41,11 @@ public record HealthThresholds(double maxErrorRate, long maxLatencyMs, boolean r
         return errorRate <= maxErrorRate && latencyMs <= maxLatencyMs;
     }
 
-    @SuppressWarnings("JBCT-VO-02") public HealthThresholds withManualApproval() {
+    public HealthThresholds withManualApproval() {
         return new HealthThresholds(maxErrorRate, maxLatencyMs, true);
     }
 
-    @SuppressWarnings("JBCT-VO-02") public HealthThresholds withAutoApproval() {
+    public HealthThresholds withAutoApproval() {
         return new HealthThresholds(maxErrorRate, maxLatencyMs, false);
     }
 }

--- a/aether/aether-invoke/src/main/java/org/pragmatica/aether/update/SplitRule.java
+++ b/aether/aether-invoke/src/main/java/org/pragmatica/aether/update/SplitRule.java
@@ -13,7 +13,7 @@ public sealed interface SplitRule {
     String resolveVariant(Map<String, String> headers, Map<String, String> cookies);
 
     record HeaderHashSplit(String headerName, int variantCount) implements SplitRule {
-        @SuppressWarnings("JBCT-VO-02") public static HeaderHashSplit headerHashSplit(String headerName,
+        public static HeaderHashSplit headerHashSplit(String headerName,
                                                                                       int variantCount) {
             return new HeaderHashSplit(headerName, variantCount);
         }
@@ -26,7 +26,7 @@ public sealed interface SplitRule {
     }
 
     record CookieHashSplit(String cookieName, int variantCount) implements SplitRule {
-        @SuppressWarnings("JBCT-VO-02") public static CookieHashSplit cookieHashSplit(String cookieName,
+        public static CookieHashSplit cookieHashSplit(String cookieName,
                                                                                       int variantCount) {
             return new CookieHashSplit(cookieName, variantCount);
         }
@@ -39,7 +39,7 @@ public sealed interface SplitRule {
     }
 
     record HeaderMatchSplit(String headerName, Map<String, String> valueToVariant, String defaultVariant) implements SplitRule {
-        @SuppressWarnings("JBCT-VO-02") public static HeaderMatchSplit headerMatchSplit(String headerName,
+        public static HeaderMatchSplit headerMatchSplit(String headerName,
                                                                                         Map<String, String> valueToVariant,
                                                                                         String defaultVariant) {
             return new HeaderMatchSplit(headerName, valueToVariant, defaultVariant);
@@ -52,12 +52,12 @@ public sealed interface SplitRule {
     }
 
     record PercentageSplit(List<VariantWeight> weights) implements SplitRule {
-        @SuppressWarnings("JBCT-VO-02") public static PercentageSplit percentageSplit(List<VariantWeight> weights) {
+        public static PercentageSplit percentageSplit(List<VariantWeight> weights) {
             return new PercentageSplit(weights);
         }
 
         public record VariantWeight(String variant, int weight) {
-            @SuppressWarnings("JBCT-VO-02") public static VariantWeight variantWeight(String variant, int weight) {
+            public static VariantWeight variantWeight(String variant, int weight) {
                 return new VariantWeight(variant, weight);
             }
         }

--- a/aether/aether-metrics/src/main/java/org/pragmatica/aether/metrics/deployment/DeploymentMetrics.java
+++ b/aether/aether-metrics/src/main/java/org/pragmatica/aether/metrics/deployment/DeploymentMetrics.java
@@ -75,7 +75,7 @@ public record DeploymentMetrics(Artifact artifact,
                                 .option();
     }
 
-    @SuppressWarnings("JBCT-VO-02") private static Result<DeploymentMetrics> buildFromEntry(Artifact artifact,
+    private static Result<DeploymentMetrics> buildFromEntry(Artifact artifact,
                                                                                             DeploymentMetricsEntry entry) {
         return NodeId.nodeId(entry.nodeId())
                             .map(nodeId -> new DeploymentMetrics(artifact,
@@ -88,13 +88,13 @@ public record DeploymentMetrics(Artifact artifact,
                                                                  DeploymentStatus.deploymentStatus(entry.status())));
     }
 
-    @SuppressWarnings("JBCT-VO-02") public static DeploymentMetrics deploymentMetrics(Artifact artifact,
+    public static DeploymentMetrics deploymentMetrics(Artifact artifact,
                                                                                       NodeId nodeId,
                                                                                       long timestamp) {
         return new DeploymentMetrics(artifact, nodeId, timestamp, 0, 0, 0, 0, DeploymentStatus.IN_PROGRESS);
     }
 
-    @SuppressWarnings("JBCT-VO-02") public DeploymentMetrics withLoadTime(long timestamp) {
+    public DeploymentMetrics withLoadTime(long timestamp) {
         return new DeploymentMetrics(artifact,
                                      nodeId,
                                      startTime,
@@ -105,15 +105,15 @@ public record DeploymentMetrics(Artifact artifact,
                                      status);
     }
 
-    @SuppressWarnings("JBCT-VO-02") public DeploymentMetrics withLoadedTime(long timestamp) {
+    public DeploymentMetrics withLoadedTime(long timestamp) {
         return new DeploymentMetrics(artifact, nodeId, startTime, loadTime, timestamp, activateTime, activeTime, status);
     }
 
-    @SuppressWarnings("JBCT-VO-02") public DeploymentMetrics withActivateTime(long timestamp) {
+    public DeploymentMetrics withActivateTime(long timestamp) {
         return new DeploymentMetrics(artifact, nodeId, startTime, loadTime, loadedTime, timestamp, activeTime, status);
     }
 
-    @SuppressWarnings("JBCT-VO-02") public DeploymentMetrics completed(long timestamp) {
+    public DeploymentMetrics completed(long timestamp) {
         return new DeploymentMetrics(artifact,
                                      nodeId,
                                      startTime,
@@ -124,7 +124,7 @@ public record DeploymentMetrics(Artifact artifact,
                                      DeploymentStatus.SUCCESS);
     }
 
-    @SuppressWarnings("JBCT-VO-02") public DeploymentMetrics failedLoading(long timestamp) {
+    public DeploymentMetrics failedLoading(long timestamp) {
         return new DeploymentMetrics(artifact,
                                      nodeId,
                                      startTime,
@@ -135,7 +135,7 @@ public record DeploymentMetrics(Artifact artifact,
                                      DeploymentStatus.FAILED_LOADING);
     }
 
-    @SuppressWarnings("JBCT-VO-02") public DeploymentMetrics failedActivating(long timestamp) {
+    public DeploymentMetrics failedActivating(long timestamp) {
         return new DeploymentMetrics(artifact,
                                      nodeId,
                                      startTime,

--- a/aether/cli/src/main/java/org/pragmatica/aether/cli/cluster/ApplyState.java
+++ b/aether/cli/src/main/java/org/pragmatica/aether/cli/cluster/ApplyState.java
@@ -35,7 +35,7 @@ import static org.pragmatica.lang.Result.success;
         destroyedNodeIds = List.copyOf(destroyedNodeIds);
     }
 
-    @SuppressWarnings("JBCT-VO-02") public static ApplyState applyState(String clusterName,
+    public static ApplyState applyState(String clusterName,
                                                                         String configHash,
                                                                         String startedAt,
                                                                         int currentWaveIndex,

--- a/aether/cli/src/main/java/org/pragmatica/aether/cli/cluster/ClusterRegistry.java
+++ b/aether/cli/src/main/java/org/pragmatica/aether/cli/cluster/ClusterRegistry.java
@@ -58,7 +58,7 @@ public record ClusterRegistry(Path registryPath, Option<String> currentContext, 
         }
     }
 
-    @SuppressWarnings("JBCT-VO-02") static ClusterRegistry clusterRegistry(Path path,
+    static ClusterRegistry clusterRegistry(Path path,
                                                                            Option<String> context,
                                                                            List<ClusterEntry> entries) {
         return new ClusterRegistry(path, context, entries);

--- a/aether/ember/src/main/java/org/pragmatica/aether/ember/EmberConfig.java
+++ b/aether/ember/src/main/java/org/pragmatica/aether/ember/EmberConfig.java
@@ -36,7 +36,7 @@ public record EmberConfig(int nodes,
 
     public static final int DEFAULT_CORE_MAX = 0;
 
-    @SuppressWarnings("JBCT-VO-02") public static final EmberConfig DEFAULT = new EmberConfig(DEFAULT_NODES,
+    public static final EmberConfig DEFAULT = new EmberConfig(DEFAULT_NODES,
                                                                                               DEFAULT_MANAGEMENT_PORT,
                                                                                               DEFAULT_DASHBOARD_PORT,
                                                                                               DEFAULT_APP_HTTP_PORT,

--- a/aether/environment-integration/src/main/java/org/pragmatica/aether/environment/CloudConfig.java
+++ b/aether/environment-integration/src/main/java/org/pragmatica/aether/environment/CloudConfig.java
@@ -30,19 +30,19 @@ public record CloudConfig(String provider,
                                        Map.of()));
     }
 
-    @SuppressWarnings("JBCT-VO-02") public CloudConfig withLoadBalancer(Map<String, String> loadBalancer) {
+    public CloudConfig withLoadBalancer(Map<String, String> loadBalancer) {
         return new CloudConfig(provider, credentials, compute, Map.copyOf(loadBalancer), discovery, secrets, security);
     }
 
-    @SuppressWarnings("JBCT-VO-02") public CloudConfig withDiscovery(Map<String, String> discovery) {
+    public CloudConfig withDiscovery(Map<String, String> discovery) {
         return new CloudConfig(provider, credentials, compute, loadBalancer, Map.copyOf(discovery), secrets, security);
     }
 
-    @SuppressWarnings("JBCT-VO-02") public CloudConfig withSecrets(Map<String, String> secrets) {
+    public CloudConfig withSecrets(Map<String, String> secrets) {
         return new CloudConfig(provider, credentials, compute, loadBalancer, discovery, Map.copyOf(secrets), security);
     }
 
-    @SuppressWarnings("JBCT-VO-02") public CloudConfig withSecurity(Map<String, String> security) {
+    public CloudConfig withSecurity(Map<String, String> security) {
         return new CloudConfig(provider, credentials, compute, loadBalancer, discovery, secrets, Map.copyOf(security));
     }
 }

--- a/aether/environment-integration/src/main/java/org/pragmatica/aether/environment/HealthCheckConfig.java
+++ b/aether/environment-integration/src/main/java/org/pragmatica/aether/environment/HealthCheckConfig.java
@@ -18,7 +18,7 @@ public record HealthCheckConfig(String protocol,
                                 TimeSpan timeout,
                                 int healthyThreshold,
                                 int unhealthyThreshold) {
-    @SuppressWarnings("JBCT-VO-02") public static final HealthCheckConfig DEFAULT = new HealthCheckConfig("http",
+    public static final HealthCheckConfig DEFAULT = new HealthCheckConfig("http",
                                                                                                           8080,
                                                                                                           "/health/ready",
                                                                                                           timeSpan(10).seconds(),

--- a/aether/environment-integration/src/main/java/org/pragmatica/aether/environment/ProvisionSpec.java
+++ b/aether/environment-integration/src/main/java/org/pragmatica/aether/environment/ProvisionSpec.java
@@ -32,15 +32,15 @@ public record ProvisionSpec(InstanceType instanceType,
                                          Option.empty()));
     }
 
-    @SuppressWarnings("JBCT-VO-02") public ProvisionSpec withImage(String imageId) {
+    public ProvisionSpec withImage(String imageId) {
         return new ProvisionSpec(instanceType, instanceSize, pool, tags, Option.some(imageId), userData, placement);
     }
 
-    @SuppressWarnings("JBCT-VO-02") public ProvisionSpec withUserData(String userData) {
+    public ProvisionSpec withUserData(String userData) {
         return new ProvisionSpec(instanceType, instanceSize, pool, tags, imageId, Option.some(userData), placement);
     }
 
-    @SuppressWarnings("JBCT-VO-02") public ProvisionSpec withPlacement(PlacementHint placement) {
+    public ProvisionSpec withPlacement(PlacementHint placement) {
         return new ProvisionSpec(instanceType, instanceSize, pool, tags, imageId, userData, Option.some(placement));
     }
 }

--- a/aether/environment/aws/src/main/java/org/pragmatica/aether/environment/aws/AwsEnvironmentConfig.java
+++ b/aether/environment/aws/src/main/java/org/pragmatica/aether/environment/aws/AwsEnvironmentConfig.java
@@ -74,7 +74,7 @@ public record AwsEnvironmentConfig(AwsConfig awsConfig,
                                                 Option.empty()));
     }
 
-    @SuppressWarnings("JBCT-VO-02") public AwsEnvironmentConfig withDiscovery(String clusterLabel) {
+    public AwsEnvironmentConfig withDiscovery(String clusterLabel) {
         return new AwsEnvironmentConfig(awsConfig,
                                         amiId,
                                         instanceType,
@@ -88,7 +88,7 @@ public record AwsEnvironmentConfig(AwsConfig awsConfig,
                                         certificateSecretPrefix);
     }
 
-    @SuppressWarnings("JBCT-VO-02") public AwsEnvironmentConfig withDiscoveryPollInterval(long intervalMs) {
+    public AwsEnvironmentConfig withDiscoveryPollInterval(long intervalMs) {
         return new AwsEnvironmentConfig(awsConfig,
                                         amiId,
                                         instanceType,
@@ -102,7 +102,7 @@ public record AwsEnvironmentConfig(AwsConfig awsConfig,
                                         certificateSecretPrefix);
     }
 
-    @SuppressWarnings("JBCT-VO-02") public AwsEnvironmentConfig withCertificateSecretPrefix(String prefix) {
+    public AwsEnvironmentConfig withCertificateSecretPrefix(String prefix) {
         return new AwsEnvironmentConfig(awsConfig,
                                         amiId,
                                         instanceType,

--- a/aether/environment/aws/src/main/java/org/pragmatica/aether/environment/aws/AwsEnvironmentIntegrationFactory.java
+++ b/aether/environment/aws/src/main/java/org/pragmatica/aether/environment/aws/AwsEnvironmentIntegrationFactory.java
@@ -77,7 +77,7 @@ public record AwsEnvironmentIntegrationFactory() implements EnvironmentIntegrati
               : envConfig.withCertificateSecretPrefix(prefix);
     }
 
-    @SuppressWarnings("JBCT-VO-02") private static AwsEnvironmentConfig withLoadBalancer(AwsEnvironmentConfig envConfig,
+    private static AwsEnvironmentConfig withLoadBalancer(AwsEnvironmentConfig envConfig,
                                                                                          AwsEnvironmentConfig.AwsLbConfig lbConfig) {
         return new AwsEnvironmentConfig(envConfig.awsConfig(),
                                         envConfig.amiId(),

--- a/aether/environment/azure/src/main/java/org/pragmatica/aether/environment/azure/AzureEnvironmentConfig.java
+++ b/aether/environment/azure/src/main/java/org/pragmatica/aether/environment/azure/AzureEnvironmentConfig.java
@@ -77,7 +77,7 @@ public record AzureEnvironmentConfig(AzureConfig azureConfig,
                                                   Option.empty()));
     }
 
-    @SuppressWarnings("JBCT-VO-02") public AzureEnvironmentConfig withDiscovery(String clusterLabel) {
+    public AzureEnvironmentConfig withDiscovery(String clusterLabel) {
         return new AzureEnvironmentConfig(azureConfig,
                                           vmSize,
                                           image,
@@ -92,7 +92,7 @@ public record AzureEnvironmentConfig(AzureConfig azureConfig,
                                           certificateSecretPrefix);
     }
 
-    @SuppressWarnings("JBCT-VO-02") public AzureEnvironmentConfig withSelfVmName(String vmName) {
+    public AzureEnvironmentConfig withSelfVmName(String vmName) {
         return new AzureEnvironmentConfig(azureConfig,
                                           vmSize,
                                           image,
@@ -107,7 +107,7 @@ public record AzureEnvironmentConfig(AzureConfig azureConfig,
                                           certificateSecretPrefix);
     }
 
-    @SuppressWarnings("JBCT-VO-02") public AzureEnvironmentConfig withDiscoveryPollInterval(long intervalMs) {
+    public AzureEnvironmentConfig withDiscoveryPollInterval(long intervalMs) {
         return new AzureEnvironmentConfig(azureConfig,
                                           vmSize,
                                           image,
@@ -122,7 +122,7 @@ public record AzureEnvironmentConfig(AzureConfig azureConfig,
                                           certificateSecretPrefix);
     }
 
-    @SuppressWarnings("JBCT-VO-02") public AzureEnvironmentConfig withCertificateSecretPrefix(String prefix) {
+    public AzureEnvironmentConfig withCertificateSecretPrefix(String prefix) {
         return new AzureEnvironmentConfig(azureConfig,
                                           vmSize,
                                           image,

--- a/aether/environment/azure/src/main/java/org/pragmatica/aether/environment/azure/AzureEnvironmentIntegrationFactory.java
+++ b/aether/environment/azure/src/main/java/org/pragmatica/aether/environment/azure/AzureEnvironmentIntegrationFactory.java
@@ -80,7 +80,7 @@ public record AzureEnvironmentIntegrationFactory() implements EnvironmentIntegra
               : envConfig.withCertificateSecretPrefix(prefix);
     }
 
-    @SuppressWarnings("JBCT-VO-02") private static AzureEnvironmentConfig withLoadBalancer(AzureEnvironmentConfig envConfig,
+    private static AzureEnvironmentConfig withLoadBalancer(AzureEnvironmentConfig envConfig,
                                                                                            AzureEnvironmentConfig.AzureLbConfig lbConfig) {
         return new AzureEnvironmentConfig(envConfig.azureConfig(),
                                           envConfig.vmSize(),

--- a/aether/environment/gcp/src/main/java/org/pragmatica/aether/environment/gcp/GcpEnvironmentConfig.java
+++ b/aether/environment/gcp/src/main/java/org/pragmatica/aether/environment/gcp/GcpEnvironmentConfig.java
@@ -70,7 +70,7 @@ public record GcpEnvironmentConfig(GcpConfig gcpConfig,
                                                 Option.empty()));
     }
 
-    @SuppressWarnings("JBCT-VO-02") public GcpEnvironmentConfig withDiscovery(String clusterLabel) {
+    public GcpEnvironmentConfig withDiscovery(String clusterLabel) {
         return new GcpEnvironmentConfig(gcpConfig,
                                         machineType,
                                         sourceImage,
@@ -84,7 +84,7 @@ public record GcpEnvironmentConfig(GcpConfig gcpConfig,
                                         certificateSecretPrefix);
     }
 
-    @SuppressWarnings("JBCT-VO-02") public GcpEnvironmentConfig withSelfInstanceName(String instanceName) {
+    public GcpEnvironmentConfig withSelfInstanceName(String instanceName) {
         return new GcpEnvironmentConfig(gcpConfig,
                                         machineType,
                                         sourceImage,
@@ -98,7 +98,7 @@ public record GcpEnvironmentConfig(GcpConfig gcpConfig,
                                         certificateSecretPrefix);
     }
 
-    @SuppressWarnings("JBCT-VO-02") public GcpEnvironmentConfig withDiscoveryPollInterval(long intervalMs) {
+    public GcpEnvironmentConfig withDiscoveryPollInterval(long intervalMs) {
         return new GcpEnvironmentConfig(gcpConfig,
                                         machineType,
                                         sourceImage,
@@ -112,7 +112,7 @@ public record GcpEnvironmentConfig(GcpConfig gcpConfig,
                                         certificateSecretPrefix);
     }
 
-    @SuppressWarnings("JBCT-VO-02") public GcpEnvironmentConfig withCertificateSecretPrefix(String prefix) {
+    public GcpEnvironmentConfig withCertificateSecretPrefix(String prefix) {
         return new GcpEnvironmentConfig(gcpConfig,
                                         machineType,
                                         sourceImage,

--- a/aether/environment/gcp/src/main/java/org/pragmatica/aether/environment/gcp/GcpEnvironmentIntegrationFactory.java
+++ b/aether/environment/gcp/src/main/java/org/pragmatica/aether/environment/gcp/GcpEnvironmentIntegrationFactory.java
@@ -77,7 +77,7 @@ public record GcpEnvironmentIntegrationFactory() implements EnvironmentIntegrati
               : envConfig.withCertificateSecretPrefix(prefix);
     }
 
-    @SuppressWarnings("JBCT-VO-02") private static GcpEnvironmentConfig withNetworkEndpointGroup(GcpEnvironmentConfig envConfig,
+    private static GcpEnvironmentConfig withNetworkEndpointGroup(GcpEnvironmentConfig envConfig,
                                                                                                  GcpEnvironmentConfig.GcpNegConfig negConfig) {
         return new GcpEnvironmentConfig(envConfig.gcpConfig(),
                                         envConfig.machineType(),

--- a/aether/environment/hetzner/src/main/java/org/pragmatica/aether/environment/hetzner/HetznerEnvironmentConfig.java
+++ b/aether/environment/hetzner/src/main/java/org/pragmatica/aether/environment/hetzner/HetznerEnvironmentConfig.java
@@ -79,7 +79,7 @@ public record HetznerEnvironmentConfig(HetznerConfig hetznerConfig,
                                                     DEFAULT_POLL_INTERVAL_MS));
     }
 
-    @SuppressWarnings("JBCT-VO-02") public HetznerEnvironmentConfig withDiscovery(String clusterLabel) {
+    public HetznerEnvironmentConfig withDiscovery(String clusterLabel) {
         return new HetznerEnvironmentConfig(hetznerConfig,
                                             serverType,
                                             image,
@@ -94,7 +94,7 @@ public record HetznerEnvironmentConfig(HetznerConfig hetznerConfig,
                                             discoveryPollIntervalMs);
     }
 
-    @SuppressWarnings("JBCT-VO-02") public HetznerEnvironmentConfig withSelfServerId(long serverId) {
+    public HetznerEnvironmentConfig withSelfServerId(long serverId) {
         return new HetznerEnvironmentConfig(hetznerConfig,
                                             serverType,
                                             image,
@@ -109,7 +109,7 @@ public record HetznerEnvironmentConfig(HetznerConfig hetznerConfig,
                                             discoveryPollIntervalMs);
     }
 
-    @SuppressWarnings("JBCT-VO-02") public HetznerEnvironmentConfig withDiscoveryPollInterval(long intervalMs) {
+    public HetznerEnvironmentConfig withDiscoveryPollInterval(long intervalMs) {
         return new HetznerEnvironmentConfig(hetznerConfig,
                                             serverType,
                                             image,

--- a/aether/environment/hetzner/src/main/java/org/pragmatica/aether/environment/hetzner/HetznerEnvironmentIntegrationFactory.java
+++ b/aether/environment/hetzner/src/main/java/org/pragmatica/aether/environment/hetzner/HetznerEnvironmentIntegrationFactory.java
@@ -73,7 +73,7 @@ public record HetznerEnvironmentIntegrationFactory() implements EnvironmentInteg
               : result.withDiscoveryPollInterval(Long.parseLong(pollInterval));
     }
 
-    @SuppressWarnings("JBCT-VO-02") private static HetznerEnvironmentConfig withLoadBalancer(HetznerEnvironmentConfig envConfig,
+    private static HetznerEnvironmentConfig withLoadBalancer(HetznerEnvironmentConfig envConfig,
                                                                                              HetznerEnvironmentConfig.HetznerLbConfig lbConfig) {
         return new HetznerEnvironmentConfig(envConfig.hetznerConfig(),
                                             envConfig.serverType(),

--- a/aether/http-handler-api/src/main/java/org/pragmatica/aether/http/handler/security/SecurityPolicy.java
+++ b/aether/http-handler-api/src/main/java/org/pragmatica/aether/http/handler/security/SecurityPolicy.java
@@ -12,7 +12,7 @@ import org.pragmatica.http.routing.security.RouteSecurityPolicy;
 @SuppressWarnings("JBCT-NAM-01") public sealed interface SecurityPolicy extends RouteSecurityPolicy {
     System.Logger log = System.getLogger(SecurityPolicy.class.getName());
 
-    @SuppressWarnings({"JBCT-VO-02", "JBCT-NAM-01"}) record Public() implements SecurityPolicy {
+    @SuppressWarnings("JBCT-NAM-01") record Public() implements SecurityPolicy {
         private static final Public INSTANCE = new Public();
 
         @Override public <T extends RequestSecurityContext> Access canAccess(T context) {
@@ -20,7 +20,7 @@ import org.pragmatica.http.routing.security.RouteSecurityPolicy;
         }
     }
 
-    @SuppressWarnings("JBCT-VO-02") record Authenticated() implements SecurityPolicy {
+    record Authenticated() implements SecurityPolicy {
         private static final Authenticated INSTANCE = new Authenticated();
 
         @Override public <T extends RequestSecurityContext> Access canAccess(T context) {
@@ -28,7 +28,7 @@ import org.pragmatica.http.routing.security.RouteSecurityPolicy;
         }
     }
 
-    @SuppressWarnings("JBCT-VO-02") record ApiKeyRequired() implements SecurityPolicy {
+    record ApiKeyRequired() implements SecurityPolicy {
         private static final ApiKeyRequired INSTANCE = new ApiKeyRequired();
 
         @Override public <T extends RequestSecurityContext> Access canAccess(T context) {
@@ -36,7 +36,7 @@ import org.pragmatica.http.routing.security.RouteSecurityPolicy;
         }
     }
 
-    @SuppressWarnings("JBCT-VO-02") record BearerTokenRequired() implements SecurityPolicy {
+    record BearerTokenRequired() implements SecurityPolicy {
         private static final BearerTokenRequired INSTANCE = new BearerTokenRequired();
 
         @Override public <T extends RequestSecurityContext> Access canAccess(T context) {

--- a/aether/node/src/main/java/org/pragmatica/aether/node/AetherNodeConfig.java
+++ b/aether/node/src/main/java/org/pragmatica/aether/node/AetherNodeConfig.java
@@ -72,7 +72,7 @@ public record AetherNodeConfig(TopologyConfig topology,
                                StreamingConfig streaming,
                                ClusterFormationConfig clusterFormation) {
     public record DeploymentDefaults(long canaryEvaluationIntervalMs, List<CanaryStageConfig> defaultCanaryStages) {
-        @SuppressWarnings("JBCT-VO-02") public static final DeploymentDefaults DEFAULT = new DeploymentDefaults(30_000,
+        public static final DeploymentDefaults DEFAULT = new DeploymentDefaults(30_000,
                                                                                                                 DeploymentConfig.defaultCanaryStages());
     }
 

--- a/aether/node/src/main/java/org/pragmatica/aether/worker/group/WorkerGroupId.java
+++ b/aether/node/src/main/java/org/pragmatica/aether/worker/group/WorkerGroupId.java
@@ -7,7 +7,7 @@ package org.pragmatica.aether.worker.group;
 public record WorkerGroupId(String groupName, String zone) {
     public static final WorkerGroupId DEFAULT = workerGroupId("default", "local");
 
-    @SuppressWarnings("JBCT-VO-02") public static WorkerGroupId workerGroupId(String groupName, String zone) {
+    public static WorkerGroupId workerGroupId(String groupName, String zone) {
         return new WorkerGroupId(groupName, zone);
     }
 

--- a/aether/resource/api/src/main/java/org/pragmatica/aether/resource/aspect/TransactionConfig.java
+++ b/aether/resource/api/src/main/java/org/pragmatica/aether/resource/aspect/TransactionConfig.java
@@ -40,11 +40,11 @@ public record TransactionConfig(TransactionPropagation propagation,
         return Result.all(validPropagation, validIsolation).map(TransactionConfig::withPropagationAndIsolation);
     }
 
-    @SuppressWarnings({"JBCT-VO-02", "JBCT-NAM-01"}) private static TransactionConfig withDefaultsFrom(TransactionPropagation p) {
+    @SuppressWarnings("JBCT-NAM-01") private static TransactionConfig withDefaultsFrom(TransactionPropagation p) {
         return new TransactionConfig(p, DEFAULT_ISOLATION, none(), false, EMPTY_ROLLBACK_FOR);
     }
 
-    @SuppressWarnings({"JBCT-VO-02", "JBCT-NAM-01"}) private static TransactionConfig withPropagationAndIsolation(TransactionPropagation p,
+    @SuppressWarnings("JBCT-NAM-01") private static TransactionConfig withPropagationAndIsolation(TransactionPropagation p,
                                                                                                                   IsolationLevel i) {
         return new TransactionConfig(p, i, none(), false, EMPTY_ROLLBACK_FOR);
     }

--- a/aether/resource/api/src/main/java/org/pragmatica/aether/resource/aspect/TransactionContext.java
+++ b/aether/resource/api/src/main/java/org/pragmatica/aether/resource/aspect/TransactionContext.java
@@ -37,7 +37,7 @@ public record TransactionContext(String id,
                                               none()));
     }
 
-    @SuppressWarnings({"JBCT-VO-02", "JBCT-NAM-01"}) public static TransactionContext nestedContext(TransactionConfig config,
+    @SuppressWarnings("JBCT-NAM-01") public static TransactionContext nestedContext(TransactionConfig config,
                                                                                                     TransactionContext parent) {
         return new TransactionContext(UUID.randomUUID().toString(),
                                       config,
@@ -46,19 +46,19 @@ public record TransactionContext(String id,
                                       option(parent));
     }
 
-    @SuppressWarnings("JBCT-VO-02") public TransactionContext commit() {
+    public TransactionContext commit() {
         return new TransactionContext(id, config, TransactionStatus.COMMITTED, startTime, parentContext);
     }
 
-    @SuppressWarnings("JBCT-VO-02") public TransactionContext rollback() {
+    public TransactionContext rollback() {
         return new TransactionContext(id, config, TransactionStatus.ROLLED_BACK, startTime, parentContext);
     }
 
-    @SuppressWarnings("JBCT-VO-02") public TransactionContext suspend() {
+    public TransactionContext suspend() {
         return new TransactionContext(id, config, TransactionStatus.SUSPENDED, startTime, parentContext);
     }
 
-    @SuppressWarnings("JBCT-VO-02") public TransactionContext resume() {
+    public TransactionContext resume() {
         return new TransactionContext(id, config, TransactionStatus.ACTIVE, startTime, parentContext);
     }
 

--- a/aether/resource/interceptors/src/main/java/org/pragmatica/aether/resource/interceptor/CacheConfig.java
+++ b/aether/resource/interceptors/src/main/java/org/pragmatica/aether/resource/interceptor/CacheConfig.java
@@ -11,7 +11,7 @@ import static org.pragmatica.lang.Verify.ensure;
 
 
 public record CacheConfig(String cacheName, CacheStrategy strategy, int ttlSeconds, int maxEntries, CacheMode mode) {
-    @SuppressWarnings("JBCT-VO-02") private static final CacheConfig DEFAULTS = new CacheConfig("default",
+    private static final CacheConfig DEFAULTS = new CacheConfig("default",
                                                                                                 CacheStrategy.CACHE_ASIDE,
                                                                                                 300,
                                                                                                 10_000,

--- a/aether/resource/interceptors/src/main/java/org/pragmatica/aether/resource/interceptor/CircuitBreakerConfig.java
+++ b/aether/resource/interceptors/src/main/java/org/pragmatica/aether/resource/interceptor/CircuitBreakerConfig.java
@@ -14,7 +14,7 @@ import static org.pragmatica.lang.io.TimeSpan.timeSpan;
 
 
 public record CircuitBreakerConfig(int failureThreshold, TimeSpan resetTimeout, int testAttempts) {
-    @SuppressWarnings("JBCT-VO-02") private static final CircuitBreakerConfig DEFAULTS = new CircuitBreakerConfig(5,
+    private static final CircuitBreakerConfig DEFAULTS = new CircuitBreakerConfig(5,
                                                                                                                   timeSpan(30).seconds(),
                                                                                                                   3);
 

--- a/aether/resource/interceptors/src/main/java/org/pragmatica/aether/resource/interceptor/LogConfig.java
+++ b/aether/resource/interceptors/src/main/java/org/pragmatica/aether/resource/interceptor/LogConfig.java
@@ -19,19 +19,19 @@ public record LogConfig(String name, LogLevel level, boolean logArgs, boolean lo
         return ensure(name, Verify.Is::notBlank).map(n -> new LogConfig(n, level, true, true, true));
     }
 
-    @SuppressWarnings("JBCT-VO-02") public LogConfig withLevel(LogLevel level) {
+    public LogConfig withLevel(LogLevel level) {
         return new LogConfig(name, level, logArgs, logResult, logDuration);
     }
 
-    @SuppressWarnings("JBCT-VO-02") public LogConfig withLogArgs(boolean logArgs) {
+    public LogConfig withLogArgs(boolean logArgs) {
         return new LogConfig(name, level, logArgs, logResult, logDuration);
     }
 
-    @SuppressWarnings("JBCT-VO-02") public LogConfig withLogResult(boolean logResult) {
+    public LogConfig withLogResult(boolean logResult) {
         return new LogConfig(name, level, logArgs, logResult, logDuration);
     }
 
-    @SuppressWarnings("JBCT-VO-02") public LogConfig withLogDuration(boolean logDuration) {
+    public LogConfig withLogDuration(boolean logDuration) {
         return new LogConfig(name, level, logArgs, logResult, logDuration);
     }
 }

--- a/aether/resource/interceptors/src/main/java/org/pragmatica/aether/resource/interceptor/MetricsConfig.java
+++ b/aether/resource/interceptors/src/main/java/org/pragmatica/aether/resource/interceptor/MetricsConfig.java
@@ -35,7 +35,7 @@ public record MetricsConfig(String name,
         return all(validName, validRegistry).map((n, r) -> new MetricsConfig(n, r, recordTiming, recordCounts, List.of()));
     }
 
-    @SuppressWarnings("JBCT-VO-02") public MetricsConfig withTags(String... tags) {
+    public MetricsConfig withTags(String... tags) {
         return new MetricsConfig(name, registry, recordTiming, recordCounts, List.of(tags));
     }
 }

--- a/aether/resource/interceptors/src/main/java/org/pragmatica/aether/resource/interceptor/RetryConfig.java
+++ b/aether/resource/interceptors/src/main/java/org/pragmatica/aether/resource/interceptor/RetryConfig.java
@@ -29,7 +29,7 @@ public record RetryConfig(int maxAttempts, BackoffStrategy backoffStrategy) {
         return all(validAttempts, validStrategy).map(RetryConfig::new);
     }
 
-    @SuppressWarnings({"JBCT-VO-02", "JBCT-NAM-01"}) private static RetryConfig withExponentialBackoff(int attempts) {
+    @SuppressWarnings("JBCT-NAM-01") private static RetryConfig withExponentialBackoff(int attempts) {
         var strategy = BackoffStrategy.exponential().initialDelay(timeSpan(100).millis())
                                                   .maxDelay(timeSpan(10).seconds())
                                                   .factor(2.0)
@@ -37,7 +37,7 @@ public record RetryConfig(int maxAttempts, BackoffStrategy backoffStrategy) {
         return new RetryConfig(attempts, strategy);
     }
 
-    @SuppressWarnings({"JBCT-VO-02", "JBCT-NAM-01"}) private static RetryConfig withFixedBackoff(int attempts,
+    @SuppressWarnings("JBCT-NAM-01") private static RetryConfig withFixedBackoff(int attempts,
                                                                                                  TimeSpan interval) {
         return new RetryConfig(attempts,
                                BackoffStrategy.fixed().interval(interval));

--- a/aether/slice/src/main/java/org/pragmatica/aether/artifact/Artifact.java
+++ b/aether/slice/src/main/java/org/pragmatica/aether/artifact/Artifact.java
@@ -23,13 +23,13 @@ import org.pragmatica.serialization.Codec;
         .map(Artifact::new);
     }
 
-    @SuppressWarnings("JBCT-VO-02") public static Artifact artifact(GroupId groupId,
+    public static Artifact artifact(GroupId groupId,
                                                                     ArtifactId artifactId,
                                                                     Version version) {
         return new Artifact(groupId, artifactId, version);
     }
 
-    @SuppressWarnings("JBCT-VO-02") public static Artifact artifact(ArtifactBase base, Version version) {
+    public static Artifact artifact(ArtifactBase base, Version version) {
         return new Artifact(base.groupId(), base.artifactId(), version);
     }
 

--- a/aether/slice/src/main/java/org/pragmatica/aether/artifact/ArtifactBase.java
+++ b/aether/slice/src/main/java/org/pragmatica/aether/artifact/ArtifactBase.java
@@ -20,11 +20,11 @@ import org.pragmatica.serialization.Codec;
         return Result.all(GroupId.groupId(parts[0]), ArtifactId.artifactId(parts[1])).map(ArtifactBase::new);
     }
 
-    @SuppressWarnings("JBCT-VO-02") public static ArtifactBase artifactBase(GroupId groupId, ArtifactId artifactId) {
+    public static ArtifactBase artifactBase(GroupId groupId, ArtifactId artifactId) {
         return new ArtifactBase(groupId, artifactId);
     }
 
-    @SuppressWarnings("JBCT-VO-02") public static ArtifactBase artifactBase(Artifact artifact) {
+    public static ArtifactBase artifactBase(Artifact artifact) {
         return new ArtifactBase(artifact.groupId(), artifact.artifactId());
     }
 

--- a/aether/slice/src/main/java/org/pragmatica/aether/slice/blueprint/DeploymentConfig.java
+++ b/aether/slice/src/main/java/org/pragmatica/aether/slice/blueprint/DeploymentConfig.java
@@ -7,7 +7,19 @@ package org.pragmatica.aether.slice.blueprint;
 import java.util.List;
 
 
-@SuppressWarnings({"JBCT-VO-02", "JBCT-UTIL-02"}) public record DeploymentConfig(Strategy strategy,
+/// Deployment strategy configuration parsed from blueprint TOML.
+///
+/// This is the blueprint-level configuration that defines HOW an application
+/// should be deployed (rolling, canary, blue-green) and the associated thresholds.
+/// The runtime deployment managers in aether-invoke consume this configuration.
+///
+/// @param strategy the deployment strategy type
+/// @param canaryStages canary stages (only used when strategy is CANARY)
+/// @param maxErrorRate maximum error rate threshold (0.0-1.0)
+/// @param maxLatencyMs maximum latency threshold in milliseconds
+/// @param drainTimeoutMs blue-green drain timeout in milliseconds
+/// @param schemaRequired whether schema migrations must complete before slice activation (default true)
+@SuppressWarnings("JBCT-UTIL-02") public record DeploymentConfig(Strategy strategy,
                                                                                  List<CanaryStageConfig> canaryStages,
                                                                                  double maxErrorRate,
                                                                                  long maxLatencyMs,
@@ -20,7 +32,7 @@ import java.util.List;
     }
 
     public record CanaryStageConfig(int trafficPercent, int observationMinutes) {
-        @SuppressWarnings("JBCT-VO-02") public static CanaryStageConfig canaryStageConfig(int trafficPercent,
+        public static CanaryStageConfig canaryStageConfig(int trafficPercent,
                                                                                           int observationMinutes) {
             return new CanaryStageConfig(trafficPercent, observationMinutes);
         }

--- a/aether/slice/src/main/java/org/pragmatica/aether/slice/blueprint/ResolvedSlice.java
+++ b/aether/slice/src/main/java/org/pragmatica/aether/slice/blueprint/ResolvedSlice.java
@@ -36,7 +36,7 @@ import static org.pragmatica.lang.Verify.ensure;
                      .map(a -> toResolvedSlice(a, instances, minAvailable, isDependency, dependencies));
     }
 
-    @SuppressWarnings("JBCT-VO-02") private static ResolvedSlice toResolvedSlice(Artifact artifact,
+    private static ResolvedSlice toResolvedSlice(Artifact artifact,
                                                                                  int instances,
                                                                                  int minAvailable,
                                                                                  boolean isDependency,

--- a/aether/slice/src/main/java/org/pragmatica/aether/slice/blueprint/SecurityOverrides.java
+++ b/aether/slice/src/main/java/org/pragmatica/aether/slice/blueprint/SecurityOverrides.java
@@ -14,7 +14,12 @@ import static org.pragmatica.lang.Option.none;
 import static org.pragmatica.lang.Option.some;
 
 
-@Codec@SuppressWarnings({"JBCT-UTIL-02", "JBCT-VO-02"}) public record SecurityOverrides(List<Entry> entries,
+/// Blueprint security overrides: a set of route pattern-to-security mappings
+/// with an override policy controlling how they are applied.
+///
+/// @param entries  route pattern to security level mappings
+/// @param policy   how overrides interact with original route security
+@Codec@SuppressWarnings("JBCT-UTIL-02") public record SecurityOverrides(List<Entry> entries,
                                                                                         SecurityOverridePolicy policy) {
     @Codec public record Entry(String routePattern, String securityLevel) {
         public static Entry entry(String routePattern, String securityLevel) {

--- a/aether/slice/src/main/java/org/pragmatica/aether/slice/kvstore/AetherKey.java
+++ b/aether/slice/src/main/java/org/pragmatica/aether/slice/kvstore/AetherKey.java
@@ -39,7 +39,7 @@ import static org.pragmatica.lang.Result.success;
             return asString();
         }
 
-        @SuppressWarnings("JBCT-VO-02") public static SliceTargetKey sliceTargetKey(ArtifactBase artifactBase) {
+        public static SliceTargetKey sliceTargetKey(ArtifactBase artifactBase) {
             return new SliceTargetKey(artifactBase);
         }
 
@@ -67,7 +67,7 @@ import static org.pragmatica.lang.Result.success;
             return BlueprintId.blueprintId(blueprintIdPart).map(AppBlueprintKey::new);
         }
 
-        @SuppressWarnings("JBCT-VO-02") public static AppBlueprintKey appBlueprintKey(BlueprintId blueprintId) {
+        public static AppBlueprintKey appBlueprintKey(BlueprintId blueprintId) {
             return new AppBlueprintKey(blueprintId);
         }
     }
@@ -85,7 +85,7 @@ import static org.pragmatica.lang.Result.success;
             return asString();
         }
 
-        @SuppressWarnings("JBCT-VO-02") public static SliceNodeKey sliceNodeKey(Artifact artifact, NodeId nodeId) {
+        public static SliceNodeKey sliceNodeKey(Artifact artifact, NodeId nodeId) {
             return new SliceNodeKey(artifact, nodeId);
         }
 
@@ -138,7 +138,7 @@ import static org.pragmatica.lang.Result.success;
             return asString();
         }
 
-        @SuppressWarnings("JBCT-VO-02") public static VersionRoutingKey versionRoutingKey(ArtifactBase artifactBase) {
+        public static VersionRoutingKey versionRoutingKey(ArtifactBase artifactBase) {
             return new VersionRoutingKey(artifactBase);
         }
 
@@ -160,7 +160,7 @@ import static org.pragmatica.lang.Result.success;
             return asString();
         }
 
-        @SuppressWarnings("JBCT-VO-02") public static DeploymentKey deploymentKey(String deploymentId) {
+        public static DeploymentKey deploymentKey(String deploymentId) {
             return new DeploymentKey(deploymentId);
         }
 
@@ -183,7 +183,7 @@ import static org.pragmatica.lang.Result.success;
             return asString();
         }
 
-        @SuppressWarnings("JBCT-VO-02") public static PreviousVersionKey previousVersionKey(ArtifactBase artifactBase) {
+        public static PreviousVersionKey previousVersionKey(ArtifactBase artifactBase) {
             return new PreviousVersionKey(artifactBase);
         }
 
@@ -209,7 +209,7 @@ import static org.pragmatica.lang.Result.success;
             return httpMethod + ":" + pathPrefix;
         }
 
-        @SuppressWarnings("JBCT-VO-02") public static HttpNodeRouteKey httpNodeRouteKey(String httpMethod,
+        public static HttpNodeRouteKey httpNodeRouteKey(String httpMethod,
                                                                                         String pathPrefix,
                                                                                         NodeId nodeId) {
             return new HttpNodeRouteKey(httpMethod.toUpperCase(), normalizePrefix(pathPrefix), nodeId);
@@ -250,7 +250,7 @@ import static org.pragmatica.lang.Result.success;
             return asString();
         }
 
-        @SuppressWarnings("JBCT-VO-02") public static LogLevelKey forLogger(String loggerName) {
+        public static LogLevelKey forLogger(String loggerName) {
             return new LogLevelKey(loggerName);
         }
 
@@ -273,7 +273,7 @@ import static org.pragmatica.lang.Result.success;
             return asString();
         }
 
-        @SuppressWarnings("JBCT-VO-02") public static ObservabilityDepthKey observabilityDepthKey(String artifactBase,
+        public static ObservabilityDepthKey observabilityDepthKey(String artifactBase,
                                                                                                   String methodName) {
             return new ObservabilityDepthKey(artifactBase, methodName);
         }
@@ -320,7 +320,7 @@ import static org.pragmatica.lang.Result.success;
             return asString();
         }
 
-        @SuppressWarnings("JBCT-VO-02") public static TopicSubscriptionKey topicSubscriptionKey(String topicName,
+        public static TopicSubscriptionKey topicSubscriptionKey(String topicName,
                                                                                                 Artifact artifact,
                                                                                                 MethodName methodName) {
             return new TopicSubscriptionKey(topicName, artifact, methodName);
@@ -356,7 +356,7 @@ import static org.pragmatica.lang.Result.success;
             return asString();
         }
 
-        @SuppressWarnings("JBCT-VO-02") public static ScheduledTaskKey scheduledTaskKey(String configSection,
+        public static ScheduledTaskKey scheduledTaskKey(String configSection,
                                                                                         Artifact artifact,
                                                                                         MethodName methodName) {
             return new ScheduledTaskKey(configSection, artifact, methodName);
@@ -392,7 +392,7 @@ import static org.pragmatica.lang.Result.success;
             return asString();
         }
 
-        @SuppressWarnings("JBCT-VO-02") public static ScheduledTaskStateKey scheduledTaskStateKey(String configSection,
+        public static ScheduledTaskStateKey scheduledTaskStateKey(String configSection,
                                                                                                   Artifact artifact,
                                                                                                   MethodName methodName) {
             return new ScheduledTaskStateKey(configSection, artifact, methodName);
@@ -428,7 +428,7 @@ import static org.pragmatica.lang.Result.success;
             return asString();
         }
 
-        @SuppressWarnings("JBCT-VO-02") public static NodeLifecycleKey nodeLifecycleKey(NodeId nodeId) {
+        public static NodeLifecycleKey nodeLifecycleKey(NodeId nodeId) {
             return new NodeLifecycleKey(nodeId);
         }
 
@@ -457,11 +457,11 @@ import static org.pragmatica.lang.Result.success;
             return nodeScope.isEmpty();
         }
 
-        @SuppressWarnings("JBCT-VO-02") public static ConfigKey forKey(String key) {
+        public static ConfigKey forKey(String key) {
             return new ConfigKey(key, none());
         }
 
-        @SuppressWarnings("JBCT-VO-02") public static ConfigKey forKey(String key, NodeId nodeId) {
+        public static ConfigKey forKey(String key, NodeId nodeId) {
             return new ConfigKey(key, some(nodeId));
         }
 
@@ -495,11 +495,11 @@ import static org.pragmatica.lang.Result.success;
             return asString();
         }
 
-        @SuppressWarnings("JBCT-VO-02") public static WorkerSliceDirectiveKey workerSliceDirectiveKey(Artifact artifact) {
+        public static WorkerSliceDirectiveKey workerSliceDirectiveKey(Artifact artifact) {
             return new WorkerSliceDirectiveKey(artifact, Option.none());
         }
 
-        @SuppressWarnings("JBCT-VO-02") public static WorkerSliceDirectiveKey workerSliceDirectiveKey(Artifact artifact,
+        public static WorkerSliceDirectiveKey workerSliceDirectiveKey(Artifact artifact,
                                                                                                       String communityId) {
             return new WorkerSliceDirectiveKey(artifact, Option.option(communityId));
         }
@@ -532,7 +532,7 @@ import static org.pragmatica.lang.Result.success;
             return asString();
         }
 
-        @SuppressWarnings("JBCT-VO-02") public static ActivationDirectiveKey activationDirectiveKey(NodeId nodeId) {
+        public static ActivationDirectiveKey activationDirectiveKey(NodeId nodeId) {
             return new ActivationDirectiveKey(nodeId);
         }
 
@@ -555,7 +555,7 @@ import static org.pragmatica.lang.Result.success;
             return asString();
         }
 
-        @SuppressWarnings("JBCT-VO-02") public static BlueprintResourcesKey blueprintResourcesKey(BlueprintId blueprintId) {
+        public static BlueprintResourcesKey blueprintResourcesKey(BlueprintId blueprintId) {
             return new BlueprintResourcesKey(blueprintId);
         }
 
@@ -577,7 +577,7 @@ import static org.pragmatica.lang.Result.success;
             return asString();
         }
 
-        @SuppressWarnings("JBCT-VO-02") public static SchemaVersionKey schemaVersionKey(String datasourceName) {
+        public static SchemaVersionKey schemaVersionKey(String datasourceName) {
             return new SchemaVersionKey(datasourceName);
         }
 
@@ -600,7 +600,7 @@ import static org.pragmatica.lang.Result.success;
             return asString();
         }
 
-        @SuppressWarnings("JBCT-VO-02") public static SchemaMigrationLockKey schemaMigrationLockKey(String datasourceName) {
+        public static SchemaMigrationLockKey schemaMigrationLockKey(String datasourceName) {
             return new SchemaMigrationLockKey(datasourceName);
         }
 
@@ -623,7 +623,7 @@ import static org.pragmatica.lang.Result.success;
             return asString();
         }
 
-        @SuppressWarnings("JBCT-VO-02") public static GossipKeyRotationKey gossipKeyRotationKey() {
+        public static GossipKeyRotationKey gossipKeyRotationKey() {
             return new GossipKeyRotationKey();
         }
 
@@ -644,7 +644,7 @@ import static org.pragmatica.lang.Result.success;
             return asString();
         }
 
-        @SuppressWarnings("JBCT-VO-02") public static GovernorAnnouncementKey forCommunity(String communityId) {
+        public static GovernorAnnouncementKey forCommunity(String communityId) {
             return new GovernorAnnouncementKey(communityId);
         }
 
@@ -686,7 +686,7 @@ import static org.pragmatica.lang.Result.success;
             return asString();
         }
 
-        @SuppressWarnings("JBCT-VO-02") public static AbTestRoutingKey abTestRoutingKey(ArtifactBase artifactBase) {
+        public static AbTestRoutingKey abTestRoutingKey(ArtifactBase artifactBase) {
             return new AbTestRoutingKey(artifactBase);
         }
 
@@ -712,7 +712,7 @@ import static org.pragmatica.lang.Result.success;
             return asString();
         }
 
-        @SuppressWarnings("JBCT-VO-02") public static NodeArtifactKey nodeArtifactKey(NodeId nodeId,
+        public static NodeArtifactKey nodeArtifactKey(NodeId nodeId,
                                                                                       Artifact artifact) {
             return new NodeArtifactKey(nodeId, artifact);
         }
@@ -746,7 +746,7 @@ import static org.pragmatica.lang.Result.success;
             return asString();
         }
 
-        @SuppressWarnings("JBCT-VO-02") public static NodeRoutesKey nodeRoutesKey(NodeId nodeId, Artifact artifact) {
+        public static NodeRoutesKey nodeRoutesKey(NodeId nodeId, Artifact artifact) {
             return new NodeRoutesKey(nodeId, artifact);
         }
 
@@ -845,7 +845,7 @@ import static org.pragmatica.lang.Result.success;
             return asString();
         }
 
-        @SuppressWarnings("JBCT-VO-02") public static StreamMetadataKey streamMetadataKey(String streamName) {
+        public static StreamMetadataKey streamMetadataKey(String streamName) {
             return new StreamMetadataKey(streamName);
         }
 
@@ -868,7 +868,7 @@ import static org.pragmatica.lang.Result.success;
             return asString();
         }
 
-        @SuppressWarnings("JBCT-VO-02") public static StreamPartitionAssignmentKey streamPartitionAssignmentKey(String streamName,
+        public static StreamPartitionAssignmentKey streamPartitionAssignmentKey(String streamName,
                                                                                                                 String consumerGroup) {
             return new StreamPartitionAssignmentKey(streamName, consumerGroup);
         }
@@ -896,7 +896,7 @@ import static org.pragmatica.lang.Result.success;
             return asString();
         }
 
-        @SuppressWarnings("JBCT-VO-02") public static StreamCursorCheckpointKey streamCursorCheckpointKey(String streamName,
+        public static StreamCursorCheckpointKey streamCursorCheckpointKey(String streamName,
                                                                                                           int partitionIndex,
                                                                                                           String consumerGroup) {
             return new StreamCursorCheckpointKey(streamName, partitionIndex, consumerGroup);
@@ -923,7 +923,7 @@ import static org.pragmatica.lang.Result.success;
             return asString();
         }
 
-        @SuppressWarnings("JBCT-VO-02") public static StreamRegistrationKey streamRegistrationKey(String streamName,
+        public static StreamRegistrationKey streamRegistrationKey(String streamName,
                                                                                                   String configSection,
                                                                                                   Artifact artifact,
                                                                                                   MethodName methodName) {
@@ -964,7 +964,7 @@ import static org.pragmatica.lang.Result.success;
             return asString();
         }
 
-        @SuppressWarnings("JBCT-VO-02") public static StorageBlockKey storageBlockKey(String instanceName,
+        public static StorageBlockKey storageBlockKey(String instanceName,
                                                                                       String blockIdHex) {
             return new StorageBlockKey(instanceName, blockIdHex);
         }
@@ -990,7 +990,7 @@ import static org.pragmatica.lang.Result.success;
             return asString();
         }
 
-        @SuppressWarnings("JBCT-VO-02") public static StorageRefKey storageRefKey(String instanceName,
+        public static StorageRefKey storageRefKey(String instanceName,
                                                                                   String referenceName) {
             return new StorageRefKey(instanceName, referenceName);
         }
@@ -1020,7 +1020,7 @@ import static org.pragmatica.lang.Result.success;
             return asString();
         }
 
-        @SuppressWarnings("JBCT-VO-02") public static StorageStatusKey storageStatusKey(NodeId nodeId,
+        public static StorageStatusKey storageStatusKey(NodeId nodeId,
                                                                                         String instanceName) {
             return new StorageStatusKey(nodeId, instanceName);
         }
@@ -1048,11 +1048,11 @@ import static org.pragmatica.lang.Result.success;
             return asString();
         }
 
-        @SuppressWarnings("JBCT-VO-02") public static final ClusterConfigKey CURRENT = new ClusterConfigKey(0);
+        public static final ClusterConfigKey CURRENT = new ClusterConfigKey(0);
 
-        @SuppressWarnings("JBCT-VO-02") public static final ClusterConfigKey TEMPLATE = new ClusterConfigKey(- 1);
+        public static final ClusterConfigKey TEMPLATE = new ClusterConfigKey(- 1);
 
-        @SuppressWarnings("JBCT-VO-02") public static ClusterConfigKey clusterConfigKey(long configVersion) {
+        public static ClusterConfigKey clusterConfigKey(long configVersion) {
             return new ClusterConfigKey(configVersion);
         }
 
@@ -1075,7 +1075,7 @@ import static org.pragmatica.lang.Result.success;
             return asString();
         }
 
-        @SuppressWarnings("JBCT-VO-02") public static TaskAssignmentKey taskAssignmentKey(TaskGroup taskGroup) {
+        public static TaskAssignmentKey taskAssignmentKey(TaskGroup taskGroup) {
             return new TaskAssignmentKey(taskGroup);
         }
 
@@ -1111,7 +1111,7 @@ import static org.pragmatica.lang.Result.success;
             return asString();
         }
 
-        @SuppressWarnings("JBCT-VO-02") public static ApiKeyKey apiKeyKey(String keyId) {
+        public static ApiKeyKey apiKeyKey(String keyId) {
             return new ApiKeyKey(keyId);
         }
 
@@ -1134,7 +1134,7 @@ import static org.pragmatica.lang.Result.success;
             return asString();
         }
 
-        @SuppressWarnings("JBCT-VO-02") public static ApiKeyAuditKey apiKeyAuditKey(String entryId) {
+        public static ApiKeyAuditKey apiKeyAuditKey(String entryId) {
             return new ApiKeyAuditKey(entryId);
         }
 
@@ -1157,7 +1157,7 @@ import static org.pragmatica.lang.Result.success;
             return asString();
         }
 
-        @SuppressWarnings("JBCT-VO-02") public static CloudCredentialsKey cloudCredentialsKey(String provider) {
+        public static CloudCredentialsKey cloudCredentialsKey(String provider) {
             return new CloudCredentialsKey(provider);
         }
 
@@ -1180,7 +1180,7 @@ import static org.pragmatica.lang.Result.success;
             return asString();
         }
 
-        @SuppressWarnings("JBCT-VO-02") public static DhtPartitionOwnershipKey dhtPartitionOwnershipKey(String partitionId) {
+        public static DhtPartitionOwnershipKey dhtPartitionOwnershipKey(String partitionId) {
             return new DhtPartitionOwnershipKey(partitionId);
         }
 
@@ -1203,7 +1203,7 @@ import static org.pragmatica.lang.Result.success;
             return asString();
         }
 
-        @SuppressWarnings("JBCT-VO-02") public static SpokesmanKey spokesmanKey(NodeId coreNodeId) {
+        public static SpokesmanKey spokesmanKey(NodeId coreNodeId) {
             return new SpokesmanKey(coreNodeId);
         }
 
@@ -1232,7 +1232,7 @@ import static org.pragmatica.lang.Result.success;
             return asString();
         }
 
-        @SuppressWarnings("JBCT-VO-02") public static ProvisioningSlotKey provisioningSlotKey(String slotId) {
+        public static ProvisioningSlotKey provisioningSlotKey(String slotId) {
             return new ProvisioningSlotKey(slotId);
         }
 
@@ -1305,7 +1305,7 @@ import static org.pragmatica.lang.Result.success;
             return asString();
         }
 
-        @SuppressWarnings("JBCT-VO-02") public static ConsumerGroupKey consumerGroupKey(String groupId,
+        public static ConsumerGroupKey consumerGroupKey(String groupId,
                                                                                         String streamName,
                                                                                         int partition) {
             return new ConsumerGroupKey(groupId, streamName, partition);

--- a/integrations/swim/src/main/java/org/pragmatica/swim/SwimProtocol.java
+++ b/integrations/swim/src/main/java/org/pragmatica/swim/SwimProtocol.java
@@ -120,7 +120,6 @@ public final class SwimProtocol implements SwimMessageHandler {
 
     /// Factory creating a SWIM protocol instance.
     /// Result wrapper retained for flatMap(SwimProtocol::start) composition.
-    @SuppressWarnings("JBCT-VO-02")
     public static Result<SwimProtocol> swimProtocol(SwimConfig config,
                                                     SwimTransport transport,
                                                     SwimMembershipListener listener,

--- a/jbct/jbct-lint/src/main/java/org/pragmatica/jbct/lint/cst/rules/CstConstructorBypassRule.java
+++ b/jbct/jbct-lint/src/main/java/org/pragmatica/jbct/lint/cst/rules/CstConstructorBypassRule.java
@@ -14,6 +14,13 @@ import java.util.stream.Stream;
 import static org.pragmatica.jbct.parser.CstNodes.*;
 
 /// JBCT-VO-02: Direct constructor calls bypass factory validation.
+///
+/// A type is considered a value object if any of its records contains a `Result<T>`
+/// factory. `new T(...)` outside a factory method is flagged unless one of:
+/// - The enclosing static method itself returns `Result<...>` (parse factory).
+/// - The enclosing type is itself a value object (parse + construct factory pattern):
+///   the inner factory builds T from already-validated typed arguments and does not
+///   need to re-wrap in Result.
 public class CstConstructorBypassRule implements CstLintRule {
     private static final String RULE_ID = "JBCT-VO-02";
     private static final Pattern NEW_PATTERN = Pattern.compile("new\\s+(\\w+)\\s*\\(");
@@ -40,7 +47,7 @@ public class CstConstructorBypassRule implements CstLintRule {
         // Find direct constructor calls outside factory methods
         return findAll(root, RuleId.Primary.class).stream()
                       .filter(node -> isDirectConstruction(node, source, valueObjectTypes))
-                      .filter(node -> !isInAllowedContext(root, node, source))
+                      .filter(node -> !isInAllowedContext(root, node, source, valueObjectTypes))
                       .map(node -> createDiagnostic(node, source, ctx));
     }
 
@@ -68,16 +75,31 @@ public class CstConstructorBypassRule implements CstLintRule {
         return false;
     }
 
-    private boolean isInAllowedContext(CstNode root, CstNode node, String source) {
-        // Check if inside factory method (static method returning Result)
-        // Note: "static" keyword is in ClassMember/RecordMember, not Member
-        // RecordMember wraps ClassMember in records (ordered choice)
+    private boolean isInAllowedContext(CstNode root, CstNode node, String source, Set<String> valueObjectTypes) {
+        // Two acceptance criteria:
+        //   (a) The construction happens inside the value-object type's own scope.
+        //       Anything inside T's body is trusted: the parse factory has validated
+        //       inputs, and any internal members (construct factories, with-builders,
+        //       static constants) operate on already-validated state.
+        //   (b) The construction happens inside a static method on another type that
+        //       returns Result<...>. This covers cross-type parse factories.
+        if (enclosingTypeIsValueObject(root, node, source, valueObjectTypes)) {
+            return true;
+        }
         return findAncestor(root, node, RuleId.ClassMember.class)
                           .orElse(() -> findAncestor(root, node, RuleId.RecordMember.class))
                           .map(member -> {
                                    var memberText = text(member, source);
                                    return memberText.contains("static ") && memberText.contains("Result<");
                                })
+                          .or(false);
+    }
+
+    private boolean enclosingTypeIsValueObject(CstNode root, CstNode node, String source, Set<String> valueObjectTypes) {
+        return findAncestor(root, node, RuleId.TypeKind.class)
+                          .flatMap(typeKind -> childByRule(typeKind, RuleId.Identifier.class))
+                          .map(id -> text(id, source))
+                          .map(valueObjectTypes::contains)
                           .or(false);
     }
 

--- a/jbct/jbct-lint/src/test/java/org/pragmatica/jbct/lint/cst/CstLinterTest.java
+++ b/jbct/jbct-lint/src/test/java/org/pragmatica/jbct/lint/cst/CstLinterTest.java
@@ -450,6 +450,84 @@ class CstLinterTest {
                 """);
             assertNoRule(diagnostics, "JBCT-VO-02");
         }
+
+        @Test
+        void allowsConstructFactoryAlongsideParseFactory() {
+            // Parse + construct factory pattern: a value-object type T may have a
+            // typed-arg static factory returning T directly (no Result wrapper) when
+            // the inputs are already-validated value objects. The Result<T> parse
+            // factory is the validation entry point; the construct factory is a typed
+            // shortcut used by callers that already hold validated components.
+            var diagnostics = lint("""
+                package com.example.domain.test;
+                import org.pragmatica.lang.Result;
+                record OrderId(String value) {
+                    public static Result<OrderId> orderId(String raw) {
+                        return Result.success(new OrderId(raw));
+                    }
+                    public static OrderId orderId(ValidatedString validated) {
+                        return new OrderId(validated.value());
+                    }
+                }
+                record ValidatedString(String value) {}
+                """);
+            assertNoRule(diagnostics, "JBCT-VO-02");
+        }
+
+        @Test
+        void allowsConstructFactoryViaStaticConstantInValueObject() {
+            // Static field initializers inside a value-object type that allocate the
+            // type itself follow the same parse + construct trust boundary as factories.
+            var diagnostics = lint("""
+                package com.example.domain.test;
+                import org.pragmatica.lang.Result;
+                record Version(int value) {
+                    public static final Version CURRENT = new Version(0);
+                    public static Result<Version> version(String raw) {
+                        return Result.success(new Version(Integer.parseInt(raw)));
+                    }
+                }
+                """);
+            assertNoRule(diagnostics, "JBCT-VO-02");
+        }
+
+        @Test
+        void allowsWithBuilderOnValueObjectRecord() {
+            // Instance-level `with*` builders create a new immutable instance from
+            // existing-validated state. Allowed inside the value-object's own scope.
+            var diagnostics = lint("""
+                package com.example.domain.test;
+                import org.pragmatica.lang.Result;
+                record Config(String name, long timeoutMs) {
+                    public static Result<Config> config(String n, long t) {
+                        return Result.success(new Config(n, t));
+                    }
+                    public Config withTimeoutMs(long timeoutMs) {
+                        return new Config(name, timeoutMs);
+                    }
+                }
+                """);
+            assertNoRule(diagnostics, "JBCT-VO-02");
+        }
+
+        @Test
+        void stillFlagsConstructionFromUnrelatedClass() {
+            // A static method on an unrelated, non-value-object class that constructs
+            // a value object directly bypasses validation — keep flagging this case.
+            var diagnostics = lint("""
+                package com.example.usecase.test;
+                import org.pragmatica.lang.Result;
+                public class Helper {
+                    public static Email bypass() {
+                        return new Email("evil@example.com");
+                    }
+                }
+                record Email(String value) {
+                    public static Result<Email> email(String v) { return Result.success(new Email(v)); }
+                }
+                """);
+            assertHasRule(diagnostics, "JBCT-VO-02");
+        }
     }
 
     // ========== JBCT-EX-* Exception Rules ==========


### PR DESCRIPTION
## Summary

Removes 148 redundant `@SuppressWarnings("JBCT-VO-02")` annotations across 48 files by teaching the lint rule to recognize the project's pervasive **parse + construct factory pattern** as legitimate.

## Why the old rule fired so much

`CstConstructorBypassRule` flagged `new T(...)` for any value-object `T` (a record with a `Result<T>` factory) unless the `new` was inside a static method whose body contained `Result<`. The codebase has a recurring pattern that didn't match:

```java
public record SliceTargetKey(ArtifactBase base) implements AetherKey {
    public static SliceTargetKey sliceTargetKey(ArtifactBase base) {            // construct factory
        return new SliceTargetKey(base);                                         // ← flagged
    }
    public static Result<SliceTargetKey> sliceTargetKey(String key) { ... }      // parse factory
}
```

The construct factory takes already-validated typed args (here `ArtifactBase` is itself a value object) and returns `T` directly. Wrapping in `Result` would be useless. Same story for instance-level `with*` builders.

## Rule change

`CstConstructorBypassRule.isInAllowedContext` now allows `new T(...)` when:
- **(a)** The construction happens inside `T`'s own scope (parse + construct + `with*` builders are all trusted within the type), or
- **(b)** The construction happens inside another type's static method that returns `Result<...>` (existing cross-type parse factory case).

External code (`new T(...)` in unrelated classes) is still flagged.

## Test additions in `CstLinterTest$ConstructorBypassTests`

- `allowsConstructFactoryAlongsideParseFactory` — typed-arg static factory in same type
- `allowsConstructFactoryViaStaticConstantInValueObject` — static field initializer
- `allowsWithBuilderOnValueObjectRecord` — instance-level `with*` builder
- `stillFlagsConstructionFromUnrelatedClass` — regression guard for the genuine bypass case

`mvn -pl jbct/jbct-lint test` — 170/170 pass.

## Sweep

Removed 148 `@SuppressWarnings("JBCT-VO-02")` annotations across 48 files. Variant breakdown:
- 138 single-element annotations on factory/builder methods, with-builders, static field initializers
- 10 multi-element annotations collapsed to keep their other rule IDs (`JBCT-UTIL-02`, `JBCT-NAM-01`, `JBCT-RET-01`)

Densest cleanup: `aether/slice/.../kvstore/AetherKey.java` — 44 → 0.

## Verification

`mvn -pl aether/aether-control,aether/aether-invoke,aether/aether-config,aether/aether-metrics,aether/cli,aether/slice,aether/environment-integration,aether/environment/{aws,azure,gcp,hetzner},aether/ember,aether/resource/interceptors,aether/resource/api,aether/http-handler-api,aether/aether-deployment compile -am -Djbct.skip=false` — **zero JBCT-VO-02 violations resurfaced** after removing 148 suppressions, confirming all were redundant under the new rule.