### PR TITLE
feat: RBAC Tier 2 MVP — KV-store keys carry authorizationRole, default VIEWER

### DIFF
--- a/aether/aether-config/src/main/java/org/pragmatica/aether/config/ApiKeyEntry.java
+++ b/aether/aether-config/src/main/java/org/pragmatica/aether/config/ApiKeyEntry.java
@@ -7,7 +7,17 @@ package org.pragmatica.aether.config;
 import java.util.Set;
 
 
+/// Metadata for a configured API key: display name, assigned roles, and authorization level.
+///
+/// @param name              human-readable name for audit logs
+/// @param roles             assigned role names (e.g., "admin", "service")
+/// @param authorizationRole hierarchical authorization level (ADMIN, OPERATOR, VIEWER); defaults to VIEWER
+///                          for secure-by-default — operators must explicitly opt up.
 public record ApiKeyEntry(String name, Set<String> roles, String authorizationRole) {
+    /// Default authorization role for keys with no explicit role specified.
+    /// Read-only access is the secure-by-default choice.
+    public static final String DEFAULT_ROLE = "VIEWER";
+
     public ApiKeyEntry {
         name = name == null || name.isBlank()
               ? "unnamed"
@@ -16,12 +26,12 @@ public record ApiKeyEntry(String name, Set<String> roles, String authorizationRo
                ? Set.of("service")
                : Set.copyOf(roles);
         authorizationRole = authorizationRole == null || authorizationRole.isBlank()
-                           ? "ADMIN"
+                           ? DEFAULT_ROLE
                            : authorizationRole.toUpperCase();
     }
 
     public static ApiKeyEntry apiKeyEntry(String name, Set<String> roles) {
-        return new ApiKeyEntry(name, roles, "ADMIN");
+        return new ApiKeyEntry(name, roles, DEFAULT_ROLE);
     }
 
     public static ApiKeyEntry apiKeyEntry(String name, Set<String> roles, String authorizationRole) {
@@ -31,6 +41,6 @@ public record ApiKeyEntry(String name, Set<String> roles, String authorizationRo
     public static ApiKeyEntry defaultEntry(String keyValue) {
         var hash = Integer.toHexString(keyValue.hashCode());
         var name = "key-" + hash;
-        return new ApiKeyEntry(name, Set.of("service"), "ADMIN");
+        return new ApiKeyEntry(name, Set.of("service"), DEFAULT_ROLE);
     }
 }

--- a/aether/aether-config/src/main/java/org/pragmatica/aether/config/ConfigLoader.java
+++ b/aether/aether-config/src/main/java/org/pragmatica/aether/config/ConfigLoader.java
@@ -681,7 +681,7 @@ public final class ConfigLoader {
                            : Set.of("service");
                 var authRole = parts.length >= 4
                               ? parts[3].trim()
-                              : "ADMIN";
+                              : ApiKeyEntry.DEFAULT_ROLE;
                 result.put(keyValue, ApiKeyEntry.apiKeyEntry(name, roles, authRole));
             }
         }
@@ -696,7 +696,7 @@ public final class ConfigLoader {
             var name = doc.getString(sectionName, "name").or(ApiKeyEntry.defaultEntry(keyValue).name());
             var roles = doc.getStringList(sectionName, "roles").map(Set::copyOf)
                                          .or(Set.of("service"));
-            var authRole = doc.getString(sectionName, "authorization_role").or("ADMIN");
+            var authRole = doc.getString(sectionName, "authorization_role").or(ApiKeyEntry.DEFAULT_ROLE);
             result.put(keyValue, ApiKeyEntry.apiKeyEntry(name, roles, authRole));
         }}
         return Map.copyOf(result);

--- a/aether/aether-config/src/test/java/org/pragmatica/aether/config/ApiKeyEntryTest.java
+++ b/aether/aether-config/src/test/java/org/pragmatica/aether/config/ApiKeyEntryTest.java
@@ -84,17 +84,17 @@ class ApiKeyEntryTest {
     }
 
     @Test
-    void constructor_defaultsNullAuthorizationRoleToAdmin() {
+    void constructor_defaultsNullAuthorizationRoleToViewer() {
         var entry = new ApiKeyEntry("my-key", Set.of("service"), null);
 
-        assertThat(entry.authorizationRole()).isEqualTo("ADMIN");
+        assertThat(entry.authorizationRole()).isEqualTo("VIEWER");
     }
 
     @Test
-    void constructor_defaultsBlankAuthorizationRoleToAdmin() {
+    void constructor_defaultsBlankAuthorizationRoleToViewer() {
         var entry = new ApiKeyEntry("my-key", Set.of("service"), "  ");
 
-        assertThat(entry.authorizationRole()).isEqualTo("ADMIN");
+        assertThat(entry.authorizationRole()).isEqualTo("VIEWER");
     }
 
     @Test

--- a/aether/aether-config/src/test/java/org/pragmatica/aether/config/ConfigLoaderSecurityTest.java
+++ b/aether/aether-config/src/test/java/org/pragmatica/aether/config/ConfigLoaderSecurityTest.java
@@ -170,7 +170,7 @@ class ConfigLoaderSecurityTest {
     }
 
     @Test
-    void loadFromString_defaultsAuthorizationRoleToAdminWhenOmitted() {
+    void loadFromString_defaultsAuthorizationRoleToViewerWhenOmitted() {
         var toml = MINIMAL_CLUSTER + """
 
             [app-http]
@@ -185,7 +185,7 @@ class ConfigLoaderSecurityTest {
             .onFailure(cause -> fail(cause.message()))
             .onSuccess(config -> {
                 var entry = config.appHttp().apiKeys().get("no-role-key");
-                assertThat(entry.authorizationRole()).isEqualTo("ADMIN");
+                assertThat(entry.authorizationRole()).isEqualTo("VIEWER");
             });
     }
 
@@ -211,7 +211,7 @@ class ConfigLoaderSecurityTest {
     }
 
     @Test
-    void loadFromString_simpleApiKeysDefaultToAdminAuthorizationRole() {
+    void loadFromString_simpleApiKeysDefaultToViewerAuthorizationRole() {
         var toml = MINIMAL_CLUSTER + """
 
             [app-http]
@@ -223,7 +223,7 @@ class ConfigLoaderSecurityTest {
             .onFailure(cause -> fail(cause.message()))
             .onSuccess(config -> {
                 var entry = config.appHttp().apiKeys().get("simple-key");
-                assertThat(entry.authorizationRole()).isEqualTo("ADMIN");
+                assertThat(entry.authorizationRole()).isEqualTo("VIEWER");
             });
     }
 

--- a/aether/cli/src/main/java/org/pragmatica/aether/cli/cluster/ClusterCommand.java
+++ b/aether/cli/src/main/java/org/pragmatica/aether/cli/cluster/ClusterCommand.java
@@ -16,7 +16,7 @@ import picocli.CommandLine.Command;
 ///
 /// Provides subcommands for managing the cluster registry:
 /// listing registered clusters, switching active context, and removing entries.
-@Command(name = "cluster", description = "Cluster lifecycle management", subcommands = {ClusterInitCommand.class, ClusterBootstrapCommand.class, ClusterListCommand.class, ClusterUseCommand.class, ClusterRemoveCommand.class, ClusterStatusCommand.class, ClusterExportCommand.class, ClusterApplyCommand.class, ClusterDrainCommand.class, ClusterDestroyCommand.class, ClusterScaleCommand.class, ClusterUpgradeCommand.class, ClusterMigrateCommand.class, ClusterTasksCommand.class, ClusterTopologyCommand.class, ClusterGenerationCommand.class, ClusterAwaitQuiescedCommand.class, ClusterRotateKeyCommand.class, ClusterRevokeKeyCommand.class, ClusterListKeysCommand.class}) @Contract public class ClusterCommand implements Runnable {
+@Command(name = "cluster", description = "Cluster lifecycle management", subcommands = {ClusterInitCommand.class, ClusterBootstrapCommand.class, ClusterListCommand.class, ClusterUseCommand.class, ClusterRemoveCommand.class, ClusterStatusCommand.class, ClusterExportCommand.class, ClusterApplyCommand.class, ClusterDrainCommand.class, ClusterDestroyCommand.class, ClusterScaleCommand.class, ClusterUpgradeCommand.class, ClusterMigrateCommand.class, ClusterTasksCommand.class, ClusterTopologyCommand.class, ClusterGenerationCommand.class, ClusterAwaitQuiescedCommand.class, ClusterCreateKeyCommand.class, ClusterRotateKeyCommand.class, ClusterRevokeKeyCommand.class, ClusterListKeysCommand.class}) @Contract public class ClusterCommand implements Runnable {
     @CommandLine.ParentCommand private AetherCli parent;
 
     OutputOptions outputOptions() {

--- a/aether/cli/src/main/java/org/pragmatica/aether/cli/cluster/ClusterCreateKeyCommand.java
+++ b/aether/cli/src/main/java/org/pragmatica/aether/cli/cluster/ClusterCreateKeyCommand.java
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2025 Pragmatica Labs - Sergiy Yevtushenko
+// Licensed under Business Source License 1.1. Change Date: 2030-01-01. Change License: Apache-2.0.
+// See LICENSE in the repository root for full terms.
+package org.pragmatica.aether.cli.cluster;
+
+import org.pragmatica.aether.cli.ExitCode;
+import org.pragmatica.aether.cli.OutputFormatter;
+import org.pragmatica.lang.Cause;
+import org.pragmatica.lang.Result;
+
+import java.security.SecureRandom;
+import java.util.Base64;
+import java.util.Set;
+import java.util.concurrent.Callable;
+
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+
+import static org.pragmatica.aether.management.route.ManagementRoute.CLUSTER_KEYS_CREATE;
+
+
+/// Creates a new cluster API key with an explicit authorization role.
+///
+/// Generates a fresh key value, hashes it, posts the key metadata to the cluster
+/// management API, and prints the new key (which the operator must save —
+/// the framework only stores the hash).
+@Command(name = "create-key", description = "Create a new cluster API key with an explicit authorization role")
+@SuppressWarnings({"JBCT-RET-01", "JBCT-PAT-01"}) class ClusterCreateKeyCommand implements Callable<Integer> {
+    private static final int KEY_BYTES = 32;
+    private static final long DEFAULT_GRACE_PERIOD_MS = 5 * 60 * 1000L;
+    private static final Set<String> VALID_ROLES = Set.of("ADMIN", "OPERATOR", "VIEWER");
+
+    @Option(names = "--role",
+            description = "Authorization role: ADMIN, OPERATOR, or VIEWER (default: VIEWER)",
+            defaultValue = "VIEWER")
+    private String role;
+
+    @Option(names = "--name",
+            description = "Human-readable name for the key (used in audit logs)",
+            defaultValue = "")
+    private String name;
+
+    @CommandLine.ParentCommand private ClusterCommand parent;
+
+    @Override public Integer call() {
+        return generateAndCreate().fold(ClusterCreateKeyCommand::onFailure, this::onSuccess);
+    }
+
+    private Result<String> generateAndCreate() {
+        var normalizedRole = role == null ? "VIEWER" : role.trim().toUpperCase();
+        if (!VALID_ROLES.contains(normalizedRole)) {
+            return new CreateKeyError.InvalidRole(role).result();
+        }
+        var newKey = generateApiKey();
+        var newKeyHash = KvStoreApiKeyHasher.hashKey(newKey);
+        var newKeyId = "ak_" + newKeyHash.substring(0, 8);
+        return postCreateKey(newKeyId, newKeyHash, normalizedRole)
+            .map(_ -> buildSuccessJson(newKeyId, newKey, normalizedRole));
+    }
+
+    private Result<String> postCreateKey(String keyId, String keyHash, String authorizationRole) {
+        var hint = name == null || name.isBlank() ? "cli-create-key" : "cli-create-key:" + name.trim();
+        var json = "{\"keyId\":\"" + keyId
+                   + "\",\"keyHash\":\"" + keyHash
+                   + "\",\"gracePeriodMs\":" + DEFAULT_GRACE_PERIOD_MS
+                   + ",\"auditAction\":\"CREATED\""
+                   + ",\"operatorHint\":\"" + hint + "\""
+                   + ",\"authorizationRole\":\"" + authorizationRole + "\"}";
+        return ClusterHttpClient.post(CLUSTER_KEYS_CREATE, json);
+    }
+
+    private static String buildSuccessJson(String keyId, String keyValue, String role) {
+        return "{\"keyId\":\"" + keyId
+               + "\",\"keyValue\":\"" + keyValue
+               + "\",\"authorizationRole\":\"" + role
+               + "\",\"status\":\"created\"}";
+    }
+
+    private int onSuccess(String json) {
+        return OutputFormatter.printAction(json,
+                                           parent.outputOptions(),
+                                           "Key created with role " + role.toUpperCase()
+                                           + ". Save the keyValue — the cluster only stores the hash.");
+    }
+
+    private static int onFailure(Cause cause) {
+        System.err.println("Error: " + cause.message());
+        return ExitCode.ERROR;
+    }
+
+    private static String generateApiKey() {
+        var bytes = new byte[KEY_BYTES];
+        new SecureRandom().nextBytes(bytes);
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
+    }
+
+    sealed interface CreateKeyError extends Cause {
+        record InvalidRole(String got) implements CreateKeyError {
+            @Override public String message() {
+                return "Invalid --role '" + got + "'. Must be ADMIN, OPERATOR, or VIEWER.";
+            }
+        }
+    }
+}

--- a/aether/cli/src/main/java/org/pragmatica/aether/cli/cluster/ClusterRotateKeyCommand.java
+++ b/aether/cli/src/main/java/org/pragmatica/aether/cli/cluster/ClusterRotateKeyCommand.java
@@ -31,6 +31,11 @@ import static org.pragmatica.aether.management.route.ManagementRoute.CLUSTER_KEY
 
     @Option(names = "--grace-period", description = "Grace period for old key (e.g., 5m, 1h)", defaultValue = "5m") private String gracePeriod;
 
+    @Option(names = "--role",
+            description = "Authorization role for the new key: ADMIN, OPERATOR, or VIEWER (default: VIEWER)",
+            defaultValue = "VIEWER")
+    private String role;
+
     @CommandLine.ParentCommand private ClusterCommand parent;
 
     @Override public Integer call() {
@@ -42,7 +47,8 @@ import static org.pragmatica.aether.management.route.ManagementRoute.CLUSTER_KEY
         var newKeyHash = KvStoreApiKeyHasher.hashKey(newKey);
         var newKeyId = "ak_" + newKeyHash.substring(0, 8);
         var gracePeriodMs = parseDurationMs(gracePeriod);
-        return findCurrentActiveKeyId().flatMap(oldKeyId -> createNewKey(newKeyId, newKeyHash, gracePeriodMs).flatMap(_ -> revokeOldKey(oldKeyId,
+        var normalizedRole = role == null ? "VIEWER" : role.trim().toUpperCase();
+        return findCurrentActiveKeyId().flatMap(oldKeyId -> createNewKey(newKeyId, newKeyHash, gracePeriodMs, normalizedRole).flatMap(_ -> revokeOldKey(oldKeyId,
                                                                                                                                         gracePeriodMs))
                                                                         .flatMap(_ -> persistLocalKey(newKey))
                                                                         .map(_ -> buildSuccessJson(newKeyId,
@@ -66,8 +72,13 @@ import static org.pragmatica.aether.management.route.ManagementRoute.CLUSTER_KEY
         return new RotateKeyError.NoActiveKey().result();
     }
 
-    private static Result<String> createNewKey(String keyId, String keyHash, long gracePeriodMs) {
-        var json = "{\"keyId\":\"" + keyId + "\",\"keyHash\":\"" + keyHash + "\",\"gracePeriodMs\":" + gracePeriodMs + ",\"auditAction\":\"ROTATED\",\"operatorHint\":\"cli-rotate-key\"}";
+    private static Result<String> createNewKey(String keyId, String keyHash, long gracePeriodMs, String authorizationRole) {
+        var json = "{\"keyId\":\"" + keyId
+                   + "\",\"keyHash\":\"" + keyHash
+                   + "\",\"gracePeriodMs\":" + gracePeriodMs
+                   + ",\"auditAction\":\"ROTATED\""
+                   + ",\"operatorHint\":\"cli-rotate-key\""
+                   + ",\"authorizationRole\":\"" + authorizationRole + "\"}";
         return ClusterHttpClient.post(CLUSTER_KEYS_CREATE, json);
     }
 

--- a/aether/node/src/main/java/org/pragmatica/aether/api/routes/ApiKeyRoutes.java
+++ b/aether/node/src/main/java/org/pragmatica/aether/api/routes/ApiKeyRoutes.java
@@ -66,7 +66,10 @@ import static org.pragmatica.http.routing.PathParameter.aString;
     }
 
     @SuppressWarnings("unchecked") private Promise<Object> handleCreateKey(CreateKeyRequest request) {
-        var keyValue = ApiKeyValue.apiKeyValue(request.keyId(), request.keyHash(), request.gracePeriodMs());
+        var role = request.authorizationRole() == null || request.authorizationRole().isBlank()
+                  ? ApiKeyValue.DEFAULT_ROLE
+                  : request.authorizationRole().toUpperCase();
+        var keyValue = ApiKeyValue.apiKeyValue(request.keyId(), request.keyHash(), request.gracePeriodMs(), role);
         var keyCommand = (KVCommand<AetherKey>)(KVCommand<?>) new KVCommand.Put<>(ApiKeyKey.apiKeyKey(request.keyId()),
                                                                                   keyValue);
         var auditValue = ApiKeyAuditValue.apiKeyAuditValue(request.keyId(),
@@ -92,7 +95,8 @@ import static org.pragmatica.http.routing.PathParameter.aString;
                                                             v.createdAt(),
                                                             v.expiresAt(),
                                                             v.revokedAt(),
-                                                            v.gracePeriodMs())));
+                                                            v.gracePeriodMs(),
+                                                            v.authorizationRole())));
         return Promise.success(List.copyOf(keys));
     }
 
@@ -161,7 +165,7 @@ import static org.pragmatica.http.routing.PathParameter.aString;
         }
     }
 
-    record CreateKeyRequest(String keyId, String keyHash, long gracePeriodMs, String auditAction, String operatorHint){}
+    record CreateKeyRequest(String keyId, String keyHash, long gracePeriodMs, String auditAction, String operatorHint, String authorizationRole){}
 
     record CreateKeyResponse(String keyId, String status){}
 
@@ -169,7 +173,7 @@ import static org.pragmatica.http.routing.PathParameter.aString;
 
     record RevokeKeyResponse(String keyId, String status, long gracePeriodMs){}
 
-    record KeyInfo(String keyId, String status, long createdAt, long expiresAt, long revokedAt, long gracePeriodMs){}
+    record KeyInfo(String keyId, String status, long createdAt, long expiresAt, long revokedAt, long gracePeriodMs, String authorizationRole){}
 
     record AuditEntry(String keyId, String action, long timestamp, String operatorHint){}
 

--- a/aether/node/src/main/java/org/pragmatica/aether/http/security/KvStoreApiKeyValidator.java
+++ b/aether/node/src/main/java/org/pragmatica/aether/http/security/KvStoreApiKeyValidator.java
@@ -93,11 +93,27 @@ import org.slf4j.LoggerFactory;
         var matched = match.get();
         return matched == null
               ? SecurityError.INVALID_API_KEY.result()
-              : buildAdminContext(matched.keyId());
+              : buildContext(matched);
     }
 
-    private static Result<SecurityContext> buildAdminContext(String keyId) {
-        return SecurityContext.securityContext("api-key:" + keyId, Set.of(Role.ADMIN), AuthorizationRole.ADMIN);
+    private static Result<SecurityContext> buildContext(ApiKeyValue keyValue) {
+        var role = parseAuthorizationRole(keyValue.authorizationRole());
+        return SecurityContext.securityContext("api-key:" + keyValue.keyId(), Set.of(Role.ADMIN), role);
+    }
+
+    private static AuthorizationRole parseAuthorizationRole(String raw) {
+        if (raw == null || raw.isBlank()) {
+            return AuthorizationRole.VIEWER;
+        }
+        return switch (raw.toUpperCase()) {
+            case "ADMIN" -> AuthorizationRole.ADMIN;
+            case "OPERATOR" -> AuthorizationRole.OPERATOR;
+            case "VIEWER" -> AuthorizationRole.VIEWER;
+            default -> {
+                log.warn("Unknown authorization role '{}' on stored API key; defaulting to VIEWER", raw);
+                yield AuthorizationRole.VIEWER;
+            }
+        };
     }
 
     private Option<String> extractApiKey(Map<String, List<String>> headers) {

--- a/aether/node/src/test/java/org/pragmatica/aether/http/security/AuthorizationPipelineTest.java
+++ b/aether/node/src/test/java/org/pragmatica/aether/http/security/AuthorizationPipelineTest.java
@@ -327,18 +327,18 @@ class AuthorizationPipelineTest {
     @Nested
     class DefaultRoleHandling {
         @Test
-        void pipeline_defaultsToAdmin_whenAuthorizationRoleOmitted() {
+        void pipeline_defaultsToViewer_whenAuthorizationRoleOmitted() {
             var keyWithNoRole = "no-role-key-value-1";
             var entries = Map.of(
                 keyWithNoRole, ApiKeyEntry.apiKeyEntry("no-role-svc", Set.of("service"))
             );
             var validatorNoRole = SecurityValidator.apiKeyValidator(entries);
-            var request = createRequest(keyWithNoRole, "POST", "/api/blueprint");
-            var permission = RoutePermissionRegistry.resolve("POST", "/api/blueprint");
+            var request = createRequest(keyWithNoRole, "GET", "/api/status");
+            var permission = RoutePermissionRegistry.resolve("GET", "/api/status");
             validatorNoRole.validate(request, policy)
                            .flatMap(sc -> RoleEnforcer.enforce(sc, permission))
-                           .onFailureRun(() -> fail("Expected success — default ADMIN role"))
-                           .onSuccess(sc -> assertThat(sc.authorizationRole()).isEqualTo(AuthorizationRole.ADMIN));
+                           .onFailureRun(() -> fail("Expected success — default VIEWER role grants /api/status"))
+                           .onSuccess(sc -> assertThat(sc.authorizationRole()).isEqualTo(AuthorizationRole.VIEWER));
         }
 
         @Test

--- a/aether/slice/src/main/java/org/pragmatica/aether/slice/kvstore/AetherValue.java
+++ b/aether/slice/src/main/java/org/pragmatica/aether/slice/kvstore/AetherValue.java
@@ -1179,15 +1179,24 @@ import static org.pragmatica.lang.Option.none;
                        long expiresAt,
                        String status,
                        long revokedAt,
-                       long gracePeriodMs) implements AetherValue {
+                       long gracePeriodMs,
+                       String authorizationRole) implements AetherValue {
         static final String ACTIVE = "ACTIVE";
 
         static final String REVOKED = "REVOKED";
 
         static final String EXPIRED = "EXPIRED";
 
+        /// Default authorization role for keys created without an explicit role.
+        /// Read-only access is the secure-by-default choice — operators must opt up.
+        public static final String DEFAULT_ROLE = "VIEWER";
+
         public static ApiKeyValue apiKeyValue(String keyId, String keyHash, long gracePeriodMs) {
-            return new ApiKeyValue(keyId, keyHash, System.currentTimeMillis(), - 1, ACTIVE, - 1, gracePeriodMs);
+            return new ApiKeyValue(keyId, keyHash, System.currentTimeMillis(), - 1, ACTIVE, - 1, gracePeriodMs, DEFAULT_ROLE);
+        }
+
+        public static ApiKeyValue apiKeyValue(String keyId, String keyHash, long gracePeriodMs, String authorizationRole) {
+            return new ApiKeyValue(keyId, keyHash, System.currentTimeMillis(), - 1, ACTIVE, - 1, gracePeriodMs, authorizationRole);
         }
 
         public static ApiKeyValue apiKeyValue(String keyId,
@@ -1196,8 +1205,9 @@ import static org.pragmatica.lang.Option.none;
                                               long expiresAt,
                                               String status,
                                               long revokedAt,
-                                              long gracePeriodMs) {
-            return new ApiKeyValue(keyId, keyHash, createdAt, expiresAt, status, revokedAt, gracePeriodMs);
+                                              long gracePeriodMs,
+                                              String authorizationRole) {
+            return new ApiKeyValue(keyId, keyHash, createdAt, expiresAt, status, revokedAt, gracePeriodMs, authorizationRole);
         }
 
         public boolean isActive() {
@@ -1223,11 +1233,12 @@ import static org.pragmatica.lang.Option.none;
                                    expiresAt,
                                    REVOKED,
                                    System.currentTimeMillis(),
-                                   gracePeriod);
+                                   gracePeriod,
+                                   authorizationRole);
         }
 
         public ApiKeyValue withExpired() {
-            return new ApiKeyValue(keyId, keyHash, createdAt, expiresAt, EXPIRED, revokedAt, gracePeriodMs);
+            return new ApiKeyValue(keyId, keyHash, createdAt, expiresAt, EXPIRED, revokedAt, gracePeriodMs, authorizationRole);
         }
     }
 

--- a/aether/slice/src/main/java/org/pragmatica/aether/slice/kvstore/KVStoreSerializer.java
+++ b/aether/slice/src/main/java/org/pragmatica/aether/slice/kvstore/KVStoreSerializer.java
@@ -1008,7 +1008,7 @@ import static org.pragmatica.lang.Result.success;
     }
 
     private static String serializeApiKey(ApiKeyValue v) {
-        return v.keyId() + PIPE + v.keyHash() + PIPE + v.createdAt() + PIPE + v.expiresAt() + PIPE + v.status() + PIPE + v.revokedAt() + PIPE + v.gracePeriodMs();
+        return v.keyId() + PIPE + v.keyHash() + PIPE + v.createdAt() + PIPE + v.expiresAt() + PIPE + v.status() + PIPE + v.revokedAt() + PIPE + v.gracePeriodMs() + PIPE + v.authorizationRole();
     }
 
     private static String serializeApiKeyAudit(ApiKeyAuditValue v) {
@@ -1017,7 +1017,7 @@ import static org.pragmatica.lang.Result.success;
 
     private static Result<Map.Entry<AetherKey, AetherValue>> parseApiKeyEntry(String identity, String raw) {
         var parts = raw.split("\\|", - 1);
-        if (parts.length != 7) {return parseFailure("api-key value requires 7 fields, got " + parts.length);}
+        if (parts.length != 8) {return parseFailure("api-key value requires 8 fields, got " + parts.length);}
         return ApiKeyKey.parseApiKeyKey("api-key/" + identity)
                                        .map(key -> entry(key,
                                                          new ApiKeyValue(parts[0],
@@ -1026,7 +1026,8 @@ import static org.pragmatica.lang.Result.success;
                                                                          Long.parseLong(parts[3]),
                                                                          parts[4],
                                                                          Long.parseLong(parts[5]),
-                                                                         Long.parseLong(parts[6]))));
+                                                                         Long.parseLong(parts[6]),
+                                                                         parts[7])));
     }
 
     private static Result<Map.Entry<AetherKey, AetherValue>> parseApiKeyAuditEntry(String identity, String raw) {

--- a/aether/slice/src/test/java/org/pragmatica/aether/slice/kvstore/KVStoreSerializerTest.java
+++ b/aether/slice/src/test/java/org/pragmatica/aether/slice/kvstore/KVStoreSerializerTest.java
@@ -341,6 +341,37 @@ class KVStoreSerializerTest {
         }
 
         @Test
+        void roundTrip_apiKeyValue_preservesAuthorizationRole() {
+            var entries = new LinkedHashMap<AetherKey, AetherValue>();
+            entries.put(ApiKeyKey.apiKeyKey("ak_admin01"),
+                        AetherValue.ApiKeyValue.apiKeyValue("ak_admin01", "deadbeef", 5000L, "ADMIN"));
+            entries.put(ApiKeyKey.apiKeyKey("ak_oper001"),
+                        AetherValue.ApiKeyValue.apiKeyValue("ak_oper001", "cafe1234", 5000L, "OPERATOR"));
+            entries.put(ApiKeyKey.apiKeyKey("ak_view001"),
+                        AetherValue.ApiKeyValue.apiKeyValue("ak_view001", "feedface", 5000L, "VIEWER"));
+
+            KVStoreSerializer.toToml(entries, TEST_PHASE, TEST_TIMESTAMP)
+                             .flatMap(KVStoreSerializer::fromToml)
+                             .onFailureRun(Assertions::fail)
+                             .onSuccess(restored -> {
+                                 var admin = (AetherValue.ApiKeyValue) restored.get(ApiKeyKey.apiKeyKey("ak_admin01"));
+                                 assertThat(admin.authorizationRole()).isEqualTo("ADMIN");
+
+                                 var operator = (AetherValue.ApiKeyValue) restored.get(ApiKeyKey.apiKeyKey("ak_oper001"));
+                                 assertThat(operator.authorizationRole()).isEqualTo("OPERATOR");
+
+                                 var viewer = (AetherValue.ApiKeyValue) restored.get(ApiKeyKey.apiKeyKey("ak_view001"));
+                                 assertThat(viewer.authorizationRole()).isEqualTo("VIEWER");
+                             });
+        }
+
+        @Test
+        void apiKeyValue_factoryWithoutRole_defaultsToViewer() {
+            var keyValue = AetherValue.ApiKeyValue.apiKeyValue("ak_test", "hash", 1000L);
+            assertThat(keyValue.authorizationRole()).isEqualTo("VIEWER");
+        }
+
+        @Test
         void roundTrip_ephemeralKeys_excludedFromOutput() {
             var entries = new LinkedHashMap<AetherKey, AetherValue>();
 


### PR DESCRIPTION
## Summary

Closes the four real gaps identified in the RBAC Tier 2 audit. Most of the heavy lifting (Layers 1–3, audit log) was already done in the codebase; this PR fills in the remaining behavioral and operator-facing gaps.

## What was missing

Per the audit (against v1-roadmap §Week 2 scope):

1. **`ApiKeyValue` had no role field** — KV-store-backed keys carried no role info; serialized as 7-field pipe-format.
2. **`KvStoreApiKeyValidator.buildAdminContext` hardcoded `AuthorizationRole.ADMIN`** for every KV-loaded key, ignoring per-key role even if it had been wired.
3. **No `aether cluster create-key --role` CLI command** — only rotate/revoke/list. Operators couldn't even create a non-ADMIN key without hand-crafting a POST to the management API.
4. **Default role was ADMIN** in `ApiKeyEntry` constructor / `defaultEntry()` / `ConfigLoader` fallback. Roadmap mandates VIEWER (secure-by-default).

## Commits

1. **`feat(slice): ApiKeyValue carries authorizationRole field`** — adds 8th field (String, default `"VIEWER"`) to `ApiKeyValue`. Updates `KVStoreSerializer` to encode/parse 8 fields. New 4-arg factory `apiKeyValue(keyId, keyHash, gracePeriodMs, role)`. Constant `DEFAULT_ROLE = "VIEWER"`.

2. **`feat(node): KV-store API keys carry authorizationRole through validator + routes`** — `KvStoreApiKeyValidator.buildContext(ApiKeyValue)` parses the stored role to `AuthorizationRole` (defaults to `VIEWER` on unknown values, with WARN log). `ApiKeyRoutes.CreateKeyRequest` and `KeyInfo` (list response) gain `authorizationRole` field. Replaces hardcoded ADMIN.

3. **`feat(config): default authorizationRole flips from ADMIN to VIEWER`** — three call sites: `ApiKeyEntry` constructor, `apiKeyEntry(name, roles)` 2-arg factory, `defaultEntry()`, plus `ConfigLoader.parseRichApiKeys` and `parseEnvApiKeys` fallbacks. Updated 3 expectation tests to match.

4. **`feat(cli): aether cluster create-key with --role; rotate-key gains --role`** — new `ClusterCreateKeyCommand` (`aether cluster create-key --role ADMIN|OPERATOR|VIEWER --name <name>`). Generates fresh key, prints to stdout (operator must save). `ClusterRotateKeyCommand` adds `--role` (default VIEWER). Both pass role through to the management API.

5. **`test(slice): authorizationRole round-trip + factory default coverage`** — KVStoreSerializer round-trip for ADMIN/OPERATOR/VIEWER values, plus factory default = VIEWER assertion.

## Verification

- `mvn -pl aether/slice test` — 557/557 ✓ (incl. 2 new ApiKeyValue serialization tests)
- `mvn -pl aether/node test` — 372/372 ✓
- `mvn -pl aether/aether-config test` — 264/264 ✓ (incl. updated VIEWER-default expectations)
- `mvn -pl aether/cli test` — 60/60 ✓

## Out of scope (tracked as follow-up)

- **Defensive route-prefix coverage check** at startup. Per audit Layer 3: `RoutePermissionRegistry` uses path-prefix matching for centralized enforcement instead of per-route annotations. A new route added with a path that doesn't match an existing prefix silently defaults — recommend adding a startup assertion that every registered route prefix is covered. Not strictly needed for MVP since centralized enforcement already works.
- **`rbac-spec.md` update** to reflect the path-prefix design (vs the spec's per-route annotation wording). Doc-only sync.

## Hot-zone safety

Touched modules: `aether/slice` (KV-store value record + serializer), `aether/node` (validator + routes — HTTP API layer), `aether/aether-config` (ApiKeyEntry + ConfigLoader), `aether/cli`. None in the consensus / control / deployment hot zones.