### PR TITLE
ci: trigger on release-* PRs (not just main)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main, release-*, feature/*]
   pull_request:
-    branches: [main]
+    branches: [main, release-*]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Adds `release-*` to the PR-event branch list so CI runs against release-branch-targeted PRs (today's 12 RC1 PRs all silently skipped CI). Workflow dispatch trigger remains for manual fallback.