### PR TITLE
fix(slice-processor): revert ENVELOPE_FORMAT_VERSION 1001->1000 (no envelope bumps until GA)

### DIFF
--- a/jbct/slice-processor/src/main/java/org/pragmatica/jbct/slice/generator/ManifestGenerator.java
+++ b/jbct/slice-processor/src/main/java/org/pragmatica/jbct/slice/generator/ManifestGenerator.java
@@ -31,7 +31,7 @@ import java.util.Properties;
 import java.util.stream.Collectors;
 
 public class ManifestGenerator {
-    static final int ENVELOPE_FORMAT_VERSION = 1001;
+    static final int ENVELOPE_FORMAT_VERSION = 1000;
 
     private final Filer filer;
     private final DependencyVersionResolver versionResolver;


### PR DESCRIPTION
## Summary

- Revert `ManifestGenerator.ENVELOPE_FORMAT_VERSION` 1001 → 1000.
- Policy: envelope format doesn't change until GA. The bump in `cd8e9c96e` ("hierarchical config composition Batch 1") was over-cautious — during RC, schema flux is expected and version bumps create noise in test fixtures without buying meaningful on-wire compatibility tracking.

## Effect

- Fixes the pre-existing `SliceProcessorTest` failure (test expects `envelope.version=1000`, source had `1001`).

## Test plan
- [x] `SliceProcessorTest` passes with the reverted constant.