### PR TITLE
feat: add ULID implementation with monotonic generation

### DIFF
--- a/aether/environment/docker/src/main/java/org/pragmatica/aether/environment/docker/DockerComputeProvider.java
+++ b/aether/environment/docker/src/main/java/org/pragmatica/aether/environment/docker/DockerComputeProvider.java
@@ -55,10 +55,10 @@ import static org.pragmatica.lang.Result.success;
             return preflight.unwrap();
         }
         // Identity: honor a caller-supplied ctx.nodeId() (bootstrap path), otherwise
-        // self-mint a fresh KSUID-suffixed id via the canonical IdGenerator path —
+        // self-mint a fresh ULID-suffixed id via the canonical IdGenerator path —
         // exactly as the cloud providers do. The single value is used for BOTH the
         // container name AND the NodeId, so `NodeId == container_name` holds and
-        // `docker kill <nodeId>` Just Works in the test harness. KSUID is k-sortable
+        // `docker kill <nodeId>` Just Works in the test harness. ULID is k-sortable
         // and unique, eliminating the slot-number reuse the old max(existing)+1 scheme
         // suffered when dead containers were swept and the observed max dropped.
         var identity = resolveIdentity(spec);
@@ -68,7 +68,7 @@ import static org.pragmatica.lang.Result.success;
 
     /// Resolve the node identity used as both container name and NodeId. Honors a
     /// caller-supplied `ctx.nodeId()` when present (bootstrap supplies it), otherwise
-    /// mints `aether-<cluster>-node-<ksuid>` via [IdGenerator]. The cluster segment is
+    /// mints `aether-<cluster>-node-<ulid>` via [IdGenerator]. The cluster segment is
     /// sourced from [#clusterOrDefault] (ProvisionContext.clusterName with an
     /// AETHER_CLUSTER_NAME env fallback) so CTM replacements carry the same
     /// `aether-<cluster>-` prefix as their compose-fixed siblings — the orphan sweeper
@@ -195,7 +195,7 @@ import static org.pragmatica.lang.Result.success;
         var role = roleOrDefault(ctx);
         var cluster = clusterOrDefault(ctx);
         // NodeId == container name (the resolved identity: caller-supplied ctx.nodeId()
-        // or a freshly-minted KSUID id). Keeping them equal means `docker kill <nodeId>`
+        // or a freshly-minted ULID id). Keeping them equal means `docker kill <nodeId>`
         // resolves to this exact container — no nodeId→container map needed.
         var nodeId = containerName;
         var peers = ctx.peers().or("");
@@ -246,7 +246,7 @@ import static org.pragmatica.lang.Result.success;
             command.add(config.dockerGid());
         }
         if (config.exposeHostPorts()) {
-            // KSUID-minted replacements have no numeric slot, so the old `base + slot`
+            // ULID-minted replacements have no numeric slot, so the old `base + slot`
             // host-port scheme no longer applies. Publish the in-container management
             // port (8080) to an ephemeral host port (`-p 8080`) — Docker picks a free
             // one. The integration harness never host-dials provider-minted replacements
@@ -350,7 +350,7 @@ import static org.pragmatica.lang.Result.success;
                                            ProvisionSpec spec) {
         // Provider-minted replacements are reached on the Docker overlay network at
         // the container's own ports (mgmt 8080, app 8070), addressed by container name
-        // == NodeId. Host-mapped per-slot ports were a seed-only convenience; KSUID
+        // == NodeId. Host-mapped per-slot ports were a seed-only convenience; ULID
         // replacements carry no slot, so report the overlay-reachable form.
         var addresses = List.of(containerName + ":8080", containerName + ":8070");
         var tags = buildInstanceTags(spec, containerName);

--- a/integrations/utility/src/main/java/org/pragmatica/utility/IdGenerator.java
+++ b/integrations/utility/src/main/java/org/pragmatica/utility/IdGenerator.java
@@ -22,8 +22,15 @@ public sealed interface IdGenerator {
     /// @param prefix the prefix for the ID
     /// @return a unique ID in the format "prefix-ulid"
     static String generate(String prefix) {
-        return prefix + "-" + ULID.ulid()
-                                  .encoded();
+        return prefix + "-" + generate();
+    }
+
+    /// Generate a unique ID without a prefix.
+    ///
+    /// @return a unique ID as the 26-character ULID string
+    static String generate() {
+        return ULID.ulid()
+                   .encoded();
     }
 
     @SuppressWarnings("unused")

--- a/integrations/utility/src/main/java/org/pragmatica/utility/IdGenerator.java
+++ b/integrations/utility/src/main/java/org/pragmatica/utility/IdGenerator.java
@@ -15,14 +15,14 @@
  */
 
 package org.pragmatica.utility;
-/// ID generator using KSUID for unique, time-sortable identifiers.
+/// ID generator using ULID for unique, time-sortable identifiers.
 public sealed interface IdGenerator {
     /// Generate a unique ID with the given prefix.
     ///
     /// @param prefix the prefix for the ID
-    /// @return a unique ID in the format "prefix-ksuid"
+    /// @return a unique ID in the format "prefix-ulid"
     static String generate(String prefix) {
-        return prefix + "-" + KSUID.ksuid()
+        return prefix + "-" + ULID.ulid()
                                   .encoded();
     }
 

--- a/integrations/utility/src/main/java/org/pragmatica/utility/ULID.java
+++ b/integrations/utility/src/main/java/org/pragmatica/utility/ULID.java
@@ -1,0 +1,323 @@
+/*
+ *  Copyright (c) 2020-2025 Sergiy Yevtushenko.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.pragmatica.utility;
+
+import org.pragmatica.lang.Cause;
+import org.pragmatica.lang.Option;
+import org.pragmatica.lang.Result;
+
+import java.security.SecureRandom;
+import java.util.Arrays;
+
+import static org.pragmatica.lang.Option.none;
+import static org.pragmatica.lang.Option.option;
+import static org.pragmatica.lang.Option.some;
+
+/// Universally Unique Lexicographically Sortable Identifier (ULID) implementation.
+///
+/// A ULID is a 16-byte (128-bit) identifier consisting of:
+///
+///   - 6 bytes: 48-bit unsigned timestamp (milliseconds since the Unix epoch, big-endian)
+///   - 10 bytes: 80-bit cryptographically random payload
+///
+/// The text representation is 26 characters using Crockford's base32 encoding. This
+/// implementation emits the lowercase alphabet (`0123456789abcdefghjkmnpqrstvwxyz`),
+/// which is still strictly ASCII-ascending, so lexicographic ordering of the text form
+/// matches chronological order. Parsing is Crockford-lenient: it is case-insensitive and
+/// accepts the ambiguous aliases `O`/`o` -> `0` and `I`/`i`/`L`/`l` -> `1`.
+///
+/// The 48-bit/26-char layout means the 80-bit random section lands on a clean character
+/// boundary, so a single uniform "two pad bits, most-significant-bit first" 5-bit packing
+/// over all 16 bytes is byte-compatible with the canonical ULID binary specification.
+///
+/// @see <a href="https://github.com/ulid/spec">ULID Specification</a>
+public final class ULID implements Comparable<ULID> {
+    /// Binary length in bytes
+    public static final int BYTE_LENGTH = 16;
+
+    /// Timestamp length in bytes
+    public static final int TIMESTAMP_LENGTH = 6;
+
+    /// Payload length in bytes
+    public static final int PAYLOAD_LENGTH = 10;
+
+    /// String-encoded length
+    public static final int STRING_LENGTH = 26;
+
+    /// Crockford base32 encoding alphabet (lowercase, lexicographically ordered)
+    private static final char[] ALPHABET = "0123456789abcdefghjkmnpqrstvwxyz".toCharArray();
+
+    /// Reverse lookup table for base32 decoding (ASCII -> value, -1 for invalid)
+    private static final byte[] DECODE = new byte[128];
+
+    static {
+        Arrays.fill(DECODE, (byte) - 1);
+        for (int i = 0; i < ALPHABET.length; i++) {
+            DECODE[Character.toUpperCase(ALPHABET[i])] = (byte) i;
+            DECODE[ALPHABET[i]] = (byte) i;
+        }
+        // Crockford-lenient aliases for visually ambiguous characters
+        DECODE['O'] = DECODE['o'] = 0;
+        DECODE['I'] = DECODE['i'] = 1;
+        DECODE['L'] = DECODE['l'] = 1;
+    }
+
+    private static final SecureRandom RANDOM = new SecureRandom();
+
+    /// Nil ULID (all zeros) - represents invalid/empty state
+    public static final ULID NIL = new ULID(new byte[BYTE_LENGTH]);
+
+    /// Maximum possible ULID (all 0xFF bytes)
+    public static final ULID MAX = new ULID(maxBytes());
+
+    /// Monotonic generator state, guarded by MONOTONIC_LOCK.
+    private static final Object MONOTONIC_LOCK = new Object();
+    private static long lastTimestamp = -1L;
+    private static final byte[] lastRandom = new byte[PAYLOAD_LENGTH];
+
+    private final byte[] data;
+
+    private ULID(byte[] data) {
+        this.data = data;
+    }
+
+    /// Generate a new random ULID using the current timestamp.
+    public static ULID ulid() {
+        var payload = new byte[PAYLOAD_LENGTH];
+        RANDOM.nextBytes(payload);
+        return new ULID(compose(System.currentTimeMillis(), payload));
+    }
+
+    /// Generate a monotonic ULID.
+    ///
+    /// Within the same millisecond (or if the system clock moves backwards), the previously
+    /// generated 80-bit random payload is incremented by one, guaranteeing a strictly larger
+    /// value while preserving the earlier timestamp. On the (practically impossible) overflow
+    /// of the random payload, the timestamp is advanced by one millisecond and a fresh payload
+    /// is drawn. Thread-safe.
+    public static ULID monotonicUlid() {
+        synchronized (MONOTONIC_LOCK) {
+            var now = System.currentTimeMillis();
+            if (now > lastTimestamp) {
+                lastTimestamp = now;
+                RANDOM.nextBytes(lastRandom);
+            } else if (!incrementPayload(lastRandom)) {
+                lastTimestamp++;
+                RANDOM.nextBytes(lastRandom);
+            }
+            return new ULID(compose(lastTimestamp, lastRandom));
+        }
+    }
+
+    /// Parse a ULID from its 26-character Crockford base32 string representation.
+    public static Result<ULID> parse(String input) {
+        return option(input).toResult(ULIDError.NULL_INPUT)
+                     .filter(ULIDError::invalidLength,
+                             s -> s.length() == STRING_LENGTH)
+                     .flatMap(s -> decodeBase32(s).toResult(ULIDError.INVALID_CHARACTER))
+                     .map(ULID::new);
+    }
+
+    /// Create a ULID from its 16-byte binary representation.
+    public static Result<ULID> fromBytes(byte[] bytes) {
+        return option(bytes).toResult(ULIDError.NULL_INPUT)
+                     .filter(ULIDError::invalidByteLength, b -> b.length == BYTE_LENGTH)
+                     .map(b -> {
+                              var copy = new byte[BYTE_LENGTH];
+                              System.arraycopy(b, 0, copy, 0, BYTE_LENGTH);
+                              return new ULID(copy);
+                          });
+    }
+
+    /// Get the 26-character Crockford base32 encoded string representation.
+    public String encoded() {
+        return encodeBase32(data);
+    }
+
+    /// Get the raw 16-byte binary representation (defensive copy).
+    public byte[] toBytes() {
+        var copy = new byte[BYTE_LENGTH];
+        System.arraycopy(data, 0, copy, 0, BYTE_LENGTH);
+        return copy;
+    }
+
+    /// Get the Unix timestamp in milliseconds (48-bit big-endian prefix).
+    public long timestamp() {
+        return ((data[0] & 0xFFL)<< 40)
+               | ((data[1] & 0xFFL)<< 32)
+               | ((data[2] & 0xFFL)<< 24)
+               | ((data[3] & 0xFFL)<< 16)
+               | ((data[4] & 0xFFL)<< 8)
+               | (data[5] & 0xFFL);
+    }
+
+    /// Check if this is the nil (all-zero) ULID.
+    public boolean isNil() {
+        for (byte b : data) {
+            if (b != 0) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public int compareTo(ULID other) {
+        return Arrays.compareUnsigned(data, other.data);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return o instanceof ULID other && Arrays.equals(data, other.data);
+    }
+
+    @Override
+    public int hashCode() {
+        return Arrays.hashCode(data);
+    }
+
+    @Override
+    public String toString() {
+        return encoded();
+    }
+
+    // ==================== Internal helpers ====================
+
+    /// Assemble 16 bytes from a 48-bit timestamp and a 10-byte payload.
+    private static byte[] compose(long timestamp, byte[] payload) {
+        var data = new byte[BYTE_LENGTH];
+        data[0] = (byte)(timestamp>>> 40);
+        data[1] = (byte)(timestamp>>> 32);
+        data[2] = (byte)(timestamp>>> 24);
+        data[3] = (byte)(timestamp>>> 16);
+        data[4] = (byte)(timestamp>>> 8);
+        data[5] = (byte) timestamp;
+        System.arraycopy(payload, 0, data, TIMESTAMP_LENGTH, PAYLOAD_LENGTH);
+        return data;
+    }
+
+    /// Increment the payload as an 80-bit big-endian integer.
+    /// Returns false on overflow (payload was all 0xFF, now wrapped to all zeros).
+    private static boolean incrementPayload(byte[] payload) {
+        for (int i = payload.length - 1; i >= 0; i--) {
+            if ((payload[i] & 0xFF) == 0xFF) {
+                payload[i] = 0;
+            } else {
+                payload[i]++;
+                return true;
+            }
+        }
+        return false;
+    }
+
+    // ==================== Crockford Base32 Encoding ====================
+
+    /// Encode 16 bytes to a 26-character base32 string.
+    /// The 128 bits are treated as 130 bits with two leading zero pad bits, then split
+    /// into 26 groups of 5 bits, most-significant first.
+    private static String encodeBase32(byte[] src) {
+        var dst = new char[STRING_LENGTH];
+        for (int i = 0; i < STRING_LENGTH; i++) {
+            int index = 0;
+            for (int b = 0; b < 5; b++) {
+                int bitPosition = i * 5 + b - 2;       // subtract the two leading pad bits
+                int bit = 0;
+                if (bitPosition >= 0) {
+                    bit = (src[bitPosition>>> 3]>>> (7 - (bitPosition & 7))) & 1;
+                }
+                index = (index<< 1) | bit;
+            }
+            dst[i] = ALPHABET[index];
+        }
+        return new String(dst);
+    }
+
+    /// Decode a 26-character base32 string to 16 bytes.
+    /// Returns none if any character is invalid. Crockford-lenient: case-insensitive with
+    /// `O`->`0` and `I`/`L`->`1` aliases. The two leading pad bits are ignored.
+    private static Option<byte[]> decodeBase32(String src) {
+        var dst = new byte[BYTE_LENGTH];
+        for (int i = 0; i < STRING_LENGTH; i++) {
+            char c = src.charAt(i);
+            if (c >= 128) {
+                return none();
+            }
+            int value = DECODE[c];
+            if (value < 0) {
+                return none();
+            }
+            for (int b = 0; b < 5; b++) {
+                int bitPosition = i * 5 + b - 2;
+                if (bitPosition < 0) {
+                    continue;
+                }
+                int bit = (value>>> (4 - b)) & 1;
+                if (bit != 0) {
+                    dst[bitPosition>>> 3] |= (byte)(1<< (7 - (bitPosition & 7)));
+                }
+            }
+        }
+        return some(dst);
+    }
+
+    private static byte[] maxBytes() {
+        var bytes = new byte[BYTE_LENGTH];
+        Arrays.fill(bytes, (byte) 0xFF);
+        return bytes;
+    }
+
+    /// Error causes for ULID operations.
+    public sealed interface ULIDError extends Cause {
+        ULIDError NULL_INPUT = new NullInput();
+        ULIDError INVALID_CHARACTER = new InvalidCharacter();
+
+        static ULIDError invalidLength(String input) {
+            return new InvalidLength(input.length());
+        }
+
+        static ULIDError invalidByteLength(byte[] bytes) {
+            return new InvalidByteLength(bytes.length);
+        }
+
+        record NullInput() implements ULIDError {
+            @Override
+            public String message() {
+                return "Input is null";
+            }
+        }
+
+        record InvalidLength(int actual) implements ULIDError {
+            @Override
+            public String message() {
+                return "Invalid string length: expected " + STRING_LENGTH + ", got " + actual;
+            }
+        }
+
+        record InvalidByteLength(int actual) implements ULIDError {
+            @Override
+            public String message() {
+                return "Invalid byte array length: expected " + BYTE_LENGTH + ", got " + actual;
+            }
+        }
+
+        record InvalidCharacter() implements ULIDError {
+            @Override
+            public String message() {
+                return "Invalid base32 character in input";
+            }
+        }
+    }
+}

--- a/integrations/utility/src/test/java/org/pragmatica/utility/IdGeneratorTest.java
+++ b/integrations/utility/src/test/java/org/pragmatica/utility/IdGeneratorTest.java
@@ -42,17 +42,17 @@ class IdGeneratorTest {
         var id = IdGenerator.generate("PREFIX");
 
         assertThat(id).startsWith("PREFIX-");
-        var ksuidPart = id.substring("PREFIX-".length());
-        // KSUID is always 27 characters
-        assertThat(ksuidPart).hasSize(KSUID.STRING_LENGTH);
+        var ulidPart = id.substring("PREFIX-".length());
+        // ULID is always 26 characters
+        assertThat(ulidPart).hasSize(ULID.STRING_LENGTH);
     }
 
     @Test
-    void generateCreatesBase62Ids() {
+    void generateCreatesBase32Ids() {
         var id = IdGenerator.generate("test");
-        var ksuidPart = id.substring("test-".length());
+        var ulidPart = id.substring("test-".length());
 
-        // KSUID uses base62: 0-9, A-Z, a-z
-        assertThat(ksuidPart).matches("[0-9A-Za-z]+");
+        // ULID uses lowercase Crockford base32 (excludes i, l, o, u)
+        assertThat(ulidPart).matches("[0-9a-hjkmnp-tv-z]+");
     }
 }

--- a/integrations/utility/src/test/java/org/pragmatica/utility/IdGeneratorTest.java
+++ b/integrations/utility/src/test/java/org/pragmatica/utility/IdGeneratorTest.java
@@ -55,4 +55,18 @@ class IdGeneratorTest {
         // ULID uses lowercase Crockford base32 (excludes i, l, o, u)
         assertThat(ulidPart).matches("[0-9a-hjkmnp-tv-z]+");
     }
+
+    @Test
+    void generateWithoutPrefixCreatesBareUlid() {
+        var id = IdGenerator.generate();
+
+        assertThat(id).doesNotContain("-")
+                      .hasSize(ULID.STRING_LENGTH)
+                      .matches("[0-9a-hjkmnp-tv-z]+");
+    }
+
+    @Test
+    void generateWithoutPrefixCreatesUniqueIds() {
+        assertThat(IdGenerator.generate()).isNotEqualTo(IdGenerator.generate());
+    }
 }

--- a/integrations/utility/src/test/java/org/pragmatica/utility/ULIDTest.java
+++ b/integrations/utility/src/test/java/org/pragmatica/utility/ULIDTest.java
@@ -1,0 +1,357 @@
+/*
+ *  Copyright (c) 2020-2025 Sergiy Yevtushenko.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.pragmatica.utility;
+
+import org.junit.jupiter.api.Test;
+import org.pragmatica.utility.ULID.ULIDError;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.HexFormat;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ULIDTest {
+
+    // ==================== Reference Test Vectors ====================
+    // Canonical ULID "01ARZ3NDEKTSV4RRFFQ69G5FAV" (lowercased here). The timestamp and byte
+    // values below were cross-checked against the binary layout used by reference
+    // implementations (oklog/ulid, the Rust `ulid` crate).
+    private static final String CANONICAL = "01arz3ndektsv4rrffq69g5fav";
+    private static final long CANONICAL_TIMESTAMP = 1469922850259L;
+    private static final byte[] CANONICAL_BYTES =
+        HexFormat.of().parseHex("01563e3ab5d3d6764c61efb99302bd5b");
+
+    @Test
+    void nilUlidEncodesToAllZeros() {
+        assertEquals("00000000000000000000000000", ULID.NIL.encoded());
+    }
+
+    @Test
+    void maxUlidEncodesToExpectedValue() {
+        // First char carries only 3 significant bits, so the maximum is '7' followed by 25 'z'.
+        assertEquals("7zzzzzzzzzzzzzzzzzzzzzzzzz", ULID.MAX.encoded());
+    }
+
+    @Test
+    void nilUlidRoundTrip() {
+        var parsed = ULID.parse("00000000000000000000000000");
+        assertTrue(parsed.isSuccess());
+        parsed.onSuccess(ulid -> {
+            assertTrue(ulid.isNil());
+            assertArrayEquals(new byte[16], ulid.toBytes());
+        });
+    }
+
+    @Test
+    void maxUlidRoundTrip() {
+        var parsed = ULID.parse("7zzzzzzzzzzzzzzzzzzzzzzzzz");
+        assertTrue(parsed.isSuccess());
+        parsed.onSuccess(ulid -> {
+            assertArrayEquals(ULID.MAX.toBytes(), ulid.toBytes());
+            assertEquals(ULID.MAX, ulid);
+        });
+    }
+
+    @Test
+    void canonicalVectorDecodesToExpectedTimestampAndBytes() {
+        ULID.parse(CANONICAL)
+            .onFailure(cause -> fail("Should parse: " + cause))
+            .onSuccess(ulid -> {
+                assertEquals(CANONICAL_TIMESTAMP, ulid.timestamp());
+                assertArrayEquals(CANONICAL_BYTES, ulid.toBytes());
+                assertEquals(CANONICAL, ulid.encoded());
+            });
+    }
+
+    @Test
+    void parseIsCaseInsensitive() {
+        var lower = ULID.parse(CANONICAL).fold(_ -> null, u -> u);
+        var upper = ULID.parse(CANONICAL.toUpperCase()).fold(_ -> null, u -> u);
+        assertEquals(lower, upper);
+        // Canonical text representation is always lowercase.
+        assertEquals(CANONICAL, upper.encoded());
+    }
+
+    @Test
+    void parseAcceptsCrockfordAliases() {
+        // 'O' -> 0, 'I' -> 1, 'L' -> 1
+        var base = ULID.parse("01000000000000000000000000").fold(_ -> null, u -> u);
+
+        var oAlias = ULID.parse("0i000000000000000000000000").fold(_ -> null, u -> u);
+        assertEquals(base, oAlias);
+
+        var lAlias = ULID.parse("0l000000000000000000000000").fold(_ -> null, u -> u);
+        assertEquals(base, lAlias);
+
+        var zeroAlias = ULID.parse("o1000000000000000000000000").fold(_ -> null, u -> u);
+        assertEquals(base, zeroAlias);
+    }
+
+    // ==================== Generation Tests ====================
+
+    @Test
+    void generatedUlidHasCorrectLength() {
+        var ulid = ULID.ulid();
+        assertEquals(26, ulid.encoded().length());
+        assertEquals(16, ulid.toBytes().length);
+    }
+
+    @Test
+    void generatedUlidIsNotNil() {
+        assertFalse(ULID.ulid().isNil());
+    }
+
+    @Test
+    void generatedUlidsAreUnique() {
+        var set = new HashSet<String>();
+        for (int i = 0; i < 10_000; i++) {
+            assertTrue(set.add(ULID.ulid().encoded()));
+        }
+    }
+
+    @Test
+    void generatedUlidHasReasonableTimestamp() {
+        var ulid = ULID.ulid();
+        var now = System.currentTimeMillis();
+        assertTrue(Math.abs(now - ulid.timestamp()) < 2000,
+                   "Timestamp " + ulid.timestamp() + " should be close to " + now);
+    }
+
+    // ==================== Monotonic Generation Tests ====================
+
+    @Test
+    void monotonicUlidsAreStrictlyIncreasing() {
+        var previous = ULID.monotonicUlid();
+        for (int i = 0; i < 10_000; i++) {
+            var next = ULID.monotonicUlid();
+            assertTrue(next.compareTo(previous) > 0,
+                       "Monotonic ULID should be strictly greater than the previous one");
+            assertTrue(next.encoded().compareTo(previous.encoded()) > 0,
+                       "Monotonic ULID text should sort strictly after the previous one");
+            previous = next;
+        }
+    }
+
+    @Test
+    void monotonicUlidsAreUnique() {
+        var set = new HashSet<String>();
+        for (int i = 0; i < 10_000; i++) {
+            assertTrue(set.add(ULID.monotonicUlid().encoded()));
+        }
+    }
+
+    // ==================== Parsing Tests ====================
+
+    @Test
+    void parseValidUlid() {
+        var original = ULID.ulid();
+        ULID.parse(original.encoded())
+            .onFailure(cause -> fail("Should parse: " + cause))
+            .onSuccess(parsed -> assertEquals(original, parsed));
+    }
+
+    @Test
+    void parseNullReturnsError() {
+        var result = ULID.parse(null);
+        assertTrue(result.isFailure());
+        result.onFailure(cause -> assertInstanceOf(ULIDError.NullInput.class, cause));
+    }
+
+    @Test
+    void parseTooShortReturnsError() {
+        var result = ULID.parse("abc");
+        assertTrue(result.isFailure());
+        result.onFailure(cause -> {
+            assertInstanceOf(ULIDError.InvalidLength.class, cause);
+            assertEquals(3, ((ULIDError.InvalidLength) cause).actual());
+        });
+    }
+
+    @Test
+    void parseTooLongReturnsError() {
+        var result = ULID.parse("000000000000000000000000000");
+        assertTrue(result.isFailure());
+        result.onFailure(cause -> assertInstanceOf(ULIDError.InvalidLength.class, cause));
+    }
+
+    @Test
+    void parseInvalidCharacterReturnsError() {
+        // 'u' is excluded from the Crockford alphabet and is not an alias.
+        var result = ULID.parse("0000000000000000000000000u");
+        assertTrue(result.isFailure());
+        result.onFailure(cause -> assertInstanceOf(ULIDError.InvalidCharacter.class, cause));
+    }
+
+    @Test
+    void parseInvalidCharacterSpaceReturnsError() {
+        var result = ULID.parse("0000000000000000000000000 ");
+        assertTrue(result.isFailure());
+        result.onFailure(cause -> assertInstanceOf(ULIDError.InvalidCharacter.class, cause));
+    }
+
+    // ==================== Byte Array Tests ====================
+
+    @Test
+    void fromBytesValidInput() {
+        var original = ULID.ulid();
+        ULID.fromBytes(original.toBytes())
+            .onFailure(cause -> fail("Should parse bytes: " + cause))
+            .onSuccess(parsed -> assertEquals(original, parsed));
+    }
+
+    @Test
+    void fromBytesNullReturnsError() {
+        var result = ULID.fromBytes(null);
+        assertTrue(result.isFailure());
+        result.onFailure(cause -> assertInstanceOf(ULIDError.NullInput.class, cause));
+    }
+
+    @Test
+    void fromBytesWrongLengthReturnsError() {
+        var result = ULID.fromBytes(new byte[10]);
+        assertTrue(result.isFailure());
+        result.onFailure(cause -> {
+            assertInstanceOf(ULIDError.InvalidByteLength.class, cause);
+            assertEquals(10, ((ULIDError.InvalidByteLength) cause).actual());
+        });
+    }
+
+    @Test
+    void toBytesReturnsDefensiveCopy() {
+        var ulid = ULID.ulid();
+        var bytes1 = ulid.toBytes();
+        var bytes2 = ulid.toBytes();
+
+        assertNotSame(bytes1, bytes2);
+        assertArrayEquals(bytes1, bytes2);
+
+        bytes1[0] = (byte) 0xFF;
+        assertFalse(java.util.Arrays.equals(bytes1, ulid.toBytes()));
+    }
+
+    // ==================== Comparison and Sorting Tests ====================
+
+    @Test
+    void nilIsLessThanMax() {
+        assertTrue(ULID.NIL.compareTo(ULID.MAX) < 0);
+        assertTrue(ULID.MAX.compareTo(ULID.NIL) > 0);
+    }
+
+    @Test
+    void equalUlidsCompareToZero() {
+        var ulid = ULID.ulid();
+        assertEquals(0, ulid.compareTo(ulid));
+        ULID.parse(ulid.encoded())
+            .onSuccess(parsed -> assertEquals(0, ulid.compareTo(parsed)));
+    }
+
+    @Test
+    void ulidsAreSortableByTimestamp() throws InterruptedException {
+        var ulids = new ArrayList<ULID>();
+        for (int i = 0; i < 5; i++) {
+            ulids.add(ULID.ulid());
+            Thread.sleep(10);
+        }
+
+        var sorted = new ArrayList<>(ulids);
+        Collections.sort(sorted);
+
+        for (int i = 0; i < sorted.size() - 1; i++) {
+            assertTrue(sorted.get(i).compareTo(sorted.get(i + 1)) <= 0);
+        }
+    }
+
+    @Test
+    void stringsSortLexicographicallyByTimestamp() throws InterruptedException {
+        var strings = new ArrayList<String>();
+        for (int i = 0; i < 5; i++) {
+            strings.add(ULID.ulid().encoded());
+            Thread.sleep(10);
+        }
+
+        var sorted = new ArrayList<>(strings);
+        Collections.sort(sorted);
+
+        for (int i = 0; i < sorted.size() - 1; i++) {
+            assertTrue(sorted.get(i).compareTo(sorted.get(i + 1)) <= 0);
+        }
+    }
+
+    // ==================== Equality and Hashing Tests ====================
+
+    @Test
+    void equalityBasedOnContent() {
+        var ulid1 = ULID.ulid();
+        var ulid2 = ULID.parse(ulid1.encoded()).fold(_ -> null, u -> u);
+
+        assertEquals(ulid1, ulid2);
+        assertEquals(ulid1.hashCode(), ulid2.hashCode());
+    }
+
+    @Test
+    void differentUlidsAreNotEqual() {
+        assertNotEquals(ULID.ulid(), ULID.ulid());
+    }
+
+    @Test
+    void equalsWithNull() {
+        assertNotEquals(ULID.ulid(), null);
+    }
+
+    @Test
+    void equalsWithDifferentType() {
+        assertNotEquals(ULID.ulid(), "not a ulid");
+    }
+
+    // ==================== toString Tests ====================
+
+    @Test
+    void toStringReturnsEncoded() {
+        var ulid = ULID.ulid();
+        assertEquals(ulid.encoded(), ulid.toString());
+    }
+
+    // ==================== Base32 Encoding Edge Cases ====================
+
+    @Test
+    void encodingIsConsistent() {
+        var ulid = ULID.ulid();
+        assertEquals(ulid.encoded(), ulid.encoded());
+    }
+
+    @Test
+    void timestampExtractionForNil() {
+        assertEquals(0L, ULID.NIL.timestamp());
+    }
+
+    @Test
+    void timestampExtractionForMax() {
+        // 48-bit maximum: 2^48 - 1
+        assertEquals(281474976710655L, ULID.MAX.timestamp());
+    }
+
+    // ==================== Constants Tests ====================
+
+    @Test
+    void constantsHaveCorrectValues() {
+        assertEquals(16, ULID.BYTE_LENGTH);
+        assertEquals(6, ULID.TIMESTAMP_LENGTH);
+        assertEquals(10, ULID.PAYLOAD_LENGTH);
+        assertEquals(26, ULID.STRING_LENGTH);
+    }
+}


### PR DESCRIPTION
## Summary

Adds a from-scratch `ULID` type to `org.pragmatica.utility`, parallel in API and style to the existing `KSUID`.

- **128-bit / 16-byte** layout: 48-bit big-endian millisecond timestamp + 80-bit `SecureRandom` payload.
- **Crockford base32**, 26 chars. Encodes the **lowercase** alphabet (`0123456789abcdefghjkmnpqrstvwxyz`), which is still strictly ASCII-ascending, so lexicographic text ordering matches chronological order.
- **Crockford-lenient `parse()`**: case-insensitive with `O`→`0` and `I`/`L`→`1` aliases.
- **`monotonicUlid()`**: within the same millisecond (or on clock regression) increments the 80-bit payload, guaranteeing strictly increasing IDs; thread-safe.
- `timestamp()` returns Unix epoch **milliseconds** (ULID's native resolution).

## API

Mirrors `KSUID`: `final class ULID implements Comparable<ULID>`, factories `ulid()` / `monotonicUlid()` / `parse()` / `fromBytes()`, instance `encoded()` / `toBytes()` / `timestamp()` / `isNil()`, constants `NIL` / `MAX` / `BYTE_LENGTH` / `TIMESTAMP_LENGTH` / `PAYLOAD_LENGTH` / `STRING_LENGTH`, and a sealed `ULIDError extends Cause`.

## Implementation note

Because 48-bit timestamp + 2 pad bits = 50 bits = exactly 10 base32 chars, the timestamp and the 80-bit entropy each fall on clean char boundaries. A single uniform "two pad bits, MSB-first" 5-bit packing over all 16 bytes is therefore byte-compatible with the canonical ULID binary spec (verified against oklog/ulid and the Rust `ulid` crate layout).

## Tests

`ULIDTest` — 36 tests, all green (module: 78/78). Covers NIL/MAX vectors, the canonical `01arz3ndektsv4rrffq69g5fav` vector (timestamp + bytes + round-trip), case-insensitivity and Crockford aliases, uniqueness (10k), monotonic strict-ordering (10k), sorting, byte round-trip, defensive copies, error cases, and constants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)