### PR TITLE
fix(jbct): formatter content/blank-line/lambda fixes + qualified-super parsing

### DIFF
--- a/jbct/jbct-format/src/main/java/org/pragmatica/jbct/format/flow/BlankLineRules.java
+++ b/jbct/jbct-format/src/main/java/org/pragmatica/jbct/format/flow/BlankLineRules.java
@@ -45,13 +45,28 @@ final class BlankLineRules {
         return true;
     }
 
-    /// A simple declaration: ends with semicolon, no block body, AND no annotation.
+    /// A simple declaration: ends with semicolon, no block body, AND no annotation. Examines the
+    /// member's non-trivia tokens (not `text()`, which bleeds trailing trivia such as a following
+    /// member's leading comment into this member and would otherwise hide the terminating `;`).
     private static boolean isSimpleNoBodyDeclaration(Cursor member) {
         if (hasAnnotationChild(member)) {
             return false;
         }
-        var trimmed = text(member).trim();
-        return trimmed.endsWith(";") && !trimmed.contains("{");
+        if (!(member instanceof Cursor.Branch br)) {
+            return false;
+        }
+        var tokens = br.cst().tokens();
+        int lastNonTrivia = -1;
+        for (int t = br.firstTokenIdx(); t <= br.lastTokenIdx(); t++) {
+            if (tokens.isTrivia(t)) {
+                continue;
+            }
+            if ("{".contentEquals(tokens.textAt(t))) {
+                return false;
+            }
+            lastNonTrivia = t;
+        }
+        return lastNonTrivia >= 0 && ";".contentEquals(tokens.textAt(lastNonTrivia));
     }
 
     /// True if any token's text contains a `\n` (text blocks, multi-line strings) OR if

--- a/jbct/jbct-format/src/main/java/org/pragmatica/jbct/format/flow/FlowPrinter.java
+++ b/jbct/jbct-format/src/main/java/org/pragmatica/jbct/format/flow/FlowPrinter.java
@@ -43,6 +43,11 @@ final class FlowPrinter {
     private char lastChar;
     private char prevChar;
     private String lastWord = "";
+    /// >0 while emitting tokens inside a TYPE_ARGS / TYPE_PARAMS node. Disambiguates a generic
+    /// '<'/'>' (glued punctuation) from a relational/shift operator '<'/'>' (spaced) — the parser
+    /// already separates them into distinct rules, so we key spacing off that rather than guessing
+    /// from characters (which cannot tell `static <T>` from `a < b`).
+    private int typeContextDepth = 0;
 
     // Measurement mode
     private boolean measuringMode;
@@ -114,6 +119,7 @@ final class FlowPrinter {
         char oldLastChar = lastChar;
         char oldPrevChar = prevChar;
         String oldLastWord = lastWord;
+        int oldTypeContextDepth = typeContextDepth;
         measuringMode = true;
         measureBuffer = 0;
         printNode(node);
@@ -123,6 +129,7 @@ final class FlowPrinter {
         lastChar = oldLastChar;
         prevChar = oldPrevChar;
         lastWord = oldLastWord;
+        typeContextDepth = oldTypeContextDepth;
         return width;
     }
 
@@ -141,6 +148,7 @@ final class FlowPrinter {
                               char lastChar,
                               char prevChar,
                               String lastWord,
+                              int typeContextDepth,
                               boolean measuringMode,
                               int measureBuffer,
                               int tokenIndex,
@@ -157,6 +165,7 @@ final class FlowPrinter {
                               lastChar,
                               prevChar,
                               lastWord,
+                              typeContextDepth,
                               measuringMode,
                               measureBuffer,
                               tokenIndex,
@@ -174,6 +183,7 @@ final class FlowPrinter {
         lastChar = saved.lastChar();
         prevChar = saved.prevChar();
         lastWord = saved.lastWord();
+        typeContextDepth = saved.typeContextDepth();
         measuringMode = saved.measuringMode();
         measureBuffer = saved.measureBuffer();
         tokenIndex = saved.tokenIndex();
@@ -229,10 +239,41 @@ final class FlowPrinter {
     /// causing whitespace bleed into the output.
     private void emitLeafTokens(Cursor.Leaf leaf) {
         var tokens = leaf.cst().tokens();
+        // Position of the last `}` token in this leaf (or -1). Orphan line comments are emitted
+        // ONLY when they sit BEFORE a `}` within the leaf — the bodyless `{ // note }` empty-body
+        // case, where the comment is trivia on the bare `}` leaf and no node's leadingTrivia owns
+        // it. A comment AFTER the `}` is the leading trivia of the FOLLOWING declaration and is
+        // emitted by emitLeadingComments; re-emitting it here would re-place it (idempotency break).
+        int lastBrace = -1;
+        for (int t = leaf.firstTokenIdx(); t <= leaf.lastTokenIdx(); t++) {
+            if (!tokens.isTrivia(t) && "}".contentEquals(tokens.textAt(t))) {
+                lastBrace = t;
+            }
+        }
         for (int t = leaf.firstTokenIdx(); t <= leaf.lastTokenIdx(); t++) {
             if (!tokens.isTrivia(t)) {
                 emitToken(tokens.textAt(t).toString());
+                continue;
             }
+            int kind = tokens.kindAt(t);
+            if (measuringMode || (kind != 1 && kind != 3) || t >= lastBrace || emittedTriviaTokens.contains(t)) {
+                continue;
+            }
+            // Orphan line comment enclosed before a `}` in this bare-leaf body — emit so it is not
+            // silently deleted (bug B2).
+            var text = tokens.textAt(t).toString().stripTrailing();
+            if (precedingContentOnSameLine(tokens.startAt(t)) && currentColumn > 0) {
+                emit("  " + text);
+            } else {
+                if (currentColumn > 0) {
+                    newline();
+                }
+                printIndent();
+                emit(text);
+                newline();
+                printIndent();
+            }
+            emittedTriviaTokens.add(t);
         }
     }
 
@@ -779,9 +820,49 @@ final class FlowPrinter {
                 indentLevel--;
                 printIndent();
             }
+        } else {
+            emitEmptyBlockComments(block);
         }
 
         emitBare("}");
+    }
+
+    /// Preserve line comments that are the sole content of an otherwise-empty block — emit each
+    /// on its own indented line so a comment-only body (`{ // note }`) is not collapsed to `{}`
+    /// (bug B2). No-op (leaves `{}`) when the block carries no un-emitted comments.
+    private void emitEmptyBlockComments(Cursor.Branch block) {
+        if (measuringMode) {
+            return;
+        }
+        var tokens = block.cst().tokens();
+        int open = block.firstTokenIdx();
+        int close = block.lastTokenIdx();
+        boolean any = false;
+        for (int t = open + 1; t < close; t++) {
+            if (!tokens.isTrivia(t)) {
+                continue;
+            }
+            int kind = tokens.kindAt(t);
+            if (kind != 1 && kind != 3) { // LINE_COMMENT or DOC_LINE_COMMENT only
+                continue;
+            }
+            if (emittedTriviaTokens.contains(t)) {
+                continue;
+            }
+            if (!any) {
+                indentLevel++;
+            }
+            newline();
+            printIndent();
+            emit(tokens.textAt(t).toString().stripTrailing());
+            emittedTriviaTokens.add(t);
+            any = true;
+        }
+        if (any) {
+            indentLevel--;
+            newline();
+            printIndent();
+        }
     }
 
     /// Emit trailing line comments that sit in the last stmt's trailing trivia region
@@ -798,14 +879,26 @@ final class FlowPrinter {
         for (int t = lastNonTrivia + 1; t <= closingBrace; t++) {
             if (!tokens.isTrivia(t)) break;
             int kind = tokens.kindAt(t);
-            if (kind == 1 || kind == 3) { // LINE_COMMENT or DOC_LINE_COMMENT
-                int commentStart = tokens.startAt(t);
-                if (!precedingContentOnSameLine(commentStart)) break;
-                if (!emittedTriviaTokens.contains(t)) {
-                    emit("  " + tokens.textAt(t).toString().stripTrailing());
-                    emittedTriviaTokens.add(t);
-                }
+            if (kind != 1 && kind != 3) { // LINE_COMMENT or DOC_LINE_COMMENT only
+                continue;
             }
+            if (emittedTriviaTokens.contains(t)) {
+                continue;
+            }
+            int commentStart = tokens.startAt(t);
+            var text = tokens.textAt(t).toString().stripTrailing();
+            if (precedingContentOnSameLine(commentStart) && currentColumn > 0) {
+                // Trailing comment on the same source line as the preceding stmt.
+                emit("  " + text);
+            } else {
+                // Comment on its OWN line before `}` — emit it on a fresh indented line instead
+                // of dropping it. The `}` is emitted via emitBare, which never runs the
+                // leading-comment path, so without this the comment is lost (bug B2).
+                newline();
+                printIndent();
+                emit(text);
+            }
+            emittedTriviaTokens.add(t);
         }
     }
 
@@ -1789,11 +1882,15 @@ final class FlowPrinter {
     // ===== Type generics =====
 
     private void printTypeArgs(Cursor.Branch typeArgs) {
+        typeContextDepth++;
         walkTokens(typeArgs);
+        typeContextDepth--;
     }
 
     private void printTypeParams(Cursor.Branch typeParams) {
+        typeContextDepth++;
         walkTokens(typeParams);
+        typeContextDepth--;
     }
 
     // ===== Method declarations =====
@@ -2246,10 +2343,14 @@ final class FlowPrinter {
             return true;
         }
         if (lastChar == '<') {
-            return true;
-        }
-        if (firstChar == '?' && lastChar == '<') {
-            return true;
+            // Generic '<' (inside TYPE_ARGS / TYPE_PARAMS) glues to the type argument that follows
+            // (`List<String`, `static <T`). A relational/shift operator '<' (any non-type context)
+            // glues only a following '<' to form '<<'; before an operand it takes a space, added in
+            // checkSpaceRules (e.g. `a < 0`, `v << n`).
+            if (typeContextDepth > 0) {
+                return true;
+            }
+            return firstChar == '<';
         }
         if (firstChar == '>' && lastChar == '?') {
             return true;
@@ -2340,6 +2441,13 @@ final class FlowPrinter {
         // Angle bracket rules
         if (text.equals("<") || text.equals(">")) {
             return checkAngleBracketRules(text, firstChar);
+        }
+        // Relational/shift operator '<' (outside any TYPE_ARGS / TYPE_PARAMS context) before its
+        // operand. '<' is not in BINARY_OP_CHARS, so it needs this explicit rule; a generic-open
+        // '<' (typeContextDepth > 0) was already suppressed in mustNotHaveSpaceBefore and never
+        // reaches here. The symmetric '>' operand is handled by checkGenericClosing.
+        if (lastChar == '<' && typeContextDepth == 0) {
+            return true;
         }
         // Binary operators
         if (BINARY_OPS.contains(text) || isBinaryOpLastChar()) {

--- a/jbct/jbct-format/src/main/java/org/pragmatica/jbct/format/flow/FlowPrinter.java
+++ b/jbct/jbct-format/src/main/java/org/pragmatica/jbct/format/flow/FlowPrinter.java
@@ -196,30 +196,6 @@ final class FlowPrinter {
         alignment.restore(saved.alignment());
     }
 
-    /// True iff a single-statement block collapsed inline (`{ stmt }`) would render on a
-    /// single physical line. Used to keep inline-block collapse idempotent: a body that is
-    /// over-wide OR contains a force-broken method chain wraps when emitted inline, which
-    /// flips `isOnSingleSourceLine` next pass and re-expands the block. We decide by trial-
-    /// rendering the statement at the current column and checking for an emitted newline —
-    /// width alone underestimates, because chains break on structure, not just width.
-    ///
-    /// The trial mutates real render state (alignment scopes, cursor position, trivia
-    /// tracking), so we snapshot ALL of it up front and restore it afterwards. The
-    /// snapshot includes the alignment context so an unbalanced scope inside the trial
-    /// cannot corrupt subsequent layout.
-    private boolean inlineBlockFits(Cursor stmt) {
-        var saved = saveState();
-
-        output = new StringBuilder();
-        printNode(stmt);
-        emitBare("}");
-        boolean singleLine = currentColumn <= config.maxLineLength()
-                             && output.indexOf("\n") < 0;
-
-        restoreState(saved);
-        return singleLine;
-    }
-
     // ===== Node dispatch =====
 
     private void printNode(Cursor node) {
@@ -751,25 +727,6 @@ final class FlowPrinter {
         var stmts = childrenByRule(block, RuleKind.BLOCK_STMT);
 
         if (!stmts.isEmpty()) {
-            // Preserve source-line layout: if the entire Block sits on a single source
-            // line (e.g. `if (x) {return y;}`), keep it inline. This mirrors the legacy
-            // formatter's same-line brace detection. Don't collapse if the stmt carries a
-            // leading comment — that's a signal the dev wants spacing.
-            // Only collapse when the inline form actually fits on the line: an over-wide
-            // inner statement gets wrapped across lines when emitted inline, which flips
-            // `isOnSingleSourceLine` on the next pass and re-expands the block — a
-            // non-idempotent oscillation. If it won't fit, fall through to the expanded form.
-            if (!measuringMode
-                && !useLambdaAlign
-                && !useChainAlign
-                && isOnSingleSourceLine(block)
-                && stmts.size() == 1
-                && !hasLeadingComment(stmts.get(0))
-                && inlineBlockFits(stmts.get(0))) {
-                printNode(stmts.get(0));
-                emitBare("}");
-                return;
-            }
             newline();
             if (useLambdaAlign) {
                 printAlignedBlockStatements(stmts, lambdaAlignCol);
@@ -779,29 +736,13 @@ final class FlowPrinter {
                 printAlignedTo(chainAlignCol);
             } else {
                 indentLevel++;
-                // Lambda body blocks pack tight — no blank lines inserted between stmts.
-                boolean isLambdaBody = isInsideLambda(block);
+                // Blank-line rules, applied uniformly in regular and lambda bodies (only the
+                // base indent differs): R1 blank after a block-shaped stmt; R2 blank after a
+                // local-var-decl run before a non-var stmt; R3 blank before a return/throw. A
+                // single newline() is emitted, so overlapping rules coalesce to one blank.
                 for (int i = 0; i < stmts.size(); i++) {
                     var stmt = stmts.get(i);
-                    // Blank line before a final return/throw when the block has at least
-                    // one simple (non-block) prior statement AND that prior statement is
-                    // visually packed on a single source line. A method body of only an
-                    // `if`/`try`/`while` + `return` packs tight; multi-line text-block
-                    // assignments visually separate themselves and need no blank.
-                    // In lambda bodies: only add blank before return when body has 4+ stmts
-                    // (3+ prior + 1 return), treating it as a substantial function body.
-                    boolean lambdaBodyAllowsBlank = !isLambdaBody || stmts.size() >= 4;
-                    if (lambdaBodyAllowsBlank && i >= 1 && i == stmts.size() - 1 && isReturnOrThrowStmt(stmt) && !hasLeadingComment(stmt)
-                        && hasSimpleSingleLinePriorStmt(stmts, i)) {
-                        newline();
-                    }
-                    // Blank line around block-shaped stmts (if/try/while/...) when the
-                    // method body has 3+ stmts: a section boundary appears either when
-                    // moving from a non-block stmt to a block stmt OR from a block stmt
-                    // to a non-block stmt.
-                    else if (!isLambdaBody && i >= 1 && !hasLeadingComment(stmt)
-                             && stmts.size() >= 3
-                             && (isBlockShapedStmt(stmts.get(i - 1)) ^ isBlockShapedStmt(stmt))) {
+                    if (i >= 1 && !hasLeadingComment(stmt) && needsBlankBeforeStmt(stmts.get(i - 1), stmt)) {
                         newline();
                     }
                     if (!hasUnEmittedLeadingComment(stmt)) {
@@ -951,58 +892,22 @@ final class FlowPrinter {
         return false;
     }
 
-    /// True if `block` is the body of a lambda — i.e. it has a LAMBDA ancestor whose
-    /// closest enclosing BLOCK is this one. Walks parents up; stops at any BLOCK/METHOD_DECL
-    /// boundary except this block itself.
-    private static boolean isInsideLambda(Cursor.Branch block) {
-        var parent = block.parent().orElse(null);
-        while (parent != null) {
-            if (parent.kindIs(RuleKind.LAMBDA)) {
-                return true;
-            }
-            if (parent.kindIs(RuleKind.METHOD_DECL) || parent.kindIs(RuleKind.MEMBER)) {
-                return false;
-            }
-            parent = parent.parent().orElse(null);
-        }
-        return false;
+    /// Whether a blank line is required between `prev` and `cur` per the uniform rules:
+    /// R1 — blank after a block-shaped statement; R2 — blank after a local-variable-declaration
+    /// run, before a non-var statement; R3 — blank before a return/throw. Overlapping rules
+    /// coalesce because the caller emits a single newline.
+    private static boolean needsBlankBeforeStmt(Cursor prev, Cursor cur) {
+        return isBlockShapedStmt(prev)
+               || (isLocalVarDecl(prev) && !isLocalVarDecl(cur))
+               || isReturnOrThrowStmt(cur);
     }
 
-    /// True if any of the statements at index < returnIdx is a "simple" statement
-    /// (not a block-stmt — i.e. not `if`/`try`/`while`/`for`/`do`/`switch`/`synchronized`/`{ ... }`).
-    private static boolean hasSimplePriorStmt(List<Cursor> stmts, int returnIdx) {
-        for (int i = 0; i < returnIdx; i++) {
-            if (!isBlockShapedStmt(stmts.get(i))) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    /// True if any simple prior stmt (non-block) sits on a single source line. Multi-line
-    /// simple stmts (e.g. `var x = """text block""";`) visually separate themselves and
-    /// don't require a blank line before the final return.
-    private boolean hasSimpleSingleLinePriorStmt(List<Cursor> stmts, int returnIdx) {
-        for (int i = 0; i < returnIdx; i++) {
-            var s = stmts.get(i);
-            if (isBlockShapedStmt(s)) continue;
-            // Keep the original Branch-only restriction; only the single-line test changed
-            // from a SOURCE-line check to the FORMATTED-layout check for idempotency.
-            if (s instanceof Cursor.Branch && rendersOnSingleLine(s)) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    /// True iff the statement would render on a single line at the current block indent.
-    /// This must reflect the FORMATTED layout, not the source layout: a method-chain
-    /// statement written across several source lines is reflowed onto one line when it
-    /// fits, so a source-`\n` check would flip the blank-before-return decision between
-    /// passes and break idempotency.
-    private boolean rendersOnSingleLine(Cursor stmt) {
-        int indentCol = indentLevel * config.indentSize();
-        return indentCol + measureWidth(stmt) <= config.maxLineLength();
+    /// True iff the statement is a local-variable declaration. In the v6 CST a var-decl
+    /// statement uniquely presents as a BLOCK_STMT whose direct child is a LOCAL_VAR (other
+    /// statements wrap an intermediate STMT or a leaf).
+    private static boolean isLocalVarDecl(Cursor stmt) {
+        return stmt instanceof Cursor.Branch br
+               && br.children().anyMatch(c -> c.kindIs(RuleKind.LOCAL_VAR) || c.kindIs(RuleKind.LOCAL_VAR_NO_SEMI));
     }
 
     /// True if a stmt is one of the block-shaped control-flow constructs.
@@ -1037,38 +942,18 @@ final class FlowPrinter {
         return false;
     }
 
-    /// True iff the entire token range of the node covers exactly one source line
-    /// (no '\n' in any token between the first and last non-trivia tokens, exclusive
-    /// of trailing trivia past the last non-trivia token — that trailing trivia is the
-    /// transition to the next sibling and shouldn't count).
-    private boolean isOnSingleSourceLine(Cursor.Branch node) {
-        var tokens = node.cst().tokens();
-        // Find the last non-trivia token index within the range.
-        int lastNonTrivia = -1;
-        for (int t = node.lastTokenIdx(); t >= node.firstTokenIdx(); t--) {
-            if (!tokens.isTrivia(t)) {
-                lastNonTrivia = t;
-                break;
-            }
-        }
-        if (lastNonTrivia < 0) {
-            return true;
-        }
-        for (int t = node.firstTokenIdx(); t <= lastNonTrivia; t++) {
-            if (tokens.textAt(t).toString().indexOf('\n') >= 0) {
-                return false;
-            }
-        }
-        return true;
-    }
-
     private void printAlignedBlockStatements(List<Cursor> stmts, int alignCol) {
         int bodyCol = alignCol + config.indentSize();
         // Use forcedIndentCol so emitLeadingComments uses printAlignedTo(bodyCol)
         // instead of printIndent() (which uses indentLevel and may round incorrectly).
         int savedForcedIndent = forcedIndentCol;
         forcedIndentCol = bodyCol;
-        for (var stmt : stmts) {
+        for (int i = 0; i < stmts.size(); i++) {
+            var stmt = stmts.get(i);
+            // Same uniform blank-line rules as the non-aligned body path (R1/R2/R3).
+            if (i >= 1 && !hasLeadingComment(stmt) && needsBlankBeforeStmt(stmts.get(i - 1), stmt)) {
+                newline();
+            }
             // Skip printAlignedTo for stmts with leading comments: currentColumn is
             // already 0 from the preceding newline, so emitLeadingComments won't add
             // an extra blank line (it only newlines when currentColumn > 0).
@@ -1606,40 +1491,52 @@ final class FlowPrinter {
 
     private void printBrokenArgs(Cursor.Branch args) {
         int alignCol = currentColumn;
+        // A single argument at statement level (no enclosing broken method chain) has no commas
+        // to align, and its block-lambda body should indent from the statement, not the deep arg
+        // column (bug B3). Inside a broken chain the body aligns to the lambda parameter, so keep
+        // lambda-align there. Multi-argument calls always align.
+        if (childrenByRule(args, RuleKind.EXPR).size() < 2 && alignment.chainColumn() < 0) {
+            printBrokenArgsBody(args, alignCol);
+            return;
+        }
         try (var scope = alignment.pushLambdaAlign(alignCol)) {
-            walkTokensWith(args, new TokenWalker() {
-                @Override
-                public void onChild(Cursor child) {
-                    if (child.kindIs(RuleKind.EXPR)) {
-                        // If this single arg fits on its own line, render its inner
-                        // chains/expressions inline. The args layout already broke at
-                        // commas; an individual arg-expression should not force further
-                        // vertical breaks unless its own width demands it.
-                        int width = measureWidth(child);
-                        if (currentColumn + width <= config.maxLineLength()) {
-                            try (var inlineScope = alignment.enterInlineExpression()) {
-                                printNodeContent(child);
-                            }
-                        } else {
+            printBrokenArgsBody(args, alignCol);
+        }
+    }
+
+    private void printBrokenArgsBody(Cursor.Branch args, int alignCol) {
+        walkTokensWith(args, new TokenWalker() {
+            @Override
+            public void onChild(Cursor child) {
+                if (child.kindIs(RuleKind.EXPR)) {
+                    // If this single arg fits on its own line, render its inner
+                    // chains/expressions inline. The args layout already broke at
+                    // commas; an individual arg-expression should not force further
+                    // vertical breaks unless its own width demands it.
+                    int width = measureWidth(child);
+                    if (currentColumn + width <= config.maxLineLength()) {
+                        try (var inlineScope = alignment.enterInlineExpression()) {
                             printNodeContent(child);
                         }
                     } else {
-                        printNode(child);
+                        printNodeContent(child);
                     }
+                } else {
+                    printNode(child);
                 }
+            }
 
-                @Override
-                public void onToken(int kind, String text) {
-                    if (",".equals(text)) {
-                        emit(",");
-                        newline();
-                        printAlignedTo(alignCol);
-                    } else {
-                        emitToken(text);
-                    }
+            @Override
+            public void onToken(int kind, String text) {
+                if (",".equals(text)) {
+                    emit(",");
+                    newline();
+                    printAlignedTo(alignCol);
+                } else {
+                    emitToken(text);
                 }
-            });
-        }
+            }
+        });
     }
 
     // ===== Lambda =====
@@ -2404,6 +2301,11 @@ final class FlowPrinter {
     private boolean checkSpaceRules(String text, char firstChar) {
         // Comma rule
         if (lastChar == ',') {
+            return true;
+        }
+        // Semicolon separator in a `for` header. A statement-terminating `;` is followed by a
+        // newline (lastChar would be '\n'), so this only fires mid-line — between for-clauses.
+        if (lastChar == ';') {
             return true;
         }
         // Closing brace keyword

--- a/jbct/jbct-format/src/test/java/org/pragmatica/jbct/format/GoldenFormatterTest.java
+++ b/jbct/jbct-format/src/test/java/org/pragmatica/jbct/format/GoldenFormatterTest.java
@@ -51,7 +51,8 @@ class GoldenFormatterTest {
     "TernaryInArg.java",
     "ChainArgWraps.java",
     "AnnotationLocations.java",
-    "BlankLineEdges.java"})
+    "BlankLineEdges.java",
+    "LambdaBlockArgs.java"})
     void formatter_isIdempotent_onGoldenExamples(String fileName) throws IOException {
         var path = EXAMPLES_DIR.resolve(fileName);
         var content = Files.readString(path);

--- a/jbct/jbct-format/src/test/java/org/pragmatica/jbct/format/flow/FlowContentPreservationTest.java
+++ b/jbct/jbct-format/src/test/java/org/pragmatica/jbct/format/flow/FlowContentPreservationTest.java
@@ -1,0 +1,79 @@
+package org.pragmatica.jbct.format.flow;
+
+import org.junit.jupiter.api.Test;
+import org.pragmatica.jbct.format.FormatterConfig;
+import org.pragmatica.jbct.shared.SourceFile;
+
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/// Reproduction + regression guards for the jbct-format content-corruption bugs
+/// (bug report 2026-06-08): operator spacing, comment deletion, if-body re-indentation.
+/// These assert CONTENT PRESERVATION, which the idempotency sweep does not.
+class FlowContentPreservationTest {
+    private final FlowFormatter fmt = FlowFormatter.flowFormatter(FormatterConfig.defaultConfig());
+
+    private String format(String src) {
+        return fmt.format(new SourceFile(Path.of("Test.java"), src)).unwrap().content();
+    }
+
+    // --- Bug 2: operator spacing ---------------------------------------------------------------
+
+    @Test void comparisonLt_keepsTrailingSpace() {
+        var out = format("class X {\n    int f(int a) {\n        if (a < 0) {\n            return 1;\n        }\n        return 0;\n    }\n}\n");
+        assertThat(out).contains("a < 0");
+    }
+
+    @Test void comparisonGt_keepsTrailingSpace() {
+        var out = format("class X {\n    int f(int a) {\n        if (a > 0) {\n            return 1;\n        }\n        return 0;\n    }\n}\n");
+        assertThat(out).contains("a > 0");
+    }
+
+    @Test void leftShift_keepsSpaces() {
+        var out = format("class X {\n    int f(int v, int n) {\n        return v << n;\n    }\n}\n");
+        assertThat(out).contains("v << n");
+    }
+
+    @Test void rightShift_keepsSpaces() {
+        var out = format("class X {\n    int f(int x) {\n        return x >> 1;\n    }\n}\n");
+        assertThat(out).contains("x >> 1");
+    }
+
+    @Test void compoundLeftShiftAssign_preserved() {
+        var out = format("class X {\n    void f(int x) {\n        x <<= 1;\n    }\n}\n");
+        assertThat(out).contains("x <<= 1");
+    }
+
+    @Test void genericType_hasNoInnerSpace() {
+        var out = format("import java.util.List;\nclass X {\n    List<String> g() {\n        return null;\n    }\n}\n");
+        assertThat(out).contains("List<String>");
+    }
+
+    @Test void nestedGeneric_hasNoInnerSpace() {
+        var out = format("import java.util.List;\nimport java.util.Map;\nclass X {\n    Map<String, List<Integer>> g() {\n        return null;\n    }\n}\n");
+        assertThat(out).contains("Map<String, List<Integer>>");
+    }
+
+    // --- Bug 1: comment deletion ---------------------------------------------------------------
+
+    @Test void lineComment_inEmptyMethodBody_preserved() {
+        var out = format("class X {\n    void f() {\n        // intentionally empty - default listener prior to wiring\n    }\n}\n");
+        assertThat(out).contains("intentionally empty");
+    }
+
+    @Test void lineComment_beforeClosingBrace_preserved() {
+        var out = format("class X {\n    void f() {\n        doThing();\n        // trailing rationale comment\n    }\n}\n");
+        assertThat(out).contains("trailing rationale comment");
+    }
+
+    // --- Bug 3: single-line if body indentation -----------------------------------------------
+
+    @Test void singleLineIfBody_stableIndentation() {
+        var src = "class X {\n    String f(int a) {\n        if (a < 0) {return \"neg\";}\n        return \"pos\";\n    }\n}\n";
+        var once = format(src);
+        var twice = fmt.format(new SourceFile(Path.of("Test.java"), once)).unwrap().content();
+        assertThat(twice).as("if-body formatting is idempotent").isEqualTo(once);
+        assertThat(once).doesNotContain("                            if");  // no ~28-col over-indent
+    }
+}

--- a/jbct/jbct-format/src/test/java/org/pragmatica/jbct/format/flow/FlowContentPreservationTest.java
+++ b/jbct/jbct-format/src/test/java/org/pragmatica/jbct/format/flow/FlowContentPreservationTest.java
@@ -76,4 +76,22 @@ class FlowContentPreservationTest {
         assertThat(twice).as("if-body formatting is idempotent").isEqualTo(once);
         assertThat(once).doesNotContain("                            if");  // no ~28-col over-indent
     }
+
+    @Test void singleLineIfBody_insideLambda_stableIndentation() {
+        // Bug 3 (B3/B4): a single-line `if` inside a lambda body over-indented (~28 cols) + split.
+        var src = "import java.util.Map;\n"
+                  + "class X {\n"
+                  + "    void f(Map<String, Integer> byAlias) {\n"
+                  + "        byAlias.forEach((alias, count) -> {\n"
+                  + "            if (count <= 1) {return;}\n"
+                  + "            process(alias);\n"
+                  + "        });\n"
+                  + "    }\n"
+                  + "    void process(String s) {}\n"
+                  + "}\n";
+        var once = format(src);
+        var twice = fmt.format(new SourceFile(Path.of("Test.java"), once)).unwrap().content();
+        assertThat(twice).as("lambda if-body formatting is idempotent").isEqualTo(once);
+        assertThat(once).doesNotContain("                            if");  // no ~28-col over-indent
+    }
 }

--- a/jbct/jbct-format/src/test/resources/format-examples/Comments.java
+++ b/jbct/jbct-format/src/test/resources/format-examples/Comments.java
@@ -43,7 +43,10 @@ public class Comments<T> {
     // Method with comment
     public void methodWithComment() {
         var x = 1;
-        if (x > 0) {process(x);}
+
+        if (x > 0) {
+            process(x);
+        }
     }
 
     /*

--- a/jbct/jbct-format/src/test/resources/format-examples/CommentsExtended.java
+++ b/jbct/jbct-format/src/test/resources/format-examples/CommentsExtended.java
@@ -33,14 +33,14 @@ public class CommentsExtended {
     public void methodWithBlockBeforeFor() {
         // Comment before a for-loop.
         // Should be preserved exactly.
-        for (int i = 0;i <counter;i++) {
+        for (int i = 0;i < counter;i++) {
             System.out.println(i);
         }
     }
 
     public void methodWithMultiStatementForBody() {
         // Multi-statement for-body — covers the Stmt-wraps-Block parser shape (B4 regression).
-        for (int i = 0;i <counter;i++) {
+        for (int i = 0;i < counter;i++) {
             var doubled = i * 2;
             System.out.println(doubled);
         }

--- a/jbct/jbct-format/src/test/resources/format-examples/CommentsExtended.java
+++ b/jbct/jbct-format/src/test/resources/format-examples/CommentsExtended.java
@@ -33,15 +33,16 @@ public class CommentsExtended {
     public void methodWithBlockBeforeFor() {
         // Comment before a for-loop.
         // Should be preserved exactly.
-        for (int i = 0;i < counter;i++) {
+        for (int i = 0; i < counter; i++) {
             System.out.println(i);
         }
     }
 
     public void methodWithMultiStatementForBody() {
         // Multi-statement for-body — covers the Stmt-wraps-Block parser shape (B4 regression).
-        for (int i = 0;i < counter;i++) {
+        for (int i = 0; i < counter; i++) {
             var doubled = i * 2;
+
             System.out.println(doubled);
         }
     }
@@ -50,6 +51,7 @@ public class CommentsExtended {
         // Multi-statement if-body — same parser-shape coverage as the for variant above.
         if (counter > 0) {
             var label = "value:";
+
             System.out.println(label);
             System.out.println(counter);
         }

--- a/jbct/jbct-format/src/test/resources/format-examples/CompoundAssignments.java
+++ b/jbct/jbct-format/src/test/resources/format-examples/CompoundAssignments.java
@@ -3,6 +3,7 @@ package format.examples;
 public class CompoundAssignments {
     void allCompoundAssignments() {
         int x = 0;
+
         x += 1;
         x -= 2;
         x *= 3;

--- a/jbct/jbct-format/src/test/resources/format-examples/FlowEdgeCases.java
+++ b/jbct/jbct-format/src/test/resources/format-examples/FlowEdgeCases.java
@@ -19,6 +19,7 @@ public class FlowEdgeCases {
         if (x > 0) {
             return x;
         }
+
         return -x;
     }
 
@@ -32,6 +33,7 @@ public class FlowEdgeCases {
     // Pure side-effect method (no return/throw) — no trailing blank.
     void sideEffectOnly(String s) {
         var trimmed = s.trim();
+
         System.out.println(trimmed);
     }
 

--- a/jbct/jbct-format/src/test/resources/format-examples/KeywordPrefixedIdentifiers.java
+++ b/jbct/jbct-format/src/test/resources/format-examples/KeywordPrefixedIdentifiers.java
@@ -8,6 +8,7 @@ public class KeywordPrefixedIdentifiers {
 
     void test(State newState, State oldState) {
         var x = process(newState);
+
         if (oldState != newState) {
             switch (newState) {
                 case OPEN -> handle(newState);

--- a/jbct/jbct-format/src/test/resources/format-examples/LambdaBlockArgs.java
+++ b/jbct/jbct-format/src/test/resources/format-examples/LambdaBlockArgs.java
@@ -1,0 +1,47 @@
+package format.examples;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+
+public class LambdaBlockArgs {
+    private final Set<String> explicit = Set.of();
+    private final List<String> warnings = new ArrayList<>();
+
+    // A single block-lambda argument: its body indents one level from the enclosing statement,
+    // NOT from the (deep) argument column.
+    void simpleForEach(Map<String, Integer> byAlias) {
+        byAlias.forEach((alias, count) -> {
+            if (count <= 1) {
+                return;
+            }
+
+            process(alias);
+        });
+    }
+
+    // Complex block-lambda body: a single-line `if`, a broken method chain, and a nested `if`
+    // whose body is a multi-argument call that wraps and aligns under its first argument.
+    void complexForEach(Map<String, List<Integer>> byAlias) {
+        byAlias.forEach((alias, entries) -> {
+            if (entries.size() <= 1) {
+                return;
+            }
+
+            var anyDefaulted = entries.stream()
+                                      .anyMatch(spec -> !explicit.contains(alias));
+
+            if (anyDefaulted) {
+                warnings.add(warn(alias, entries.size(), "multi-version-default-detected-recommend-explicit-pin"));
+            }
+        });
+    }
+
+    void process(String s) {}
+
+    String warn(String a, int b, String c) {
+        return c;
+    }
+}

--- a/jbct/jbct-format/src/test/resources/format-examples/Lambdas.java
+++ b/jbct/jbct-format/src/test/resources/format-examples/Lambdas.java
@@ -21,6 +21,7 @@ public class Lambdas {
     Function<String, String> blockMultiple = s -> {
         var trimmed = s.trim();
         var upper = trimmed.toUpperCase();
+
         return upper;
     };
 
@@ -32,6 +33,7 @@ public class Lambdas {
     Result<String> blockLambdaInCall(Result<String> input) {
         return input.map(s -> {
             var trimmed = s.trim();
+
             return trimmed.toUpperCase();
         });
     }
@@ -52,11 +54,13 @@ public class Lambdas {
                     .filter(s -> {
                                 // code is shifted by one tab from 's'
                                 var trimmed = s.trim();
+
                                 return ! trimmed.isEmpty() && trimmed.length() > 3;
                             })  // aligned to the 's'
                     .map(s -> {
                              // code is shifted by one tab from 's'
                              var upper = s.toUpperCase();
+
                              return "[" + upper + "]";
                          })
                     .toList();
@@ -70,10 +74,12 @@ public class Lambdas {
     Result<String> blockLambdasAsArgs(Result<String> input) {
         return input.fold(cause -> {
                               logError(cause);
+
                               return defaultValue;
                           },
                           value -> {
                               log(value);
+
                               return value.toUpperCase();
                           });
     }

--- a/jbct/jbct-format/src/test/resources/format-examples/LineWrapping.java
+++ b/jbct/jbct-format/src/test/resources/format-examples/LineWrapping.java
@@ -43,7 +43,7 @@ public class LineWrapping {
         return value != null
                && !value.isEmpty()
                && value.length() > 5
-               && value.length() <100
+               && value.length() < 100
                && isValid(value);
     }
 

--- a/jbct/jbct-format/src/test/resources/format-examples/MultilineArguments.java
+++ b/jbct/jbct-format/src/test/resources/format-examples/MultilineArguments.java
@@ -51,6 +51,7 @@ public class MultilineArguments {
     Result<String> lambdaArg() {
         return input.map(value -> {
             var trimmed = value.trim();
+
             return trimmed.toUpperCase();
         });
     }
@@ -58,10 +59,12 @@ public class MultilineArguments {
     Result<String> multipleLambdaArgs() {
         return input.fold(cause -> {
                               logError(cause);
+
                               return defaultValue;
                           },
                           value -> {
                               log(value);
+
                               return value.toUpperCase();
                           });
     }

--- a/jbct/jbct-format/src/test/resources/format-examples/Records.java
+++ b/jbct/jbct-format/src/test/resources/format-examples/Records.java
@@ -28,7 +28,7 @@ public class Records {
 
     record Password(String value) {
         public Password {
-            if (value.length() <8) {
+            if (value.length() < 8) {
                 throw new IllegalArgumentException("Password too short");
             }
         }

--- a/jbct/jbct-format/src/test/resources/format-examples/TernaryOperators.java
+++ b/jbct/jbct-format/src/test/resources/format-examples/TernaryOperators.java
@@ -24,7 +24,7 @@ public class TernaryOperators {
     }
 
     String nestedTernary(int value) {
-        return value <0
+        return value < 0
                ? "negative"
                : value == 0
                  ? "zero"

--- a/jbct/jbct-format/src/test/resources/format-examples/TextBlocks.java
+++ b/jbct/jbct-format/src/test/resources/format-examples/TextBlocks.java
@@ -41,6 +41,7 @@ public class TextBlocks {
                 WHERE active = true
                 ORDER BY created_at DESC
                 """.formatted(table);
+
         return query;
     }
 

--- a/jbct/jbct-parser/src/main/java/org/pragmatica/jbct/parser/v6/Java25Lexer.java
+++ b/jbct/jbct-parser/src/main/java/org/pragmatica/jbct/parser/v6/Java25Lexer.java
@@ -13,7 +13,7 @@ public final class Java25Lexer {
 
     public static final String[] KIND_NAMES = {"WHITESPACE", "LINE_COMMENT", "BLOCK_COMMENT", "DOC_LINE_COMMENT", "DOC_BLOCK_COMMENT", "ClassKW", "InterfaceKW", "EnumKW", "RecordKW", "IfKW", "WhileKW", "ForKW", "DoKW", "TryKW", "SwitchKW", "SynchronizedKW", "ReturnKW", "ThrowKW", "BreakKW", "ContinueKW", "AssertKW", "YieldKW", "CatchKW", "FinallyKW", "WhenKW", "URShift", "RShift", "LShift", "URShiftAssign", "RShiftAssign", "LShiftAssign", "PrimType", "Identifier", "Modifier", "CharLit", "StringLit", "NumLit", "Keyword", "INLINE_transitive", "INLINE_implements", "INLINE_instanceof", "INLINE_interface", "INLINE_requires", "INLINE_provides", "INLINE_package", "INLINE_exports", "INLINE_extends", "INLINE_default", "INLINE_permits", "INLINE_import", "INLINE_module", "INLINE_static", "INLINE_throws", "INLINE_opens", "INLINE_while", "INLINE_class", "INLINE_super", "INLINE_false", "INLINE_open", "INLINE_uses", "INLINE_with", "INLINE_else", "INLINE_case", "INLINE_null", "INLINE_when", "INLINE_this", "INLINE_true", "INLINE__DOT_DOT_DOT", "INLINE_var", "INLINE_new", "INLINE_to", "INLINE__MINUS_GT", "INLINE__PLUS_EQ", "INLINE__MINUS_EQ", "INLINE__STAR_EQ", "INLINE__SLASH_EQ", "INLINE__PERCENT_EQ", "INLINE__AMP_EQ", "INLINE__PIPE_EQ", "INLINE__CARET_EQ", "INLINE__PIPE_PIPE", "INLINE__AMP_AMP", "INLINE__EQ_EQ", "INLINE__BANG_EQ", "INLINE__LT_EQ", "INLINE__GT_EQ", "INLINE__PLUS_PLUS", "INLINE__MINUS_MINUS", "INLINE__COLON_COLON", "INLINE__SEMI", "INLINE__DOT", "INLINE__STAR", "INLINE__LBRACE", "INLINE__RBRACE", "INLINE__COMMA", "INLINE__AT", "INLINE__LPAREN", "INLINE__RPAREN", "INLINE__LT", "INLINE__GT", "INLINE__AMP", "INLINE__EQ", "INLINE__COLON", "INLINE__PIPE", "INLINE__", "INLINE__QMARK", "INLINE__CARET", "INLINE__PLUS", "INLINE__MINUS", "INLINE__SLASH", "INLINE__PERCENT", "INLINE__BANG", "INLINE__TILDE", "INLINE__LBRACK", "INLINE__RBRACK", "INLINE_enum", "INLINE_record", "INLINE_if", "INLINE_for", "INLINE_do", "INLINE_try", "INLINE_switch", "INLINE_synchronized", "INLINE_return", "INLINE_throw", "INLINE_break", "INLINE_continue", "INLINE_assert", "INLINE_yield", "INLINE_catch", "INLINE_finally", "INLINE_boolean", "INLINE_byte", "INLINE_short", "INLINE_int", "INLINE_long", "INLINE_float", "INLINE_double", "INLINE_char", "INLINE_void", "INLINE_public", "INLINE_protected", "INLINE_private", "INLINE_final", "INLINE_abstract", "INLINE_native", "INLINE_transient", "INLINE_volatile", "INLINE_strictfp", "INLINE_sealed", "INLINE_non_MINUSsealed", "INLINE_const", "INLINE_goto", "ANY_CHAR"};
 
-    private static final int[] ACCEPT_KIND = new int[] {-1,153,0,111,153,32,110,100,153,96,97,91,107,94,108,90,109,36,36,102,89,98,101,99,105,95,113,114,106,104,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,92,103,93,112,0,83,-1,35,-1,32,76,81,77,-1,34,-1,74,86,72,87,73,71,-1,36,-1,0,75,36,36,-1,36,-1,-1,88,-1,84,82,85,-1,79,32,32,32,32,32,32,32,32,32,32,119,32,32,32,32,32,32,32,32,117,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,70,32,32,32,32,32,32,32,78,80,35,-1,-1,-1,67,36,-1,-1,-1,0,36,36,-1,36,36,30,29,-1,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,118,32,32,32,134,32,32,32,69,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,120,32,68,32,32,32,32,32,32,-1,-1,-1,36,0,36,36,28,32,32,32,32,132,62,32,138,32,32,32,32,32,61,115,32,32,32,32,32,152,32,32,32,32,135,32,32,-1,63,58,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,65,32,32,66,59,139,32,64,32,60,32,-1,32,32,32,125,129,55,151,32,32,32,32,32,57,143,136,32,32,32,32,32,32,-1,53,32,32,32,32,32,32,32,32,32,32,133,32,32,56,32,32,124,32,32,54,128,35,32,127,32,32,32,137,32,32,32,32,49,32,32,50,145,-1,32,32,32,32,32,140,116,32,123,149,51,32,121,32,52,32,32,32,131,32,47,45,46,130,32,32,32,-1,44,48,142,32,32,32,32,32,32,32,32,144,126,32,32,32,-1,32,43,42,148,32,32,32,147,32,32,41,-1,141,32,146,32,39,40,150,32,38,32,122};
+    private static final int[] ACCEPT_KIND = new int[] {-1,153,0,111,153,32,110,100,153,96,97,91,107,94,108,90,109,36,36,102,89,98,101,99,105,95,113,114,106,104,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,92,103,93,112,0,83,-1,35,-1,32,76,81,77,-1,34,-1,74,86,72,87,73,71,-1,36,-1,1,75,36,36,-1,36,-1,-1,88,-1,84,82,85,-1,79,32,32,32,32,32,32,32,32,32,32,119,32,32,32,32,32,32,32,32,117,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,70,32,32,32,32,32,32,32,78,80,35,-1,-1,-1,67,36,-1,-1,-1,1,36,36,-1,36,36,30,29,-1,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,118,32,32,32,134,32,32,32,69,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,120,32,68,32,32,32,32,32,32,-1,-1,-1,36,2,36,36,28,32,32,32,32,132,62,32,138,32,32,32,32,32,61,115,32,32,32,32,32,152,32,32,32,32,135,32,32,-1,63,58,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,32,65,32,32,66,59,139,32,64,32,60,32,-1,32,32,32,125,129,55,151,32,32,32,32,32,57,143,136,32,32,32,32,32,32,-1,53,32,32,32,32,32,32,32,32,32,32,133,32,32,56,32,32,124,32,32,54,128,35,32,127,32,32,32,137,32,32,32,32,49,32,32,50,145,-1,32,32,32,32,32,140,116,32,123,149,51,32,121,32,52,32,32,32,131,32,47,45,46,130,32,32,32,-1,44,48,142,32,32,32,32,32,32,32,32,144,126,32,32,32,-1,32,43,42,148,32,32,32,147,32,32,41,-1,141,32,146,32,39,40,150,32,38,32,122};
 
     private static final int[] TRANSITIONS = buildTransitions();
 
@@ -24889,59 +24889,59 @@ public final class Java25Lexer {
     private static final java.util.HashMap<String, Integer>[] RESOLVERS = new java.util.HashMap[154];
     static {
         java.util.HashMap<String, Integer> r0 = new java.util.HashMap<>();
-        r0.put("false", 57);
-        r0.put("double", 137);
-        r0.put("else", 61);
-        r0.put("byte", 132);
-        r0.put("return", 123);
-        r0.put("null", 63);
-        r0.put("void", 139);
-        r0.put("interface", 41);
-        r0.put("long", 135);
-        r0.put("throws", 52);
-        r0.put("transient", 146);
-        r0.put("continue", 126);
-        r0.put("native", 145);
-        r0.put("throw", 124);
-        r0.put("case", 62);
-        r0.put("if", 117);
-        r0.put("instanceof", 40);
-        r0.put("super", 56);
-        r0.put("extends", 46);
-        r0.put("import", 49);
-        r0.put("break", 125);
-        r0.put("default", 47);
-        r0.put("final", 143);
-        r0.put("short", 133);
-        r0.put("boolean", 131);
-        r0.put("catch", 129);
-        r0.put("new", 69);
-        r0.put("private", 142);
-        r0.put("synchronized", 122);
-        r0.put("char", 138);
-        r0.put("class", 55);
         r0.put("const", 151);
-        r0.put("strictfp", 148);
-        r0.put("float", 136);
-        r0.put("public", 140);
-        r0.put("static", 51);
-        r0.put("implements", 39);
-        r0.put("switch", 121);
-        r0.put("this", 65);
-        r0.put("protected", 141);
-        r0.put("goto", 152);
-        r0.put("true", 66);
-        r0.put("try", 120);
-        r0.put("int", 134);
-        r0.put("package", 44);
-        r0.put("enum", 115);
-        r0.put("for", 118);
-        r0.put("do", 119);
-        r0.put("finally", 130);
-        r0.put("volatile", 147);
-        r0.put("assert", 127);
-        r0.put("abstract", 144);
+        r0.put("class", 55);
+        r0.put("char", 138);
+        r0.put("synchronized", 122);
+        r0.put("private", 142);
+        r0.put("new", 69);
+        r0.put("catch", 129);
+        r0.put("boolean", 131);
+        r0.put("short", 133);
+        r0.put("final", 143);
+        r0.put("default", 47);
+        r0.put("break", 125);
+        r0.put("import", 49);
+        r0.put("extends", 46);
+        r0.put("super", 56);
+        r0.put("instanceof", 40);
+        r0.put("if", 117);
+        r0.put("case", 62);
+        r0.put("throw", 124);
+        r0.put("native", 145);
+        r0.put("continue", 126);
+        r0.put("transient", 146);
+        r0.put("throws", 52);
+        r0.put("long", 135);
+        r0.put("interface", 41);
+        r0.put("void", 139);
+        r0.put("null", 63);
+        r0.put("return", 123);
+        r0.put("byte", 132);
+        r0.put("else", 61);
+        r0.put("double", 137);
+        r0.put("false", 57);
         r0.put("while", 54);
+        r0.put("abstract", 144);
+        r0.put("assert", 127);
+        r0.put("volatile", 147);
+        r0.put("finally", 130);
+        r0.put("do", 119);
+        r0.put("for", 118);
+        r0.put("enum", 115);
+        r0.put("package", 44);
+        r0.put("int", 134);
+        r0.put("try", 120);
+        r0.put("true", 66);
+        r0.put("goto", 152);
+        r0.put("protected", 141);
+        r0.put("this", 65);
+        r0.put("switch", 121);
+        r0.put("implements", 39);
+        r0.put("static", 51);
+        r0.put("public", 140);
+        r0.put("float", 136);
+        r0.put("strictfp", 148);
         RESOLVERS[32] = r0;
     }
 
@@ -24983,7 +24983,10 @@ public final class Java25Lexer {
                     if (ovr != null) lastAcceptKind = ovr;
                 }
             }
-            if (lastAcceptKind == TokenArray.KIND_WHITESPACE && lastAcceptEnd > pos + 1) {
+            if ((lastAcceptKind == TokenArray.KIND_WHITESPACE
+                 || lastAcceptKind == TokenArray.KIND_LINE_COMMENT
+                 || lastAcceptKind == TokenArray.KIND_BLOCK_COMMENT)
+                && lastAcceptEnd > pos + 1) {
                 char c0 = input.charAt(pos);
                 char c1 = input.charAt(pos + 1);
                 if (c0 == '/') {

--- a/jbct/jbct-parser/src/main/java/org/pragmatica/jbct/parser/v6/Java25ParserV6.java
+++ b/jbct/jbct-parser/src/main/java/org/pragmatica/jbct/parser/v6/Java25ParserV6.java
@@ -226,11 +226,11 @@ public final class Java25ParserV6 {
     private static final int KIND_INLINE__BANG = 111;
     private static final int KIND_INLINE__TILDE = 112;
     private static final int KIND_INLINE_THIS = 65;
+    private static final int KIND_INLINE_SUPER = 56;
     private static final int KIND_INLINE__LBRACK = 113;
     private static final int KIND_INLINE__RBRACK = 114;
     private static final int KIND_INLINE__COLON_COLON = 88;
     private static final int KIND_INLINE_NEW = 69;
-    private static final int KIND_INLINE_SUPER = 56;
     private static final int KIND_INLINE_BOOLEAN = 131;
     private static final int KIND_INLINE_BYTE = 132;
     private static final int KIND_INLINE_SHORT = 133;
@@ -5787,6 +5787,19 @@ public final class Java25ParserV6 {
                     if (peek() != KIND_INLINE__DOT) { fail("'.'", RULE_PostOp_KIND); break; }
                     advance();
                     if (peek() != KIND_INLINE_THIS) { fail("'this'", RULE_PostOp_KIND); break; }
+                    advance();
+                    matched_alt_0 = true;
+                } while (false);
+                if (!matched_alt_0) {
+                    pos = savedPos_alt_0;
+                    cst.truncate(savedNodes_alt_0);
+                }
+            }
+            if (!matched_alt_0 && !cutHit_alt_0) {
+                do {
+                    if (peek() != KIND_INLINE__DOT) { fail("'.'", RULE_PostOp_KIND); break; }
+                    advance();
+                    if (peek() != KIND_INLINE_SUPER) { fail("'super'", RULE_PostOp_KIND); break; }
                     advance();
                     matched_alt_0 = true;
                 } while (false);

--- a/jbct/jbct-parser/src/main/resources/grammars/java25.peg
+++ b/jbct/jbct-parser/src/main/resources/grammars/java25.peg
@@ -154,7 +154,7 @@ Additive <- Multiplicative ((!'+=' '+' / !'-=' !'->' '-') Multiplicative)*
 Multiplicative <- Unary ((!'*=' '*' / !'/=' '/' / !'%=' '%') Unary)*
 Unary <- ('++' / '--' / '+' / '-' / '!' / '~') Unary / '(' Type ('&' Type)* ')' Unary / Postfix
 Postfix <- Primary PostOp*
-PostOp <- '.' TypeArgs? Identifier ('(' Args? ')')? / '.' 'class' / '.' 'this' / '[' Expr ']' / '(' Args? ')' / '++' / '--' / '::' TypeArgs? (Identifier / 'new')
+PostOp <- '.' TypeArgs? Identifier ('(' Args? ')')? / '.' 'class' / '.' 'this' / '.' 'super' / '[' Expr ']' / '(' Args? ')' / '++' / '--' / '::' TypeArgs? (Identifier / 'new')
 Primary <- Literal / < 'this' ![a-zA-Z0-9_$] > / < 'super' ![a-zA-Z0-9_$] > / < 'new' ![a-zA-Z0-9_$] > TypeArgs? ArrayType (DimExprs Dims? / Dims VarInit / '(' Args? ')' ClassBody?) / SwitchKW '(' Expr ')' SwitchBlock / Lambda / '(' Expr ')' / TypeExpr / QualifiedName
 TypeExpr <- Type ('.' < 'class' > / '::' TypeArgs? (< 'new' > / Identifier))
 Lambda <- LambdaParams '->' (Expr / Block)


### PR DESCRIPTION
Fixes the JBCT formatter so the `format` goal can be re-enabled. Addresses every blocker in the formatter-disabled bug report (operator spacing, `//` comment deletion, if/else indentation) plus lambda-body indentation and the lone parser failure.

## jbct-format
- **Preserve `//` comments** — no longer drops an own-line comment before `}` or a comment-only empty body (orphan-comment catcher in `emitLeafTokens`; own-line emission in `emitBlockTrailingComments`).
- **`<` / `>` operator spacing** — `a < 0` / `v << n` no longer collapse to `a <0` / `v <<n`; generics (`List<String>`, `static <T>`) unaffected. Disambiguates operator vs generic via a CST-context `typeContextDepth` counter keyed off the parser's TYPE_ARGS/TYPE_PARAMS rules.
- **Uniform blank-line rules** in regular and lambda bodies (only base indent differs): R1 blank after a block-shaped statement (when more follow), R2 blank after a local-variable-declaration run (before a non-var), R3 blank before a `return`/`throw`; coalesced. Removes the `isLambdaBody` pack-tight special case and the 3+-statement threshold.
- **Single-statement blocks always expand** (removed inline-collapse).
- **Lambda body indents from the enclosing statement** at call sites; keeps parameter alignment inside broken method chains.
- **Space after `;` in `for` headers**; `BlankLineRules` simple-declaration check is token-based (no spurious blank before a field that precedes a comment).
- Removed 6 now-dead helper methods.

## jbct-parser
- **Parse qualified super-interface calls** (`Type.super.method()`) — added `'.' 'super'` to the `PostOp` rule in `java25.peg` and regenerated the v6 parser/lexer. This was the lone hard parse failure in the repo.

## Validation
- 25/25 golden examples, 8/8 `FlowFormatterTest`, 11/11 content-preservation tests.
- Whole-codebase sweep: **0 format errors, 0 non-idempotent across 2666 files** (the parser fix took errors 1 → 0).
