### PR TITLE
fix(jbct-format): eliminate residual comment deletion (post-#242)

### DIFF
--- a/jbct/jbct-format/src/main/java/org/pragmatica/jbct/format/flow/FlowPrinter.java
+++ b/jbct/jbct-format/src/main/java/org/pragmatica/jbct/format/flow/FlowPrinter.java
@@ -210,6 +210,39 @@ final class FlowPrinter {
         }
     }
 
+    /// Emit `node`'s own-line leading comments (if any) at the current indent level, then its
+    /// content via the trivia-free `printNodeContent` path. The CALLER MUST be at column 0 (have
+    /// just emitted a `newline()`) and MUST NOT pre-indent: when the node carries leading comments
+    /// `emitLeadingComments` owns the indentation of both the comment lines and the following
+    /// content — pre-indenting would leave a stripped spaces-only line (a spurious blank) ahead of
+    /// the comment; when it does not, we indent here. Custom printers that place a child on its own
+    /// line (enum-body members/constants, switch rules) route through this so a comment claimed as
+    /// the child's leading trivia is not silently deleted — `printNodeContent` skips trivia by
+    /// contract (bug report S1–S4). Output is byte-identical for comment-free nodes.
+    private void printOwnLineChildContent(Cursor node) {
+        if (!measuringMode && hasUnEmittedLeadingComment(node)) {
+            emitLeadingComments(node);
+        } else {
+            printIndent();
+        }
+        printNodeContent(node);
+    }
+
+    /// As `printOwnLineChildContent`, but indents to an explicit column via `printAlignedTo` rather
+    /// than the indent level — for aligned list layouts (broken record components). Caller must be
+    /// at column 0.
+    private void printOwnLineChildContentAligned(Cursor node, int col) {
+        if (!measuringMode && hasUnEmittedLeadingComment(node)) {
+            int savedForcedIndentCol = forcedIndentCol;
+            forcedIndentCol = col;
+            emitLeadingComments(node);
+            forcedIndentCol = savedForcedIndentCol;
+        } else {
+            printAlignedTo(col);
+        }
+        printNodeContent(node);
+    }
+
     /// Emit a Leaf node's tokens by walking the TokenArray range (skipping trivia).
     /// Using `leaf.text()` instead would return the source slice covering trailing trivia,
     /// causing whitespace bleed into the output.
@@ -232,13 +265,19 @@ final class FlowPrinter {
                 continue;
             }
             int kind = tokens.kindAt(t);
-            if (measuringMode || (kind != 1 && kind != 3) || t >= lastBrace || emittedTriviaTokens.contains(t)) {
+            boolean isLine = kind == 1 || kind == 3;   // LINE_COMMENT / DOC_LINE_COMMENT
+            boolean isBlock = kind == 2 || kind == 4;  // BLOCK_COMMENT / DOC_BLOCK_COMMENT
+            if (measuringMode || (!isLine && !isBlock) || t >= lastBrace || emittedTriviaTokens.contains(t)) {
                 continue;
             }
-            // Orphan line comment enclosed before a `}` in this bare-leaf body — emit so it is not
-            // silently deleted (bug B2).
+            // Orphan comment enclosed before a `}` in this bare-leaf body — emit so it is not
+            // silently deleted (bug B2 / report mechanism C). A single-line block comment stays
+            // inline (`{ /* note */ }`); line comments and multi-line block comments go own-line.
             var text = tokens.textAt(t).toString().stripTrailing();
-            if (precedingContentOnSameLine(tokens.startAt(t)) && currentColumn > 0) {
+            boolean sameLine = precedingContentOnSameLine(tokens.startAt(t)) && currentColumn > 0;
+            if (isBlock && sameLine && text.indexOf('\n') < 0) {
+                emit(" " + text + " ");
+            } else if (isLine && sameLine) {
                 emit("  " + text);
             } else {
                 if (currentColumn > 0) {
@@ -316,7 +355,22 @@ final class FlowPrinter {
                 printNode(kid);
                 t = kid.lastTokenIdx() + 1;
                 kidIdx++;
+                // Rescue self-closing block comments inside the child's span (safe: cannot swallow).
+                flushInSpanBlockComments(kid);
                 if (breakAfterAnnotation && kid.kindIs(RuleKind.ANNOTATION)) {
+                    // Flush a same-line trailing comment after the annotation (e.g. `@Ann // note`)
+                    // BEFORE the break newline — safe here precisely because a newline immediately
+                    // follows, so the comment cannot swallow trailing tokens (bug report mechanism
+                    // B, annotation-trailing). The parser may attach it INSIDE the annotation span
+                    // (flushInSpanTrailingComment) or as a gap token after it (the while-scan).
+                    flushInSpanTrailingComment(kid);
+                    while (t <= end && tokens.isTrivia(t)) {
+                        int kind = tokens.kindAt(t);
+                        if (kind >= 1 && kind <= 4 && !emitTrailingOrphanComment(tokens, t)) {
+                            break;
+                        }
+                        t++;
+                    }
                     newline();
                     printIndent();
                 } else if (spaceAfterAnnotation && kid.kindIs(RuleKind.ANNOTATION)) {
@@ -325,6 +379,8 @@ final class FlowPrinter {
             } else {
                 if (!tokens.isTrivia(t)) {
                     emitToken(tokens.textAt(t).toString());
+                } else {
+                    emitInlineBlockComment(tokens, t);
                 }
                 t++;
             }
@@ -373,9 +429,13 @@ final class FlowPrinter {
                 walker.onChild(kid);
                 t = kid.lastTokenIdx() + 1;
                 kidIdx++;
+                // Rescue self-closing block comments inside the child's span (safe: cannot swallow).
+                flushInSpanBlockComments(kid);
             } else {
                 if (!tokens.isTrivia(t)) {
                     walker.onToken(tokens.kindAt(t), tokens.textAt(t).toString());
+                } else {
+                    emitInlineBlockComment(tokens, t);
                 }
                 t++;
             }
@@ -577,6 +637,9 @@ final class FlowPrinter {
                 first = false;
                 prevMember = Option.some(member);
             }
+            // Own-line comments dangling after the last member, before the body's `}` (mechanism
+            // E3). Deduped against comments already emitted as members' leading trivia.
+            emitTrailingBodyComments(parent, members.get(members.size() - 1));
             indentLevel--;
             printIndent();
         }
@@ -670,8 +733,7 @@ final class FlowPrinter {
 
         for (var member : classMembers) {
             newline();
-            printIndent();
-            printNodeContent(member);
+            printOwnLineChildContent(member);
         }
 
         indentLevel--;
@@ -681,7 +743,8 @@ final class FlowPrinter {
     }
 
     private void printEnumConstsWithIndent(Cursor consts) {
-        printIndent();
+        // No pre-indent: printOwnLineChildContent (called per constant) owns the indentation so a
+        // constant carrying a leading doc comment isn't preceded by a spurious blank line.
         printEnumConsts(consts);
     }
 
@@ -691,9 +754,8 @@ final class FlowPrinter {
             if (i > 0) {
                 emit(",");
                 newline();
-                printIndent();
             }
-            printNodeContent(constNodes.get(i));
+            printOwnLineChildContent(constNodes.get(i));
         }
     }
 
@@ -778,32 +840,46 @@ final class FlowPrinter {
         var tokens = block.cst().tokens();
         int open = block.firstTokenIdx();
         int close = block.lastTokenIdx();
-        boolean any = false;
+        var comments = new ArrayList<Integer>();
+        boolean needsOwnLines = false; // a line comment or a multi-line block comment forces expansion
         for (int t = open + 1; t < close; t++) {
             if (!tokens.isTrivia(t)) {
                 continue;
             }
             int kind = tokens.kindAt(t);
-            if (kind != 1 && kind != 3) { // LINE_COMMENT or DOC_LINE_COMMENT only
+            boolean isLine = kind == 1 || kind == 3;   // LINE_COMMENT / DOC_LINE_COMMENT
+            boolean isBlock = kind == 2 || kind == 4;  // BLOCK_COMMENT / DOC_BLOCK_COMMENT
+            if ((!isLine && !isBlock) || emittedTriviaTokens.contains(t)) {
                 continue;
             }
-            if (emittedTriviaTokens.contains(t)) {
-                continue;
+            comments.add(t);
+            if (isLine || tokens.textAt(t).toString().indexOf('\n') >= 0) {
+                needsOwnLines = true;
             }
-            if (!any) {
-                indentLevel++;
+        }
+        if (comments.isEmpty()) {
+            return;
+        }
+        if (!needsOwnLines) {
+            // Only single-line block comments: keep them inline so `{ /* note */ }` stays one line.
+            for (int t : comments) {
+                emit(" " + tokens.textAt(t).toString().stripTrailing());
+                emittedTriviaTokens.add(t);
             }
+            emit(" ");
+            return;
+        }
+        // A line comment (or multi-line block comment) can't share the `}` line — expand the body.
+        indentLevel++;
+        for (int t : comments) {
             newline();
             printIndent();
             emit(tokens.textAt(t).toString().stripTrailing());
             emittedTriviaTokens.add(t);
-            any = true;
         }
-        if (any) {
-            indentLevel--;
-            newline();
-            printIndent();
-        }
+        indentLevel--;
+        newline();
+        printIndent();
     }
 
     /// Emit trailing line comments that sit in the last stmt's trailing trivia region
@@ -875,6 +951,171 @@ final class FlowPrinter {
 
     private boolean hasLeadingComment(Cursor node) {
         return node.leadingTrivia().anyMatch(t -> t.isLineComment() || t.isBlockComment());
+    }
+
+    /// Emit token `t` as a trailing comment when it is an unclaimed comment sitting at the END of a
+    /// source line (non-whitespace precedes it on the same source line) — e.g. `// note` after an
+    /// annotation, or after the last argument before `)`. Such comments are claimed by no node, so
+    /// the trivia-skipping token walk would otherwise delete them (bug report mechanism B). Returns
+    /// true when it emitted a comment. Own-line comments return false and are left for the
+    /// leading-comment machinery. No-op in measuring mode, for non-comments, for already-emitted
+    /// tokens, and for multi-line block comments (which cannot be inlined as a trailing comment).
+    private boolean emitTrailingOrphanComment(TokenArray tokens, int t) {
+        if (measuringMode || emittedTriviaTokens.contains(t)) {
+            return false;
+        }
+        int kind = tokens.kindAt(t);
+        boolean isLine = kind == 1 || kind == 3;
+        boolean isBlock = kind == 2 || kind == 4;
+        if (!isLine && !isBlock) {
+            return false;
+        }
+        if (currentColumn == 0 || !precedingContentOnSameLine(tokens.startAt(t))) {
+            return false;
+        }
+        var text = tokens.textAt(t).toString().stripTrailing();
+        if (isBlock && text.indexOf('\n') >= 0) {
+            return false;
+        }
+        emit("  " + text);
+        emittedTriviaTokens.add(t);
+        return true;
+    }
+
+    /// Emit token `t` as an inline block comment (`/* note */`) when it is an unclaimed,
+    /// single-line block comment in mid-line position. Block comments are self-closing, so —
+    /// unlike line comments — emitting one inline cannot swallow the tokens that follow it on the
+    /// same line; this is the safe way to preserve `x /* note */ y` comments that the trivia-
+    /// skipping walk would otherwise delete (bug report mechanism E1). No-op for line comments,
+    /// multi-line block comments, start-of-line positions, measuring mode, and already-emitted
+    /// tokens.
+    private void emitInlineBlockComment(TokenArray tokens, int t) {
+        if (measuringMode || emittedTriviaTokens.contains(t) || currentColumn == 0) {
+            return;
+        }
+        int kind = tokens.kindAt(t);
+        if (kind != 2 && kind != 4) {
+            return;
+        }
+        // Only inline a block comment that was a same-line trailing comment in the source. An
+        // own-line standalone block comment (`\n/* note */\n`) belongs to the leading-comment
+        // machinery and must NOT be pulled up onto the previous token's line.
+        if (!precedingContentOnSameLine(tokens.startAt(t))) {
+            return;
+        }
+        var text = tokens.textAt(t).toString().stripTrailing();
+        if (text.indexOf('\n') >= 0) {
+            return;
+        }
+        emit(" " + text);
+        emittedTriviaTokens.add(t);
+    }
+
+    /// Emit any unclaimed single-line block comments living INSIDE `node`'s token span, inline at
+    /// the current position (after the node has rendered). Block comments are self-closing, so this
+    /// cannot corrupt following tokens; it rescues `x /* note */ y` comments that the parser places
+    /// inside a child expression span where the trivia-skipping walk never visits them (bug report
+    /// mechanism E1). No-op for comment-free spans and for comments already emitted by their own
+    /// node's leading-trivia handling (deduped via emittedTriviaTokens).
+    private void flushInSpanBlockComments(Cursor node) {
+        if (measuringMode) {
+            return;
+        }
+        var tokens = node.cst().tokens();
+        for (int t = node.firstTokenIdx(); t <= node.lastTokenIdx(); t++) {
+            if (tokens.isTrivia(t)) {
+                emitInlineBlockComment(tokens, t);
+            }
+        }
+    }
+
+    /// Emit same-line trailing comments that live INSIDE `node`'s own token span (e.g. the comment
+    /// in `arg // note` trailing the last argument before `)`, which the parser places inside the
+    /// argument expression rather than after it). Returns true if a LINE comment was emitted — the
+    /// caller must then break the following delimiter (`,`/`)`) onto a new line so the line comment
+    /// does not swallow it. No-op for comment-free spans.
+    private boolean flushInSpanTrailingComment(Cursor node) {
+        var tokens = node.cst().tokens();
+        boolean lineEmitted = false;
+        for (int t = node.firstTokenIdx(); t <= node.lastTokenIdx(); t++) {
+            if (!tokens.isTrivia(t)) {
+                continue;
+            }
+            int kind = tokens.kindAt(t);
+            boolean wasLine = kind == 1 || kind == 3;
+            if (emitTrailingOrphanComment(tokens, t) && wasLine) {
+                lineEmitted = true;
+            }
+        }
+        return lineEmitted;
+    }
+
+    /// Emit unclaimed own-line comments dangling between the last member and the body's closing
+    /// `}` — i.e. comments that trail the final member of a class/interface/annotation body (bug
+    /// report mechanism E3). Boundaries are computed from the actual tokens, NOT `lastTokenIdx()`,
+    /// which includes trailing trivia attributed PAST the brace (e.g. the next sibling's leading
+    /// comment) and would otherwise both over-reach (pulling a sibling's comment inside this body)
+    /// and under-reach (skipping genuine tail comments absorbed into the member's trailing span).
+    private void emitTrailingBodyComments(Cursor.Branch parent, Cursor lastMember) {
+        if (measuringMode) {
+            return;
+        }
+        var tokens = parent.cst().tokens();
+        // First token after the last member's last NON-trivia token.
+        int afterToken = lastMember.lastTokenIdx();
+        while (afterToken >= lastMember.firstTokenIdx() && tokens.isTrivia(afterToken)) {
+            afterToken--;
+        }
+        afterToken++;
+        // The body's own closing `}` (last non-trivia `}` within the parent span).
+        int close = parent.lastTokenIdx();
+        while (close >= afterToken && (tokens.isTrivia(close) || !"}".contentEquals(tokens.textAt(close)))) {
+            close--;
+        }
+        for (int t = afterToken; t < close; t++) {
+            if (!tokens.isTrivia(t)) {
+                continue;
+            }
+            int kind = tokens.kindAt(t);
+            if (kind < 1 || kind > 4 || emittedTriviaTokens.contains(t)) {
+                continue;
+            }
+            if (currentColumn > 0) {
+                newline();
+            }
+            printIndent();
+            emit(tokens.textAt(t).toString().stripTrailing());
+            newline();
+            emittedTriviaTokens.add(t);
+        }
+    }
+
+    /// Emit unclaimed OWN-LINE comments dangling inside an argument list before its `)` (e.g.
+    /// `f(a,\n // note\n)`), each on its own line aligned to `alignCol`. Returns true if any was
+    /// emitted, so the caller can break the closing `)` onto a new line (bug report mechanism E2).
+    /// Same-line comments are handled by `flushInSpanTrailingComment` / `emitInlineBlockComment`.
+    private boolean emitDanglingOwnLineArgComments(Cursor args, int alignCol) {
+        if (measuringMode) {
+            return false;
+        }
+        var tokens = args.cst().tokens();
+        boolean any = false;
+        for (int t = args.firstTokenIdx(); t <= args.lastTokenIdx(); t++) {
+            if (!tokens.isTrivia(t)) {
+                continue;
+            }
+            int kind = tokens.kindAt(t);
+            if (kind < 1 || kind > 4 || emittedTriviaTokens.contains(t)
+                || precedingContentOnSameLine(tokens.startAt(t))) {
+                continue;
+            }
+            newline();
+            printAlignedTo(alignCol);
+            emit(tokens.textAt(t).toString().stripTrailing());
+            any = true;
+            emittedTriviaTokens.add(t);
+        }
+        return any;
     }
 
     /// True if `node` has any line/block comment in its leading trivia that has NOT yet
@@ -975,12 +1216,14 @@ final class FlowPrinter {
         if (!rules.isEmpty()) {
             newline();
             for (var rule : rules) {
-                printIndent();
                 // Switch case bodies render inline regardless of width — wrap in an
                 // inline-expression scope so chain/additive/etc. break logic stays inline.
                 try (var inlineScope = alignment.enterInlineExpression()) {
-                    printNodeContent(rule);
+                    printOwnLineChildContent(rule);
                 }
+                // Rescue a same-line trailing comment after the arm (e.g. `default -> null; // x`)
+                // before the newline — safe because a newline follows (bug report mechanism E4).
+                flushInSpanTrailingComment(rule);
                 newline();
             }
         }
@@ -1218,7 +1461,23 @@ final class FlowPrinter {
             for (int pi = 0; pi < postOps.size(); pi++) {
                 var postOp = postOps.get(pi);
                 boolean isMethodCall = methodCallSet.contains(postOp);
-                if (isMethodCall && !firstMethodCallPending) {
+                // A leading comment on this post-op forces it onto its own line at the chain
+                // column. Handle positioning here (a single newline to column 0, then let
+                // emitLeadingComments own the indent) and SKIP the normal pre-align below, which
+                // would otherwise stack a spurious blank line ahead of the comment (bug report S5).
+                boolean hasLead = !measuringMode && hasUnEmittedLeadingComment(postOp);
+                if (hasLead) {
+                    if (currentColumn > 0) {
+                        newline();
+                    }
+                    if (isMethodCall && !firstMethodCallPending && scope.lastPostOpWasBrokenArgs()) {
+                        scope.clearBrokenArgsAnchor();
+                    }
+                    int savedForcedIndentCol = forcedIndentCol;
+                    forcedIndentCol = alignColumn;
+                    emitLeadingComments(postOp);
+                    forcedIndentCol = savedForcedIndentCol;
+                } else if (isMethodCall && !firstMethodCallPending) {
                     if (scope.lastPostOpWasBrokenArgs()
                         && countMethodCallsFromIndex(postOps, methodCallSet, pi) >= 2) {
                         // 2+ follow-ups remain after a broken-args invocation: the first
@@ -1419,7 +1678,26 @@ final class FlowPrinter {
         }
     }
 
+    /// True if the node's token range contains a line (`//`) or doc-line (`///`) comment token.
+    /// Token-based (not text-based), so `//` inside a string literal does not trigger it.
+    private boolean hasLineCommentToken(Cursor node) {
+        var tokens = node.cst().tokens();
+        for (int t = node.firstTokenIdx(); t <= node.lastTokenIdx(); t++) {
+            int kind = tokens.kindAt(t);
+            if (kind == 1 || kind == 3) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     private boolean hasComplexArguments(Cursor args) {
+        // A line comment anywhere in the argument list cannot be rendered inline (`f(a, b // c)`
+        // would swallow `)` into the comment), so force broken layout — the broken walk then emits
+        // the trailing comment on its argument's line (bug report mechanism B, last-arg trailing).
+        if (hasLineCommentToken(args)) {
+            return true;
+        }
         // Block lambda args that contain line comments are underestimated by measureWidth()
         // (comments are emitted to output, not measureBuffer). Force broken layout when
         // a block lambda body has leading comments — the `//` check is a reliable proxy.
@@ -1505,6 +1783,7 @@ final class FlowPrinter {
     }
 
     private void printBrokenArgsBody(Cursor.Branch args, int alignCol) {
+        boolean[] pendingLineBreak = {false};
         walkTokensWith(args, new TokenWalker() {
             @Override
             public void onChild(Cursor child) {
@@ -1521,6 +1800,11 @@ final class FlowPrinter {
                     } else {
                         printNodeContent(child);
                     }
+                    // Rescue a comment trailing this argument (inside its span) before the next
+                    // delimiter; a line comment forces that delimiter onto a new line.
+                    if (flushInSpanTrailingComment(child)) {
+                        pendingLineBreak[0] = true;
+                    }
                 } else {
                     printNode(child);
                 }
@@ -1529,6 +1813,11 @@ final class FlowPrinter {
             @Override
             public void onToken(int kind, String text) {
                 if (",".equals(text)) {
+                    if (pendingLineBreak[0]) {
+                        newline();
+                        printAlignedTo(alignCol);
+                        pendingLineBreak[0] = false;
+                    }
                     emit(",");
                     newline();
                     printAlignedTo(alignCol);
@@ -1537,6 +1826,14 @@ final class FlowPrinter {
                 }
             }
         });
+        // Last argument carried a trailing line comment, OR own-line comments dangle before `)`:
+        // break so the enclosing `)` (emitted by the post-op after this returns) lands on its own
+        // line instead of being swallowed (bug report mechanisms B last-arg / E2).
+        boolean danglingOwnLine = emitDanglingOwnLineArgComments(args, alignCol);
+        if (pendingLineBreak[0] || danglingOwnLine) {
+            newline();
+            printAlignedTo(Math.max(0, alignCol - 1));
+        }
     }
 
     // ===== Lambda =====
@@ -1688,7 +1985,9 @@ final class FlowPrinter {
         }
 
         int width = measureWidth(components);
-        if (currentColumn + width + 3 <= config.maxLineLength()) {
+        // A line comment between components cannot be inlined — force broken layout so each
+        // component (and its leading comment) lands on its own line (bug report mechanism A).
+        if (!hasLineCommentToken(components) && currentColumn + width + 3 <= config.maxLineLength()) {
             walkTokensWith(components, new TokenWalker() {
                 @Override public void onChild(Cursor c) { printNodeContent(c); }
                 @Override public void onToken(int kind, String text) { emitToken(text); }
@@ -1704,7 +2003,7 @@ final class FlowPrinter {
             @Override
             public void onChild(Cursor child) {
                 if (child.kindIs(RuleKind.RECORD_COMP)) {
-                    printNodeContent(child);
+                    printOwnLineChildContentAligned(child, alignCol);
                 } else {
                     printNode(child);
                 }
@@ -1715,7 +2014,6 @@ final class FlowPrinter {
                 if (",".equals(text)) {
                     emit(",");
                     newline();
-                    printAlignedTo(alignCol);
                 } else {
                     emitToken(text);
                 }

--- a/jbct/jbct-format/src/test/java/org/pragmatica/jbct/format/flow/FlowCodebaseCheckTest.java
+++ b/jbct/jbct-format/src/test/java/org/pragmatica/jbct/format/flow/FlowCodebaseCheckTest.java
@@ -129,4 +129,100 @@ class FlowCodebaseCheckTest {
         assertThat(errors).as("Files with format errors").isZero();
         assertThat(nonIdempotent).as("Non-idempotent files").isZero();
     }
+
+    /// Corpus-level CONTENT-PRESERVATION sweep: every comment token present in the input must
+    /// survive into the output. The idempotency gate above does NOT catch comment deletion — a
+    /// deleted comment stays deleted, so format(format(x)) == format(x) while content is lost
+    /// (bug report 2026-06-09). This sweep re-parses the output and asserts the input comment
+    /// multiset is a subset of the output comment multiset (compared by whitespace-normalized
+    /// text, so re-indentation of block-comment continuation lines does not register as loss).
+    @Disabled("Slow — full codebase scan. Run manually when changing trivia handling.")
+    @Test
+    @SuppressWarnings("JBCT-PAT-01")
+    void formatEntireCodebase_preservesAllComments() throws IOException {
+        var formatter = FlowFormatter.flowFormatter(FormatterConfig.defaultConfig());
+        var projectRoot = Path.of("").toAbsolutePath();
+        while (projectRoot != null && !Files.exists(projectRoot.resolve("jbct/jbct-format/pom.xml"))) {
+            projectRoot = projectRoot.getParent();
+        }
+        assertThat(projectRoot).isNotNull();
+
+        var files = Files.walk(projectRoot)
+                         .filter(p -> p.toString().endsWith(".java"))
+                         .filter(p -> !p.toString().contains("/target/"))
+                         .filter(p -> !p.toString().contains("Java25Parser.java"))
+                         .filter(p -> { try { return Files.size(p) < 1_000_000; } catch (Exception e) { return true; } })
+                         .sorted()
+                         .toList();
+
+        int total = 0, scanned = 0, withDeletions = 0, deletedComments = 0;
+        var deletionFiles = new ArrayList<String>();
+
+        for (var file : files) {
+            total++;
+            try {
+                var source = SourceFile.sourceFile(file).unwrap();
+                var inComments = commentMultiset(source.content());
+                if (inComments.isEmpty()) {
+                    continue;
+                }
+                var result = formatter.format(source);
+                if (result.isFailure()) {
+                    continue; // format errors are owned by the other sweep
+                }
+                scanned++;
+                var outComments = commentMultiset(result.unwrap().content());
+                var missing = new ArrayList<String>();
+                for (var e : inComments.entrySet()) {
+                    long out = outComments.getOrDefault(e.getKey(), 0L);
+                    if (out < e.getValue()) {
+                        long lost = e.getValue() - out;
+                        deletedComments += lost;
+                        missing.add(lost + "x [" + e.getKey().replace("\n", "\\n") + "]");
+                    }
+                }
+                if (!missing.isEmpty()) {
+                    withDeletions++;
+                    deletionFiles.add(projectRoot.relativize(file) + " -> " + String.join(", ", missing));
+                }
+            } catch (Exception e) {
+                // parse/other failures are not this sweep's concern
+            }
+        }
+
+        System.out.println("=== Flow Formatter Comment-Preservation Check ===");
+        System.out.println("Total files:          " + total);
+        System.out.println("Scanned (w/ comments):" + scanned);
+        System.out.println("Files with deletions: " + withDeletions);
+        System.out.println("Comments deleted:     " + deletedComments);
+        if (!deletionFiles.isEmpty()) {
+            System.out.println("\n--- COMMENT DELETIONS (first 60) ---");
+            deletionFiles.stream().limit(60).forEach(System.out::println);
+        }
+
+        assertThat(deletedComments).as("Total comments deleted across the codebase").isZero();
+        assertThat(withDeletions).as("Files losing comments").isZero();
+    }
+
+    /// Whitespace-normalized comment multiset of `src`: maps each comment token's text (each line
+    /// stripped, rejoined) to its occurrence count. Empty if the source does not parse.
+    private static java.util.Map<String, Long> commentMultiset(String src) {
+        var bag = new java.util.HashMap<String, Long>();
+        var parsed = new org.pragmatica.jbct.parser.Java25Parser().parse(src);
+        if (parsed.isFailure()) {
+            return bag;
+        }
+        var tokens = parsed.unwrap().cst().tokens();
+        for (int i = 0; i < tokens.count(); i++) {
+            int k = tokens.kindAt(i);
+            if (k == 1 || k == 2 || k == 3 || k == 4) {
+                var norm = tokens.textAt(i).toString().lines()
+                                 .map(String::strip)
+                                 .reduce((a, b) -> a + "\n" + b)
+                                 .orElse("");
+                bag.merge(norm, 1L, Long::sum);
+            }
+        }
+        return bag;
+    }
 }

--- a/jbct/jbct-format/src/test/java/org/pragmatica/jbct/format/flow/FlowContentPreservationTest.java
+++ b/jbct/jbct-format/src/test/java/org/pragmatica/jbct/format/flow/FlowContentPreservationTest.java
@@ -94,4 +94,89 @@ class FlowContentPreservationTest {
         assertThat(twice).as("lambda if-body formatting is idempotent").isEqualTo(once);
         assertThat(once).doesNotContain("                            if");  // no ~28-col over-indent
     }
+
+    // --- Residual comment-deletion bugs (post-PR#242, 2026-06-09) -------------------------------
+    // Each asserts the comment survives AND that formatting is idempotent. The exhaustive guard is
+    // FlowCodebaseCheckTest#formatEntireCodebase_preservesAllComments (whole-repo, @Disabled).
+
+    private void assertPreservedAndIdempotent(String src, String... comments) {
+        var once = format(src);
+        for (var c : comments) {
+            assertThat(once).as("comment preserved: " + c).contains(c);
+        }
+        var twice = fmt.format(new SourceFile(Path.of("Test.java"), once)).unwrap().content();
+        assertThat(twice).as("idempotent").isEqualTo(once);
+    }
+
+    @Test void s1_docComment_betweenEnumConstantsAndFirstMethod_preserved() {
+        assertPreservedAndIdempotent(
+            "enum E {\n    A, B;\n\n    /// parse the wire value\n    public static E fromWire(String w) { return A; }\n}\n",
+            "/// parse the wire value");
+    }
+
+    @Test void s3_lineComment_beforeFirstSwitchCase_preserved() {
+        assertPreservedAndIdempotent(
+            "class X {\n    int f(Object o) {\n        return switch (o) {\n            // first-case rationale\n            case String s -> 1;\n            default -> 0;\n        };\n    }\n}\n",
+            "// first-case rationale");
+    }
+
+    @Test void s4_lineComment_betweenCaseArms_preserved() {
+        assertPreservedAndIdempotent(
+            "class X {\n    void f(Object o) {\n        switch (o) {\n            case Integer i -> g(i);\n            // why the next arm is special\n            case String s -> h();\n            default -> {}\n        }\n    }\n    void g(int x) {}\n    void h() {}\n}\n",
+            "// why the next arm is special");
+    }
+
+    @Test void s5_lineComment_betweenChainedCalls_preserved() {
+        assertPreservedAndIdempotent(
+            "class X {\n    Object f() {\n        return a().flatMap(x -> b())\n                  // chain rationale\n                  .onSuccess(x -> c());\n    }\n    java.util.Optional<Object> a() { return null; }\n}\n",
+            "// chain rationale");
+    }
+
+    @Test void annotationTrailingComment_beforeMethod_preserved() {
+        assertPreservedAndIdempotent(
+            "class X {\n    @SuppressWarnings(\"x\") // netty future callback chain\n    void f() {}\n}\n",
+            "// netty future callback chain");
+    }
+
+    @Test void recordComponentLeadingComment_preserved() {
+        assertPreservedAndIdempotent(
+            "record R(\n    long startTime,\n    // T0: blueprint change\n    long loadTime\n) {}\n",
+            "// T0: blueprint change");
+    }
+
+    @Test void trailingCommentOnLastArgument_preserved() {
+        assertPreservedAndIdempotent(
+            "class X {\n    int f() {\n        return g(\n            aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,\n            bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb // trailing on last arg\n        );\n    }\n    int g(int a, int b) { return a; }\n}\n",
+            "// trailing on last arg");
+    }
+
+    @Test void ownLineCommentAsLastArgument_preserved() {
+        assertPreservedAndIdempotent(
+            "import java.util.Map;\nclass X {\n    Object f() {\n        return Map.of(\n            \"k\", \"v\"\n            // missing the other entries\n        );\n    }\n}\n",
+            "// missing the other entries");
+    }
+
+    @Test void blockComment_inEmptyArrowBody_preserved() {
+        assertPreservedAndIdempotent(
+            "class X {\n    void f(Object o) {\n        switch (o) {\n            case Integer i -> g(i);\n            default -> { /* ignore unknown */ }\n        }\n    }\n    void g(int x) {}\n}\n",
+            "/* ignore unknown */");
+    }
+
+    @Test void inlineBlockComment_midExpression_preserved() {
+        assertPreservedAndIdempotent(
+            "class X {\n    boolean f(int k) {\n        return k == 92 /* LB */ || k == 93 /* RB */;\n    }\n}\n",
+            "/* LB */", "/* RB */");
+    }
+
+    @Test void trailingCommentOnSwitchArmExpression_preserved() {
+        assertPreservedAndIdempotent(
+            "class X {\n    String f(int k) {\n        return switch (k) {\n            case 1 -> \"a\";\n            default -> null; // not reactive — interceptor\n        };\n    }\n}\n",
+            "// not reactive — interceptor");
+    }
+
+    @Test void danglingCommentsAtEndOfClassBody_preserved() {
+        assertPreservedAndIdempotent(
+            "class X {\n    void a() {}\n\n    // tail note line one\n    // tail note line two\n}\n",
+            "// tail note line one", "// tail note line two");
+    }
 }


### PR DESCRIPTION
## Problem

A whole-codebase format pass silently deleted comments (`//`, `///`, `/* */`) that sit in structural gaps the trivia-skipping flow walk never visits. PR #242 narrowed this but did not eliminate it. The bug-report's idempotency-only gate masked the loss (a deleted comment stays deleted, so `format(format(x)) == format(x)`).

## Root cause

Comments are emitted only via leading/trailing *claims* on nodes that go through `printNode`/`emitLeadingComments`. Custom printers (enum body, switch block, postfix chains, records) route children through the trivia-free `printNodeContent`, and trailing/in-span/dangling comments are claimed by no node — so they were dropped.

## Fix (by category)

- **Leading own-line** (`printOwnLineChildContent`): enum members/constants, switch rules, broken chain post-ops, record components — emit the child's leading comments before the trivia-free content path.
- **Trailing** (`emitTrailingOrphanComment` / `flushInSpanTrailingComment`): annotation-trailing (`@Ann // note`) before the break newline; last-argument trailing before `)` (post-op `)` broken to its own line); switch-arm expression trailing.
- **Inline block** (`emitInlineBlockComment`): self-closing `/* */` mid-expression/args, guarded to same-line so own-line block comments stay with leading handling.
- **Empty bodies** (`emitEmptyBlockComments` / `emitLeafTokens`): block comments in `{ /* */ }` arrow/empty bodies.
- **Dangling** (`emitTrailingBodyComments` / `emitDanglingOwnLineArgComments`): own-line comments at end of a class body before `}`, and as the last element in an argument list before `)`. Boundaries computed from real tokens (not `lastTokenIdx()`, which over-reaches into trailing trivia).

Line comments are only emitted where a newline immediately follows, so they can never swallow trailing tokens.

## Validation

- **0 comment deletions** across the repo (was 50+; `FlowCodebaseCheckTest#formatEntireCodebase_preservesAllComments`, a new corpus comment-multiset sweep — the report's recommended assertion).
- **0 errors / 0 non-idempotent** across 2667 files (`formatEntireCodebase_noErrorsAndIdempotent`).
- Full unit suite green (25/25 goldens, 23 `FlowContentPreservationTest` incl. 12 new per-category cases).

Re-enabling the `format` goal remains owned by the repo-owner agent.