### PR TITLE
fix: correct coding-technology repo link in jbct README

### DIFF
--- a/jbct/README.md
+++ b/jbct/README.md
@@ -55,7 +55,7 @@ Categories: Return Kinds, Value Objects, Exceptions, Naming, Lambda/Composition,
 
 ## JBCT Specification
 
-The full Java Backend Coding Technology specification — including structural patterns (Leaf, Sequencer, Fork-Join, Condition, Iteration), zone architecture, and BPMN integration guide — lives in the [coding-technology](https://github.com/pragmaticalabs/coding-technology) repository.
+The full Java Backend Coding Technology specification — including structural patterns (Leaf, Sequencer, Fork-Join, Condition, Iteration), zone architecture, and BPMN integration guide — lives in the [coding-technology](https://github.com/siy/coding-technology) repository.
 
 Key references:
 - **Structural patterns** → BPMN correspondence: Leaf↔Task, Sequencer↔Sequence Flow, Fork-Join↔Parallel Gateway, Condition↔Exclusive Gateway, Iteration↔Multi-Instance Activity


### PR DESCRIPTION
## Problem

The "coding-technology" link in `jbct/README.md` (under the **JBCT Specification** section) points at `https://github.com/pragmaticalabs/coding-technology`, which does not exist.

## Fix

Point it at `https://github.com/siy/coding-technology`, matching every other reference to the repo in the jbct module:

- `jbct-init/.../AiToolsInstaller.java` — `REPO = "siy/coding-technology"`
- `jbct-init/.../update/AiToolsUpdater.java` — `REPO = "siy/coding-technology"`
- `jbct-lint/.../rules/*Rule.java` — `DOC_LINK` constants
- `jbct-cli/.../LintCommand.java` — SARIF `informationUri`

Docs-only change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated JBCT specification reference link to the latest repository location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->