### PR TITLE
feat: #241 slice 1 — committed CommunityId substrate (community mint on worker join)

### DIFF
--- a/aether/aether-deployment/src/main/java/org/pragmatica/aether/deployment/cluster/ClusterDeploymentManager.java
+++ b/aether/aether-deployment/src/main/java/org/pragmatica/aether/deployment/cluster/ClusterDeploymentManager.java
@@ -302,6 +302,38 @@ public interface ClusterDeploymentManager {
                                                              Supplier<Set<NodeId>> coreCountedMembersSupplier,
                                                              Supplier<Set<NodeId>> readyNodesSupplier,
                                                              Supplier<Set<NodeId>> drainingNodesSupplier) {
+        return clusterDeploymentManager(self,
+                                        cluster,
+                                        kvStore,
+                                        router,
+                                        initialTopology,
+                                        topologyManager,
+                                        atomicity,
+                                        coreMax,
+                                        reconcileInterval,
+                                        schemaOrchestrator,
+                                        healthSignalSink,
+                                        coreCountedMembersSupplier,
+                                        readyNodesSupplier,
+                                        drainingNodesSupplier,
+                                        node -> Option.none());
+    }
+
+    static ClusterDeploymentManager clusterDeploymentManager(NodeId self,
+                                                             ClusterNode<KVCommand<AetherKey>> cluster,
+                                                             KVStore<AetherKey, AetherValue> kvStore,
+                                                             MessageRouter router,
+                                                             List<NodeId> initialTopology,
+                                                             TopologyManager topologyManager,
+                                                             DeploymentAtomicity atomicity,
+                                                             int coreMax,
+                                                             TimeSpan reconcileInterval,
+                                                             SchemaOrchestratorService schemaOrchestrator,
+                                                             HealthSignalSink healthSignalSink,
+                                                             Supplier<Set<NodeId>> coreCountedMembersSupplier,
+                                                             Supplier<Set<NodeId>> readyNodesSupplier,
+                                                             Supplier<Set<NodeId>> drainingNodesSupplier,
+                                                             Function<NodeId, Option<String>> memberSourceSupplier) {
         var ctx = buildContext(self,
                                cluster,
                                kvStore,
@@ -315,7 +347,8 @@ public interface ClusterDeploymentManager {
                                healthSignalSink,
                                coreCountedMembersSupplier,
                                readyNodesSupplier,
-                               drainingNodesSupplier);
+                               drainingNodesSupplier,
+                               memberSourceSupplier);
 
         return new ClusterDeploymentManagerAdapter(ctx);
     }
@@ -333,7 +366,8 @@ public interface ClusterDeploymentManager {
                                                          HealthSignalSink healthSignalSink,
                                                          Supplier<Set<NodeId>> coreCountedMembersSupplier,
                                                          Supplier<Set<NodeId>> readyNodesSupplier,
-                                                         Supplier<Set<NodeId>> drainingNodesSupplier) {
+                                                         Supplier<Set<NodeId>> drainingNodesSupplier,
+                                                         Function<NodeId, Option<String>> memberSourceSupplier) {
         var ctxHolder = new AtomicReference<ClusterDeploymentContext>();
         Function<Fsm<ClusterDeploymentState, ClusterFsmEvent>, ClusterDeploymentState> initialStateFactory = fsm -> buildContextAndDormant(fsm,
                                                                                                                                            ctxHolder,
@@ -350,7 +384,8 @@ public interface ClusterDeploymentManager {
                                                                                                                                            healthSignalSink,
                                                                                                                                            coreCountedMembersSupplier,
                                                                                                                                            readyNodesSupplier,
-                                                                                                                                           drainingNodesSupplier);
+                                                                                                                                           drainingNodesSupplier,
+                                                                                                                                           memberSourceSupplier);
         var _fsm = Fsm.fsm("cluster-deployment", self.id(), initialStateFactory);
 
         return ctxHolder.get();
@@ -371,7 +406,8 @@ public interface ClusterDeploymentManager {
                                                                  HealthSignalSink healthSignalSink,
                                                                  Supplier<Set<NodeId>> coreCountedMembersSupplier,
                                                                  Supplier<Set<NodeId>> readyNodesSupplier,
-                                                                 Supplier<Set<NodeId>> drainingNodesSupplier) {
+                                                                 Supplier<Set<NodeId>> drainingNodesSupplier,
+                                                                 Function<NodeId, Option<String>> memberSourceSupplier) {
         var ctx = new ClusterDeploymentContext(fsm,
                                                self,
                                                cluster,
@@ -386,7 +422,9 @@ public interface ClusterDeploymentManager {
                                                seedNodes,
                                                atomicity,
                                                coreMax,
-                                               reconcileInterval);
+                                               reconcileInterval,
+                                               System::currentTimeMillis,
+                                               memberSourceSupplier);
 
         ctxHolder.set(ctx);
 

--- a/aether/aether-deployment/src/main/java/org/pragmatica/aether/deployment/cluster/fsm/ClusterDeploymentContext.java
+++ b/aether/aether-deployment/src/main/java/org/pragmatica/aether/deployment/cluster/fsm/ClusterDeploymentContext.java
@@ -19,12 +19,14 @@ import org.pragmatica.lang.Contract;
 import org.pragmatica.lang.concurrent.CancellableTask;
 import org.pragmatica.lang.io.TimeSpan;
 import org.pragmatica.messaging.MessageRouter;
+import org.pragmatica.lang.Option;
 import org.pragmatica.statemachine.Fsm;
 
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
 import java.util.function.LongSupplier;
 import java.util.function.Supplier;
 
@@ -46,6 +48,13 @@ public final class ClusterDeploymentContext {
     private final int coreMax;
     private final TimeSpan reconcileInterval;
     private final LongSupplier clock;
+    /// Per-node membership `source` read-seam (worker-membership-spec §4.1 / D2): resolves the
+    /// joining node's source label (from the membership FSM's [`MemberDescriptor#source`]) so the
+    /// leader can mint/reuse a per-source community at role-assignment time. `none()` (or a blank
+    /// source) means "unknown" and the caller falls back to the `"default"` source. Wired in
+    /// `AetherNode` to `membershipFsmRef`; defaults to `node -> none()` in the legacy constructors
+    /// so existing call sites (and tests) keep the community-less behaviour.
+    private final Function<NodeId, Option<String>> memberSourceSupplier;
     private final ClusterDeploymentState dormant;
     private final ClusterDeploymentState stopped;
 
@@ -98,6 +107,42 @@ public final class ClusterDeploymentContext {
                                     int coreMax,
                                     TimeSpan reconcileInterval,
                                     LongSupplier clock) {
+        this(fsm,
+             self,
+             cluster,
+             kvStore,
+             router,
+             topologyManager,
+             schemaOrchestrator,
+             healthSignalSink,
+             coreCountedMembersSupplier,
+             readyNodesSupplier,
+             drainingNodesSupplier,
+             seedNodes,
+             atomicity,
+             coreMax,
+             reconcileInterval,
+             clock,
+             node -> Option.none());
+    }
+
+    public ClusterDeploymentContext(Fsm<ClusterDeploymentState, ClusterFsmEvent> fsm,
+                                    NodeId self,
+                                    ClusterNode<KVCommand<AetherKey>> cluster,
+                                    KVStore<AetherKey, AetherValue> kvStore,
+                                    MessageRouter router,
+                                    TopologyManager topologyManager,
+                                    SchemaOrchestratorService schemaOrchestrator,
+                                    HealthSignalSink healthSignalSink,
+                                    Supplier<Set<NodeId>> coreCountedMembersSupplier,
+                                    Supplier<Set<NodeId>> readyNodesSupplier,
+                                    Supplier<Set<NodeId>> drainingNodesSupplier,
+                                    Set<NodeId> seedNodes,
+                                    DeploymentAtomicity atomicity,
+                                    int coreMax,
+                                    TimeSpan reconcileInterval,
+                                    LongSupplier clock,
+                                    Function<NodeId, Option<String>> memberSourceSupplier) {
         this.fsm = fsm;
         this.self = self;
         this.cluster = cluster;
@@ -114,6 +159,7 @@ public final class ClusterDeploymentContext {
         this.coreMax = coreMax;
         this.reconcileInterval = reconcileInterval;
         this.clock = clock;
+        this.memberSourceSupplier = memberSourceSupplier;
         this.dormant = new ClusterDeploymentState.Dormant(this);
         this.stopped = new ClusterDeploymentState.Stopped(this);
     }
@@ -199,6 +245,14 @@ public final class ClusterDeploymentContext {
     /// readiness snapshot.
     public Supplier<Set<NodeId>> drainingNodesSupplier() {
         return drainingNodesSupplier;
+    }
+
+    /// The joining node's membership `source` label (worker-membership-spec §4.1 / D2), used by the
+    /// leader to mint/reuse a per-source community at role-assignment time. `none()` when the source
+    /// is unknown (untracked member or no descriptor yet); the caller defaults such a node to the
+    /// `"default"` source. A blank source is surfaced as-is and normalized by the caller.
+    public Option<String> memberSource(NodeId nodeId) {
+        return memberSourceSupplier.apply(nodeId);
     }
 
     public Set<NodeId> seedNodes() {

--- a/aether/aether-deployment/src/main/java/org/pragmatica/aether/deployment/cluster/fsm/ClusterDeploymentState.java
+++ b/aether/aether-deployment/src/main/java/org/pragmatica/aether/deployment/cluster/fsm/ClusterDeploymentState.java
@@ -42,6 +42,7 @@ import org.pragmatica.aether.slice.kvstore.AetherKey;
 import org.pragmatica.aether.slice.kvstore.AetherKey.ActivationDirectiveKey;
 import org.pragmatica.aether.slice.kvstore.AetherKey.AppBlueprintKey;
 import org.pragmatica.aether.slice.kvstore.AetherKey.ClusterConfigKey;
+import org.pragmatica.aether.slice.kvstore.AetherKey.CommunityKey;
 import org.pragmatica.aether.slice.kvstore.AetherKey.NodeArtifactKey;
 import org.pragmatica.aether.slice.kvstore.AetherKey.NodeRoutesKey;
 import org.pragmatica.aether.slice.kvstore.AetherKey.SchemaMigrationLockKey;
@@ -55,6 +56,7 @@ import org.pragmatica.aether.slice.kvstore.AetherValue;
 import org.pragmatica.aether.slice.kvstore.AetherValue.ActivationDirectiveValue;
 import org.pragmatica.aether.slice.kvstore.AetherValue.AppBlueprintValue;
 import org.pragmatica.aether.slice.kvstore.AetherValue.ClusterConfigValue;
+import org.pragmatica.aether.slice.kvstore.AetherValue.CommunityValue;
 import org.pragmatica.aether.slice.kvstore.AetherValue.NodeArtifactValue;
 import org.pragmatica.aether.slice.kvstore.AetherValue.SchemaMigrationLockValue;
 import org.pragmatica.aether.slice.kvstore.AetherValue.SchemaStatus;
@@ -154,6 +156,18 @@ public sealed interface ClusterDeploymentState extends FsmState<ClusterDeploymen
         private static final Logger log = LoggerFactory.getLogger(Active.class);
         private static final int MAX_RETRIES = 5;
         private static final long MAX_RETRY_DELAY_SECONDS = 30;
+        /// The default per-community target size used when minting a FORMING community at WORKER
+        /// role-assignment time (worker-membership-spec §4.1 step 5). The community-growth comparator
+        /// (slice 2) will source the real per-source target from the desired cluster topology; until
+        /// then a sensible single-community cap is stamped so the community has a non-zero target.
+        private static final int DEFAULT_COMMUNITY_TARGET_SIZE = 100;
+        /// The deterministic, single-community-per-source suffix (worker-membership-spec A10): one
+        /// community `<source>-w-0` per source keeps community ids stable across rejoins (no
+        /// renumbering). The growth-comparator slice introduces additional `-w-N` slots.
+        private static final String WORKER_COMMUNITY_SUFFIX = "-w-0";
+        /// The fallback source label for a joining worker whose membership `source` is absent or
+        /// blank (worker-membership-spec D2).
+        private static final String DEFAULT_SOURCE = "default";
 
         // --- move-only extraction seams (package-private helpers operating on this Active) ---
         StuckTransitionalRemediator stuckRemediator() {
@@ -653,17 +667,69 @@ public sealed interface ClusterDeploymentState extends FsmState<ClusterDeploymen
                 submitActivationDirective(addedNode, ActivationDirectiveValue.core());
             } else {
                 log.info("Assigning node {} as worker (core count at max: {})", addedNode, ctx.coreMax());
-                submitActivationDirective(addedNode, ActivationDirectiveValue.worker());
+                assignWorkerRole(addedNode);
             }
+        }
+
+        /// Community-aware WORKER role assignment (worker-membership-spec §4.1 / §3.3): resolve the
+        /// joining node's source (defaulting to `"default"` when absent/blank, D2), derive the
+        /// deterministic single community id `<source>-w-0` (A10-stable), and atomically commit —
+        /// in one batch — a FORMING [`CommunityKey`] Put (only when the community does not yet exist;
+        /// reuse otherwise, no renumber) together with the community-assigned WORKER
+        /// [`ActivationDirectiveKey`] Put. The directive carries an empty governor hint because a
+        /// FORMING community has no governor yet (§4.1 step 5).
+        private void assignWorkerRole(NodeId addedNode) {
+            var source = resolveSource(addedNode);
+            var communityId = source + WORKER_COMMUNITY_SUFFIX;
+            var commands = new ArrayList<KVCommand<AetherKey>>();
+
+            if (!communityExists(communityId)) {
+                log.info("Minting FORMING community '{}' for source '{}' (worker {})", communityId, source, addedNode);
+                commands.add(mintCommunityCommand(communityId, source));
+            }
+
+            commands.add(workerDirectiveCommand(addedNode, communityId));
+            submitActivationCommands(addedNode, commands);
+        }
+
+        /// The joining node's membership source label, normalized to the `"default"` fallback when
+        /// the descriptor is absent or its source is blank (worker-membership-spec D2).
+        private String resolveSource(NodeId addedNode) {
+            return ctx.memberSource(addedNode)
+                      .filter(source -> !source.isBlank())
+                      .or(DEFAULT_SOURCE);
+        }
+
+        private boolean communityExists(String communityId) {
+            return ctx.kvStore()
+                      .get(CommunityKey.communityKey(communityId))
+                      .filter(CommunityValue.class::isInstance)
+                      .isPresent();
+        }
+
+        private KVCommand<AetherKey> mintCommunityCommand(String communityId, String source) {
+            return new KVCommand.Put<>(CommunityKey.communityKey(communityId),
+                                       CommunityValue.communityValue(source,
+                                                                     ActivationDirectiveValue.WORKER,
+                                                                     DEFAULT_COMMUNITY_TARGET_SIZE));
+        }
+
+        private KVCommand<AetherKey> workerDirectiveCommand(NodeId targetNode, String communityId) {
+            return new KVCommand.Put<>(ActivationDirectiveKey.activationDirectiveKey(targetNode),
+                                       ActivationDirectiveValue.worker(communityId, ""));
         }
 
         private void submitActivationDirective(NodeId targetNode, ActivationDirectiveValue directive) {
             var command = new KVCommand.Put<AetherKey, AetherValue>(ActivationDirectiveKey.activationDirectiveKey(targetNode),
                                                                     directive);
 
-            ctx.cluster().apply(List.of(command)).onFailure(cause -> log.error("Failed to submit activation directive for {}: {}",
-                                                                               targetNode,
-                                                                               cause.message()));
+            submitActivationCommands(targetNode, List.of(command));
+        }
+
+        private void submitActivationCommands(NodeId targetNode, List<KVCommand<AetherKey>> commands) {
+            ctx.cluster().apply(commands).onFailure(cause -> log.error("Failed to submit activation directive for {}: {}",
+                                                                       targetNode,
+                                                                       cause.message()));
         }
 
         private boolean shouldPromoteToCore(int currentCoreCount) {

--- a/aether/aether-deployment/src/main/java/org/pragmatica/aether/deployment/cluster/fsm/CommunityPlacementPlanner.java
+++ b/aether/aether-deployment/src/main/java/org/pragmatica/aether/deployment/cluster/fsm/CommunityPlacementPlanner.java
@@ -8,11 +8,14 @@ import org.pragmatica.aether.artifact.Artifact;
 import org.pragmatica.aether.deployment.cluster.AllocationPool;
 import org.pragmatica.aether.deployment.cluster.fsm.ClusterDeploymentState.Active;
 import org.pragmatica.aether.slice.kvstore.AetherKey;
+import org.pragmatica.aether.slice.kvstore.AetherKey.CommunityKey;
 import org.pragmatica.aether.slice.kvstore.AetherKey.GovernorAnnouncementKey;
 import org.pragmatica.aether.slice.kvstore.AetherKey.WorkerSliceDirectiveKey;
 import org.pragmatica.aether.slice.kvstore.AetherValue;
+import org.pragmatica.aether.slice.kvstore.AetherValue.CommunityValue;
 import org.pragmatica.aether.slice.kvstore.AetherValue.GovernorAnnouncementValue;
 import org.pragmatica.aether.slice.kvstore.AetherValue.WorkerSliceDirectiveValue;
+import org.pragmatica.aether.slice.kvstore.CommunityState;
 import org.pragmatica.cluster.state.kvstore.KVCommand;
 import org.pragmatica.consensus.NodeId;
 import org.pragmatica.lang.Contract;
@@ -38,14 +41,35 @@ import org.slf4j.LoggerFactory;
 record CommunityPlacementPlanner(Active active) {
     private static final Logger log = LoggerFactory.getLogger(CommunityPlacementPlanner.class);
 
+    /// The authoritative DESIRED community set (worker-membership-spec D1 / §3.3): the committed,
+    /// leader-authored [`CommunityKey`]/[`CommunityValue`] facts, filtered to the live states
+    /// (everything except the terminal `DISSOLVING`/`DISSOLVED`). This is the desired-state source
+    /// of truth — a community exists the moment the leader mints its `CommunityKey`, before any
+    /// governor has announced itself. (The previous source enumerated the governor-OWNED
+    /// [`GovernorAnnouncementKey`], which is the OBSERVED statement; that read is preserved in the
+    /// governor/worker-map methods below.) Slice 2's per-community FSM drives the `ACTIVE` state, so
+    /// `FORMING` is deliberately included here to keep placement working before that lands.
     Set<String> activeCommunityIds() {
         var ids = new LinkedHashSet<String>();
 
-        active.ctx().kvStore().forEach(GovernorAnnouncementKey.class,
-                                       GovernorAnnouncementValue.class,
-                                       (key, value) -> ids.add(key.communityId()));
+        active.ctx().kvStore().forEach(CommunityKey.class,
+                                       CommunityValue.class,
+                                       (key, value) -> collectDesiredCommunity(ids, key, value));
 
         return Set.copyOf(ids);
+    }
+
+    private static void collectDesiredCommunity(Set<String> ids, CommunityKey key, CommunityValue value) {
+        if (isDesiredState(value.state())) {
+            ids.add(key.communityId());
+        }
+    }
+
+    /// A community counts toward the desired set unless it has reached its terminal teardown states
+    /// (`DISSOLVING`/`DISSOLVED`). `FORMING`/`ACTIVE`/`DEGRADED` are all desired (worker-membership-spec
+    /// §3.3); strict-`ACTIVE` filtering waits for slice 2's community FSM.
+    private static boolean isDesiredState(CommunityState state) {
+        return state != CommunityState.DISSOLVING && state != CommunityState.DISSOLVED;
     }
 
     private Option<GovernorAnnouncementValue> communityGovernor(String communityId) {

--- a/aether/aether-deployment/src/test/java/org/pragmatica/aether/deployment/cluster/ClusterDeploymentManagerTest.java
+++ b/aether/aether-deployment/src/test/java/org/pragmatica/aether/deployment/cluster/ClusterDeploymentManagerTest.java
@@ -275,7 +275,11 @@ class ClusterDeploymentManagerTest {
 
             cdm.onMembershipDecision(MembershipDecision.nodeJoined(NEW_NODE, List.of(NODE_1, NODE_2, NODE_3, NEW_NODE)));
 
-            assertThat(directivesFor(NEW_NODE)).containsExactly(AetherValue.ActivationDirectiveValue.worker());
+            // #241: a WORKER assignment now mints/joins the joiner's source community and the directive
+            // carries that community id. With no source seam wired here the source defaults to "default"
+            // (D2), so the directive targets the "default-w-0" community (empty governor hint: FORMING).
+            assertThat(directivesFor(NEW_NODE)).containsExactly(AetherValue.ActivationDirectiveValue.worker("default-w-0",
+                                                                                                            ""));
         }
 
         /// The W3 regression shape: 2 cores + 2 workers in a role-BLIND count (4 ≥ coreMax 3)
@@ -378,7 +382,10 @@ class ClusterDeploymentManagerTest {
             cdm.onMembershipDecision(MembershipDecision.nodeJoined(REPLACEMENT,
                                                                    List.of(NODE_1, NODE_2, NODE_3, NODE_4, NODE_5, REPLACEMENT)));
 
-            assertThat(directivesFor(REPLACEMENT)).containsExactly(AetherValue.ActivationDirectiveValue.worker());
+            // #241: the 6th node is WORKER, and the directive now carries the joiner's source community
+            // (source-absent → "default" → "default-w-0", FORMING ⇒ empty governor hint).
+            assertThat(directivesFor(REPLACEMENT)).containsExactly(AetherValue.ActivationDirectiveValue.worker("default-w-0",
+                                                                                                              ""));
         }
 
         /// Double-kill heal (the only shape that got a CORE promotion live, because the count

--- a/aether/aether-deployment/src/test/java/org/pragmatica/aether/deployment/cluster/fsm/ClusterDeploymentStateCommunityMintTest.java
+++ b/aether/aether-deployment/src/test/java/org/pragmatica/aether/deployment/cluster/fsm/ClusterDeploymentStateCommunityMintTest.java
@@ -1,0 +1,425 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2025 Pragmatica Labs - Sergiy Yevtushenko
+// Licensed under Business Source License 1.1. Change Date: 2030-01-01. Change License: Apache-2.0.
+// See LICENSE in the repository root for full terms.
+package org.pragmatica.aether.deployment.cluster.fsm;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.pragmatica.aether.deployment.cluster.ClusterDeploymentManager.DeploymentAtomicity;
+import org.pragmatica.aether.deployment.cluster.fsm.ClusterDeploymentEvents.Activate;
+import org.pragmatica.aether.deployment.cluster.fsm.ClusterDeploymentEvents.MembershipDecisionReceived;
+import org.pragmatica.aether.deployment.schema.SchemaOrchestratorService;
+import org.pragmatica.aether.slice.generation.HealthSignalSink;
+import org.pragmatica.aether.slice.kvstore.AetherKey;
+import org.pragmatica.aether.slice.kvstore.AetherKey.ActivationDirectiveKey;
+import org.pragmatica.aether.slice.kvstore.AetherKey.CommunityKey;
+import org.pragmatica.aether.slice.kvstore.AetherValue;
+import org.pragmatica.aether.slice.kvstore.AetherValue.ActivationDirectiveValue;
+import org.pragmatica.aether.slice.kvstore.AetherValue.CommunityValue;
+import org.pragmatica.aether.slice.kvstore.CommunityState;
+import org.pragmatica.cluster.node.ClusterNode;
+import org.pragmatica.cluster.state.kvstore.KVCommand;
+import org.pragmatica.cluster.state.kvstore.KVStore;
+import org.pragmatica.consensus.NodeId;
+import org.pragmatica.consensus.fsm.ClusterFsmEvent;
+import org.pragmatica.consensus.net.NodeInfo;
+import org.pragmatica.consensus.topology.MembershipDecision;
+import org.pragmatica.consensus.topology.NodeState;
+import org.pragmatica.consensus.topology.TopologyManager;
+import org.pragmatica.lang.Option;
+import org.pragmatica.lang.Promise;
+import org.pragmatica.lang.Unit;
+import org.pragmatica.lang.io.TimeSpan;
+import org.pragmatica.messaging.MessageRouter;
+import org.pragmatica.net.tcp.NodeAddress;
+import org.pragmatica.serialization.Deserializer;
+import org.pragmatica.serialization.Serializer;
+import org.pragmatica.statemachine.Fsm;
+import org.pragmatica.statemachine.FsmTestHarness;
+
+import java.net.SocketAddress;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
+
+import io.netty.buffer.ByteBuf;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.pragmatica.lang.io.TimeSpan.timeSpan;
+
+/// #241 leader-stamp (worker-membership-spec §4.1 / §3.3 / A10): when the leader assigns a WORKER
+/// role at NodeJoined time it must, in ONE atomic batch, mint a FORMING [`CommunityKey`] for the
+/// joining node's source (only the FIRST worker of a source mints it; subsequent workers REUSE the
+/// same community id with no second Put — A10 no-renumber) and write a community-assigned WORKER
+/// [`ActivationDirectiveKey`] carrying that community id. The CORE path is unchanged: no community
+/// Put, a bare CORE directive. An absent/blank source falls back to `"default"` (D2).
+///
+/// The harness drives the real FSM (`Activate` → `MembershipDecisionReceived(NodeJoined)`) and
+/// inspects the commands recorded by the stub cluster — mirrors `ClusterDeploymentStateActiveTest`.
+class ClusterDeploymentStateCommunityMintTest {
+    private static final NodeId SELF = new NodeId("node-self");
+    private static final NodeId WORKER_1 = new NodeId("node-worker-1");
+    private static final NodeId WORKER_2 = new NodeId("node-worker-2");
+    private static final NodeId CORE_CANDIDATE = new NodeId("node-core-candidate");
+    private static final String SOURCE_EU = "eu-west";
+    private static final String EXPECTED_COMMUNITY = SOURCE_EU + "-w-0";
+
+    private RecordingClusterNode cluster;
+    private InMemoryKvStore kvStore;
+    private final Map<NodeId, String> sources = new ConcurrentHashMap<>();
+    private FsmTestHarness<ClusterDeploymentState, ClusterFsmEvent> harness;
+
+    @BeforeEach
+    void setUp() {
+        var router = MessageRouter.mutable();
+        kvStore = new InMemoryKvStore(router);
+        cluster = new RecordingClusterNode(SELF, kvStore);
+        Function<NodeId, Option<String>> memberSourceSupplier = nodeId -> Option.option(sources.get(nodeId));
+
+        Function<Fsm<ClusterDeploymentState, ClusterFsmEvent>, ClusterDeploymentState> factory =
+                fsm -> new ClusterDeploymentContext(fsm,
+                                                    SELF,
+                                                    cluster,
+                                                    kvStore,
+                                                    router,
+                                                    stubTopologyManager(SELF),
+                                                    stubSchemaOrchestrator(),
+                                                    HealthSignalSink.noop(),
+                                                    () -> Set.of(SELF),
+                                                    () -> Set.of(SELF),
+                                                    Set::of,
+                                                    Set.of(SELF),
+                                                    DeploymentAtomicity.ALL_OR_NOTHING,
+                                                    1,
+                                                    timeSpan(300).seconds(),
+                                                    System::currentTimeMillis,
+                                                    memberSourceSupplier).dormant();
+        harness = FsmTestHarness.harness("community-mint-" + SELF.id(), factory);
+        harness.dispatch(new Activate());
+    }
+
+    private void joinWorker(NodeId nodeId, String source) {
+        sources.put(nodeId, source);
+        dispatchJoin(nodeId);
+    }
+
+    private void dispatchJoin(NodeId nodeId) {
+        harness.dispatch(new MembershipDecisionReceived(MembershipDecision.nodeJoined(nodeId, List.of(SELF, nodeId))));
+    }
+
+    private List<CommunityValue> communityPutsFor(String communityId) {
+        var key = CommunityKey.communityKey(communityId);
+
+        return cluster.commands.stream()
+                               .filter(command -> command instanceof KVCommand.Put<AetherKey, ?> put
+                                                  && put.key().equals(key)
+                                                  && put.value() instanceof CommunityValue)
+                               .map(command -> (CommunityValue) ((KVCommand.Put<AetherKey, AetherValue>) command).value())
+                               .toList();
+    }
+
+    private List<ActivationDirectiveValue> directivesFor(NodeId nodeId) {
+        var key = ActivationDirectiveKey.activationDirectiveKey(nodeId);
+
+        return cluster.commands.stream()
+                               .filter(command -> command instanceof KVCommand.Put<AetherKey, ?> put
+                                                  && put.key().equals(key)
+                                                  && put.value() instanceof ActivationDirectiveValue)
+                               .map(command -> (ActivationDirectiveValue) ((KVCommand.Put<AetherKey, AetherValue>) command).value())
+                               .toList();
+    }
+
+    @Nested
+    class WorkerCommunityMint {
+        @Test
+        void assignNodeRole_firstWorkerOfSource_mintsFormingCommunityAndStampsDirective() {
+            joinWorker(WORKER_1, SOURCE_EU);
+
+            var puts = communityPutsFor(EXPECTED_COMMUNITY);
+
+            assertThat(puts)
+                    .as("the first WORKER of a source must mint exactly one FORMING community")
+                    .hasSize(1);
+            assertThat(puts.getFirst().state())
+                    .as("the minted community must be FORMING")
+                    .isEqualTo(CommunityState.FORMING);
+            assertThat(puts.getFirst().sourceName())
+                    .as("the minted community carries the resolved source")
+                    .isEqualTo(SOURCE_EU);
+            assertThat(puts.getFirst().role()).isEqualTo(ActivationDirectiveValue.WORKER);
+
+            var directives = directivesFor(WORKER_1);
+
+            assertThat(directives).as("a worker directive must be written").hasSize(1);
+            assertThat(directives.getFirst().role()).isEqualTo(ActivationDirectiveValue.WORKER);
+            assertThat(directives.getFirst().communityId())
+                    .as("the WORKER directive carries the minted community id")
+                    .isEqualTo(EXPECTED_COMMUNITY);
+            assertThat(directives.getFirst().governorHint())
+                    .as("a FORMING community has no governor yet")
+                    .isEmpty();
+        }
+
+        @Test
+        void assignNodeRole_mintBatch_isAtomicWithCommunityBeforeDirective() {
+            joinWorker(WORKER_1, SOURCE_EU);
+
+            var batch = cluster.lastBatchContaining(ActivationDirectiveKey.activationDirectiveKey(WORKER_1));
+
+            assertThat(batch)
+                    .as("the community Put and the directive Put must be committed in one atomic batch")
+                    .hasSize(2);
+            assertThat(batch.getFirst())
+                    .as("the community Put precedes the directive Put in the batch")
+                    .isInstanceOf(KVCommand.Put.class);
+            assertThat(((KVCommand.Put<AetherKey, AetherValue>) batch.getFirst()).key())
+                    .isEqualTo(CommunityKey.communityKey(EXPECTED_COMMUNITY));
+        }
+
+        @Test
+        void assignNodeRole_secondWorkerOfSameSource_reusesCommunityWithoutSecondPut() {
+            joinWorker(WORKER_1, SOURCE_EU);
+            joinWorker(WORKER_2, SOURCE_EU);
+
+            assertThat(communityPutsFor(EXPECTED_COMMUNITY))
+                    .as("A10 no-renumber: the second worker of a source must NOT mint a second community")
+                    .hasSize(1);
+
+            var directives = directivesFor(WORKER_2);
+
+            assertThat(directives).as("second worker directive must be written").hasSize(1);
+            assertThat(directives.getFirst().communityId())
+                    .as("the second worker reuses the same community id")
+                    .isEqualTo(EXPECTED_COMMUNITY);
+        }
+
+        @Test
+        void assignNodeRole_secondWorker_batchIsDirectiveOnly() {
+            joinWorker(WORKER_1, SOURCE_EU);
+            joinWorker(WORKER_2, SOURCE_EU);
+
+            var batch = cluster.lastBatchContaining(ActivationDirectiveKey.activationDirectiveKey(WORKER_2));
+
+            assertThat(batch)
+                    .as("reuse path commits only the directive (community already exists)")
+                    .hasSize(1);
+        }
+    }
+
+    @Nested
+    class CoreAssignment {
+        @Test
+        void assignNodeRole_coreCandidate_writesBareCoreDirectiveAndNoCommunity() {
+            // coreMax is 1 and SELF already counts as core; promote only when below max. To exercise
+            // the CORE branch, raise the counted set to leave room: re-wire with an empty core set.
+            var router = MessageRouter.mutable();
+            var localKv = new InMemoryKvStore(router);
+            var localCluster = new RecordingClusterNode(SELF, localKv);
+            Function<NodeId, Option<String>> noSource = nodeId -> Option.none();
+            Function<Fsm<ClusterDeploymentState, ClusterFsmEvent>, ClusterDeploymentState> factory =
+                    fsm -> new ClusterDeploymentContext(fsm,
+                                                        SELF,
+                                                        localCluster,
+                                                        localKv,
+                                                        router,
+                                                        stubTopologyManager(SELF),
+                                                        stubSchemaOrchestrator(),
+                                                        HealthSignalSink.noop(),
+                                                        Set::of,
+                                                        () -> Set.of(SELF),
+                                                        Set::of,
+                                                        Set.of(SELF),
+                                                        DeploymentAtomicity.ALL_OR_NOTHING,
+                                                        5,
+                                                        timeSpan(300).seconds(),
+                                                        System::currentTimeMillis,
+                                                        noSource).dormant();
+            var localHarness = FsmTestHarness.harness("core-assign-" + SELF.id(), factory);
+            localHarness.dispatch(new Activate());
+
+            localHarness.dispatch(new MembershipDecisionReceived(MembershipDecision.nodeJoined(CORE_CANDIDATE,
+                                                                                              List.of(SELF, CORE_CANDIDATE))));
+
+            var communityPuts = localCluster.commands.stream()
+                                                     .filter(command -> command instanceof KVCommand.Put<AetherKey, ?> put
+                                                                        && put.value() instanceof CommunityValue)
+                                                     .toList();
+            assertThat(communityPuts)
+                    .as("the CORE path must never mint a community")
+                    .isEmpty();
+
+            var directiveKey = ActivationDirectiveKey.activationDirectiveKey(CORE_CANDIDATE);
+            var coreDirective = localCluster.commands.stream()
+                                                     .filter(command -> command instanceof KVCommand.Put<AetherKey, ?> put
+                                                                        && put.key().equals(directiveKey)
+                                                                        && put.value() instanceof ActivationDirectiveValue)
+                                                     .map(command -> (ActivationDirectiveValue) ((KVCommand.Put<AetherKey, AetherValue>) command).value())
+                                                     .toList();
+            assertThat(coreDirective).hasSize(1);
+            assertThat(coreDirective.getFirst().role()).isEqualTo(ActivationDirectiveValue.CORE);
+            assertThat(coreDirective.getFirst().communityId())
+                    .as("a CORE directive carries no community id")
+                    .isEmpty();
+        }
+    }
+
+    @Nested
+    class SourceFallback {
+        @Test
+        void assignNodeRole_workerWithAbsentSource_usesDefaultCommunity() {
+            dispatchJoin(WORKER_1); // no source registered → none()
+
+            assertThat(communityPutsFor("default-w-0"))
+                    .as("an absent source falls back to the 'default' community (D2)")
+                    .hasSize(1);
+
+            var directives = directivesFor(WORKER_1);
+
+            assertThat(directives).as("a worker directive must be written").hasSize(1);
+            assertThat(directives.getFirst().communityId()).isEqualTo("default-w-0");
+        }
+
+        @Test
+        void assignNodeRole_workerWithBlankSource_usesDefaultCommunity() {
+            joinWorker(WORKER_1, "   ");
+
+            assertThat(communityPutsFor("default-w-0"))
+                    .as("a blank source falls back to the 'default' community (D2)")
+                    .hasSize(1);
+        }
+    }
+
+    // --- test fixtures (mirrors ClusterDeploymentStateActiveTest) ---
+
+    private static SchemaOrchestratorService stubSchemaOrchestrator() {
+        return new SchemaOrchestratorService() {
+            @Override public Promise<Unit> migrateIfNeeded(String datasourceName) {
+                return Promise.success(Unit.unit());
+            }
+
+            @Override public Promise<Unit> undoTo(String datasourceName, int targetVersion) {
+                return Promise.success(Unit.unit());
+            }
+
+            @Override public Promise<Unit> baseline(String datasourceName, int version) {
+                return Promise.success(Unit.unit());
+            }
+        };
+    }
+
+    private static TopologyManager stubTopologyManager(NodeId self) {
+        return new TopologyManager() {
+            @Override public NodeInfo self() {
+                return NodeInfo.nodeInfo(self, new NodeAddress("localhost", 9000));
+            }
+
+            @Override public Option<NodeInfo> get(NodeId id) {
+                return Option.some(NodeInfo.nodeInfo(id, new NodeAddress("localhost", 9000)));
+            }
+
+            @Override public int clusterSize() {
+                return 1;
+            }
+
+            @Override public Option<NodeId> reverseLookup(SocketAddress socketAddress) {
+                return Option.empty();
+            }
+
+            @Override public Promise<Unit> start() {
+                return Promise.unitPromise();
+            }
+
+            @Override public Promise<Unit> stop() {
+                return Promise.unitPromise();
+            }
+
+            @Override public TimeSpan pingInterval() {
+                return timeSpan(5).seconds();
+            }
+
+            @Override public TimeSpan helloTimeout() {
+                return timeSpan(5).seconds();
+            }
+
+            @Override public Option<NodeState> getState(NodeId id) {
+                return Option.empty();
+            }
+
+            @Override public List<NodeId> topology() {
+                return List.of(self);
+            }
+        };
+    }
+
+    private static final class RecordingClusterNode implements ClusterNode<KVCommand<AetherKey>> {
+        final NodeId self;
+        final List<KVCommand<AetherKey>> commands = Collections.synchronizedList(new ArrayList<>());
+        final List<List<KVCommand<AetherKey>>> batches = Collections.synchronizedList(new ArrayList<>());
+        private final InMemoryKvStore committed;
+
+        RecordingClusterNode(NodeId self, InMemoryKvStore committed) {
+            this.self = self;
+            this.committed = committed;
+        }
+
+        @Override public NodeId self() {return self;}
+
+        @Override public TopologyManager topologyManager() {return stubTopologyManager(self);}
+
+        @Override public Promise<Unit> start() {return Promise.unitPromise();}
+
+        @Override public Promise<Unit> stop() {return Promise.unitPromise();}
+
+        // Mirror the real consensus → KV replication loop: an applied batch is recorded AND committed
+        // into the shared KV store, so a subsequent community-existence read observes it (the reuse /
+        // A10 no-renumber path depends on this closed loop).
+        @Override public <R> Promise<List<R>> apply(List<KVCommand<AetherKey>> batch) {
+            commands.addAll(batch);
+            batches.add(List.copyOf(batch));
+            committed.commit(batch);
+            return Promise.success(Collections.emptyList());
+        }
+
+        List<KVCommand<AetherKey>> lastBatchContaining(AetherKey key) {
+            return batches.stream()
+                          .filter(batch -> batch.stream().anyMatch(command -> command instanceof KVCommand.Put<AetherKey, ?> put
+                                                                              && put.key().equals(key)))
+                          .reduce((first, second) -> second)
+                          .orElse(List.of());
+        }
+    }
+
+    private static final class InMemoryKvStore extends KVStore<AetherKey, AetherValue> {
+        InMemoryKvStore(MessageRouter router) {
+            super(router, stubSerializer(), stubDeserializer());
+        }
+
+        void put(AetherKey key, AetherValue value) {
+            process(createBatch(List.of(new KVCommand.Put<>(key, value))));
+        }
+
+        void commit(List<KVCommand<AetherKey>> batch) {
+            process(createBatch(batch));
+        }
+    }
+
+    private static Serializer stubSerializer() {
+        return new Serializer() {
+            @Override public <T> void write(ByteBuf byteBuf, T object) {}
+        };
+    }
+
+    private static Deserializer stubDeserializer() {
+        return new Deserializer() {
+            @Override public <T> T read(ByteBuf byteBuf) {
+                return null;
+            }
+        };
+    }
+}

--- a/aether/aether-deployment/src/test/java/org/pragmatica/aether/deployment/cluster/fsm/CommunityPlacementPlannerTest.java
+++ b/aether/aether-deployment/src/test/java/org/pragmatica/aether/deployment/cluster/fsm/CommunityPlacementPlannerTest.java
@@ -1,0 +1,240 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2025 Pragmatica Labs - Sergiy Yevtushenko
+// Licensed under Business Source License 1.1. Change Date: 2030-01-01. Change License: Apache-2.0.
+// See LICENSE in the repository root for full terms.
+package org.pragmatica.aether.deployment.cluster.fsm;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.pragmatica.aether.deployment.cluster.ClusterDeploymentManager.DeploymentAtomicity;
+import org.pragmatica.aether.deployment.cluster.fsm.ClusterDeploymentEvents.Activate;
+import org.pragmatica.aether.deployment.schema.SchemaOrchestratorService;
+import org.pragmatica.aether.slice.generation.HealthSignalSink;
+import org.pragmatica.aether.slice.kvstore.AetherKey;
+import org.pragmatica.aether.slice.kvstore.AetherKey.CommunityKey;
+import org.pragmatica.aether.slice.kvstore.AetherValue;
+import org.pragmatica.aether.slice.kvstore.AetherValue.CommunityValue;
+import org.pragmatica.aether.slice.kvstore.CommunityState;
+import org.pragmatica.cluster.node.ClusterNode;
+import org.pragmatica.cluster.state.kvstore.KVCommand;
+import org.pragmatica.cluster.state.kvstore.KVStore;
+import org.pragmatica.consensus.NodeId;
+import org.pragmatica.consensus.fsm.ClusterFsmEvent;
+import org.pragmatica.consensus.net.NodeInfo;
+import org.pragmatica.consensus.topology.NodeState;
+import org.pragmatica.consensus.topology.TopologyManager;
+import org.pragmatica.lang.Option;
+import org.pragmatica.lang.Promise;
+import org.pragmatica.lang.Unit;
+import org.pragmatica.lang.io.TimeSpan;
+import org.pragmatica.messaging.MessageRouter;
+import org.pragmatica.net.tcp.NodeAddress;
+import org.pragmatica.serialization.Deserializer;
+import org.pragmatica.serialization.Serializer;
+import org.pragmatica.statemachine.Fsm;
+import org.pragmatica.statemachine.FsmTestHarness;
+
+import java.net.SocketAddress;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Function;
+
+import io.netty.buffer.ByteBuf;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.pragmatica.lang.io.TimeSpan.timeSpan;
+
+/// #241 (worker-membership-spec D1 / §3.3): the placement planner's DESIRED community set is the
+/// committed [`CommunityKey`]/[`CommunityValue`] facts — a community exists the moment the leader
+/// mints its key (FORMING), before any governor has announced. Terminal teardown states
+/// (`DISSOLVING`/`DISSOLVED`) are excluded; `FORMING`/`ACTIVE`/`DEGRADED` are all desired (the
+/// per-community FSM that drives strict `ACTIVE` is slice 2).
+class CommunityPlacementPlannerTest {
+    private static final NodeId SELF = new NodeId("node-self");
+
+    private InMemoryKvStore kvStore;
+    private FsmTestHarness<ClusterDeploymentState, ClusterFsmEvent> harness;
+
+    @BeforeEach
+    void setUp() {
+        var router = MessageRouter.mutable();
+        kvStore = new InMemoryKvStore(router);
+        var cluster = new RecordingClusterNode(SELF);
+        Function<Fsm<ClusterDeploymentState, ClusterFsmEvent>, ClusterDeploymentState> factory =
+                fsm -> new ClusterDeploymentContext(fsm,
+                                                    SELF,
+                                                    cluster,
+                                                    kvStore,
+                                                    router,
+                                                    stubTopologyManager(SELF),
+                                                    stubSchemaOrchestrator(),
+                                                    HealthSignalSink.noop(),
+                                                    () -> Set.of(SELF),
+                                                    () -> Set.of(SELF),
+                                                    Set::of,
+                                                    Set.of(SELF),
+                                                    DeploymentAtomicity.ALL_OR_NOTHING,
+                                                    1,
+                                                    timeSpan(300).seconds()).dormant();
+        harness = FsmTestHarness.harness("planner-desired-" + SELF.id(), factory);
+        harness.dispatch(new Activate());
+    }
+
+    private CommunityPlacementPlanner planner() {
+        return ((ClusterDeploymentState.Active) harness.state()).communityPlanner();
+    }
+
+    private void seedCommunity(String communityId, CommunityState state) {
+        kvStore.put(CommunityKey.communityKey(communityId),
+                    new CommunityValue("src", "WORKER", 100, state, 1L, Option.none()));
+    }
+
+    @Test
+    void activeCommunityIds_committedFormingCommunity_isIncludedInDesiredSet() {
+        seedCommunity("src-w-0", CommunityState.FORMING);
+
+        assertThat(planner().activeCommunityIds())
+                .as("a committed FORMING community is desired before any governor announces")
+                .containsExactly("src-w-0");
+    }
+
+    @Test
+    void activeCommunityIds_activeAndDegraded_areIncluded() {
+        seedCommunity("a-w-0", CommunityState.ACTIVE);
+        seedCommunity("b-w-0", CommunityState.DEGRADED);
+
+        assertThat(planner().activeCommunityIds())
+                .as("ACTIVE and DEGRADED communities are both desired")
+                .containsExactlyInAnyOrder("a-w-0", "b-w-0");
+    }
+
+    @Test
+    void activeCommunityIds_dissolvedCommunity_isExcluded() {
+        seedCommunity("live-w-0", CommunityState.FORMING);
+        seedCommunity("dead-w-0", CommunityState.DISSOLVED);
+
+        assertThat(planner().activeCommunityIds())
+                .as("a DISSOLVED community must be excluded from the desired set")
+                .containsExactly("live-w-0");
+    }
+
+    @Test
+    void activeCommunityIds_dissolvingCommunity_isExcluded() {
+        seedCommunity("tearing-w-0", CommunityState.DISSOLVING);
+
+        assertThat(planner().activeCommunityIds())
+                .as("a DISSOLVING community is in terminal teardown and must be excluded")
+                .isEmpty();
+    }
+
+    @Test
+    void activeCommunityIds_noCommittedCommunities_isEmpty() {
+        assertThat(planner().activeCommunityIds())
+                .as("with no committed CommunityKey the desired set is empty")
+                .isEmpty();
+    }
+
+    // --- test fixtures (mirrors ClusterDeploymentStateActiveTest) ---
+
+    private static SchemaOrchestratorService stubSchemaOrchestrator() {
+        return new SchemaOrchestratorService() {
+            @Override public Promise<Unit> migrateIfNeeded(String datasourceName) {
+                return Promise.success(Unit.unit());
+            }
+
+            @Override public Promise<Unit> undoTo(String datasourceName, int targetVersion) {
+                return Promise.success(Unit.unit());
+            }
+
+            @Override public Promise<Unit> baseline(String datasourceName, int version) {
+                return Promise.success(Unit.unit());
+            }
+        };
+    }
+
+    private static TopologyManager stubTopologyManager(NodeId self) {
+        return new TopologyManager() {
+            @Override public NodeInfo self() {
+                return NodeInfo.nodeInfo(self, new NodeAddress("localhost", 9000));
+            }
+
+            @Override public Option<NodeInfo> get(NodeId id) {
+                return Option.some(NodeInfo.nodeInfo(id, new NodeAddress("localhost", 9000)));
+            }
+
+            @Override public int clusterSize() {
+                return 1;
+            }
+
+            @Override public Option<NodeId> reverseLookup(SocketAddress socketAddress) {
+                return Option.empty();
+            }
+
+            @Override public Promise<Unit> start() {
+                return Promise.unitPromise();
+            }
+
+            @Override public Promise<Unit> stop() {
+                return Promise.unitPromise();
+            }
+
+            @Override public TimeSpan pingInterval() {
+                return timeSpan(5).seconds();
+            }
+
+            @Override public TimeSpan helloTimeout() {
+                return timeSpan(5).seconds();
+            }
+
+            @Override public Option<NodeState> getState(NodeId id) {
+                return Option.empty();
+            }
+
+            @Override public List<NodeId> topology() {
+                return List.of(self);
+            }
+        };
+    }
+
+    private static final class RecordingClusterNode implements ClusterNode<KVCommand<AetherKey>> {
+        final NodeId self;
+
+        RecordingClusterNode(NodeId self) {this.self = self;}
+
+        @Override public NodeId self() {return self;}
+
+        @Override public TopologyManager topologyManager() {return stubTopologyManager(self);}
+
+        @Override public Promise<Unit> start() {return Promise.unitPromise();}
+
+        @Override public Promise<Unit> stop() {return Promise.unitPromise();}
+
+        @Override public <R> Promise<List<R>> apply(List<KVCommand<AetherKey>> batch) {
+            return Promise.success(List.of());
+        }
+    }
+
+    private static final class InMemoryKvStore extends KVStore<AetherKey, AetherValue> {
+        InMemoryKvStore(MessageRouter router) {
+            super(router, stubSerializer(), stubDeserializer());
+        }
+
+        void put(AetherKey key, AetherValue value) {
+            process(createBatch(List.of(new KVCommand.Put<>(key, value))));
+        }
+    }
+
+    private static Serializer stubSerializer() {
+        return new Serializer() {
+            @Override public <T> void write(ByteBuf byteBuf, T object) {}
+        };
+    }
+
+    private static Deserializer stubDeserializer() {
+        return new Deserializer() {
+            @Override public <T> T read(ByteBuf byteBuf) {
+                return null;
+            }
+        };
+    }
+}

--- a/aether/node/src/main/java/org/pragmatica/aether/node/AetherNode.java
+++ b/aether/node/src/main/java/org/pragmatica/aether/node/AetherNode.java
@@ -264,6 +264,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BooleanSupplier;
 import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.function.IntSupplier;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
@@ -1384,6 +1385,13 @@ public interface AetherNode extends ManageableNode {
         var cdmDrainingNodesRef = new AtomicReference<Supplier<Set<NodeId>>>(Set::of);
         Supplier<Set<NodeId>> stableCdmDrainingNodesSupplier = () -> cdmDrainingNodesRef.get()
                                                                                         .get();
+        // #241 (worker-membership-spec §4.1 / D2): the CDM resolves a joining worker's membership
+        // source at role-assignment time to mint/reuse its per-source community. Reads the last-wins
+        // MemberDescriptor.source from the membership FSM (retained even across DEAD/rejoin), through
+        // the same shared membershipFsmRef the other CDM suppliers deref. Absent → none() → "default".
+        Function<NodeId, Option<String>> cdmMemberSourceSupplier = nodeId -> Option.option(membershipFsmRef.get())
+                                                                                   .flatMap(fsm -> fsm.memberDescriptor(nodeId))
+                                                                                   .map(MemberDescriptor::source);
         var clusterDeploymentManager = ClusterDeploymentManager.clusterDeploymentManager(config.self(),
                                                                                          clusterNode,
                                                                                          kvStore,
@@ -1397,7 +1405,8 @@ public interface AetherNode extends ManageableNode {
                                                                                          stableHealthSink,
                                                                                          cdmCoreCountedMembersSupplier,
                                                                                          stableCdmReadyNodesSupplier,
-                                                                                         stableCdmDrainingNodesSupplier);
+                                                                                         stableCdmDrainingNodesSupplier,
+                                                                                         cdmMemberSourceSupplier);
         var loadBalancerManager = config.environment().flatMap(EnvironmentIntegration::loadBalancer).map(provider -> LoadBalancerManager.loadBalancerManager(config.self(),
                                                                                                                                                              kvStore,
                                                                                                                                                              clusterNode.topologyManager(),

--- a/aether/slice/src/main/java/org/pragmatica/aether/slice/kvstore/AetherKey.java
+++ b/aether/slice/src/main/java/org/pragmatica/aether/slice/kvstore/AetherKey.java
@@ -943,6 +943,41 @@ public sealed interface AetherKey extends StructuredKey {
         }
     }
 
+    /// Desired-state community identity (worker-membership-spec §2, D1): a leader-minted, stable,
+    /// committed KV fact keyed on the immutable `communityId`. Mirrors [GovernorAnnouncementKey]
+    /// (the governor-owned *observed* statement for the same community) at the key level.
+    record CommunityKey(String communityId) implements AetherKey {
+        private static final String PREFIX = "community/";
+
+        @Override
+        public String asString() {
+            return PREFIX + communityId;
+        }
+
+        @Override
+        public String toString() {
+            return asString();
+        }
+
+        public static CommunityKey communityKey(String communityId) {
+            return new CommunityKey(communityId);
+        }
+
+        public static Result<CommunityKey> parseCommunityKey(String key) {
+            if (!key.startsWith(PREFIX)) {
+                return COMMUNITY_KEY_FORMAT_ERROR.apply(key).result();
+            }
+
+            var communityId = key.substring(PREFIX.length());
+
+            if (communityId.isEmpty()) {
+                return COMMUNITY_KEY_FORMAT_ERROR.apply(key).result();
+            }
+
+            return success(new CommunityKey(communityId));
+        }
+    }
+
     record AbTestKey(String testId) implements AetherKey {
         private static final String PREFIX = "ab-test/";
 
@@ -1088,6 +1123,8 @@ public sealed interface AetherKey extends StructuredKey {
     Fn1<Cause, String> NODE_ROUTES_KEY_FORMAT_ERROR = Causes.forOneValue("Invalid node-routes key format: %s");
 
     Fn1<Cause, String> GOVERNOR_ANNOUNCEMENT_KEY_FORMAT_ERROR = Causes.forOneValue("Invalid governor-announcement key format: %s");
+
+    Fn1<Cause, String> COMMUNITY_KEY_FORMAT_ERROR = Causes.forOneValue("Invalid community key format: %s");
 
     Fn1<Cause, String> GOSSIP_KEY_ROTATION_KEY_FORMAT_ERROR = Causes.forOneValue("Invalid gossip-key-rotation key format: %s");
 

--- a/aether/slice/src/main/java/org/pragmatica/aether/slice/kvstore/AetherValue.java
+++ b/aether/slice/src/main/java/org/pragmatica/aether/slice/kvstore/AetherValue.java
@@ -413,16 +413,47 @@ public sealed interface AetherValue {
         }
     }
 
-    record ActivationDirectiveValue(String role) implements AetherValue {
+    /// Worker/core activation directive (worker-membership-spec §4 line 79): the leader-authored,
+    /// node-keyed role assignment. Extended additively with `communityId` + `governorHint` so a
+    /// WORKER directive carries its community assignment and a governor address hint through the
+    /// already-canonical directive path — community assignment happens at the same moment as role
+    /// assignment. Both are empty for a CORE directive (and for a community-less WORKER).
+    ///
+    /// Optional-field idiom mirrors [DhtPartitionOwnershipValue.ownerCommunityId]: empty-string is
+    /// the canonical "absent" form, normalized in the compact constructor so a `null` from a
+    /// wire/codec edge collapses to `""` (preserving `equals` with the role-only constructors).
+    record ActivationDirectiveValue(String role, String communityId, String governorHint) implements AetherValue {
         public static final String CORE = "CORE";
         public static final String WORKER = "WORKER";
 
+        public ActivationDirectiveValue {
+            if (communityId == null) {
+                communityId = "";
+            }
+
+            if (governorHint == null) {
+                governorHint = "";
+            }
+        }
+
+        /// Backward-compatible role-only constructor — pre-existing call sites pass a bare role;
+        /// `communityId`/`governorHint` default empty (CORE or community-less WORKER semantics).
+        public ActivationDirectiveValue(String role) {
+            this(role, "", "");
+        }
+
         public static ActivationDirectiveValue core() {
-            return new ActivationDirectiveValue(CORE);
+            return new ActivationDirectiveValue(CORE, "", "");
         }
 
         public static ActivationDirectiveValue worker() {
-            return new ActivationDirectiveValue(WORKER);
+            return new ActivationDirectiveValue(WORKER, "", "");
+        }
+
+        /// Community-assigned WORKER directive — carries the committed `communityId` and a governor
+        /// address hint alongside the WORKER role (§4 line 79).
+        public static ActivationDirectiveValue worker(String communityId, String governorHint) {
+            return new ActivationDirectiveValue(WORKER, communityId, governorHint);
         }
     }
 
@@ -1306,6 +1337,59 @@ public sealed interface AetherValue {
         ASSIGNED,
         ACTIVE,
         FAILED
+    }
+
+    /// Desired-state community record (worker-membership-spec §2 line 78): the leader-authored
+    /// target for a committed [AetherKey.CommunityKey]. `state` is the per-community FSM state
+    /// (leader-evaluated, §3.3). `dissolvedAt` is present only once the community reaches the
+    /// `DISSOLVED` terminal fact; absent (`none()`) for every live state.
+    ///
+    /// Mirrors [DhtPartitionOwnershipValue] for optional-field canonicalization: empty Option /
+    /// empty string are the canonical "absent" forms, normalized in the compact constructor so a
+    /// `null` from a wire/codec edge collapses to the same value (and the same `equals`).
+    record CommunityValue(String sourceName,
+                          String role,
+                          int targetSize,
+                          CommunityState state,
+                          long createdAt,
+                          Option<Long> dissolvedAt) implements AetherValue {
+        public CommunityValue {
+            if (sourceName == null) {
+                sourceName = "";
+            }
+
+            if (role == null) {
+                role = "";
+            }
+
+            if (state == null) {
+                state = CommunityState.FORMING;
+            }
+
+            if (dissolvedAt == null) {
+                dissolvedAt = Option.none();
+            }
+        }
+
+        public static CommunityValue communityValue(String sourceName,
+                                                    String role,
+                                                    int targetSize,
+                                                    CommunityState state,
+                                                    long createdAt,
+                                                    Option<Long> dissolvedAt) {
+            return new CommunityValue(sourceName, role, targetSize, state, createdAt, dissolvedAt);
+        }
+
+        /// FORMING mint — the leader creating a fresh community (growth policy demands a new slot,
+        /// §3.3): stamps `createdAt = now`, `state = FORMING`, `dissolvedAt = none()`.
+        public static CommunityValue communityValue(String sourceName, String role, int targetSize) {
+            return new CommunityValue(sourceName,
+                                      role,
+                                      targetSize,
+                                      CommunityState.FORMING,
+                                      System.currentTimeMillis(),
+                                      none());
+        }
     }
 
     /// Canonical field order: `(spawnedAtMs, assignedNodeId, occupantEpoch, supersededNodeId)`.

--- a/aether/slice/src/main/java/org/pragmatica/aether/slice/kvstore/CommunityState.java
+++ b/aether/slice/src/main/java/org/pragmatica/aether/slice/kvstore/CommunityState.java
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2025 Pragmatica Labs - Sergiy Yevtushenko
+// Licensed under Business Source License 1.1. Change Date: 2030-01-01. Change License: Apache-2.0.
+// See LICENSE in the repository root for full terms.
+package org.pragmatica.aether.slice.kvstore;
+
+import org.pragmatica.serialization.Codec;
+
+
+/// Per-community lifecycle FSM state (leader-evaluated), the `state` field of
+/// [AetherValue.CommunityValue]. Death of a community is the explicit `DISSOLVED` terminal fact,
+/// not a disappearance (worker-membership-spec A10). Transitions (spec §3.3):
+/// minted → `FORMING` → `ACTIVE` → (`DEGRADED` ↔) `DISSOLVING` → `DISSOLVED`.
+@Codec
+public enum CommunityState {
+    FORMING,
+    ACTIVE,
+    DEGRADED,
+    DISSOLVING,
+    DISSOLVED
+}

--- a/aether/slice/src/main/java/org/pragmatica/aether/slice/kvstore/KVStoreSerializer.java
+++ b/aether/slice/src/main/java/org/pragmatica/aether/slice/kvstore/KVStoreSerializer.java
@@ -158,6 +158,7 @@ public final class KVStoreSerializer {
             case ActivationDirectiveKey _ -> "activation";
             case GossipKeyRotationKey _ -> "gossip-key-rotation";
             case GovernorAnnouncementKey _ -> "governor-announcement";
+            case CommunityKey _ -> "community";
             case NodeArtifactKey _ -> "node-artifact";
             case NodeRoutesKey _ -> "node-routes";
             case SchemaVersionKey _ -> "schema-version";
@@ -222,11 +223,12 @@ public final class KVStoreSerializer {
             case ObservabilityDepthValue v -> serializeObservabilityDepth(v);
             case ConfigValue v -> serializeConfig(v);
             case WorkerSliceDirectiveValue v -> serializeWorkerDirective(v);
-            case ActivationDirectiveValue v -> v.role();
+            case ActivationDirectiveValue v -> serializeActivationDirective(v);
             case GossipKeyRotationValue v -> serializeGossipKeyRotation(v);
             case JoinDeadlineValue v -> v.deadlineMs() + PIPE + v.setAt();
             case DrainDeadlineValue v -> v.deadlineMs() + PIPE + v.setAt();
             case GovernorAnnouncementValue v -> serializeGovernorAnnouncement(v);
+            case CommunityValue v -> serializeCommunity(v);
             case NodeArtifactValue v -> serializeNodeArtifact(v);
             case NodeRoutesValue v -> serializeNodeRoutes(v);
             case AppBlueprintValue _ -> "";
@@ -414,6 +416,26 @@ public final class KVStoreSerializer {
                 .id() + PIPE + v.memberCount() + PIPE + memberIds + PIPE + v.tcpAddress() + PIPE + v.announcedAt();
     }
 
+    /// Pipe-delimited community wire form `(sourceName|role|targetSize|state|createdAt|dissolvedAt)`.
+    /// Mirrors [#serializeDhtPartitionOwnership]'s empty-field canonicalization: the optional
+    /// `dissolvedAt` renders as the empty string when absent (`none()`), symmetric with
+    /// [#parseCommunityEntry].
+    private static String serializeCommunity(CommunityValue v) {
+        return v.sourceName() + PIPE + v.role() + PIPE + v.targetSize() + PIPE + v.state()
+                                                                                  .name() + PIPE + v.createdAt() + PIPE + v.dissolvedAt()
+                                                                                                                           .map(String::valueOf)
+                                                                                                                           .or("");
+    }
+
+    /// Pipe-delimited activation wire form `(role|communityId|governorHint)`. Replaces the prior
+    /// bare-`role()` form so the additive community fields round-trip symmetrically with
+    /// [#parseActivationEntry]. Empty community fields canonicalize to empty strings, mirroring
+    /// [#serializeDhtPartitionOwnership]'s empty-field idiom. Package-visible for direct round-trip
+    /// testing (the `activation` section is ephemeral, so it never flows through `toToml`).
+    static String serializeActivationDirective(ActivationDirectiveValue v) {
+        return v.role() + PIPE + v.communityId() + PIPE + v.governorHint();
+    }
+
     private static String serializeClusterConfig(ClusterConfigValue v) {
         return v.clusterName() + PIPE + v.version() + PIPE + v.coreCount() + PIPE + v.coreMin() + PIPE + v.coreMax() + PIPE + v.deploymentType() + PIPE + v.configVersion() + PIPE + v.updatedAt() + PIPE + v.tomlContent()
                                                                                                                                                                                                              .replace("|",
@@ -474,6 +496,7 @@ public final class KVStoreSerializer {
             case "activation" -> parseActivationEntry(identity, rawValue);
             case "gossip-key-rotation" -> parseGossipKeyRotationEntry(identity, rawValue);
             case "governor-announcement" -> parseGovernorAnnouncementEntry(identity, rawValue);
+            case "community" -> parseCommunityEntry(identity, rawValue);
             case "node-artifact" -> parseNodeArtifactEntry(identity, rawValue);
             case "node-routes" -> parseNodeRoutesEntry(identity, rawValue);
             case "schema-version" -> parseSchemaVersionEntry(identity, rawValue);
@@ -812,9 +835,28 @@ public final class KVStoreSerializer {
                                                                                                                                         val)));
     }
 
-    private static Result<Map.Entry<AetherKey, AetherValue>> parseActivationEntry(String identity, String raw) {
+    /// Inverse of [#serializeActivationDirective]. Tolerates TWO wire forms by field count
+    /// (standard trailing-field backward-compat, spec §7): the 3-field CURRENT form
+    /// `(role|communityId|governorHint)`, and the legacy 1-field bare-`role` form written before
+    /// the community fields existed (community fields default empty via the role-only constructor).
+    /// Package-visible for direct round-trip testing (the `activation` section is ephemeral).
+    static Result<Map.Entry<AetherKey, AetherValue>> parseActivationEntry(String identity, String raw) {
+        var parts = raw.split("\\|", -1);
+
+        if (parts.length != 1 && parts.length != 3) {
+            return parseFailure("activation value requires 1 or 3 fields, got " + parts.length);
+        }
+
         return ActivationDirectiveKey.activationDirectiveKey("activation/" + identity).map(key -> entry(key,
-                                                                                                        new ActivationDirectiveValue(raw)));
+                                                                                                        buildActivationDirectiveValue(parts)));
+    }
+
+    private static ActivationDirectiveValue buildActivationDirectiveValue(String[] parts) {
+        if (parts.length == 1) {
+            return new ActivationDirectiveValue(parts[0]);
+        }
+
+        return new ActivationDirectiveValue(parts[0], parts[1], parts[2]);
     }
 
     private static Result<Map.Entry<AetherKey, AetherValue>> parseGovernorAnnouncementEntry(String identity,
@@ -850,6 +892,33 @@ public final class KVStoreSerializer {
                                                                    members,
                                                                    parts[3],
                                                                    Long.parseLong(parts[4]));
+    }
+
+    /// Inverse of [#serializeCommunity]. Wire form (6 fields, pipe-delimited):
+    /// `sourceName|role|targetSize|state|createdAt|dissolvedAt`. The optional `dissolvedAt` field
+    /// is reconstructed as `none()` when empty, mirroring the empty-Option idiom used across the
+    /// serializer (e.g. provisioning-slot's `assignedNodeId`).
+    private static Result<Map.Entry<AetherKey, AetherValue>> parseCommunityEntry(String identity, String raw) {
+        var parts = raw.split("\\|", -1);
+
+        if (parts.length != 6) {
+            return parseFailure("community value requires 6 fields, got " + parts.length);
+        }
+
+        return CommunityKey.parseCommunityKey("community/" + identity).map(key -> entry(key, buildCommunityValue(parts)));
+    }
+
+    private static CommunityValue buildCommunityValue(String[] parts) {
+        var dissolvedAt = parts[5].isEmpty()
+                          ? Option.<Long> none()
+                          : Option.some(Long.parseLong(parts[5]));
+
+        return new CommunityValue(parts[0],
+                                  parts[1],
+                                  Integer.parseInt(parts[2]),
+                                  CommunityState.valueOf(parts[3]),
+                                  Long.parseLong(parts[4]),
+                                  dissolvedAt);
     }
 
     private static Result<Map.Entry<AetherKey, AetherValue>> parseNodeArtifactEntry(String identity, String raw) {

--- a/aether/slice/src/test/java/org/pragmatica/aether/slice/kvstore/CommunityKeyTest.java
+++ b/aether/slice/src/test/java/org/pragmatica/aether/slice/kvstore/CommunityKeyTest.java
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2025 Pragmatica Labs - Sergiy Yevtushenko
+// Licensed under Business Source License 1.1. Change Date: 2030-01-01. Change License: Apache-2.0.
+// See LICENSE in the repository root for full terms.
+package org.pragmatica.aether.slice.kvstore;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.pragmatica.aether.slice.kvstore.AetherKey.CommunityKey;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CommunityKeyTest {
+    @Test
+    void communityKey_withCommunityId_buildsKey() {
+        var key = CommunityKey.communityKey("prod:us-east-1");
+
+        assertThat(key.communityId()).isEqualTo("prod:us-east-1");
+        assertThat(key.asString()).isEqualTo("community/prod:us-east-1");
+    }
+
+    @Test
+    void asString_prefixesWithSection() {
+        var key = CommunityKey.communityKey("worker-pool-a");
+
+        assertThat(key.asString()).isEqualTo("community/worker-pool-a");
+    }
+
+    @Test
+    void parseCommunityKey_validKey_succeeds() {
+        CommunityKey.parseCommunityKey("community/prod:us-east-1")
+                    .onFailureRun(Assertions::fail)
+                    .onSuccess(parsed -> assertThat(parsed.communityId()).isEqualTo("prod:us-east-1"));
+    }
+
+    @Test
+    void parseCommunityKey_missingPrefix_fails() {
+        CommunityKey.parseCommunityKey("invalid/foo")
+                    .onSuccessRun(Assertions::fail)
+                    .onFailure(cause -> assertThat(cause.message()).contains("Invalid community key format"));
+    }
+
+    @Test
+    void parseCommunityKey_emptyId_fails() {
+        CommunityKey.parseCommunityKey("community/")
+                    .onSuccessRun(Assertions::fail)
+                    .onFailure(cause -> assertThat(cause.message()).contains("Invalid community key format"));
+    }
+
+    @Test
+    void roundTrip_preservesCommunityId() {
+        var key = CommunityKey.communityKey("shard-42");
+
+        CommunityKey.parseCommunityKey(key.asString())
+                    .onFailureRun(Assertions::fail)
+                    .onSuccess(parsed -> assertThat(parsed).isEqualTo(key));
+    }
+
+    @Test
+    void toString_matchesAsString() {
+        var key = CommunityKey.communityKey("prod:us-east-1");
+
+        assertThat(key.toString()).isEqualTo(key.asString());
+    }
+}

--- a/aether/slice/src/test/java/org/pragmatica/aether/slice/kvstore/CommunityValueTest.java
+++ b/aether/slice/src/test/java/org/pragmatica/aether/slice/kvstore/CommunityValueTest.java
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2025 Pragmatica Labs - Sergiy Yevtushenko
+// Licensed under Business Source License 1.1. Change Date: 2030-01-01. Change License: Apache-2.0.
+// See LICENSE in the repository root for full terms.
+package org.pragmatica.aether.slice.kvstore;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Nested;
+import org.pragmatica.aether.slice.kvstore.AetherValue.CommunityValue;
+import org.pragmatica.lang.Option;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CommunityValueTest {
+    @Nested
+    class Fields {
+        @Test
+        void communityValue_withAllFields_populatesRecord() {
+            var v = CommunityValue.communityValue("orders",
+                                                  "WORKER",
+                                                  5,
+                                                  CommunityState.ACTIVE,
+                                                  1710072000000L,
+                                                  Option.some(1710072500000L));
+
+            assertThat(v.sourceName()).isEqualTo("orders");
+            assertThat(v.role()).isEqualTo("WORKER");
+            assertThat(v.targetSize()).isEqualTo(5);
+            assertThat(v.state()).isEqualTo(CommunityState.ACTIVE);
+            assertThat(v.createdAt()).isEqualTo(1710072000000L);
+            assertThat(v.dissolvedAt()).isEqualTo(Option.some(1710072500000L));
+        }
+
+        @Test
+        void communityValue_formingMint_hasFormingStateAndNoDissolvedAt() {
+            var v = CommunityValue.communityValue("orders", "WORKER", 3);
+
+            assertThat(v.state()).isEqualTo(CommunityState.FORMING);
+            assertThat(v.dissolvedAt().isPresent()).isFalse();
+            assertThat(v.createdAt()).isPositive();
+        }
+    }
+
+    @Nested
+    class Canonicalization {
+        @Test
+        void construct_nullDissolvedAt_normalizesToNone() {
+            var v = new CommunityValue("orders", "WORKER", 3, CommunityState.FORMING, 1000L, null);
+
+            assertThat(v.dissolvedAt().isPresent()).isFalse();
+        }
+
+        @Test
+        void construct_presentDissolvedAt_preserved() {
+            var v = new CommunityValue("orders", "WORKER", 3, CommunityState.DISSOLVED, 1000L, Option.some(2000L));
+
+            assertThat(v.dissolvedAt()).isEqualTo(Option.some(2000L));
+        }
+
+        @Test
+        void construct_nullSourceName_normalizesToEmpty() {
+            var v = new CommunityValue(null, "WORKER", 3, CommunityState.FORMING, 1000L, Option.none());
+
+            assertThat(v.sourceName()).isEmpty();
+        }
+
+        @Test
+        void construct_nullRole_normalizesToEmpty() {
+            var v = new CommunityValue("orders", null, 3, CommunityState.FORMING, 1000L, Option.none());
+
+            assertThat(v.role()).isEmpty();
+        }
+
+        @Test
+        void construct_nullState_normalizesToForming() {
+            var v = new CommunityValue("orders", "WORKER", 3, null, 1000L, Option.none());
+
+            assertThat(v.state()).isEqualTo(CommunityState.FORMING);
+        }
+    }
+
+    @Nested
+    class AllStates {
+        @Test
+        void communityValue_eachState_preservesState() {
+            for (var state : CommunityState.values()) {
+                var dissolvedAt = state == CommunityState.DISSOLVED
+                                  ? Option.some(2000L)
+                                  : Option.<Long> none();
+
+                var v = CommunityValue.communityValue("orders", "WORKER", 3, state, 1000L, dissolvedAt);
+
+                assertThat(v.state()).isEqualTo(state);
+                assertThat(v.dissolvedAt()).isEqualTo(dissolvedAt);
+            }
+        }
+    }
+}

--- a/aether/slice/src/test/java/org/pragmatica/aether/slice/kvstore/KVStoreSerializerTest.java
+++ b/aether/slice/src/test/java/org/pragmatica/aether/slice/kvstore/KVStoreSerializerTest.java
@@ -435,6 +435,104 @@ class KVStoreSerializerTest {
                                  assertThat(wdv.targetCommunity().isPresent()).isFalse();
                              });
         }
+
+        @Test
+        void roundTrip_communityValue_preservesAllFields() {
+            var entries = new LinkedHashMap<AetherKey, AetherValue>();
+            var key = CommunityKey.communityKey("orders:worker");
+            var value = CommunityValue.communityValue("orders",
+                                                      "WORKER",
+                                                      5,
+                                                      CommunityState.ACTIVE,
+                                                      1710072000000L,
+                                                      Option.none());
+            entries.put(key, value);
+
+            KVStoreSerializer.toToml(entries, TEST_PHASE, TEST_TIMESTAMP)
+                             .flatMap(KVStoreSerializer::fromToml)
+                             .onFailureRun(Assertions::fail)
+                             .onSuccess(restored -> {
+                                 assertThat(restored).hasSize(1);
+                                 assertThat(restored).containsKey(key);
+                                 var cv = (CommunityValue) restored.get(key);
+                                 assertThat(cv.sourceName()).isEqualTo("orders");
+                                 assertThat(cv.role()).isEqualTo("WORKER");
+                                 assertThat(cv.targetSize()).isEqualTo(5);
+                                 assertThat(cv.state()).isEqualTo(CommunityState.ACTIVE);
+                                 assertThat(cv.createdAt()).isEqualTo(1710072000000L);
+                                 assertThat(cv.dissolvedAt().isPresent()).isFalse();
+                             });
+        }
+
+        @Test
+        void roundTrip_communityValueDissolved_preservesDissolvedAt() {
+            var entries = new LinkedHashMap<AetherKey, AetherValue>();
+            var key = CommunityKey.communityKey("orders:worker");
+            var value = CommunityValue.communityValue("orders",
+                                                      "WORKER",
+                                                      5,
+                                                      CommunityState.DISSOLVED,
+                                                      1710072000000L,
+                                                      Option.some(1710072500000L));
+            entries.put(key, value);
+
+            KVStoreSerializer.toToml(entries, TEST_PHASE, TEST_TIMESTAMP)
+                             .flatMap(KVStoreSerializer::fromToml)
+                             .onFailureRun(Assertions::fail)
+                             .onSuccess(restored -> {
+                                 var cv = (CommunityValue) restored.get(key);
+                                 assertThat(cv.state()).isEqualTo(CommunityState.DISSOLVED);
+                                 assertThat(cv.dissolvedAt()).isEqualTo(Option.some(1710072500000L));
+                                 assertThat(cv).isEqualTo(value);
+                             });
+        }
+
+        @Test
+        void roundTrip_activationDirectiveWithCommunity_preservesRoleCommunityAndHint() {
+            var original = AetherValue.ActivationDirectiveValue.worker("orders:worker", "10.0.0.1:7201");
+
+            var serialized = KVStoreSerializer.serializeActivationDirective(original);
+
+            KVStoreSerializer.parseActivationEntry("node-1", serialized)
+                             .onFailureRun(Assertions::fail)
+                             .onSuccess(entry -> {
+                                 var value = (AetherValue.ActivationDirectiveValue) entry.getValue();
+                                 assertThat(value.role()).isEqualTo("WORKER");
+                                 assertThat(value.communityId()).isEqualTo("orders:worker");
+                                 assertThat(value.governorHint()).isEqualTo("10.0.0.1:7201");
+                                 assertThat(value).isEqualTo(original);
+                             });
+        }
+
+        @Test
+        void roundTrip_activationDirectiveNoCommunity_preservesEmptyFields() {
+            var original = AetherValue.ActivationDirectiveValue.core();
+
+            var serialized = KVStoreSerializer.serializeActivationDirective(original);
+
+            KVStoreSerializer.parseActivationEntry("node-1", serialized)
+                             .onFailureRun(Assertions::fail)
+                             .onSuccess(entry -> {
+                                 var value = (AetherValue.ActivationDirectiveValue) entry.getValue();
+                                 assertThat(value.role()).isEqualTo("CORE");
+                                 assertThat(value.communityId()).isEmpty();
+                                 assertThat(value.governorHint()).isEmpty();
+                                 assertThat(value).isEqualTo(original);
+                             });
+        }
+
+        @Test
+        void parseActivationEntry_legacyBareRole_defaultsEmptyCommunityFields() {
+            KVStoreSerializer.parseActivationEntry("node-1", "WORKER")
+                             .onFailureRun(Assertions::fail)
+                             .onSuccess(entry -> {
+                                 var value = (AetherValue.ActivationDirectiveValue) entry.getValue();
+                                 assertThat(value.role()).isEqualTo("WORKER");
+                                 assertThat(value.communityId()).isEmpty();
+                                 assertThat(value.governorHint()).isEmpty();
+                                 assertThat(value).isEqualTo(AetherValue.ActivationDirectiveValue.worker());
+                             });
+        }
     }
 
     @Nested


### PR DESCRIPTION
## #241 slice 1 — committed `CommunityId` substrate

First slice of Phase A of `worker-membership-spec.md`. The community/worker membership tier is designed but was unbuilt; the overhaul gate (Waves 2/4/5/7) is satisfied, so it's unblocked. This slice gives communities a **stable, leader-minted committed identity** and assigns workers to them on join through the canonical directive path. Behind it, communities now actually *exist* as desired-state records (formation previously never ran).

### What's here (two halves)
**KV schema (slice module):**
- `CommunityKey(communityId)` + `CommunityValue{sourceName, role, targetSize, state, createdAt, dissolvedAt}` + `CommunityState{FORMING…DISSOLVED}` — mirroring `DhtPartitionOwnershipKey/Value`.
- `ActivationDirectiveValue` extended `(role)` → `(role, communityId, governorHint)` — community assignment rides the directive (spec §3.3). Backward-compat 1-arg ctor; new `worker(communityId, governorHint)` factory.
- `KVStoreSerializer`: `community` wired into all three switches **and the `ActivationDirectiveValue` round-trip fixed** (it serialized as bare `role()`; extending the record broke it — now pipe-delimited, with explicit round-trip regression tests for present/absent community + legacy bare-role).

**Leader mint (deployment FSM):**
- `ClusterDeploymentState.assignWorkerRole` (the leader-canonical join author): resolves the node's `source` (via a new `memberSourceSupplier` read-seam → `MembershipFsm.memberDescriptor`, default `"default"` per D2), mints the deterministic `<source>-w-0` FORMING community **only if absent**, and atomically commits `[CommunityKey Put?] + [WORKER directive Put with communityId]` in one `ctx.cluster().apply` batch (mirrors the existing batch idiom; A10 — directive never references an uncommitted id).
- `CommunityPlacementPlanner` reads the **committed `CommunityKey`** as the desired set (non-dissolved), keeping `GovernorAnnouncement` as the observed read.

### Design notes
- **Leader-canonical:** mint is in the CDM FSM (Active-on-leader only), not the operator-promote route (`NodeLifecycleRoutes`, untouched).
- **Race-safe:** the id is deterministic, so a concurrent double-join Puts the *same* key (idempotent) — no renumber, no split community (A10).
- **Scoped to single-community:** `<source>-w-0` and `targetSize=100` are placeholders; the **growth comparator (a later Phase-A slice)** replaces both. State minted FORMING; the planner reads non-dissolved for now — **strict ACTIVE-gating arrives with the per-community FSM (slice 2)**, which keeps placement working without pulling the FSM forward.
- **No slice-envelope bump** — this is KV-store consensus format, not the slice envelope.

### Tests
`CommunityKeyTest`, `CommunityValueTest`, `KVStoreSerializerTest` (community + extended-directive round-trips), `ClusterDeploymentStateCommunityMintTest` (mint-once + reuse proven via a real consensus→KV loop), `CommunityPlacementPlannerTest`. Full reactor green.

### Heads-up
Touches `ClusterDeploymentState`/`ClusterDeploymentContext`/`ClusterDeploymentManager` — the deployment FSM stabilized in the overhaul. The change is **additive** (worker branch only; CORE path unchanged) and the read-seam uses backward-compat constructors (zero existing-call-site churn). Flagged on #241.

### Next (Phase A)
Per-community FSM (FORMING→…→DISSOLVED) · worker `connectionSet` projection · governor read-source swap · announcement-TTL liveness + spokesman retirement · `NodeInfo` lazy label pull · `GroupAssignment` deletion.

Per our flow: **please review + merge — I won't self-merge.**
