### PR TITLE
feat: #241 slice 2 — per-community FSM (leader-evaluated FORMING/ACTIVE/DEGRADED)

### DIFF
--- a/aether/aether-deployment/src/main/java/org/pragmatica/aether/deployment/cluster/fsm/ClusterDeploymentState.java
+++ b/aether/aether-deployment/src/main/java/org/pragmatica/aether/deployment/cluster/fsm/ClusterDeploymentState.java
@@ -43,6 +43,7 @@ import org.pragmatica.aether.slice.kvstore.AetherKey.ActivationDirectiveKey;
 import org.pragmatica.aether.slice.kvstore.AetherKey.AppBlueprintKey;
 import org.pragmatica.aether.slice.kvstore.AetherKey.ClusterConfigKey;
 import org.pragmatica.aether.slice.kvstore.AetherKey.CommunityKey;
+import org.pragmatica.aether.slice.kvstore.AetherKey.GovernorAnnouncementKey;
 import org.pragmatica.aether.slice.kvstore.AetherKey.NodeArtifactKey;
 import org.pragmatica.aether.slice.kvstore.AetherKey.NodeRoutesKey;
 import org.pragmatica.aether.slice.kvstore.AetherKey.SchemaMigrationLockKey;
@@ -57,6 +58,7 @@ import org.pragmatica.aether.slice.kvstore.AetherValue.ActivationDirectiveValue;
 import org.pragmatica.aether.slice.kvstore.AetherValue.AppBlueprintValue;
 import org.pragmatica.aether.slice.kvstore.AetherValue.ClusterConfigValue;
 import org.pragmatica.aether.slice.kvstore.AetherValue.CommunityValue;
+import org.pragmatica.aether.slice.kvstore.AetherValue.GovernorAnnouncementValue;
 import org.pragmatica.aether.slice.kvstore.AetherValue.NodeArtifactValue;
 import org.pragmatica.aether.slice.kvstore.AetherValue.SchemaMigrationLockValue;
 import org.pragmatica.aether.slice.kvstore.AetherValue.SchemaStatus;
@@ -65,6 +67,7 @@ import org.pragmatica.aether.slice.kvstore.AetherValue.SliceNodeValue;
 import org.pragmatica.aether.slice.kvstore.AetherValue.SliceTargetValue;
 import org.pragmatica.aether.slice.kvstore.AetherValue.StreamMetadataValue;
 import org.pragmatica.aether.slice.kvstore.AetherValue.VersionRoutingValue;
+import org.pragmatica.aether.slice.kvstore.CommunityState;
 import org.pragmatica.cluster.state.kvstore.KVCommand;
 import org.pragmatica.cluster.state.kvstore.KVStoreNotification.ValuePut;
 import org.pragmatica.cluster.state.kvstore.KVStoreNotification.ValueRemove;
@@ -168,6 +171,10 @@ public sealed interface ClusterDeploymentState extends FsmState<ClusterDeploymen
         /// The fallback source label for a joining worker whose membership `source` is absent or
         /// blank (worker-membership-spec D2).
         private static final String DEFAULT_SOURCE = "default";
+        /// Minimum observed live members for a community to be VIABLE = the DHT replication factor
+        /// (worker-membership-spec §3.3 / §7). The per-community FSM promotes FORMING/DEGRADED →
+        /// ACTIVE at or above this floor and demotes ACTIVE → DEGRADED below it.
+        private static final int COMMUNITY_VIABILITY_FLOOR = 3;
 
         // --- move-only extraction seams (package-private helpers operating on this Active) ---
         StuckTransitionalRemediator stuckRemediator() {
@@ -1588,11 +1595,78 @@ public sealed interface ClusterDeploymentState extends FsmState<ClusterDeploymen
             }
 
             log.debug("Reconciliation complete: {} of {} blueprints required adjustment", reconciled, blueprints.size());
+            evaluateCommunityStates();
             cleanupOrphanedSliceEntries();
             cleanupStaleNodeRoutes();
             cleanupStaleNodeArtifactEntries();
             cleanupStaleSliceEntries();
             detectStuckTransitionalStates();
+        }
+
+        /// Per-community FSM evaluation (worker-membership-spec §3.3): the leader walks every committed
+        /// community, recomputes its desired `state` from observed live membership, and commits ONE
+        /// batch of `Put`s for exactly the communities whose state changed. Edge-driven — an unchanged
+        /// state emits NO command. Reached only from `reconcile()`, which is leader-guarded by the
+        /// `deactivated` check, so this evaluation runs on the leader alone.
+        @Contract
+        private void evaluateCommunityStates() {
+            var batch = new ArrayList<KVCommand<AetherKey>>();
+
+            ctx.kvStore().forEach(CommunityKey.class,
+                                  CommunityValue.class,
+                                  (key, value) -> collectCommunityTransition(batch, key, value));
+            if (!batch.isEmpty()) {
+                ctx.cluster().apply(batch).onFailure(cause -> log.error("Failed to apply {} community state transition(s): {}",
+                                                                        batch.size(),
+                                                                        cause.message()));
+            }
+        }
+
+        private void collectCommunityTransition(List<KVCommand<AetherKey>> batch,
+                                                CommunityKey key,
+                                                CommunityValue value) {
+            var next = nextCommunityState(value.state(), communityLiveMembers(key.communityId()));
+
+            if (next != value.state()) {
+                log.info("Community '{}' {} -> {} ({} live member(s), floor {})",
+                         key.communityId(),
+                         value.state(),
+                         next,
+                         communityLiveMembers(key.communityId()),
+                         COMMUNITY_VIABILITY_FLOOR);
+                batch.add(new KVCommand.Put<>(key, value.withState(next)));
+            }
+        }
+
+        /// Observed live membership of a community = its governor announcement's member count
+        /// (worker-membership-spec §3.3). No announcement (no governor yet) reads as `0`, which keeps
+        /// a FORMING community below the floor and demotes an ACTIVE community to DEGRADED.
+        private int communityLiveMembers(String communityId) {
+            return ctx.kvStore()
+                      .get(GovernorAnnouncementKey.forCommunity(communityId))
+                      .filter(GovernorAnnouncementValue.class::isInstance)
+                      .map(GovernorAnnouncementValue.class::cast)
+                      .map(GovernorAnnouncementValue::memberCount)
+                      .or(0);
+        }
+
+        /// Pure per-community state edge (worker-membership-spec §3.3). FORMING/DEGRADED promote to
+        /// ACTIVE once observed live membership reaches the viability floor; ACTIVE demotes to DEGRADED
+        /// below it. The terminal teardown states (DISSOLVING/DISSOLVED) are leader-decision/scale-down
+        /// concerns (Phase C) and are left unchanged here.
+        private static CommunityState nextCommunityState(CommunityState current, int liveMembers) {
+            return switch (current) {
+                case FORMING -> liveMembers >= COMMUNITY_VIABILITY_FLOOR
+                                ? CommunityState.ACTIVE
+                                : CommunityState.FORMING;
+                case ACTIVE -> liveMembers < COMMUNITY_VIABILITY_FLOOR
+                               ? CommunityState.DEGRADED
+                               : CommunityState.ACTIVE;
+                case DEGRADED -> liveMembers >= COMMUNITY_VIABILITY_FLOOR
+                                 ? CommunityState.ACTIVE
+                                 : CommunityState.DEGRADED;
+                case DISSOLVING, DISSOLVED -> current;
+            };
         }
 
         private boolean reconcileBlueprint(Blueprint blueprint,

--- a/aether/aether-deployment/src/main/java/org/pragmatica/aether/deployment/cluster/fsm/CommunityPlacementPlanner.java
+++ b/aether/aether-deployment/src/main/java/org/pragmatica/aether/deployment/cluster/fsm/CommunityPlacementPlanner.java
@@ -42,13 +42,13 @@ record CommunityPlacementPlanner(Active active) {
     private static final Logger log = LoggerFactory.getLogger(CommunityPlacementPlanner.class);
 
     /// The authoritative DESIRED community set (worker-membership-spec D1 / §3.3): the committed,
-    /// leader-authored [`CommunityKey`]/[`CommunityValue`] facts, filtered to the live states
-    /// (everything except the terminal `DISSOLVING`/`DISSOLVED`). This is the desired-state source
-    /// of truth — a community exists the moment the leader mints its `CommunityKey`, before any
-    /// governor has announced itself. (The previous source enumerated the governor-OWNED
+    /// leader-authored [`CommunityKey`]/[`CommunityValue`] facts, filtered to the strictly `ACTIVE`
+    /// state. Slice 2's per-community FSM (leader-evaluated in `reconcile()`) now drives a community
+    /// to `ACTIVE` once its observed live membership reaches the viability floor, so placement gates
+    /// on `ACTIVE` and excludes the still-`FORMING`, transiently-`DEGRADED`, and terminal
+    /// `DISSOLVING`/`DISSOLVED` communities. (The previous source enumerated the governor-OWNED
     /// [`GovernorAnnouncementKey`], which is the OBSERVED statement; that read is preserved in the
-    /// governor/worker-map methods below.) Slice 2's per-community FSM drives the `ACTIVE` state, so
-    /// `FORMING` is deliberately included here to keep placement working before that lands.
+    /// governor/worker-map methods below.)
     Set<String> activeCommunityIds() {
         var ids = new LinkedHashSet<String>();
 
@@ -65,11 +65,11 @@ record CommunityPlacementPlanner(Active active) {
         }
     }
 
-    /// A community counts toward the desired set unless it has reached its terminal teardown states
-    /// (`DISSOLVING`/`DISSOLVED`). `FORMING`/`ACTIVE`/`DEGRADED` are all desired (worker-membership-spec
-    /// §3.3); strict-`ACTIVE` filtering waits for slice 2's community FSM.
+    /// A community counts toward the desired set only once the per-community FSM has driven it to
+    /// `ACTIVE` (worker-membership-spec §3.3). `FORMING` (not yet viable), `DEGRADED` (lost quorum),
+    /// and the terminal `DISSOLVING`/`DISSOLVED` teardown states are all excluded.
     private static boolean isDesiredState(CommunityState state) {
-        return state != CommunityState.DISSOLVING && state != CommunityState.DISSOLVED;
+        return state == CommunityState.ACTIVE;
     }
 
     private Option<GovernorAnnouncementValue> communityGovernor(String communityId) {

--- a/aether/aether-deployment/src/test/java/org/pragmatica/aether/deployment/cluster/fsm/ClusterDeploymentStateCommunityFsmTest.java
+++ b/aether/aether-deployment/src/test/java/org/pragmatica/aether/deployment/cluster/fsm/ClusterDeploymentStateCommunityFsmTest.java
@@ -1,0 +1,369 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2025 Pragmatica Labs - Sergiy Yevtushenko
+// Licensed under Business Source License 1.1. Change Date: 2030-01-01. Change License: Apache-2.0.
+// See LICENSE in the repository root for full terms.
+package org.pragmatica.aether.deployment.cluster.fsm;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.pragmatica.aether.deployment.cluster.ClusterDeploymentManager.DeploymentAtomicity;
+import org.pragmatica.aether.deployment.cluster.fsm.ClusterDeploymentEvents.Activate;
+import org.pragmatica.aether.deployment.schema.SchemaOrchestratorService;
+import org.pragmatica.aether.slice.generation.HealthSignalSink;
+import org.pragmatica.aether.slice.kvstore.AetherKey;
+import org.pragmatica.aether.slice.kvstore.AetherKey.CommunityKey;
+import org.pragmatica.aether.slice.kvstore.AetherKey.GovernorAnnouncementKey;
+import org.pragmatica.aether.slice.kvstore.AetherValue;
+import org.pragmatica.aether.slice.kvstore.AetherValue.CommunityValue;
+import org.pragmatica.aether.slice.kvstore.AetherValue.GovernorAnnouncementValue;
+import org.pragmatica.aether.slice.kvstore.CommunityState;
+import org.pragmatica.cluster.node.ClusterNode;
+import org.pragmatica.cluster.state.kvstore.KVCommand;
+import org.pragmatica.cluster.state.kvstore.KVStore;
+import org.pragmatica.consensus.NodeId;
+import org.pragmatica.consensus.fsm.ClusterFsmEvent;
+import org.pragmatica.consensus.net.NodeInfo;
+import org.pragmatica.consensus.topology.NodeState;
+import org.pragmatica.consensus.topology.TopologyManager;
+import org.pragmatica.lang.Option;
+import org.pragmatica.lang.Promise;
+import org.pragmatica.lang.Unit;
+import org.pragmatica.lang.io.TimeSpan;
+import org.pragmatica.messaging.MessageRouter;
+import org.pragmatica.net.tcp.NodeAddress;
+import org.pragmatica.serialization.Deserializer;
+import org.pragmatica.serialization.Serializer;
+import org.pragmatica.statemachine.Fsm;
+import org.pragmatica.statemachine.FsmTestHarness;
+
+import java.net.SocketAddress;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Function;
+
+import io.netty.buffer.ByteBuf;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.pragmatica.lang.io.TimeSpan.timeSpan;
+
+/// #241 per-community FSM (worker-membership-spec §3.3): the leader, inside `reconcile()`, evaluates
+/// each committed community's OBSERVED live membership (= its governor announcement's member count)
+/// and drives `CommunityValue.state` on edges against the viability floor (= DHT RF, 3):
+/// FORMING → ACTIVE (>=3), ACTIVE → DEGRADED (<3), DEGRADED → ACTIVE (>=3). The evaluation is
+/// edge-driven — an unchanged state emits NO `Put` — and leaves the terminal DISSOLVING/DISSOLVED
+/// states untouched (Phase C).
+///
+/// The harness drives the real `Active` state (`Activate` then a direct `reconcile()`) and inspects
+/// the commands recorded by the stub cluster, which closes the consensus → KV loop so a re-read
+/// observes the committed transition — mirrors `ClusterDeploymentStateCommunityMintTest`.
+class ClusterDeploymentStateCommunityFsmTest {
+    private static final NodeId SELF = new NodeId("node-self");
+    private static final NodeId GOVERNOR = new NodeId("node-governor");
+    private static final int VIABLE = 3;
+    private static final int NOT_VIABLE = 2;
+
+    private RecordingClusterNode cluster;
+    private InMemoryKvStore kvStore;
+    private FsmTestHarness<ClusterDeploymentState, ClusterFsmEvent> harness;
+
+    @BeforeEach
+    void setUp() {
+        var router = MessageRouter.mutable();
+        kvStore = new InMemoryKvStore(router);
+        cluster = new RecordingClusterNode(SELF, kvStore);
+        Function<NodeId, Option<String>> noSource = nodeId -> Option.none();
+
+        Function<Fsm<ClusterDeploymentState, ClusterFsmEvent>, ClusterDeploymentState> factory =
+                fsm -> new ClusterDeploymentContext(fsm,
+                                                    SELF,
+                                                    cluster,
+                                                    kvStore,
+                                                    router,
+                                                    stubTopologyManager(SELF),
+                                                    stubSchemaOrchestrator(),
+                                                    HealthSignalSink.noop(),
+                                                    () -> Set.of(SELF),
+                                                    () -> Set.of(SELF),
+                                                    Set::of,
+                                                    Set.of(SELF),
+                                                    DeploymentAtomicity.ALL_OR_NOTHING,
+                                                    1,
+                                                    timeSpan(300).seconds(),
+                                                    System::currentTimeMillis,
+                                                    noSource).dormant();
+        harness = FsmTestHarness.harness("community-fsm-" + SELF.id(), factory);
+        harness.dispatch(new Activate());
+    }
+
+    private void seedCommunity(String communityId, CommunityState state) {
+        kvStore.put(CommunityKey.communityKey(communityId),
+                    new CommunityValue("src", "WORKER", 100, state, 1L, Option.none()));
+    }
+
+    private void seedAnnouncement(String communityId, int memberCount) {
+        kvStore.put(GovernorAnnouncementKey.forCommunity(communityId),
+                    GovernorAnnouncementValue.governorAnnouncementValue(GOVERNOR, memberCount));
+    }
+
+    private void reconcile() {
+        ((ClusterDeploymentState.Active) harness.state()).reconcile();
+    }
+
+    private List<CommunityValue> communityPutsFor(String communityId) {
+        var key = CommunityKey.communityKey(communityId);
+
+        return cluster.commands.stream()
+                               .filter(command -> command instanceof KVCommand.Put<AetherKey, ?> put
+                                                  && put.key().equals(key)
+                                                  && put.value() instanceof CommunityValue)
+                               .map(command -> (CommunityValue) ((KVCommand.Put<AetherKey, AetherValue>) command).value())
+                               .toList();
+    }
+
+    @Nested
+    class Promotion {
+        @Test
+        void reconcile_formingCommunityAtFloor_transitionsToActive() {
+            seedCommunity("orders-w-0", CommunityState.FORMING);
+            seedAnnouncement("orders-w-0", VIABLE);
+
+            reconcile();
+
+            var puts = communityPutsFor("orders-w-0");
+
+            assertThat(puts).as("a FORMING community at the viability floor is promoted to ACTIVE").hasSize(1);
+            assertThat(puts.getFirst().state()).isEqualTo(CommunityState.ACTIVE);
+        }
+
+        @Test
+        void reconcile_promotionPreservesEveryOtherField() {
+            seedCommunity("orders-w-0", CommunityState.FORMING);
+            seedAnnouncement("orders-w-0", VIABLE);
+
+            reconcile();
+
+            var put = communityPutsFor("orders-w-0").getFirst();
+
+            assertThat(put.sourceName()).as("the transition re-stamps only state").isEqualTo("src");
+            assertThat(put.role()).isEqualTo("WORKER");
+            assertThat(put.targetSize()).isEqualTo(100);
+            assertThat(put.createdAt()).isEqualTo(1L);
+        }
+
+        @Test
+        void reconcile_degradedCommunityAtFloor_transitionsToActive() {
+            seedCommunity("orders-w-0", CommunityState.DEGRADED);
+            seedAnnouncement("orders-w-0", VIABLE);
+
+            reconcile();
+
+            var puts = communityPutsFor("orders-w-0");
+
+            assertThat(puts).as("a DEGRADED community that regains the floor is promoted to ACTIVE").hasSize(1);
+            assertThat(puts.getFirst().state()).isEqualTo(CommunityState.ACTIVE);
+        }
+    }
+
+    @Nested
+    class Demotion {
+        @Test
+        void reconcile_activeCommunityBelowFloor_transitionsToDegraded() {
+            seedCommunity("orders-w-0", CommunityState.ACTIVE);
+            seedAnnouncement("orders-w-0", NOT_VIABLE);
+
+            reconcile();
+
+            var puts = communityPutsFor("orders-w-0");
+
+            assertThat(puts).as("an ACTIVE community below the floor is demoted to DEGRADED").hasSize(1);
+            assertThat(puts.getFirst().state()).isEqualTo(CommunityState.DEGRADED);
+        }
+
+        @Test
+        void reconcile_activeCommunityWithNoAnnouncement_transitionsToDegraded() {
+            seedCommunity("orders-w-0", CommunityState.ACTIVE);
+            // no governor announcement → observed live members = 0 < floor
+
+            reconcile();
+
+            var puts = communityPutsFor("orders-w-0");
+
+            assertThat(puts).as("an ACTIVE community with no governor (0 live members) is demoted to DEGRADED").hasSize(1);
+            assertThat(puts.getFirst().state()).isEqualTo(CommunityState.DEGRADED);
+        }
+    }
+
+    @Nested
+    class EdgeDriven {
+        @Test
+        void reconcile_activeCommunityAtFloor_emitsNoPut() {
+            seedCommunity("orders-w-0", CommunityState.ACTIVE);
+            seedAnnouncement("orders-w-0", VIABLE);
+
+            reconcile();
+
+            assertThat(communityPutsFor("orders-w-0"))
+                    .as("an already-ACTIVE community at the floor is unchanged — no Put may be emitted")
+                    .isEmpty();
+        }
+
+        @Test
+        void reconcile_formingCommunityBelowFloor_emitsNoPut() {
+            seedCommunity("orders-w-0", CommunityState.FORMING);
+            seedAnnouncement("orders-w-0", NOT_VIABLE);
+
+            reconcile();
+
+            assertThat(communityPutsFor("orders-w-0"))
+                    .as("a FORMING community still below the floor stays FORMING — no Put may be emitted")
+                    .isEmpty();
+        }
+    }
+
+    @Nested
+    class TerminalStatesUntouched {
+        @Test
+        void reconcile_dissolvingCommunity_isLeftUntouched() {
+            seedCommunity("orders-w-0", CommunityState.DISSOLVING);
+            seedAnnouncement("orders-w-0", VIABLE);
+
+            reconcile();
+
+            assertThat(communityPutsFor("orders-w-0"))
+                    .as("a DISSOLVING community is a Phase-C teardown concern and must not be touched")
+                    .isEmpty();
+        }
+
+        @Test
+        void reconcile_dissolvedCommunity_isLeftUntouched() {
+            seedCommunity("orders-w-0", CommunityState.DISSOLVED);
+            seedAnnouncement("orders-w-0", VIABLE);
+
+            reconcile();
+
+            assertThat(communityPutsFor("orders-w-0"))
+                    .as("a DISSOLVED community is terminal and must not be touched")
+                    .isEmpty();
+        }
+    }
+
+    // --- test fixtures (mirrors ClusterDeploymentStateCommunityMintTest) ---
+
+    private static SchemaOrchestratorService stubSchemaOrchestrator() {
+        return new SchemaOrchestratorService() {
+            @Override public Promise<Unit> migrateIfNeeded(String datasourceName) {
+                return Promise.success(Unit.unit());
+            }
+
+            @Override public Promise<Unit> undoTo(String datasourceName, int targetVersion) {
+                return Promise.success(Unit.unit());
+            }
+
+            @Override public Promise<Unit> baseline(String datasourceName, int version) {
+                return Promise.success(Unit.unit());
+            }
+        };
+    }
+
+    private static TopologyManager stubTopologyManager(NodeId self) {
+        return new TopologyManager() {
+            @Override public NodeInfo self() {
+                return NodeInfo.nodeInfo(self, new NodeAddress("localhost", 9000));
+            }
+
+            @Override public Option<NodeInfo> get(NodeId id) {
+                return Option.some(NodeInfo.nodeInfo(id, new NodeAddress("localhost", 9000)));
+            }
+
+            @Override public int clusterSize() {
+                return 1;
+            }
+
+            @Override public Option<NodeId> reverseLookup(SocketAddress socketAddress) {
+                return Option.empty();
+            }
+
+            @Override public Promise<Unit> start() {
+                return Promise.unitPromise();
+            }
+
+            @Override public Promise<Unit> stop() {
+                return Promise.unitPromise();
+            }
+
+            @Override public TimeSpan pingInterval() {
+                return timeSpan(5).seconds();
+            }
+
+            @Override public TimeSpan helloTimeout() {
+                return timeSpan(5).seconds();
+            }
+
+            @Override public Option<NodeState> getState(NodeId id) {
+                return Option.empty();
+            }
+
+            @Override public List<NodeId> topology() {
+                return List.of(self);
+            }
+        };
+    }
+
+    private static final class RecordingClusterNode implements ClusterNode<KVCommand<AetherKey>> {
+        final NodeId self;
+        final List<KVCommand<AetherKey>> commands = Collections.synchronizedList(new ArrayList<>());
+        private final InMemoryKvStore committed;
+
+        RecordingClusterNode(NodeId self, InMemoryKvStore committed) {
+            this.self = self;
+            this.committed = committed;
+        }
+
+        @Override public NodeId self() {return self;}
+
+        @Override public TopologyManager topologyManager() {return stubTopologyManager(self);}
+
+        @Override public Promise<Unit> start() {return Promise.unitPromise();}
+
+        @Override public Promise<Unit> stop() {return Promise.unitPromise();}
+
+        // Mirror the real consensus → KV replication loop: an applied batch is recorded AND committed
+        // into the shared KV store, so a subsequent community-state read observes it.
+        @Override public <R> Promise<List<R>> apply(List<KVCommand<AetherKey>> batch) {
+            commands.addAll(batch);
+            committed.commit(batch);
+            return Promise.success(Collections.emptyList());
+        }
+    }
+
+    private static final class InMemoryKvStore extends KVStore<AetherKey, AetherValue> {
+        InMemoryKvStore(MessageRouter router) {
+            super(router, stubSerializer(), stubDeserializer());
+        }
+
+        void put(AetherKey key, AetherValue value) {
+            process(createBatch(List.of(new KVCommand.Put<>(key, value))));
+        }
+
+        void commit(List<KVCommand<AetherKey>> batch) {
+            process(createBatch(batch));
+        }
+    }
+
+    private static Serializer stubSerializer() {
+        return new Serializer() {
+            @Override public <T> void write(ByteBuf byteBuf, T object) {}
+        };
+    }
+
+    private static Deserializer stubDeserializer() {
+        return new Deserializer() {
+            @Override public <T> T read(ByteBuf byteBuf) {
+                return null;
+            }
+        };
+    }
+}

--- a/aether/aether-deployment/src/test/java/org/pragmatica/aether/deployment/cluster/fsm/CommunityPlacementPlannerTest.java
+++ b/aether/aether-deployment/src/test/java/org/pragmatica/aether/deployment/cluster/fsm/CommunityPlacementPlannerTest.java
@@ -45,10 +45,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.pragmatica.lang.io.TimeSpan.timeSpan;
 
 /// #241 (worker-membership-spec D1 / §3.3): the placement planner's DESIRED community set is the
-/// committed [`CommunityKey`]/[`CommunityValue`] facts — a community exists the moment the leader
-/// mints its key (FORMING), before any governor has announced. Terminal teardown states
-/// (`DISSOLVING`/`DISSOLVED`) are excluded; `FORMING`/`ACTIVE`/`DEGRADED` are all desired (the
-/// per-community FSM that drives strict `ACTIVE` is slice 2).
+/// committed [`CommunityKey`]/[`CommunityValue`] facts, gated on the strictly `ACTIVE` state. Slice
+/// 2's per-community FSM drives a community to `ACTIVE` once observed live membership reaches the
+/// viability floor, so `FORMING` (not yet viable), `DEGRADED` (lost quorum), and terminal
+/// `DISSOLVING`/`DISSOLVED` are all excluded from placement.
 class CommunityPlacementPlannerTest {
     private static final NodeId SELF = new NodeId("node-self");
 
@@ -90,27 +90,38 @@ class CommunityPlacementPlannerTest {
     }
 
     @Test
-    void activeCommunityIds_committedFormingCommunity_isIncludedInDesiredSet() {
-        seedCommunity("src-w-0", CommunityState.FORMING);
+    void activeCommunityIds_committedActiveCommunity_isIncludedInDesiredSet() {
+        seedCommunity("src-w-0", CommunityState.ACTIVE);
 
         assertThat(planner().activeCommunityIds())
-                .as("a committed FORMING community is desired before any governor announces")
+                .as("a committed ACTIVE community is desired")
                 .containsExactly("src-w-0");
     }
 
     @Test
-    void activeCommunityIds_activeAndDegraded_areIncluded() {
-        seedCommunity("a-w-0", CommunityState.ACTIVE);
-        seedCommunity("b-w-0", CommunityState.DEGRADED);
+    void activeCommunityIds_formingAndDegraded_areExcluded() {
+        seedCommunity("forming-w-0", CommunityState.FORMING);
+        seedCommunity("degraded-w-0", CommunityState.DEGRADED);
 
         assertThat(planner().activeCommunityIds())
-                .as("ACTIVE and DEGRADED communities are both desired")
-                .containsExactlyInAnyOrder("a-w-0", "b-w-0");
+                .as("FORMING (not yet viable) and DEGRADED (lost quorum) are excluded under strict-ACTIVE gating")
+                .isEmpty();
+    }
+
+    @Test
+    void activeCommunityIds_onlyActiveAmongMixedStates_isIncluded() {
+        seedCommunity("forming-w-0", CommunityState.FORMING);
+        seedCommunity("active-w-0", CommunityState.ACTIVE);
+        seedCommunity("degraded-w-0", CommunityState.DEGRADED);
+
+        assertThat(planner().activeCommunityIds())
+                .as("only the ACTIVE community survives strict-ACTIVE gating")
+                .containsExactly("active-w-0");
     }
 
     @Test
     void activeCommunityIds_dissolvedCommunity_isExcluded() {
-        seedCommunity("live-w-0", CommunityState.FORMING);
+        seedCommunity("live-w-0", CommunityState.ACTIVE);
         seedCommunity("dead-w-0", CommunityState.DISSOLVED);
 
         assertThat(planner().activeCommunityIds())

--- a/aether/slice/src/main/java/org/pragmatica/aether/slice/kvstore/AetherValue.java
+++ b/aether/slice/src/main/java/org/pragmatica/aether/slice/kvstore/AetherValue.java
@@ -1448,6 +1448,13 @@ public sealed interface AetherValue {
                                       System.currentTimeMillis(),
                                       none());
         }
+
+        /// Per-community FSM transition (worker-membership-spec §3.3): the leader re-stamps only the
+        /// `state` on an edge, preserving every other committed field. Mirrors
+        /// [NodeArtifactValue#withState] — a copy via the canonical constructor.
+        public CommunityValue withState(CommunityState newState) {
+            return new CommunityValue(sourceName, role, targetSize, newState, createdAt, dissolvedAt);
+        }
     }
 
     /// Canonical field order: `(spawnedAtMs, assignedNodeId, occupantEpoch, supersededNodeId)`.

--- a/aether/slice/src/test/java/org/pragmatica/aether/slice/kvstore/CommunityValueTest.java
+++ b/aether/slice/src/test/java/org/pragmatica/aether/slice/kvstore/CommunityValueTest.java
@@ -95,4 +95,35 @@ class CommunityValueTest {
             }
         }
     }
+
+    @Nested
+    class WithState {
+        @Test
+        void withState_swapsStateAndPreservesEveryOtherField() {
+            var original = CommunityValue.communityValue("orders",
+                                                         "WORKER",
+                                                         5,
+                                                         CommunityState.FORMING,
+                                                         1710072000000L,
+                                                         Option.some(1710072500000L));
+
+            var updated = original.withState(CommunityState.ACTIVE);
+
+            assertThat(updated.state()).isEqualTo(CommunityState.ACTIVE);
+            assertThat(updated.sourceName()).isEqualTo(original.sourceName());
+            assertThat(updated.role()).isEqualTo(original.role());
+            assertThat(updated.targetSize()).isEqualTo(original.targetSize());
+            assertThat(updated.createdAt()).isEqualTo(original.createdAt());
+            assertThat(updated.dissolvedAt()).isEqualTo(original.dissolvedAt());
+        }
+
+        @Test
+        void withState_leavesOriginalUnchanged() {
+            var original = CommunityValue.communityValue("orders", "WORKER", 3);
+
+            original.withState(CommunityState.DEGRADED);
+
+            assertThat(original.state()).isEqualTo(CommunityState.FORMING);
+        }
+    }
 }


### PR DESCRIPTION
## #241 slice 2 — per-community FSM (leader-evaluated)

Second slice of Phase A, building on the merged slice 1 (#357). Communities now have a **driven lifecycle**: the leader evaluates each committed community's observed membership every reconcile tick and transitions its `CommunityValue.state` on edges. Before this, communities only ever sat in `FORMING`.

### Transitions (spec §3.3, viability floor = RF = 3)
| From → To | Trigger |
|---|---|
| FORMING → ACTIVE | live members ≥ 3 (first governor announcement reaching RF) |
| ACTIVE → DEGRADED | live members < 3 (or no governor announcement → 0) |
| DEGRADED → ACTIVE | live members ≥ 3 (recovery) |
| DISSOLVING / DISSOLVED | **unchanged** — leader-decision/scale-down/drain → **Phase C** |

`liveMembers` = the community's `GovernorAnnouncementValue.memberCount()` (0 when no governor has announced).

### How
- `nextCommunityState(current, liveMembers)` — pure, exhaustive switch over `CommunityState`.
- `evaluateCommunityStates()` — enumerates committed `CommunityKey`/`CommunityValue`, and for each that **changes** state adds a `CommunityKey` Put to one batch (`ctx.cluster().apply`), then applies atomically. **Edge-driven**: no write when state is unchanged. Called inside `reconcile()` (after blueprint reconciliation, before cleanups) — under the existing leader-only `deactivated` guard.
- `CommunityValue.withState(...)` — field-preserving state re-stamp.
- `CommunityPlacementPlanner.activeCommunityIds()` **tightened to strict `state == ACTIVE`** (the FSM now drives ACTIVE, so placement targets only viable communities; FORMING/DEGRADED are excluded from the desired set).

### Tests
`ClusterDeploymentStateCommunityFsmTest` (9 — every transition + **edge-driven no-write** for unchanged state + DISSOLVING/DISSOLVED left untouched, via the `RecordingClusterNode` consensus→KV loop), `CommunityValueTest.withState` (preserves all other fields), `CommunityPlacementPlannerTest` (strict-ACTIVE). **Full reactor green, 736 tests, 0 failures.**

### Heads-up
Adds a step to `ClusterDeploymentState.reconcile()` (your deployment FSM) — purely additive, leader-guarded, edge-driven (no extra consensus traffic at steady state). `CommunityPlacementPlanner` is the slice-1 file.

*(Note: `jbct:check` flags 2 pre-existing format issues in `AetherKey.java` / `OwnershipEpochHighWater.java` — untouched merged files from slice-1 squash / #345; left scoped out. Full reactor install is green.)*

### Next
Phase A continues — worker `connectionSet` projection · governor election read-source swap · announcement-TTL liveness + spokesman retirement (D4) · `NodeInfo` lazy label pull · `GroupAssignment` deletion. The DISSOLVING/DISSOLVED transitions land with Phase C (growth/scale/drain).

Per our flow: **please review + merge — I won't self-merge.**
