### PR TITLE
fix: fully-qualify generated type references in slice-processor codegen

### DIFF
--- a/jbct/slice-processor-tests/src/main/java/com/example/collisionslice/BuyError.java
+++ b/jbct/slice-processor-tests/src/main/java/com/example/collisionslice/BuyError.java
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2025 Pragmatica Labs - Sergiy Yevtushenko
+// Licensed under Business Source License 1.1. Change Date: 2030-01-01. Change License: Apache-2.0.
+// See LICENSE in the repository root for full terms.
+
+package com.example.collisionslice;
+
+import org.pragmatica.lang.Cause;
+
+/// Buy-side failures. Its nested `StoreUnavailable` deliberately shares a simple name with
+/// [CancelError.StoreUnavailable] to exercise the generator's simple-name collision handling.
+public sealed interface BuyError extends Cause {
+    record StoreUnavailable(String reason) implements BuyError {
+        @Override
+        public String message() {
+            return "buy store unavailable: " + reason;
+        }
+    }
+}

--- a/jbct/slice-processor-tests/src/main/java/com/example/collisionslice/CancelError.java
+++ b/jbct/slice-processor-tests/src/main/java/com/example/collisionslice/CancelError.java
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2025 Pragmatica Labs - Sergiy Yevtushenko
+// Licensed under Business Source License 1.1. Change Date: 2030-01-01. Change License: Apache-2.0.
+// See LICENSE in the repository root for full terms.
+
+package com.example.collisionslice;
+
+import org.pragmatica.lang.Cause;
+
+/// Cancel-side failures. Its nested `StoreUnavailable` deliberately shares a simple name with
+/// [BuyError.StoreUnavailable] to exercise the generator's simple-name collision handling.
+public sealed interface CancelError extends Cause {
+    record StoreUnavailable(String reason) implements CancelError {
+        @Override
+        public String message() {
+            return "cancel store unavailable: " + reason;
+        }
+    }
+}

--- a/jbct/slice-processor-tests/src/main/java/com/example/collisionslice/CollisionSlice.java
+++ b/jbct/slice-processor-tests/src/main/java/com/example/collisionslice/CollisionSlice.java
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2025 Pragmatica Labs - Sergiy Yevtushenko
+// Licensed under Business Source License 1.1. Change Date: 2030-01-01. Change License: Apache-2.0.
+// See LICENSE in the repository root for full terms.
+
+package com.example.collisionslice;
+
+import org.pragmatica.aether.slice.annotation.Slice;
+import org.pragmatica.lang.Promise;
+
+/// Regression slice for the route-import simple-name collision bug.
+///
+/// The package declares two unrelated error families ([BuyError] and [CancelError]) whose nested
+/// failure records share the simple name `StoreUnavailable`. Both are discovered for this slice and
+/// mapped via `routes.toml`. The generator must reference them by fully-qualified name in the error
+/// switch and must NOT emit two single-type imports of the same simple name (which fails to compile).
+@Slice
+public interface CollisionSlice {
+    record BuyRequest(Long id) {}
+
+    record CancelRequest(Long id) {}
+
+    record OpResponse(Long id, String status) {}
+
+    Promise<OpResponse> buy(BuyRequest request);
+
+    Promise<OpResponse> cancel(CancelRequest request);
+
+    static CollisionSlice collisionSlice() {
+        return new CollisionSlice() {
+            @Override
+            public Promise<OpResponse> buy(BuyRequest request) {
+                return Promise.success(new OpResponse(request.id(), "bought"));
+            }
+
+            @Override
+            public Promise<OpResponse> cancel(CancelRequest request) {
+                return Promise.success(new OpResponse(request.id(), "cancelled"));
+            }
+        };
+    }
+}

--- a/jbct/slice-processor-tests/src/main/resources/com/example/collisionslice/routes.toml
+++ b/jbct/slice-processor-tests/src/main/resources/com/example/collisionslice/routes.toml
@@ -1,0 +1,9 @@
+prefix = "/api/collision"
+
+[routes]
+buy = "GET /buy/{id:Long}"
+cancel = "GET /cancel/{id:Long}"
+
+[errors]
+default = 500
+HTTP_503 = ["*StoreUnavailable*"]

--- a/jbct/slice-processor-tests/src/test/java/com/example/collisionslice/GeneratedCollisionRouteTest.java
+++ b/jbct/slice-processor-tests/src/test/java/com/example/collisionslice/GeneratedCollisionRouteTest.java
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2025 Pragmatica Labs - Sergiy Yevtushenko
+// Licensed under Business Source License 1.1. Change Date: 2030-01-01. Change License: Apache-2.0.
+// See LICENSE in the repository root for full terms.
+
+package com.example.collisionslice;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/// Regression gate for the route-import simple-name collision bug in `RouteSourceGenerator`.
+///
+/// [CollisionSlice]'s package declares two error families ([BuyError], [CancelError]) whose nested
+/// failure records both have the simple name `StoreUnavailable`. Before the fix the generator emitted
+/// one single-type `import` per mapped error type unconditionally, so it produced
+/// `import com.example.collisionslice.BuyError.StoreUnavailable;` AND
+/// `import com.example.collisionslice.CancelError.StoreUnavailable;` — two single-type imports of the
+/// same simple name, which is a compile error. The generated `CollisionSliceRoutes` therefore failed
+/// to compile, and (because this module compiles generated sources with javac) so did the whole
+/// module. The fix skips the colliding imports and the error switch references those types by their
+/// fully-qualified name, mirroring the logic already used by `generateErrorMapperMethod`.
+///
+/// The strongest assertion here is implicit: if the generator regressed, this module would not
+/// compile and these tests would not run at all. The explicit assertions pin the generated shape.
+class GeneratedCollisionRouteTest {
+
+    private static String generated;
+
+    @BeforeAll
+    static void readGeneratedSource() throws IOException {
+        generated = Files.readString(locateGeneratedRoutes());
+    }
+
+    private static Path locateGeneratedRoutes() {
+        var moduleDir = Paths.get(System.getProperty("user.dir"));
+        var relative = Paths.get("target", "generated-sources", "annotations",
+                                 "com", "example", "collisionslice", "CollisionSliceRoutes.java");
+        var candidate = moduleDir.resolve(relative);
+        if (Files.exists(candidate)) {
+            return candidate;
+        }
+        // Reactor builds may run from the repo root; fall back to the module-qualified path.
+        return moduleDir.resolve(Paths.get("jbct", "slice-processor-tests")).resolve(relative);
+    }
+
+    @Test
+    void collidingErrorSimpleNames_doNotProduceDuplicateSingleTypeImports() {
+        assertThat(generated).doesNotContain("import com.example.collisionslice.BuyError.StoreUnavailable;");
+        assertThat(generated).doesNotContain("import com.example.collisionslice.CancelError.StoreUnavailable;");
+    }
+
+    @Test
+    void collidingErrorSimpleNames_areReferencedByFullyQualifiedCase() {
+        assertThat(generated).contains("case com.example.collisionslice.BuyError.StoreUnavailable");
+        assertThat(generated).contains("case com.example.collisionslice.CancelError.StoreUnavailable");
+        assertThat(generated).contains("public ErrorMapper errorMapper()");
+    }
+}

--- a/jbct/slice-processor/src/main/java/org/pragmatica/jbct/slice/generator/FactoryClassGenerator.java
+++ b/jbct/slice-processor/src/main/java/org/pragmatica/jbct/slice/generator/FactoryClassGenerator.java
@@ -1539,7 +1539,11 @@ public class FactoryClassGenerator {
     }
 
     private void generateTypeCodecEntry(PrintWriter out, CodecTypeEntry entry, String comma) {
-        var name = entry.simpleName();
+        // Fully-qualify type references: the codec() body lives inside the slice adapter record, which
+        // implements the host slice interface. The host's nested Request/Response are inherited member
+        // types that shadow single-type imports (JLS 6.5.5.2), so a simple name for an injected slice's
+        // Request/Response would silently resolve to the host's types. FQN is always valid and avoids this.
+        var name = entry.qualifiedName();
         var fqn = entry.qualifiedName();
         switch (entry.kind()) {
             case RECORD -> generateRecordTypeCodec(out, entry, comma);
@@ -1559,7 +1563,9 @@ public class FactoryClassGenerator {
     }
 
     private void generateRecordTypeCodec(PrintWriter out, CodecTypeEntry entry, String comma) {
-        var name = entry.simpleName();
+        // Fully-qualify the type reference (see generateTypeCodecEntry): a simple name here would be
+        // shadowed by the host slice's inherited nested Request/Response member types (JLS 6.5.5.2).
+        var name = entry.qualifiedName();
         var fqn = entry.qualifiedName();
         var components = entry.components();
         out.println("                    new SliceCodec.TypeCodec<" + name + ">(" + name + ".class,");

--- a/jbct/slice-processor/src/main/java/org/pragmatica/jbct/slice/routing/RouteSourceGenerator.java
+++ b/jbct/slice-processor/src/main/java/org/pragmatica/jbct/slice/routing/RouteSourceGenerator.java
@@ -312,8 +312,16 @@ public class RouteSourceGenerator {
         if (routeConfig.isVersioned()) {
             out.println("import java.util.List;");
         }
-        // Import error types
+        // Import error types -- skip simple-name collisions. When two error types share a simple
+        // name, the error switch (generateErrorMapperMethod) references them by fully-qualified
+        // name, so two single-type imports of the same simple name would only fail to compile.
+        var errorSimpleNameCounts = errorMappings.stream()
+                                                 .collect(Collectors.groupingBy(ErrorTypeMapping::simpleName,
+                                                                                Collectors.counting()));
         for (var mapping : errorMappings) {
+            if (errorSimpleNameCounts.get(mapping.simpleName()) > 1) {
+                continue;
+            }
             out.println("import " + mapping.qualifiedName() + ";");
         }
     }

--- a/jbct/slice-processor/src/test/java/org/pragmatica/jbct/slice/SliceProcessorTest.java
+++ b/jbct/slice-processor/src/test/java/org/pragmatica/jbct/slice/SliceProcessorTest.java
@@ -538,6 +538,76 @@ class SliceProcessorTest {
     }
 
     @Test
+    void should_fully_qualify_codec_types_for_injected_slice_with_colliding_nested_records() throws Exception {
+        // Regression for codec-generation shadowing bug: the host slice's adapter record `implements`
+        // the host interface, whose nested Request/Response are inherited member types. By JLS 6.5.5.2
+        // they shadow single-type imports, so a SIMPLE name for an injected slice's nested Request/Response
+        // in the generated codec() body silently resolves to the HOST's types -> wrong-arity constructor /
+        // missing accessor compile errors. The fix emits fully-qualified names for codec type references.
+        // The two slices below use nested Request/Response with DIFFERENT arity so any regression is a hard
+        // compile failure that compile-testing's succeeded() will catch.
+        var quote = JavaFileObjects.forSourceString("pricing.Quote",
+                                                    """
+            package pricing;
+
+            import org.pragmatica.lang.Promise;
+
+            public interface Quote {
+                Promise<Response> price(Request request);
+
+                record Request(String event) {}
+                record Response(String event, long amountMinor) {}
+            }
+            """);
+
+        var source = JavaFileObjects.forSourceString("test.Reservation",
+                                                     """
+            package test;
+
+            import org.pragmatica.aether.slice.annotation.Slice;
+            import org.pragmatica.lang.Promise;
+            import pricing.Quote;
+
+            @Slice
+            public interface Reservation {
+                Promise<Response> reserve(Request request);
+
+                record Request(String seat, String customer) {}
+                record Response(String booking, long total, String currency) {}
+
+                static Reservation reservation(Quote quote) {
+                    return null;
+                }
+            }
+            """);
+
+        var sources = commonSources();
+        sources.add(quote);
+        sources.add(source);
+
+        Compilation compilation = javac()
+                                       .withProcessors(new SliceProcessor())
+                                       .compile(sources);
+
+        assertCompilation(compilation).succeeded();
+
+        var factoryContent = compilation.generatedSourceFile("test.ReservationFactory")
+                                        .get()
+                                        .getCharContent(false)
+                                        .toString();
+
+        // The injected slice's codec entries must be fully qualified, not the bare simple name that
+        // would be shadowed by the host's inherited Reservation.Request/Response member types.
+        assertThat(factoryContent).contains("new SliceCodec.TypeCodec<pricing.Quote.Response>(pricing.Quote.Response.class,");
+        assertThat(factoryContent).contains("return new pricing.Quote.Response(");
+        assertThat(factoryContent).contains("new SliceCodec.TypeCodec<pricing.Quote.Request>(pricing.Quote.Request.class,");
+        assertThat(factoryContent).contains("return new pricing.Quote.Request(");
+        // The buggy bare form must never be emitted.
+        assertThat(factoryContent).doesNotContain("new SliceCodec.TypeCodec<Response>(Response.class,");
+        assertThat(factoryContent).doesNotContain("new SliceCodec.TypeCodec<Request>(Request.class,");
+    }
+
+    @Test
     void should_generate_correct_type_tokens_for_slice_methods() throws Exception {
         var request = JavaFileObjects.forSourceString("test.dto.CreateUserRequest",
                                                       """


### PR DESCRIPTION
Two slice-processor code-generation bugs, both rooted in emitting **simple** type names where the generated code's context can shadow them. Both surfaced building a real one-slice-per-use-case Aether application whose idioms (per-VO `Blank`/`Malformed` errors; every slice exposing nested `Request`/`Response`) make the collisions unavoidable.

**1. Route import collision** — `RouteSourceGenerator` emitted one single-type `import` per error type by simple name. When two error types share a simple name (e.g. `BuyError.StoreUnavailable` and `CancelError.StoreUnavailable`, or `Blank`/`Malformed` across several value objects) the generated `*Routes.java` has duplicate single-type imports and fails to compile — even though the error `switch` already references them by FQN. Fix: skip the colliding imports (the switch already qualifies them).

**2. Codec type shadowing** — when a slice injects another slice, `FactoryClassGenerator` emitted the injected slice's nested `Request`/`Response` by simple name in the generated codec table. That code lives inside the adapter record which `implements` the host slice, so the host's inherited nested `Request`/`Response` member types shadow the single-type imports (JLS 6.5.5.2) — silently binding to the wrong record. Fix: fully-qualify the type references (always valid Java).

Both fixes emit fully-qualified names; each has a regression test (route: a colliding-error integration slice in `slice-processor-tests`; codec: a host-injecting-slice compile test in `SliceProcessorTest`). `slice-processor` and `slice-processor-tests` suites pass.