### PR TITLE
test: pin ARCH-04 absent-own-slice behaviour and document the ARCH-01/02 asymmetry (#548)

### DIFF
--- a/jbct/jbct-lint/src/main/java/org/pragmatica/jbct/lint/cst/rules/CstArchSliceInternalRule.java
+++ b/jbct/jbct-lint/src/main/java/org/pragmatica/jbct/lint/cst/rules/CstArchSliceInternalRule.java
@@ -23,6 +23,17 @@ import static org.pragmatica.jbct.parser.CstNodes.*;
 /// child of a `usecase` segment (`com.example.usecase.registeruser`). With no slice classification
 /// available for the referenced package, the rule is silent.
 ///
+/// An absent slice root for the *analysed file* is a different case, and deliberately NOT silent.
+/// The question this rule asks is whether the file sits in the same slice as the internal it reaches
+/// into, and "belongs to no slice" answers that definitively: a file outside every slice may still
+/// only touch a slice's public root. Note the asymmetry with JBCT-ARCH-01/02, which need *both*
+/// endpoints ranked before a direction can be compared and therefore must stay silent when either is
+/// unclassified — this rule needs only a same-or-different answer, so one endpoint suffices. A file
+/// genuinely inside the referenced slice cannot lose its own root: `explicitSliceRoot` walks prefixes
+/// shortest-first, so a slice member and its sibling internal resolve to the same root, and if the
+/// globs miss the slice entirely then the referenced package does not classify either and the rule
+/// falls silent anyway.
+///
 /// Lineage: this rule delivers the cross-slice import boundary that the retired no-op JBCT-SLICE-01
 /// surface (removed in #450) never enforced; it is realised as a specialization of the #452
 /// package-classification engine rather than by reviving the SLICE-01 ID. Severity ships at WARNING

--- a/jbct/jbct-lint/src/test/java/org/pragmatica/jbct/lint/cst/rules/CstArchSliceInternalRuleTest.java
+++ b/jbct/jbct-lint/src/test/java/org/pragmatica/jbct/lint/cst/rules/CstArchSliceInternalRuleTest.java
@@ -57,6 +57,21 @@ class CstArchSliceInternalRuleTest {
                     }
                     """));
         }
+
+        /// A file belonging to no slice is NOT an unclassified endpoint the rule should skip. The
+        /// check asks "same slice as the internal being reached into?", and "no slice" answers it —
+        /// code outside every slice may still only touch a slice's public root. Pins the asymmetry
+        /// with JBCT-ARCH-01/02, which do fall silent on an unclassified own-layer because a
+        /// direction cannot be compared without both endpoints ranked (see #548, closed as
+        /// not-a-bug after this behaviour was mistaken for that one).
+        @Test
+        void detects_referenceFromFileBelongingToNoSlice() {
+            assertTrue(hasRule("""
+                    package com.example.shared;
+                    import com.example.usecase.loginuser.internal.Token;
+                    class SharedHelper {}
+                    """));
+        }
     }
 
     @Nested


### PR DESCRIPTION
Closes #548, **as not-a-bug**. Documentation and a pinning test only — no behaviour change.

## #548 was wrong, and it was my misreading

The issue claimed `CstArchSliceInternalRule` over-flags because `belongsToSameSlice` maps an absent own-slice-root to `false`, treating "unknown" as "outside every slice". Reading the full check rather than that method in isolation shows the opposite:

```java
sliceRootOf(referencedPackage)
  .filter(root -> !referencedPackage.equals(root))       // referenced package is an *internal*
  .filter(root -> !belongsToSameSlice(fileSliceRoot, root))
```

The rule's invariant is that only a slice may touch its own internals. So the question is **"is this file in the same slice as the internal it reaches into?"** — and "belongs to no slice" answers that definitively. Code outside every slice may still only touch a slice's public root. `.or(false)` is correct.

The bad analogy was to JBCT-ARCH-01/02. Those rules genuinely must stay silent on an unclassified own-layer, because comparing a *direction* needs both endpoints ranked. This rule needs only a same-or-different answer, so one endpoint suffices. Same-shaped `Option` code, different requirement.

I also checked the one path that would make it a real false positive — a file genuinely inside the referenced slice that fails to resolve its own root. It cannot happen: `explicitSliceRoot` walks prefixes shortest-first, so a slice member and its sibling internal resolve to the same root; and if the globs miss the slice entirely, the *referenced* package does not classify either and the rule falls silent anyway.

## What this PR does

Records the reasoning where the next reader will find it, so the same inference is not made twice:

- **Javadoc** on `CstArchSliceInternalRule` stating that an absent own-slice root is deliberately not silent, why the ARCH-01/02 asymmetry exists, and why a slice member cannot lose its root. The class previously documented only the *referenced*-side absent case, which is precisely the gap that made the file-side behaviour look accidental.
- **A pinning test**, `Violations.detects_referenceFromFileBelongingToNoSlice`: a file in `com.example.shared` importing `com.example.usecase.loginuser.internal.Token` is flagged.

## Verification

- **Inert.** `git diff --stat`: 2 files, 26 insertions, 0 deletions — 11 lines of `///` javadoc and one 15-line test. No code line changed. A full lint sweep over 2107 aether files is byte-identical between this branch and rc3: 13636 diagnostics, 44 rules with hits, matching sha256 digest.
- **691/691 tests pass**; `CstArchSliceInternalRuleTest$Violations` goes 3 → 4, confirming the new test executes.
- **The test pins the disputed behaviour**, verified by falsification: patching `.or(false)` → `.or(true)` — implementing exactly what #548 requested — fails **only** the new test, with the other nine ARCH-04 tests still green.

Caveat stated plainly: ARCH-04 fires **0 times** on the aether corpus, on both branches, because aether has no `usecase`-segment packages and no project configures `slices` globs. The no-regression claim therefore rests on the other 43 rules being identical and the diff containing no code, not on this rule's own count. It also confirms the path is unreachable in practice today — which is why the correctness argument, not live exposure, is what settles this.
