### PR TITLE
fix: wildcard in array creation gained a space — new Class<?>[0] became new Class< ?>[0] (#621)

### DIFF
--- a/aether/resource/api/src/main/java/org/pragmatica/aether/resource/aspect/TransactionConfig.java
+++ b/aether/resource/api/src/main/java/org/pragmatica/aether/resource/aspect/TransactionConfig.java
@@ -20,7 +20,7 @@ public record TransactionConfig(TransactionPropagation propagation,
                                 Class<?>[] rollbackFor) {
     private static final TransactionPropagation DEFAULT_PROPAGATION = TransactionPropagation.REQUIRED;
     private static final IsolationLevel DEFAULT_ISOLATION = IsolationLevel.DEFAULT;
-    private static final Class<?>[] EMPTY_ROLLBACK_FOR = new Class< ?>[0];
+    private static final Class<?>[] EMPTY_ROLLBACK_FOR = new Class<?>[0];
 
     public static Result<TransactionConfig> transactionConfig() {
         return success(new TransactionConfig(DEFAULT_PROPAGATION, DEFAULT_ISOLATION, none(), false, EMPTY_ROLLBACK_FOR));

--- a/jbct/jbct-format/src/main/java/org/pragmatica/jbct/format/flow/FlowPrinter.java
+++ b/jbct/jbct-format/src/main/java/org/pragmatica/jbct/format/flow/FlowPrinter.java
@@ -3115,6 +3115,15 @@ final class FlowPrinter {
             return true;
         }
 
+        // A `?` directly after `<` is a WILDCARD, never a ternary: `<` cannot precede a ternary's
+        // `?` in valid Java. `?` sits in the spaced-operator set for ternaries, and that spacing is
+        // normally suppressed by `typeContextDepth`, which the array-creation path leaves at 0 — so
+        // `new Class<?>[0]` was emitted as `new Class< ?>[0]` (#621). Keying off the preceding token
+        // rather than the depth fixes it wherever the depth is not raised.
+        if (firstChar == '?' && text.length() == 1 && lastChar == '<') {
+            return true;
+        }
+
         if (lastChar == '<') {
             // Generic '<' (inside TYPE_ARGS / TYPE_PARAMS) glues to the type argument that follows
             // (`List<String`, `static <T`). A relational/shift operator '<' (any non-type context)

--- a/jbct/jbct-format/src/test/java/org/pragmatica/jbct/format/WildcardSpacingTest.java
+++ b/jbct/jbct-format/src/test/java/org/pragmatica/jbct/format/WildcardSpacingTest.java
@@ -1,0 +1,87 @@
+package org.pragmatica.jbct.format;
+
+import org.pragmatica.jbct.shared.SourceFile;
+
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.pragmatica.jbct.format.JbctFormatter.jbctFormatter;
+
+/// `new Class<?>[0]` was reformatted to `new Class< ?>[0]` (#621).
+///
+/// `?` sits in the spaced-operator set because of the ternary, and that spacing is normally
+/// suppressed by `typeContextDepth`. The array-creation path leaves that depth at 0, so the
+/// wildcard was printed as a ternary operator. The declaration form `Class<?>[] field` goes through
+/// a path that does raise the depth and was never affected — which is why the two forms are pinned
+/// separately here: they exercise different code and only one of them regressed.
+///
+/// The output still compiled (Java permits whitespace inside type arguments) and was idempotent, so
+/// nothing caught it until a full build reformatted the one file in the corpus that uses the shape.
+class WildcardSpacingTest {
+    private final JbctFormatter formatter = jbctFormatter();
+
+    @Test
+    void format_keepsWildcardGlued_inArrayCreation() {
+        assertThat(format("    Object a = new Class<?>[0];"))
+                  .contains("new Class<?>[0]")
+                  .doesNotContain("< ?");
+    }
+
+    @Test
+    void format_keepsWildcardGlued_inMultiDimensionalArrayCreation() {
+        assertThat(format("    Object a = new Class<?>[0][0];"))
+                  .contains("new Class<?>[0][0]")
+                  .doesNotContain("< ?");
+    }
+
+    @Test
+    void format_keepsWildcardGlued_inArrayCreationWithInitializer() {
+        assertThat(format("    Object a = new Class<?>[]{};"))
+                  .contains("new Class<?>[]")
+                  .doesNotContain("< ?");
+    }
+
+    /// Only the FIRST wildcard was affected — the one directly after `<`. The second sits after a
+    /// comma and was always correct, so this pins that the fix did not disturb it.
+    @Test
+    void format_keepsBothWildcardsGlued_inTwoArgumentArrayCreation() {
+        assertThat(format("    Object a = new java.util.Map<?, ?>[0];"))
+                  .contains("new java.util.Map<?, ?>[0]")
+                  .doesNotContain("< ?");
+    }
+
+    /// The declaration form always worked. Pinned so a fix for the creation form cannot break it.
+    @Test
+    void format_keepsWildcardGlued_inFieldDeclaration() {
+        assertThat(format("    Class<?>[] a = null;"))
+                  .contains("Class<?>[] a")
+                  .doesNotContain("< ?");
+    }
+
+    /// The `?` really is the ternary operator elsewhere, and must keep its spacing.
+    @Test
+    void format_stillSpacesTernaryOperator() {
+        var formatted = format("""
+                    int f(boolean flag) {
+                        return flag ? 1 : 2;
+                    }
+                """);
+
+        assertThat(formatted).contains("?");
+        assertThat(formatted).doesNotContain("flag? 1");
+    }
+
+    private String format(String body) {
+        var result = new String[] {null};
+
+        formatter.format(new SourceFile(Path.of("T.java"),
+                                        "package com.example;\n\npublic class T {\n" + body + "\n}\n"))
+                 .onFailure(cause -> Assertions.fail(cause.message()))
+                 .onSuccess(formatted -> result[0] = formatted.content());
+
+        return result[0];
+    }
+}


### PR DESCRIPTION
Fixes #621. Also reverts the line the repo accepted under protest in `e69392abe`, so the tree no longer carries the odd spelling.

## Cause

`?` is in the formatter's spaced-operator set because of the ternary. That spacing is normally suppressed by `typeContextDepth`, raised in `printTypeArgs` / `printTypeParams`.

**The array-creation path leaves that depth at 0.** Instrumenting `needsSpaceBefore` shows it directly — the two `new Class<?>[…]` occurrences emit `?` at `typeContextDepth=0`, while every correct occurrence emits at depth 1:

```
2 @@Q typeContextDepth=0 lastChar='<'      <- new Class<?>[0]   (wrong)
4 @@Q typeContextDepth=1 lastChar='<'      <- declarations, returns (right)
1 @@Q typeContextDepth=1 lastChar=','      <- second arg of Map<?, ?>
```

So the wildcard was printed as if it were a ternary operator.

## Fix

A `?` directly after `<` is **always** a wildcard — `<` cannot precede a ternary's `?` in valid Java. Keying off the preceding token rather than the depth fixes it wherever the depth is not raised:

```java
if (firstChar == '?' && text.length() == 1 && lastChar == '<') {
    return true;   // mustNotHaveSpaceBefore
}
```

I deliberately did **not** chase the deeper cause (making the array-creation path raise `typeContextDepth`). `<` and `>` are already spaced correctly in that position, so `?` is the only observable symptom, and widening the change would touch every generic-printing path for no measured gain. The comment at the guard records the root cause so the next person has it.

## Scope, measured

| shape | before | after |
|---|---|---|
| `new Class<?>[0]` | `new Class< ?>[0]` | ✅ |
| `new Class<?>[0][0]` | `new Class< ?>[0][0]` | ✅ |
| `new Class<?>[]{}` | `new Class< ?>[]{}` | ✅ |
| `new java.util.Map<?, ?>[0]` | `new java.util.Map< ?, ?>[0]` — first only | ✅ |
| `Class<?>[] field` (declaration) | already correct | unchanged |
| `flag ? 1 : 2` (ternary) | already correct | unchanged |

Only the wildcard directly after `<` was affected; the second wildcard in `Map<?, ?>` follows a comma and was always right.

## Verification

- `WildcardSpacingTest` — 6 cases, pinning the creation form and the declaration form **separately**, because they exercise different paths and only one regressed. Ternary spacing pinned too.
- **Mutation-checked**: disabling the guard turns **4 of 6** red. The 2 that stay green are the declaration and ternary cases — correctly unaffected either way.
- jbct reactor: **1481 tests, 0 failures**.
- `TransactionConfig.java` restored to `new Class<?>[0]`, and the fixed formatter now leaves that file **byte-identical**.

## Note on the guard's blast radius

The change only ever makes `mustNotHaveSpaceBefore` return `true` where it previously returned `false`, and only for the two-character sequence `<?`. It can therefore only remove a space, never add one, and cannot affect a file that does not contain that sequence.
