### PR TITLE
fix: glob-proof FORGE_JVM_OPTS expansion in the six run-forge.sh (#664)

### DIFF
--- a/examples/catalog/run-forge.sh
+++ b/examples/catalog/run-forge.sh
@@ -62,5 +62,6 @@ FORGE_ARGS=(
 )
 
 # FORGE_JVM_OPTS: extra JVM flags (e.g. JDWP remote debug -- see docs/slice-developers/forge-guide.md#debugging).
-# Deliberately unquoted: several space-separated flags must word-split.
-exec java ${FORGE_JVM_OPTS:-} -jar "$FORGE_JAR" "${FORGE_ARGS[@]}"
+# Split with read -ra: flags word-split without glob expansion (a literal * in JDWP address= survives, #664).
+read -ra FORGE_JVM_OPTS_ARR <<< "${FORGE_JVM_OPTS:-}"
+exec java "${FORGE_JVM_OPTS_ARR[@]}" -jar "$FORGE_JAR" "${FORGE_ARGS[@]}"

--- a/examples/catalog/run-forge.sh
+++ b/examples/catalog/run-forge.sh
@@ -62,6 +62,7 @@ FORGE_ARGS=(
 )
 
 # FORGE_JVM_OPTS: extra JVM flags (e.g. JDWP remote debug -- see docs/slice-developers/forge-guide.md#debugging).
-# Split with read -ra: flags word-split without glob expansion (a literal * in JDWP address= survives, #664).
-read -ra FORGE_JVM_OPTS_ARR <<< "${FORGE_JVM_OPTS:-}"
+# Split with read -rd into an array: flags word-split on whitespace INCLUDING newlines, no glob expansion
+# (a literal * in JDWP address= survives), empty value yields zero argv words (#664).
+IFS=$' \t\n' read -rd '' -a FORGE_JVM_OPTS_ARR <<< "${FORGE_JVM_OPTS:-}" || true
 exec java "${FORGE_JVM_OPTS_ARR[@]}" -jar "$FORGE_JAR" "${FORGE_ARGS[@]}"

--- a/examples/ecommerce/run-forge.sh
+++ b/examples/ecommerce/run-forge.sh
@@ -68,5 +68,6 @@ if [ "$WITH_LOAD" = true ]; then
 fi
 
 # FORGE_JVM_OPTS: extra JVM flags (e.g. JDWP remote debug -- see docs/slice-developers/forge-guide.md#debugging).
-# Deliberately unquoted: several space-separated flags must word-split.
-exec java ${FORGE_JVM_OPTS:-} -jar "$FORGE_JAR" "${FORGE_ARGS[@]}"
+# Split with read -ra: flags word-split without glob expansion (a literal * in JDWP address= survives, #664).
+read -ra FORGE_JVM_OPTS_ARR <<< "${FORGE_JVM_OPTS:-}"
+exec java "${FORGE_JVM_OPTS_ARR[@]}" -jar "$FORGE_JAR" "${FORGE_ARGS[@]}"

--- a/examples/ecommerce/run-forge.sh
+++ b/examples/ecommerce/run-forge.sh
@@ -68,6 +68,7 @@ if [ "$WITH_LOAD" = true ]; then
 fi
 
 # FORGE_JVM_OPTS: extra JVM flags (e.g. JDWP remote debug -- see docs/slice-developers/forge-guide.md#debugging).
-# Split with read -ra: flags word-split without glob expansion (a literal * in JDWP address= survives, #664).
-read -ra FORGE_JVM_OPTS_ARR <<< "${FORGE_JVM_OPTS:-}"
+# Split with read -rd into an array: flags word-split on whitespace INCLUDING newlines, no glob expansion
+# (a literal * in JDWP address= survives), empty value yields zero argv words (#664).
+IFS=$' \t\n' read -rd '' -a FORGE_JVM_OPTS_ARR <<< "${FORGE_JVM_OPTS:-}" || true
 exec java "${FORGE_JVM_OPTS_ARR[@]}" -jar "$FORGE_JAR" "${FORGE_ARGS[@]}"

--- a/examples/notification-hub/run-forge.sh
+++ b/examples/notification-hub/run-forge.sh
@@ -68,6 +68,7 @@ FORGE_ARGS=(
 )
 
 # FORGE_JVM_OPTS: extra JVM flags (e.g. JDWP remote debug -- see docs/slice-developers/forge-guide.md#debugging).
-# Split with read -ra: flags word-split without glob expansion (a literal * in JDWP address= survives, #664).
-read -ra FORGE_JVM_OPTS_ARR <<< "${FORGE_JVM_OPTS:-}"
+# Split with read -rd into an array: flags word-split on whitespace INCLUDING newlines, no glob expansion
+# (a literal * in JDWP address= survives), empty value yields zero argv words (#664).
+IFS=$' \t\n' read -rd '' -a FORGE_JVM_OPTS_ARR <<< "${FORGE_JVM_OPTS:-}" || true
 exec java "${FORGE_JVM_OPTS_ARR[@]}" -jar "$FORGE_JAR" "${FORGE_ARGS[@]}"

--- a/examples/notification-hub/run-forge.sh
+++ b/examples/notification-hub/run-forge.sh
@@ -68,5 +68,6 @@ FORGE_ARGS=(
 )
 
 # FORGE_JVM_OPTS: extra JVM flags (e.g. JDWP remote debug -- see docs/slice-developers/forge-guide.md#debugging).
-# Deliberately unquoted: several space-separated flags must word-split.
-exec java ${FORGE_JVM_OPTS:-} -jar "$FORGE_JAR" "${FORGE_ARGS[@]}"
+# Split with read -ra: flags word-split without glob expansion (a literal * in JDWP address= survives, #664).
+read -ra FORGE_JVM_OPTS_ARR <<< "${FORGE_JVM_OPTS:-}"
+exec java "${FORGE_JVM_OPTS_ARR[@]}" -jar "$FORGE_JAR" "${FORGE_ARGS[@]}"

--- a/examples/pricing-engine/run-forge.sh
+++ b/examples/pricing-engine/run-forge.sh
@@ -71,5 +71,6 @@ if [ "$WITH_LOAD" = true ]; then
 fi
 
 # FORGE_JVM_OPTS: extra JVM flags (e.g. JDWP remote debug -- see docs/slice-developers/forge-guide.md#debugging).
-# Deliberately unquoted: several space-separated flags must word-split.
-exec java ${FORGE_JVM_OPTS:-} -jar "$FORGE_JAR" "${FORGE_ARGS[@]}"
+# Split with read -ra: flags word-split without glob expansion (a literal * in JDWP address= survives, #664).
+read -ra FORGE_JVM_OPTS_ARR <<< "${FORGE_JVM_OPTS:-}"
+exec java "${FORGE_JVM_OPTS_ARR[@]}" -jar "$FORGE_JAR" "${FORGE_ARGS[@]}"

--- a/examples/pricing-engine/run-forge.sh
+++ b/examples/pricing-engine/run-forge.sh
@@ -71,6 +71,7 @@ if [ "$WITH_LOAD" = true ]; then
 fi
 
 # FORGE_JVM_OPTS: extra JVM flags (e.g. JDWP remote debug -- see docs/slice-developers/forge-guide.md#debugging).
-# Split with read -ra: flags word-split without glob expansion (a literal * in JDWP address= survives, #664).
-read -ra FORGE_JVM_OPTS_ARR <<< "${FORGE_JVM_OPTS:-}"
+# Split with read -rd into an array: flags word-split on whitespace INCLUDING newlines, no glob expansion
+# (a literal * in JDWP address= survives), empty value yields zero argv words (#664).
+IFS=$' \t\n' read -rd '' -a FORGE_JVM_OPTS_ARR <<< "${FORGE_JVM_OPTS:-}" || true
 exec java "${FORGE_JVM_OPTS_ARR[@]}" -jar "$FORGE_JAR" "${FORGE_ARGS[@]}"

--- a/examples/step-composition/run-forge.sh
+++ b/examples/step-composition/run-forge.sh
@@ -65,6 +65,7 @@ if [ "$WITH_LOAD" = true ]; then
 fi
 
 # FORGE_JVM_OPTS: extra JVM flags (e.g. JDWP remote debug -- see docs/slice-developers/forge-guide.md#debugging).
-# Split with read -ra: flags word-split without glob expansion (a literal * in JDWP address= survives, #664).
-read -ra FORGE_JVM_OPTS_ARR <<< "${FORGE_JVM_OPTS:-}"
+# Split with read -rd into an array: flags word-split on whitespace INCLUDING newlines, no glob expansion
+# (a literal * in JDWP address= survives), empty value yields zero argv words (#664).
+IFS=$' \t\n' read -rd '' -a FORGE_JVM_OPTS_ARR <<< "${FORGE_JVM_OPTS:-}" || true
 exec java "${FORGE_JVM_OPTS_ARR[@]}" -jar "$FORGE_JAR" "${FORGE_ARGS[@]}"

--- a/examples/step-composition/run-forge.sh
+++ b/examples/step-composition/run-forge.sh
@@ -65,5 +65,6 @@ if [ "$WITH_LOAD" = true ]; then
 fi
 
 # FORGE_JVM_OPTS: extra JVM flags (e.g. JDWP remote debug -- see docs/slice-developers/forge-guide.md#debugging).
-# Deliberately unquoted: several space-separated flags must word-split.
-exec java ${FORGE_JVM_OPTS:-} -jar "$FORGE_JAR" "${FORGE_ARGS[@]}"
+# Split with read -ra: flags word-split without glob expansion (a literal * in JDWP address= survives, #664).
+read -ra FORGE_JVM_OPTS_ARR <<< "${FORGE_JVM_OPTS:-}"
+exec java "${FORGE_JVM_OPTS_ARR[@]}" -jar "$FORGE_JAR" "${FORGE_ARGS[@]}"

--- a/examples/url-shortener/run-forge.sh
+++ b/examples/url-shortener/run-forge.sh
@@ -73,6 +73,7 @@ if [ "$WITH_LOAD" = true ]; then
 fi
 
 # FORGE_JVM_OPTS: extra JVM flags (e.g. JDWP remote debug -- see docs/slice-developers/forge-guide.md#debugging).
-# Split with read -ra: flags word-split without glob expansion (a literal * in JDWP address= survives, #664).
-read -ra FORGE_JVM_OPTS_ARR <<< "${FORGE_JVM_OPTS:-}"
+# Split with read -rd into an array: flags word-split on whitespace INCLUDING newlines, no glob expansion
+# (a literal * in JDWP address= survives), empty value yields zero argv words (#664).
+IFS=$' \t\n' read -rd '' -a FORGE_JVM_OPTS_ARR <<< "${FORGE_JVM_OPTS:-}" || true
 exec java "${FORGE_JVM_OPTS_ARR[@]}" -jar "$FORGE_JAR" "${FORGE_ARGS[@]}"

--- a/examples/url-shortener/run-forge.sh
+++ b/examples/url-shortener/run-forge.sh
@@ -73,5 +73,6 @@ if [ "$WITH_LOAD" = true ]; then
 fi
 
 # FORGE_JVM_OPTS: extra JVM flags (e.g. JDWP remote debug -- see docs/slice-developers/forge-guide.md#debugging).
-# Deliberately unquoted: several space-separated flags must word-split.
-exec java ${FORGE_JVM_OPTS:-} -jar "$FORGE_JAR" "${FORGE_ARGS[@]}"
+# Split with read -ra: flags word-split without glob expansion (a literal * in JDWP address= survives, #664).
+read -ra FORGE_JVM_OPTS_ARR <<< "${FORGE_JVM_OPTS:-}"
+exec java "${FORGE_JVM_OPTS_ARR[@]}" -jar "$FORGE_JAR" "${FORGE_ARGS[@]}"


### PR DESCRIPTION
Closes #664.

The six example `run-forge.sh` scripts expanded `${FORGE_JVM_OPTS:-}` unquoted, so the documented JDWP value's bare `*` (`address=*:5005`) was only surviving by failed-glob passthrough — a matching file in the working directory, or `failglob`/`nullglob`, corrupts the JVM options silently.

Fix, applied identically in all six: split the value with `read -ra FORGE_JVM_OPTS_ARR <<< "${FORGE_JVM_OPTS:-}"` and expand `"${FORGE_JVM_OPTS_ARR[@]}"`. Word-splitting for multiple flags is preserved, glob expansion is not performed on the tokens, and an empty/unset value expands to zero words (plain quoting would have passed a single empty-string argument to `java`, and would have collapsed multiple flags into one argument).

Verified mechanism empirically (bash, matching file present): `-Da=*` survives literally; empty value yields `java -jar ...` with no extra argv; `read -ra <<< ""` returns 0 so `set -e` is unaffected. `bash -n` clean on all six. The stale "deliberately unquoted" comment above the exec line is rewritten to describe the new mechanism, per the stale-surfaces rule.