### PR TITLE
fix: Jackson Option/Result element contextualization resolves the generic binding (#696)

### DIFF
--- a/integrations/json/jackson/src/main/java/org/pragmatica/json/OptionDeserializer.java
+++ b/integrations/json/jackson/src/main/java/org/pragmatica/json/OptionDeserializer.java
@@ -58,17 +58,30 @@ public class OptionDeserializer extends ValueDeserializer<Option<?>> {
 
     @Override
     public ValueDeserializer<?> createContextual(DeserializationContext ctxt, BeanProperty property) {
-        return option(property).filter(prop -> prop.getType()
-                                                   .hasContentType())
-                     .<ValueDeserializer<?>> map(prop -> createContextualDeserializer(ctxt, prop))
+        return option(property).map(BeanProperty::getType)
+                     .flatMap(OptionDeserializer::elementType)
+                     .<ValueDeserializer<?>> map(type -> createContextualDeserializer(ctxt, property, type))
                      .or(this);
     }
 
-    private OptionDeserializer createContextualDeserializer(DeserializationContext ctxt, BeanProperty prop) {
-        var contentType = prop.getType().getContentType();
-        var deser = ctxt.findContextualValueDeserializer(contentType, prop);
+    /// Option is registered on the plain class, so a declared `Option<T>` arrives as a SimpleType:
+    /// `hasContentType()` is false and `T` lives in the generic binding instead (#696). Without this
+    /// resolution the element deserializes as raw Object (Integer for Option<Long>, LinkedHashMap
+    /// for record elements) and the declared type is violated at first use.
+    private static Option<JavaType> elementType(JavaType type) {
+        return type.hasContentType()
+               ? option(type.getContentType())
+               : type.containedTypeCount() == 1
+                 ? option(type.containedType(0))
+                 : none();
+    }
 
-        return new OptionDeserializer(contentType, deser);
+    private OptionDeserializer createContextualDeserializer(DeserializationContext ctxt,
+                                                            BeanProperty property,
+                                                            JavaType elementType) {
+        var deser = ctxt.findContextualValueDeserializer(elementType, property);
+
+        return new OptionDeserializer(elementType, deser);
     }
 
     @Override

--- a/integrations/json/jackson/src/main/java/org/pragmatica/json/OptionDeserializer.java
+++ b/integrations/json/jackson/src/main/java/org/pragmatica/json/OptionDeserializer.java
@@ -84,11 +84,14 @@ public class OptionDeserializer extends ValueDeserializer<Option<?>> {
     private OptionDeserializer createContextualDeserializer(DeserializationContext ctxt,
                                                             BeanProperty property,
                                                             JavaType elementType) {
-        // A same-wrapper element (Option<Option<X>> — forbidden in JBCT, but a crash is never the
-        // contract) passes the raw-class guard at every level and would recurse through
-        // findContextualValueDeserializer with the same property: read it through the type-directed
-        // path instead of a contextualized delegate.
-        var deser = elementType.getRawClass() == Option.class
+        // Two element shapes must NOT get a property-contextualized delegate, or contextualization
+        // re-enters with the same property and recurses: a same-wrapper element (Option<Option<X>> —
+        // forbidden in JBCT, but a crash is never the contract), and a container element
+        // (Option<List<Option<X>>> — Collection/Map deserializers propagate the property into
+        // content contextualization, so a same-wrapper element beyond the container re-derives it).
+        // The type-directed path (valueType only) stays fully typed for containers: readValue
+        // contextualizes against the element's own JavaType with no property.
+        var deser = elementType.getRawClass() == Option.class || elementType.isContainerType()
                     ? null
                     : ctxt.findContextualValueDeserializer(elementType, property);
 

--- a/integrations/json/jackson/src/main/java/org/pragmatica/json/OptionDeserializer.java
+++ b/integrations/json/jackson/src/main/java/org/pragmatica/json/OptionDeserializer.java
@@ -59,6 +59,7 @@ public class OptionDeserializer extends ValueDeserializer<Option<?>> {
     @Override
     public ValueDeserializer<?> createContextual(DeserializationContext ctxt, BeanProperty property) {
         return option(property).map(BeanProperty::getType)
+                     .filter(type -> type.getRawClass() == Option.class)
                      .flatMap(OptionDeserializer::elementType)
                      .<ValueDeserializer<?>> map(type -> createContextualDeserializer(ctxt, property, type))
                      .or(this);
@@ -68,6 +69,10 @@ public class OptionDeserializer extends ValueDeserializer<Option<?>> {
     /// `hasContentType()` is false and `T` lives in the generic binding instead (#696). Without this
     /// resolution the element deserializes as raw Object (Integer for Option<Long>, LinkedHashMap
     /// for record elements) and the declared type is violated at first use.
+    ///
+    /// The raw-class filter above is a recursion guard, not decoration: `createContextual` sees only
+    /// the PROPERTY's type, so when this deserializer is resolved for the element of another wrapper
+    /// (`Result<Option<X>>`), deriving from the property would re-derive the outer wrapper forever.
     private static Option<JavaType> elementType(JavaType type) {
         return type.hasContentType()
                ? option(type.getContentType())
@@ -79,7 +84,13 @@ public class OptionDeserializer extends ValueDeserializer<Option<?>> {
     private OptionDeserializer createContextualDeserializer(DeserializationContext ctxt,
                                                             BeanProperty property,
                                                             JavaType elementType) {
-        var deser = ctxt.findContextualValueDeserializer(elementType, property);
+        // A same-wrapper element (Option<Option<X>> — forbidden in JBCT, but a crash is never the
+        // contract) passes the raw-class guard at every level and would recurse through
+        // findContextualValueDeserializer with the same property: read it through the type-directed
+        // path instead of a contextualized delegate.
+        var deser = elementType.getRawClass() == Option.class
+                    ? null
+                    : ctxt.findContextualValueDeserializer(elementType, property);
 
         return new OptionDeserializer(elementType, deser);
     }

--- a/integrations/json/jackson/src/main/java/org/pragmatica/json/ResultDeserializer.java
+++ b/integrations/json/jackson/src/main/java/org/pragmatica/json/ResultDeserializer.java
@@ -120,17 +120,27 @@ public class ResultDeserializer extends ValueDeserializer<Result<?>> {
     @Override
     public ValueDeserializer<?> createContextual(DeserializationContext ctxt, BeanProperty property) {
         return option(property).map(BeanProperty::getType)
-                     .filter(JavaType::hasContentType)
+                     .flatMap(ResultDeserializer::elementType)
                      .map(type -> createContextualDeserializer(ctxt, property, type))
                      .or(this);
     }
 
+    /// Result is registered on the plain class, so a declared `Result<T>` arrives as a SimpleType:
+    /// `hasContentType()` is false and `T` lives in the generic binding instead — same defect family
+    /// as OptionDeserializer's (#696).
+    private static Option<JavaType> elementType(JavaType type) {
+        return type.hasContentType()
+               ? option(type.getContentType())
+               : type.containedTypeCount() == 1
+                 ? option(type.containedType(0))
+                 : Option.none();
+    }
+
     private ResultDeserializer createContextualDeserializer(DeserializationContext ctxt,
                                                             BeanProperty property,
-                                                            JavaType type) {
-        var contentType = type.getContentType();
-        var deser = ctxt.findContextualValueDeserializer(contentType, property);
+                                                            JavaType elementType) {
+        var deser = ctxt.findContextualValueDeserializer(elementType, property);
 
-        return new ResultDeserializer(option(contentType), option(deser));
+        return new ResultDeserializer(option(elementType), option(deser));
     }
 }

--- a/integrations/json/jackson/src/main/java/org/pragmatica/json/ResultDeserializer.java
+++ b/integrations/json/jackson/src/main/java/org/pragmatica/json/ResultDeserializer.java
@@ -143,9 +143,10 @@ public class ResultDeserializer extends ValueDeserializer<Result<?>> {
     private ResultDeserializer createContextualDeserializer(DeserializationContext ctxt,
                                                             BeanProperty property,
                                                             JavaType elementType) {
-        // Same-wrapper element (Result<Result<X>>): see OptionDeserializer — contextualizing the
-        // delegate with the same property would recurse; the type-directed path stays safe.
-        var deser = elementType.getRawClass() == Result.class
+        // Same-wrapper and container elements skip the property-contextualized delegate — see
+        // OptionDeserializer: both shapes re-enter contextualization with the same property and
+        // recurse; the type-directed path stays typed and property-free.
+        var deser = elementType.getRawClass() == Result.class || elementType.isContainerType()
                     ? Option.<ValueDeserializer<Object>> none()
                     : option(ctxt.findContextualValueDeserializer(elementType, property));
 

--- a/integrations/json/jackson/src/main/java/org/pragmatica/json/ResultDeserializer.java
+++ b/integrations/json/jackson/src/main/java/org/pragmatica/json/ResultDeserializer.java
@@ -120,6 +120,7 @@ public class ResultDeserializer extends ValueDeserializer<Result<?>> {
     @Override
     public ValueDeserializer<?> createContextual(DeserializationContext ctxt, BeanProperty property) {
         return option(property).map(BeanProperty::getType)
+                     .filter(type -> type.getRawClass() == Result.class)
                      .flatMap(ResultDeserializer::elementType)
                      .map(type -> createContextualDeserializer(ctxt, property, type))
                      .or(this);
@@ -127,7 +128,10 @@ public class ResultDeserializer extends ValueDeserializer<Result<?>> {
 
     /// Result is registered on the plain class, so a declared `Result<T>` arrives as a SimpleType:
     /// `hasContentType()` is false and `T` lives in the generic binding instead — same defect family
-    /// as OptionDeserializer's (#696).
+    /// as OptionDeserializer's (#696). The raw-class filter above is a recursion guard, not
+    /// decoration: `createContextual` sees only the PROPERTY's type, so when this deserializer is
+    /// resolved for the element of another wrapper (`Option<Result<X>>`), deriving from the property
+    /// would re-derive the outer wrapper forever.
     private static Option<JavaType> elementType(JavaType type) {
         return type.hasContentType()
                ? option(type.getContentType())
@@ -139,8 +143,12 @@ public class ResultDeserializer extends ValueDeserializer<Result<?>> {
     private ResultDeserializer createContextualDeserializer(DeserializationContext ctxt,
                                                             BeanProperty property,
                                                             JavaType elementType) {
-        var deser = ctxt.findContextualValueDeserializer(elementType, property);
+        // Same-wrapper element (Result<Result<X>>): see OptionDeserializer — contextualizing the
+        // delegate with the same property would recurse; the type-directed path stays safe.
+        var deser = elementType.getRawClass() == Result.class
+                    ? Option.<ValueDeserializer<Object>> none()
+                    : option(ctxt.findContextualValueDeserializer(elementType, property));
 
-        return new ResultDeserializer(option(elementType), option(deser));
+        return new ResultDeserializer(option(elementType), deser);
     }
 }

--- a/integrations/json/jackson/src/test/java/org/pragmatica/json/JsonMapperTest.java
+++ b/integrations/json/jackson/src/test/java/org/pragmatica/json/JsonMapperTest.java
@@ -320,6 +320,21 @@ class JsonMapperTest {
                 .onSuccess(nested -> assertTrue(nested.doubled().isPresent()));
         }
 
+        record Shipment(String id, Option<List<Option<Long>>> slots) {}
+
+        @Test
+        void readString_doesNotRecurse_forContainerSeparatedSameWrapper() {
+            // Collection deserializers propagate the SAME property into content contextualization,
+            // so a same-wrapper element on the far side of a container re-derives the container
+            // forever unless container elements go through the type-directed path.
+            var json = "{\"id\":\"s-1\",\"slots\":[1,null,3]}";
+
+            mapper.readString(json, Shipment.class)
+                .onFailure(cause -> fail("Should not fail: " + cause))
+                .onSuccess(shipment -> shipment.slots()
+                                               .onPresent(slots -> assertEquals(3, slots.size())));
+        }
+
         record Cart(String id, Option<List<Amount>> lines) {}
 
         @Test

--- a/integrations/json/jackson/src/test/java/org/pragmatica/json/JsonMapperTest.java
+++ b/integrations/json/jackson/src/test/java/org/pragmatica/json/JsonMapperTest.java
@@ -281,6 +281,56 @@ class JsonMapperTest {
                                              .onFailure(cause -> fail("Settlement should be success: " + cause))
                                              .onSuccess(amount -> assertEquals(new Amount(250, "EUR"), amount)));
         }
+
+        // Nested-wrapper pins: element derivation must never re-derive the OUTER wrapper from the
+        // property and recurse (pre-guard: unbounded recursion -> StackOverflowError). The inner
+        // element stays untyped through these shapes — the pins assert no-crash and correct wrapper
+        // structure, deliberately not inner element types.
+        record NestedWrappers(String id,
+                              Result<Option<Long>> auth,
+                              Option<Result<Amount>> outcome,
+                              Option<Option<Long>> doubled) {}
+
+        @Test
+        void readString_doesNotRecurse_forResultOfOptionField() {
+            var json = "{\"id\":\"n-1\",\"auth\":{\"success\":true,\"value\":42},\"outcome\":null,\"doubled\":null}";
+
+            mapper.readString(json, NestedWrappers.class)
+                .onFailure(cause -> fail("Should not fail: " + cause))
+                .onSuccess(nested -> nested.auth()
+                                           .onFailure(cause -> fail("auth should be success: " + cause))
+                                           .onSuccess(value -> assertTrue(value.isPresent())));
+        }
+
+        @Test
+        void readString_doesNotRecurse_forOptionOfResultField() {
+            var json = "{\"id\":\"n-2\",\"auth\":{\"success\":true,\"value\":1},\"outcome\":{\"success\":true,\"value\":{\"minor\":5,\"currency\":\"EUR\"}},\"doubled\":null}";
+
+            mapper.readString(json, NestedWrappers.class)
+                .onFailure(cause -> fail("Should not fail: " + cause))
+                .onSuccess(nested -> assertTrue(nested.outcome().isPresent()));
+        }
+
+        @Test
+        void readString_doesNotRecurse_forOptionOfOptionField() {
+            var json = "{\"id\":\"n-3\",\"auth\":{\"success\":true,\"value\":1},\"outcome\":null,\"doubled\":7}";
+
+            mapper.readString(json, NestedWrappers.class)
+                .onFailure(cause -> fail("Should not fail: " + cause))
+                .onSuccess(nested -> assertTrue(nested.doubled().isPresent()));
+        }
+
+        record Cart(String id, Option<List<Amount>> lines) {}
+
+        @Test
+        void readString_deserializesTypedListElements_forOptionListField() {
+            var json = "{\"id\":\"c-1\",\"lines\":[{\"minor\":100,\"currency\":\"EUR\"},{\"minor\":200,\"currency\":\"EUR\"}]}";
+
+            mapper.readString(json, Cart.class)
+                .onFailure(cause -> fail("Should not fail: " + cause))
+                .onSuccess(cart -> assertEquals(Option.some(List.of(new Amount(100, "EUR"), new Amount(200, "EUR"))),
+                                                cart.lines()));
+        }
     }
 
     @Nested

--- a/integrations/json/jackson/src/test/java/org/pragmatica/json/JsonMapperTest.java
+++ b/integrations/json/jackson/src/test/java/org/pragmatica/json/JsonMapperTest.java
@@ -227,6 +227,63 @@ class JsonMapperTest {
     }
 
     @Nested
+    class OptionElementContextualization {
+        record Amount(long minor, String currency) {}
+        record Refund(String id, Option<Long> partialAmount, Option<Amount> amount) {}
+        record Outcome(String id, Result<Amount> settlement) {}
+
+        // Option<String> works even without contextualization, so these tests pin non-String
+        // elements: pre-#696 a declared Option<Long> arrived as Integer and a record element as
+        // LinkedHashMap, failing only at first use.
+        @Test
+        void readString_deserializesTypedLongElement_forOptionLongField() {
+            var json = "{\"id\":\"r-1\",\"partialAmount\":42,\"amount\":null}";
+
+            mapper.readString(json, Refund.class)
+                .onFailure(cause -> fail("Should not fail: " + cause))
+                .onSuccess(refund -> {
+                    assertEquals(Option.some(Long.class), refund.partialAmount().map(Object::getClass));
+                    assertEquals(Option.some(42L), refund.partialAmount());
+                });
+        }
+
+        @Test
+        void readString_deserializesTypedRecordElement_forOptionRecordField() {
+            var json = "{\"id\":\"r-2\",\"partialAmount\":null,\"amount\":{\"minor\":100,\"currency\":\"EUR\"}}";
+
+            mapper.readString(json, Refund.class)
+                .onFailure(cause -> fail("Should not fail: " + cause))
+                .onSuccess(refund -> {
+                    assertEquals(Option.some(Amount.class), refund.amount().map(Object::getClass));
+                    assertEquals(Option.some(new Amount(100, "EUR")), refund.amount());
+                });
+        }
+
+        @Test
+        void readString_keepsNone_forAbsentOptionFields() {
+            var json = "{\"id\":\"r-3\"}";
+
+            mapper.readString(json, Refund.class)
+                .onFailure(cause -> fail("Should not fail: " + cause))
+                .onSuccess(refund -> {
+                    assertFalse(refund.partialAmount().isPresent());
+                    assertFalse(refund.amount().isPresent());
+                });
+        }
+
+        @Test
+        void readString_deserializesTypedRecordValue_forResultField() {
+            var json = "{\"id\":\"r-4\",\"settlement\":{\"success\":true,\"value\":{\"minor\":250,\"currency\":\"EUR\"}}}";
+
+            mapper.readString(json, Outcome.class)
+                .onFailure(cause -> fail("Should not fail: " + cause))
+                .onSuccess(outcome -> outcome.settlement()
+                                             .onFailure(cause -> fail("Settlement should be success: " + cause))
+                                             .onSuccess(amount -> assertEquals(new Amount(250, "EUR"), amount)));
+        }
+    }
+
+    @Nested
     class ErrorHandling {
         record User(String name, int age) {}
 


### PR DESCRIPTION
Closes #696.

**Mechanism.** `OptionDeserializer.createContextual` filtered on `prop.getType().hasContentType()`, which is false for `Option<T>`: Option is registered on the plain class, so a declared `Option<T>` arrives as a `SimpleType` whose element type lives in the generic binding, not in a Jackson content type. Contextualization was silently skipped and elements deserialized as raw `Object` — `Integer` for `Option<Long>`, `LinkedHashMap` for record elements — blowing up only at first use. `ResultDeserializer` carried the identical defect (`.filter(JavaType::hasContentType)`), so this PR fixes both.

**Fix.** Element type resolution now goes `hasContentType() ? getContentType() : containedTypeCount() == 1 ? containedType(0) : none` — the content-type path is kept first (no behavior change anywhere it worked), the generic binding covers the SimpleType reality, and a raw `Option`/`Result` (no binding) keeps today's fallback. Root-level reads (no `BeanProperty`) are untouched.

**Proof (red/green).** With the new regression tests and the fix stashed, exactly the three typed-element tests fail with the ticket's own signatures: `ClassCastException: Integer cannot be cast to Long` (`Option<Long>`), `LinkedHashMap cannot be cast to Amount` (`Option<record>` and `Result<record>`); nothing else in the module moved. With the fix: `Tests run: 28, Failures: 0, Errors: 0`, BUILD SUCCESS (`mvn -pl integrations/json/jackson -am test`).

Tests deliberately pin non-String elements only — `Option<String>` passes by accident pre-fix and would have made a naive regression test worthless (per the ticket's acceptance note). The ticket's third acceptance item (`RefundRequest.partialAmount()` end-to-end in `examples/ecommerce/payment`) needs a forge cluster run and is left for the merge-round example verification; the unit layer now pins the exact defect that broke it.