### PR TITLE
fix: #672 — correct notification-hub SMTP resources.toml to the real SmtpConfig shape

### DIFF
--- a/examples/notification-hub/notification-emailer/src/main/resources/resources.toml
+++ b/examples/notification-hub/notification-emailer/src/main/resources/resources.toml
@@ -5,12 +5,29 @@ retention-value = "5m"
 max-event-size = "64KB"
 
 # `@Notify NotificationSender` is provisioned from this section.
-# Backend can be "smtp" or "http". Below is a MailHog-friendly local SMTP setup;
-# real deployments would point at a production SMTP relay or vendor (SendGrid,
-# Mailgun, Postmark) via the [notification.http] backend.
+# Backend can be "smtp" or "http". Below is a Mailpit/MailHog-friendly local
+# SMTP setup; real deployments would point at a production SMTP relay or vendor
+# (SendGrid, Mailgun, Postmark) via the [notification.http] backend.
 #
-# TODO(example-coverage): add a MailHog container to the parent example so
-# `./run-forge.sh` actually delivers and captures these emails.
+# Fields mirror SmtpConfig (integrations/net/smtp): host, port, tls_mode
+# (NONE | STARTTLS | IMPLICIT), connect_timeout, command_timeout. Credentials,
+# when a relay requires them, go in a nested [notification.smtp.auth] section
+# with `username` and `password` (SmtpAuth); omit the section for no auth —
+# an empty-credential AUTH PLAIN is not "no auth". Local sinks need none:
+#
+#   [notification.smtp.auth]
+#   username = "noreply@example.com"
+#   password = "${secrets:smtp/password}"
+#
+# NOTE: binding this section from TOML is currently gated on #671 — the config
+# binder does not yet recurse Option<Record> components (NotificationConfig
+# declares the SMTP block as Option<SmtpConfig>), so the SMTP backend cannot
+# be provisioned from TOML until that lands. Shape below is the documented
+# target shape (docs/slice-developers/resource-reference.md).
+#
+# TODO(example-coverage, #672): add a Mailpit/MailHog container to the parent
+# example so `./run-forge.sh` actually delivers and captures these emails.
+# Gated on #671 (see NOTE above).
 [notification]
 backend = "smtp"
 
@@ -18,9 +35,5 @@ backend = "smtp"
 host = "localhost"
 port = 1025
 tls_mode = "NONE"
-username = ""
-password = ""
-pool_size = 2
 connect_timeout = "5s"
 command_timeout = "10s"
-helo_hostname = "notification-hub.example"

--- a/examples/notification-hub/notification-emailer/src/main/resources/resources.toml
+++ b/examples/notification-hub/notification-emailer/src/main/resources/resources.toml
@@ -23,7 +23,7 @@ max-event-size = "64KB"
 # binder does not yet recurse Option<Record> components (NotificationConfig
 # declares the SMTP block as Option<SmtpConfig>), so the SMTP backend cannot
 # be provisioned from TOML until that lands. Shape below is the documented
-# target shape (docs/slice-developers/resource-reference.md).
+# target shape (aether/docs/slice-developers/resource-reference.md).
 #
 # TODO(example-coverage, #672): add a Mailpit/MailHog container to the parent
 # example so `./run-forge.sh` actually delivers and captures these emails.


### PR DESCRIPTION
## What was wrong (Refs #672)

`examples/notification-hub/notification-emailer/src/main/resources/resources.toml` declared two fields `SmtpConfig` does not have, and flat credentials instead of the nested auth record:

| Old key | Verdict |
|---|---|
| `pool_size = 2` | no such component — removed |
| `helo_hostname = "notification-hub.example"` | no such component — removed |
| `username = ""` / `password = ""` (flat) | wrong shape — auth is a nested record; documented as `[notification.smtp.auth]` in a comment (empty-string AUTH PLAIN is not "no auth", so the no-auth local-sink default omits the section entirely) |

## Symbol-verified target shape

`SmtpConfig` — `integrations/net/smtp/src/main/java/org/pragmatica/net/smtp/SmtpConfig.java:27-32`: `host`, `port`, `tlsMode`, `auth: Option<SmtpAuth>`, `connectTimeout`, `commandTimeout`.
`SmtpAuth` — `.../SmtpAuth.java:23`: `username`, `password`.
`SmtpTlsMode` — `.../SmtpTlsMode.java:19-25`: `NONE | STARTTLS | IMPLICIT`.
`NotificationConfig` — `aether/resource/notification/src/main/java/org/pragmatica/aether/resource/notification/NotificationConfig.java:15-18`: `backend`, `smtpConfig: Option<SmtpConfig>`, `httpConfig`, `retryConfig`.

Kept keys `host`, `port`, `tls_mode`, `connect_timeout`, `command_timeout` (TimeSpan strings `5s`/`10s` parse via `org.pragmatica.lang.parse.TimeSpan`, `COMPONENT_PATTERN` at TimeSpan.java:117).

**Marked naming choice:** the section stays `[notification.smtp]` per `aether/docs/slice-developers/resource-reference.md:582-590,660-668` and `notification-resource-spec.md`. The binder's literal component mapping would be `smtp_config` (`toSnakeCase("smtpConfig")`; precedent: `ProviderBasedConfigServiceTest.config_nestedRecord_bindsExplicitValues` binds `innerConfig` from `inner_config.*`). Both spellings were probed against the running binder and both bind to `None()` today (see below), so the name is not yet load-bearing; #671's fix must reconcile docs vs component mapping.

## E2E status: blocked — three walls, in order (evidence below)

Attempted per the example's own path (forge + Mailpit sink on :1025/:8025), with all builds and the forge run against an isolated `-Dmaven.repo.local` clone. Example compiles clean: `mvn -f examples/notification-hub/pom.xml package -DskipTests` → BUILD SUCCESS, jbct resource-config validation passed (2 references, 3 sections).

**Wall 1 — #547 deploy preflight (example ships no path to satisfy it).** Deploying the emailer blueprint fails because the section must be in the leader's composite view, and nothing routes the blueprint-embedded `resources.toml` there:

```
slice 'EmailerService' requires config section [notification] for its NotificationSender resource — not found in the leader's composite configuration view (node.toml layered with the operator KV overlay), checked at deploy time.
```

Worked around manually: 11 keys via `POST /api/config` (both `notification.smtp.*` and `notification.smtp_config.*` spellings) — after which the deploy passed preflight (`{"status":"deployed","slices":2}`).

**Wall 2 — slice packaging drops shared classes (hard block, same "never became reachable" family as #704).** Both slices then fail to load and ALL_OR_NOTHING rolls back:

```
Caused by: java.lang.ClassNotFoundException: org.pragmatica.aether.example.notification.NotificationEvent
	at org.pragmatica.aether.slice.SliceClassLoader.loadClass(SliceClassLoader.java:47)
ALL_OR_NOTHING: Deterministic failure of org.pragmatica.aether.example:notification-hub-notification-service-notification-service:1.0.0-rc3 triggers rollback of blueprint org.pragmatica.aether.example:notification-hub-notification-emailer:1.0.0-rc3
```

Verified on disk: `NotificationEvent.class` is in the module jar (`notification-hub-notification-service-1.0.0-rc3.jar`) but absent from both per-slice jars the blueprint deploys; the emailer slice jar also lacks `NotificationConsumer`.

**Wall 3 — #671 (would be next), now reproduced with a running binder, not just code-read.** Binding this PR's exact `resources.toml` through `TomlConfigService.config("notification", NotificationConfig.class)`:

```
backend      = smtp
smtpConfig   = None()
```

Same result for the `[notification.smtp_config]` spelling — `Option<Record>` components are never recursed (`ProviderBasedConfigService.extractOptionalPrimitive` and `TomlConfigService.extractOptionalPrimitive` both fall through to `success(none())` for non-primitive/non-enum inner types). Provisioning would fail with `BackendNotConfigured("SMTP backend selected but no SMTP configuration provided")` (`NotificationSenderFactory.provisionSmtp`).

Sink stayed empty end-to-end: Mailpit `/api/v1/messages` → `"total":0`.

## Also observed (not fixed here)

- `run-forge.sh` builds only `notification-service,notification-analytics` in its `-pl` list and deploys only the notification-service `:blueprint` (which contains that one slice) — the emailer never deploys via the shipped script at all.
- Unlike #704's interceptor gap, the rc3 forge jar **does** bundle `NotificationSenderFactory` in `META-INF/services/org.pragmatica.aether.resource.ResourceFactory` — @Notify is not provider-blocked.
- A first forge run picked up stale `~/.aether/forge-data` consensus state (committed leader `si-1` not in transport topology) and wedged; reproduced clean under a fresh `AETHER_HOME`.

## What remains for #672

Run-it-end-to-end gates on: the slice-packaging missing-class defect (now tracked as #712, fix in PR #719), #671 (Option<Record> binding), and an example-side path for `[notification]` to reach the node config view (plus `run-forge.sh` covering the emailer). Also still owed from #672's own scope: the example's scope statement per #650's examples-teach-what-runs convention — examples/notification-hub has no README, so the "what runs / what doesn't" statement has no home yet and must be added when the e2e lands. Hence **Refs #672**, not Closes.

Refs #672

