### PR TITLE
fix: package manifest-declared message/event classes and full shared tree into slice jars (#712)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,28 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [1.0.0-rc3] - Unreleased
 
+### Fixed (2026-08-28 — #712: slice jars ship the message classes their manifests declare)
+- **A slice jar now contains the topic message and stream event classes its own manifest
+  declares, plus the full sibling `shared` package tree.** Two packaging gaps compounded:
+  `SliceManifest.allImplClasses()` — the single source `PackageSlicesMojo` packages from — merged
+  only impl/request/response classes, never the manifest's own `publish.message.classes` and
+  `stream.event.classes` (publisher message types are constructor-injected `MessagePublisher<T>` /
+  `StreamPublisher<T>` type arguments, so they appear in no method-derived list); and the sibling
+  `shared` package walk was non-recursive (`Files.list`) while the slice-subpackage walk was
+  recursive, so records in `shared.event` and their component types in other `shared.*`
+  subpackages never reached the jar. Evidence: ticketing-sweep-holds' jar omitted the declared
+  `shared.event.SeatReleased` and slice activation died with `NoClassDefFoundError`;
+  notification-hub's `NotificationEvent` was present in the module jar but absent from the slice
+  jars. Closure depth: declared classes by name plus their nested/member classes plus the entire
+  sibling `shared` tree — no bytecode reference walk, matching the existing convention-based
+  closure. Manifest keys are unchanged (consumption-side fix only), so the envelope format is
+  untouched. Same-module subscribers were already covered via `request.classes` (reactive methods
+  are interface methods); cross-module message-type delivery is the dependency-edge sibling #717.
+  [verified: `jbct/jbct-core/src/test/java/org/pragmatica/jbct/slice/SliceManifestTest.java` and
+  `jbct/jbct-maven-plugin/src/test/java/org/pragmatica/jbct/maven/PackageSlicesMessageClassesTest.java`
+  (red against unfixed code, green after; jar-level assertion on a built archive); final e2e
+  against the #704 rf=1 reproduction runs in the coordinating session before #712 closes]
+
 ### Fixed (2026-08-28 — #644: periodic tasks arm in start(), not at assembly)
 - **A created-but-never-started node now performs no periodic work and holds no timers.**
   `AetherNode.assembleNode` used to hand all fourteen of the node's recurring tasks to

--- a/docs/rfc/RFC-0004-slice-packaging.md
+++ b/docs/rfc/RFC-0004-slice-packaging.md
@@ -53,8 +53,10 @@ commerce-order-service-1.0.0.jar
 │   ├── OrderResult.class               # Response types
 │   └── internal/                       # Subpackage classes
 │       └── OrderValidator.class
-├── org/example/shared/                 # Sibling shared package
-│   └── CommonUtils.class
+├── org/example/shared/                 # Sibling shared package (full tree, recursive)
+│   ├── CommonUtils.class
+│   └── event/
+│       └── OrderPlaced.class           # Shared message records and their components
 ├── com/fasterxml/jackson/...           # Bundled external libs
 ├── META-INF/
 │   ├── MANIFEST.MF                     # With Slice-* entries
@@ -71,7 +73,10 @@ commerce-order-service-1.0.0.jar
 - Implementation class
 - Generated factory and proxy classes
 - All request/response types referenced by slice methods
-- Nested classes of request/response types
+- Declared message/event types (`publish.message.classes`, `stream.event.classes`) — topic
+  publisher message types and stream event types the generated factory references (#712)
+- Nested classes of request/response and message/event types
+- Sibling `shared` package tree (recursive) and slice subpackages
 - Bundled external dependencies
 ```
 
@@ -227,7 +232,8 @@ processor.version=0.5.0
 
 Application shared code is automatically included in the impl JAR:
 
-1. **Sibling shared package**: `org.example.shared` for slice `org.example.order.OrderService`
+1. **Sibling shared package**: `org.example.shared` for slice `org.example.order.OrderService` —
+   the whole tree, including subpackages such as `org.example.shared.event` (#712)
 2. **Slice subpackages**: `org.example.order.internal`, `org.example.order.utils`, etc.
 
 ```

--- a/jbct/jbct-core/src/main/java/org/pragmatica/jbct/slice/SliceManifest.java
+++ b/jbct/jbct-core/src/main/java/org/pragmatica/jbct/slice/SliceManifest.java
@@ -30,6 +30,7 @@ public record SliceManifest(String sliceName,
                             List<String> implClasses,
                             List<String> requestClasses,
                             List<String> responseClasses,
+                            List<String> messageClasses,
                             String baseArtifact,
                             String implArtifactId,
                             List<SliceDependency> dependencies,
@@ -42,6 +43,7 @@ public record SliceManifest(String sliceName,
         implClasses = List.copyOf(implClasses);
         requestClasses = List.copyOf(requestClasses);
         responseClasses = List.copyOf(responseClasses);
+        messageClasses = List.copyOf(messageClasses);
         dependencies = List.copyOf(dependencies);
         resourceConfigRefs = List.copyOf(resourceConfigRefs);
     }
@@ -89,6 +91,7 @@ public record SliceManifest(String sliceName,
         var implClasses = parseList(getPropertyOrEmpty(props, "impl.classes"));
         var requestClasses = parseList(getPropertyOrEmpty(props, "request.classes"));
         var responseClasses = parseList(getPropertyOrEmpty(props, "response.classes"));
+        var messageClasses = parseMessageClasses(props);
         var baseArtifact = getPropertyOrEmpty(props, "base.artifact");
         var implArtifactId = getPropertyOrEmpty(props, "slice.artifactId");
         var dependencies = parseDependencies(props);
@@ -101,11 +104,26 @@ public record SliceManifest(String sliceName,
                                  implClasses,
                                  requestClasses,
                                  responseClasses,
+                                 messageClasses,
                                  baseArtifact,
                                  implArtifactId,
                                  dependencies,
                                  configFile,
                                  resourceConfigRefs);
+    }
+
+    /// Message/event classes the manifest declares for serializer registration: topic publisher
+    /// message types (`publish.message.classes`) and stream event types (`stream.event.classes`).
+    /// Generated factory code references them, so they must reach the packaged slice jar even when
+    /// they live outside the slice package — e.g. a `shared.event` record (#712). Subscriber-side
+    /// topic message types already arrive via `request.classes` (reactive methods are interface
+    /// methods); stream consumer event types are folded into `stream.event.classes` at generation.
+    private static List<String> parseMessageClasses(Properties props) {
+        return Stream.of(parseList(getPropertyOrEmpty(props, "publish.message.classes")),
+                         parseList(getPropertyOrEmpty(props, "stream.event.classes")))
+                     .flatMap(List::stream)
+                     .distinct()
+                     .toList();
     }
 
     private static String getPropertyOrEmpty(Properties props, String key) {
@@ -187,10 +205,14 @@ public record SliceManifest(String sliceName,
     }
 
     /// Get all classes that should go into the impl artifact.
-    /// Includes implementation classes, request types, and response types.
+    /// Includes implementation classes, request/response types, and the manifest-declared
+    /// message/event classes (topic publisher message types, stream event types) — the generated
+    /// factory references those at runtime, so omitting them fails slice activation with
+    /// NoClassDefFoundError when they live outside the slice package (#712).
     public List<String> allImplClasses() {
-        return Stream.of(implClasses, requestClasses, responseClasses)
+        return Stream.of(implClasses, requestClasses, responseClasses, messageClasses)
                      .flatMap(List::stream)
+                     .distinct()
                      .toList();
     }
 

--- a/jbct/jbct-core/src/test/java/org/pragmatica/jbct/slice/SliceManifestTest.java
+++ b/jbct/jbct-core/src/test/java/org/pragmatica/jbct/slice/SliceManifestTest.java
@@ -1,0 +1,97 @@
+package org.pragmatica.jbct.slice;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/// Packaged-class-set tests for #712: message/event classes the manifest itself declares
+/// (`publish.message.classes`, `stream.event.classes`) must reach allImplClasses() — the single
+/// source PackageSlicesMojo packages the slice jar from. Omitting them fails slice activation
+/// with NoClassDefFoundError when the message record lives outside the slice package.
+class SliceManifestTest {
+
+    private static SliceManifest load(String manifestText) {
+        return SliceManifest.load(new ByteArrayInputStream(manifestText.getBytes(StandardCharsets.UTF_8)))
+                            .unwrap();
+    }
+
+    @Test
+    void allImplClasses_publishMessageClassOutsideSlicePackage_includedInPackagedSet() {
+        // Mirrors ticketing-sweep-holds: publisher of a shared.event record outside the slice package
+        var manifest = load("""
+            slice.name=SweepHolds
+            slice.package=org.pragmatica.example.ticketing.sweepholds
+            impl.classes=org.pragmatica.example.ticketing.sweepholds.SweepHolds,org.pragmatica.example.ticketing.sweepholds.SweepHoldsFactory
+            request.classes=org.pragmatica.example.ticketing.sweepholds.SweepRequest
+            response.classes=org.pragmatica.example.ticketing.sweepholds.SweepResponse
+            publish.message.classes=org.pragmatica.example.ticketing.shared.event.SeatReleased
+            publish.topics.count=1
+            publish.topic.0.config=seat-released
+            publish.topic.0.messageType=org.pragmatica.example.ticketing.shared.event.SeatReleased
+            """);
+
+        assertTrue(manifest.allImplClasses()
+                           .contains("org.pragmatica.example.ticketing.shared.event.SeatReleased"),
+                   "publish.message.classes entry must be part of the packaged class set, got: "
+                   + manifest.allImplClasses());
+    }
+
+    @Test
+    void allImplClasses_streamEventClass_includedInPackagedSet() {
+        // Mirrors notification-hub: StreamPublisher<NotificationEvent> where the event is not a
+        // request/response type of any slice method
+        var manifest = load("""
+            slice.name=NotificationService
+            slice.package=org.pragmatica.aether.example.notification
+            impl.classes=org.pragmatica.aether.example.notification.NotificationService,org.pragmatica.aether.example.notification.NotificationServiceFactory
+            stream.publishers.count=1
+            stream.publisher.0.config=notification-stream
+            stream.publisher.0.eventType=org.pragmatica.aether.example.notification.NotificationEvent
+            stream.event.classes=org.pragmatica.aether.example.notification.NotificationEvent
+            """);
+
+        assertTrue(manifest.allImplClasses()
+                           .contains("org.pragmatica.aether.example.notification.NotificationEvent"),
+                   "stream.event.classes entry must be part of the packaged class set, got: "
+                   + manifest.allImplClasses());
+    }
+
+    @Test
+    void allImplClasses_messageClassAlsoRequestClass_appearsOnce() {
+        var manifest = load("""
+            slice.name=Echo
+            slice.package=com.example.echo
+            impl.classes=com.example.echo.Echo
+            request.classes=com.example.echo.Ping
+            publish.message.classes=com.example.echo.Ping
+            """);
+
+        var occurrences = manifest.allImplClasses()
+                                  .stream()
+                                  .filter("com.example.echo.Ping"::equals)
+                                  .count();
+
+        assertEquals(1, occurrences, "duplicate declarations must collapse to one packaged entry");
+    }
+
+    @Test
+    void allImplClasses_manifestWithoutMessageKeys_containsExactlyImplRequestResponse() {
+        // Backward compatibility: manifests produced before message/event keys existed still load
+        // and package the same set as before
+        var manifest = load("""
+            slice.name=Plain
+            slice.package=com.example.plain
+            impl.classes=com.example.plain.Plain
+            request.classes=com.example.plain.Req
+            response.classes=com.example.plain.Resp
+            """);
+
+        assertEquals(List.of("com.example.plain.Plain", "com.example.plain.Req", "com.example.plain.Resp"),
+                     manifest.allImplClasses());
+    }
+}

--- a/jbct/jbct-maven-plugin/src/main/java/org/pragmatica/jbct/maven/PackageSlicesMojo.java
+++ b/jbct/jbct-maven-plugin/src/main/java/org/pragmatica/jbct/maven/PackageSlicesMojo.java
@@ -43,7 +43,8 @@ import org.codehaus.plexus.archiver.jar.JarArchiver;
 /// Packages slices into separate JAR artifacts.
 /// Reads slice manifests from META-INF/slice/*.manifest and creates:
 /// - {module}-{slice}-api.jar - API interface only
-/// - {module}-{slice}.jar - Implementation + factory + request/response types (fat JAR)
+/// - {module}-{slice}.jar - Implementation + factory + request/response types
+///   + declared message/event types (fat JAR)
 ///
 ///
 /// The impl JAR includes:
@@ -51,7 +52,7 @@ import org.codehaus.plexus.archiver.jar.JarArchiver;
 ///   - META-INF/dependencies/{FactoryClass} - runtime dependency file
 ///   - META-INF/MANIFEST.MF with Slice-Artifact and Slice-Class entries
 ///   - Bundled external libs (compile scope, non-slice, non-infra, non-provided)
-///   - Application shared code (sibling shared package or slice subpackages)
+///   - Application shared code (sibling shared package tree, recursively, or slice subpackages)
 ///
 @Mojo(name = "package-slices", defaultPhase = LifecyclePhase.PACKAGE, requiresDependencyResolution = ResolutionScope.COMPILE)
 public class PackageSlicesMojo extends AbstractMojo {
@@ -375,7 +376,7 @@ public class PackageSlicesMojo extends AbstractMojo {
             var parentPackage = String.join("/", java.util.Arrays.copyOf(packageParts, packageParts.length - 1));
             var sharedDir = classesPath.resolve(parentPackage).resolve("shared");
 
-            addDirectoryClasses(archiver, sharedDir, classesPath);
+            addPackageTreeClasses(archiver, sharedDir, classesPath);
         }
         // Find subpackages of slice package (e.g., org.example.order.utils)
         var sliceDir = classesPath.resolve(slicePackage.replace('.', '/'));
@@ -388,6 +389,24 @@ public class PackageSlicesMojo extends AbstractMojo {
             } catch (IOException e) {
                 getLog().debug("Could not scan slice subpackages: " + e.getMessage());
             }
+        }
+    }
+
+    /// Add every class in the package tree rooted at `root` — the directory itself and all
+    /// subdirectories. The sibling `shared` package is a tree, not a flat directory: message
+    /// records in `shared.event` and the component types they reference from other `shared.*`
+    /// subpackages must ship with the slice (#712). Mirrors the recursive slice-subpackage walk
+    /// in addSharedCode.
+    private void addPackageTreeClasses(JarArchiver archiver, Path root, Path classesPath) {
+        if (!Files.isDirectory(root)) {
+            return;
+        }
+
+        try (var stream = Files.walk(root)) {
+            stream.filter(Files::isDirectory)
+                  .forEach(dir -> addDirectoryClasses(archiver, dir, classesPath));
+        } catch (IOException e) {
+            getLog().debug("Could not scan shared package tree: " + root + " - " + e.getMessage());
         }
     }
 

--- a/jbct/jbct-maven-plugin/src/test/java/org/pragmatica/jbct/maven/PackageSlicesMessageClassesTest.java
+++ b/jbct/jbct-maven-plugin/src/test/java/org/pragmatica/jbct/maven/PackageSlicesMessageClassesTest.java
@@ -1,0 +1,134 @@
+package org.pragmatica.jbct.maven;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.jar.JarFile;
+
+import org.pragmatica.jbct.slice.SliceManifest;
+
+import org.codehaus.plexus.archiver.jar.JarArchiver;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/// Slice-jar packaging tests for #712: a topic message record living in a shared package OUTSIDE
+/// the slice package (ticketing shape: `shared.event.SeatReleased`) must land in the packaged
+/// slice jar, together with its member classes and the component types it references from other
+/// `shared.*` subpackages. Drives the same collection walk createImplJar performs
+/// (allImplClasses + addSharedCode) against a real JarArchiver and asserts on the built jar.
+class PackageSlicesMessageClassesTest {
+    private static final String SLICE_PKG_DIR = "org/pragmatica/example/ticketing/sweepholds";
+    private static final String SHARED_EVENT_DIR = "org/pragmatica/example/ticketing/shared/event";
+    private static final String SHARED_MODEL_DIR = "org/pragmatica/example/ticketing/shared/model";
+
+    private static final String MANIFEST_TEXT = """
+        slice.name=SweepHolds
+        slice.package=org.pragmatica.example.ticketing.sweepholds
+        slice.artifactId=ticketing-sweep-holds
+        impl.classes=org.pragmatica.example.ticketing.sweepholds.SweepHolds,org.pragmatica.example.ticketing.sweepholds.SweepHoldsFactory
+        request.classes=org.pragmatica.example.ticketing.sweepholds.SweepRequest
+        publish.message.classes=org.pragmatica.example.ticketing.shared.event.SeatReleased
+        publish.topics.count=1
+        publish.topic.0.config=seat-released
+        publish.topic.0.messageType=org.pragmatica.example.ticketing.shared.event.SeatReleased
+        """;
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void createImplJarClassSet_messageRecordInSharedSubpackage_landsInJarWithMembersAndComponents() throws Exception {
+        var classesDir = tempDir.resolve("classes");
+
+        writeClass(classesDir, SLICE_PKG_DIR + "/SweepHolds.class");
+        writeClass(classesDir, SLICE_PKG_DIR + "/SweepHoldsFactory.class");
+        writeClass(classesDir, SLICE_PKG_DIR + "/SweepRequest.class");
+        // Message record + member (nested) class in shared.event — OUTSIDE the slice package
+        writeClass(classesDir, SHARED_EVENT_DIR + "/SeatReleased.class");
+        writeClass(classesDir, SHARED_EVENT_DIR + "/SeatReleased$SeatRef.class");
+        // Component type the message record references, in a different shared subpackage
+        writeClass(classesDir, SHARED_MODEL_DIR + "/SeatId.class");
+
+        var manifest = SliceManifest.load(new ByteArrayInputStream(MANIFEST_TEXT.getBytes(StandardCharsets.UTF_8)))
+                                    .unwrap();
+        var mojo = new PackageSlicesMojo();
+
+        setClassesDirectory(mojo, classesDir.toFile());
+
+        var jarPath = tempDir.resolve("ticketing-sweep-holds.jar");
+        var archiver = new JarArchiver();
+
+        archiver.setDestFile(jarPath.toFile());
+        // Same collection walk createImplJar performs: manifest class set, then shared code
+        for (var className : manifest.allImplClasses()) {
+            invokeAddClassFiles(mojo, archiver, className);
+        }
+
+        invokeAddSharedCode(mojo, archiver, manifest);
+        archiver.createArchive();
+
+        var entries = jarEntries(jarPath);
+
+        assertTrue(entries.contains(SHARED_EVENT_DIR + "/SeatReleased.class"),
+                   "manifest-declared publish message class must land in the slice jar, got: " + entries);
+        assertTrue(entries.contains(SHARED_EVENT_DIR + "/SeatReleased$SeatRef.class"),
+                   "member classes of the message record must land in the slice jar, got: " + entries);
+        assertTrue(entries.contains(SHARED_MODEL_DIR + "/SeatId.class"),
+                   "component types in other shared subpackages must land in the slice jar, got: " + entries);
+        assertTrue(entries.contains(SLICE_PKG_DIR + "/SweepHolds.class"),
+                   "slice impl classes must still land in the slice jar, got: " + entries);
+    }
+
+    private static void writeClass(Path classesDir, String relativePath) throws Exception {
+        var file = classesDir.resolve(relativePath);
+
+        Files.createDirectories(file.getParent());
+        // Content is never parsed: no bytecode transformation runs with an empty version map
+        Files.write(file, new byte[]{(byte) 0xCA, (byte) 0xFE, (byte) 0xBA, (byte) 0xBE});
+    }
+
+    private static Set<String> jarEntries(Path jarPath) throws Exception {
+        var entries = new HashSet<String>();
+
+        try (var jar = new JarFile(jarPath.toFile())) {
+            jar.entries()
+               .asIterator()
+               .forEachRemaining(entry -> entries.add(entry.getName()));
+        }
+
+        return entries;
+    }
+
+    private static void setClassesDirectory(PackageSlicesMojo mojo, File classesDir) throws Exception {
+        var field = PackageSlicesMojo.class.getDeclaredField("classesDirectory");
+
+        field.setAccessible(true);
+        field.set(mojo, classesDir);
+    }
+
+    private static void invokeAddClassFiles(PackageSlicesMojo mojo, JarArchiver archiver, String className) throws Exception {
+        var method = PackageSlicesMojo.class.getDeclaredMethod("addClassFiles",
+                                                               JarArchiver.class,
+                                                               String.class,
+                                                               Map.class);
+
+        method.setAccessible(true);
+        method.invoke(mojo, archiver, className, Map.of());
+    }
+
+    private static void invokeAddSharedCode(PackageSlicesMojo mojo, JarArchiver archiver, SliceManifest manifest) throws Exception {
+        var method = PackageSlicesMojo.class.getDeclaredMethod("addSharedCode",
+                                                               JarArchiver.class,
+                                                               SliceManifest.class);
+
+        method.setAccessible(true);
+        method.invoke(mojo, archiver, manifest);
+    }
+}


### PR DESCRIPTION
## Mechanism — what the closure missed and why

Slice jars are packaged by `PackageSlicesMojo.createImplJar` from exactly two sources: `SliceManifest.allImplClasses()` (name-based, with nested-class expansion) and `addSharedCode` (convention-based directory copy). Both had a gap, and topic message types fell through both:

1. **`SliceManifest.allImplClasses()`** (`jbct-core`) merged only `implClasses + requestClasses + responseClasses`. The manifest's own `publish.message.classes` and `stream.event.classes` keys — written by `ManifestGenerator` precisely so the runtime can register serializers for these types — were never parsed into the packaged set. Publisher message types are constructor-injected type arguments (`MessagePublisher<T>`, `StreamPublisher<T>`), so they appear in no method-derived list; nothing else could catch them.
2. **`PackageSlicesMojo.addSharedCode`** walked the sibling `shared` package with non-recursive `Files.list`, while the slice-subpackage walk right below it uses recursive `Files.walk`. A record in `shared.event` (ticketing's `SeatReleased`) or a component type in `shared.model` never reached the jar.

Reproductions explained: `ticketing-sweep-holds` declares `publish.message.classes=...shared.event.SeatReleased` but the jar's 23 classes omit it (gap 1 + gap 2) → `NoClassDefFoundError` in `SweepHoldsFactory.lambda$sweepHolds$0`. notification-hub's `NotificationEvent` (declared in `stream.event.classes`, living in the slice's own package top level, not a method param type) hit gap 1 alone.

**Both directions checked**: same-module topic *subscribers* were already covered — reactive methods are slice interface methods, so their single message param lands in `request.classes`; stream *consumers* (incl. batch) are folded into `stream.event.classes` by `collectStreamEventTypes`. Cross-module message-type delivery is the dependency-edge sibling #717, not this PR.

## Fix

- `SliceManifest` gains a `messageClasses` component: the union of `publish.message.classes` and `stream.event.classes`, folded into `allImplClasses()` (now deduplicated). Consumption-side only — `ManifestGenerator` is untouched.
- `addSharedCode` walks the sibling `shared` package tree recursively (`addPackageTreeClasses`), mirroring the slice-subpackage walk.
- Stale surfaces swept: `PackageSlicesMojo` class doc, `allImplClasses` doc, RFC-0004 inclusion rules, CHANGELOG.

## Closure depth

Declared message/event classes **by name + their nested/member classes** (`classToPathsWithInner`, same expansion every other named class gets) **+ the entire sibling `shared` package tree, recursively**. No bytecode reference-graph walk — the existing closure never walks references for request/response types either; transitive components are covered by the `shared`-tree convention, which the recursive walk now actually honors. A referenced type living outside `shared`, the slice package, and the declared lists remains out of closure — same rule as before this PR, now uniformly applied.

## Red/green evidence

RED (fix stashed, tests present) — jbct-core:

```
[ERROR]   SliceManifestTest.allImplClasses_publishMessageClassOutsideSlicePackage_includedInPackagedSet:38 publish.message.classes entry must be part of the packaged class set, got: [org.pragmatica.example.ticketing.sweepholds.SweepHolds, org.pragmatica.example.ticketing.sweepholds.SweepHoldsFactory, org.pragmatica.example.ticketing.sweepholds.SweepRequest, org.pragmatica.example.ticketing.sweepholds.SweepResponse] ==> expected: <true> but was: <false>
[ERROR]   SliceManifestTest.allImplClasses_streamEventClass_includedInPackagedSet:58 stream.event.classes entry must be part of the packaged class set, got: [org.pragmatica.aether.example.notification.NotificationService, org.pragmatica.aether.example.notification.NotificationServiceFactory] ==> expected: <true> but was: <false>
```

RED — jbct-maven-plugin (jar built from a ticketing-shaped fixture: message record + member class in `shared/event`, component in `shared/model`):

```
org.opentest4j.AssertionFailedError: manifest-declared publish message class must land in the slice jar, got: [org/pragmatica/example/ticketing/sweepholds/SweepHolds.class, ... org/pragmatica/example/ticketing/sweepholds/SweepHoldsFactory.class, org/pragmatica/example/ticketing/sweepholds/SweepRequest.class, META-INF/, META-INF/MANIFEST.MF, org/] ==> expected: <true> but was: <false>
```

GREEN (fix restored):

```
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0 -- in org.pragmatica.jbct.slice.SliceManifestTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0 -- in org.pragmatica.jbct.maven.PackageSlicesMessageClassesTest
```

FULL suites (`mvn -f jbct/pom.xml test -pl jbct-core,jbct-maven-plugin,slice-processor,slice-processor-tests -am`):

```
[INFO] JBCT Parser ........................................ SUCCESS
[INFO] JBCT Core .......................................... SUCCESS
[INFO] JBCT Formatter ..................................... SUCCESS
[INFO] JBCT Linter ........................................ SUCCESS
[INFO] JBCT Maven Plugin .................................. SUCCESS
[INFO] JBCT Slice Processor ............................... SUCCESS
[INFO] Slice Processor Integration Tests .................. SUCCESS
[INFO] BUILD SUCCESS
```

Zero regressions. The jar-level GREEN also empirically confirms the archiver tolerates the now-systematic duplicate add (message class reachable via both `allImplClasses` and the shared tree) — jar builds, single logical entry per path asserted.

## Envelope statement

No manifest keys added, removed, or changed — `ManifestGenerator` output is byte-identical; the fix reads keys the manifest already carries. Adding classes to the JAR is not a manifest structure change, so no `ENVELOPE_FORMAT_VERSION` question arises; the GA freeze at 1000 (owner ruling #386, PR #708 pattern) is untouched.

Refs #712. Final e2e verification against the rf=1 reproduction (#704 setup) happens in the coordinating session before the ticket closes.
