### PR TITLE
fix: bundle resource-interceptors providers into the node runtime image (#716)

### DIFF
--- a/aether/node/pom.xml
+++ b/aether/node/pom.xml
@@ -152,6 +152,22 @@
             <artifactId>resource-db-jdbc</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <!--
+            #716: third instance of the missing-provider class documented above (resource-http/
+            resource-notification) and by #345 I1(b) (resource-durable-entity). A slice declaring a
+            cache/log interceptor resolves both the interceptor TYPE (CacheMethodInterceptor/
+            LoggingMethodInterceptor, through SliceClassLoader's parent chain) and its
+            `ResourceFactory` (via SpiResourceProvider's ServiceLoader) from the runtime image;
+            resource-interceptors was a dependency of nothing but its own parent, so neither
+            aether-node.jar nor aether-forge.jar carried the factories, and every interceptor-using
+            slice failed to load with "No resource provider registered" — 8 of the ticketing
+            reference app's 24 slices, amplified to a full-blueprint rollback under ALL_OR_NOTHING.
+        -->
+        <dependency>
+            <groupId>org.pragmatica-lite.aether</groupId>
+            <artifactId>resource-interceptors</artifactId>
+            <version>${project.version}</version>
+        </dependency>
         <dependency>
             <groupId>com.zaxxer</groupId>
             <artifactId>HikariCP</artifactId>


### PR DESCRIPTION
Refs #716 — owner-cleared one-dependency fix (clearance recorded on the ticket; the earlier mid-edit interrupt was confirmed incidental).

**Mechanism.** Third instance of the missing-provider class the pom block itself documents: a slice declaring a cache/log interceptor resolves both the interceptor TYPE (through SliceClassLoader's parent chain) and its ResourceFactory (via SpiResourceProvider's ServiceLoader) from the runtime image, and `resource-interceptors` was a dependency of nothing but its own parent — so neither aether-node.jar nor aether-forge.jar (which inherits this block via ember → node) carried the factories. Every interceptor-using slice failed with "No resource provider registered" — 8 of ticketing's 24 slices, amplified to full-blueprint rollback under ALL_OR_NOTHING (#704). Same fix shape as resource-durable-entity (#345 I1(b)) and resource-http/notification before it; house-style comment added at the entry.

**Fix-ALL enumeration** (every aether/resource module with a ResourceFactory SPI vs the node block): interceptors was the only gap among the bundled families — notification/http/durable-entity/db-async/db-jdbc all present (notification verified, matching #672's evidence). The four jooq/r2dbc variants also carry SPIs and are NOT in the block — flagged as an open question for the owner rather than silently added: bundling four optional DB stacks into every node image is a size/policy decision, not obviously a defect, and the clearance covered the one dependency.

**Gate:** `mvn -pl aether/node -am test` — BUILD SUCCESS, aether/node 705 tests, 0 failures. `mvn jbct:check -pl aether/node` — 0 format issues, 0 lint errors. 

**Before/after proof (shaded forge jar):** shipped dist (Aug 23): 0 `resource/interceptor` classes, SPI file has 12 lines, no interceptor entry. Fresh build from this branch: 37 provider classes, SPI file carries the same 12 lines plus **8** interceptor factories (Retry, CircuitBreaker, RateLimit, Logging, Metrics, Cache, Idempotency, RateGuard — note: 8, not the 7 the ticket implied).

**Live verification (in flight, will be posted on #716):** rf=1 ticketing cluster run under the suite-lock protocol with this jar — "No resource provider registered" count is ZERO and the 8 interceptor slices load; combined with #712's packaging fix (PR #719), the only remaining per-slice failures are #717's two SeatSellability injectors (stream-operator).