### PR TITLE
test: #386 D5 falsifier — intercepted host method coexists with a transitive context-carrying subscriber

### DIFF
--- a/jbct/slice-processor-tests/src/main/java/com/example/durabletopicstep/OrderAuditSlice.java
+++ b/jbct/slice-processor-tests/src/main/java/com/example/durabletopicstep/OrderAuditSlice.java
@@ -10,8 +10,15 @@ import org.pragmatica.lang.Promise;
 
 /// Host slice for the transitive context-carrying subscriber fixture: it declares no subscription
 /// itself, and picks one up through its [OrderAuditListener] step.
+///
+/// Its own method carries an interceptor ([WithAuditRetry]) on purpose. That makes this the
+/// falsifying case for the D5 interceptor rule: the refusal of interceptor-plus-MessageContext is
+/// scoped to the slice's OWN methods, because only those are walked by the generated wrapper. If
+/// that scope were widened bluntly to "the slice has interceptors anywhere", this legal combination
+/// would be refused and this module would fail to compile.
 @Slice
 public interface OrderAuditSlice {
+    @WithAuditRetry
     Promise<AuditReport> report(AuditQuery query);
 
     static OrderAuditSlice orderAuditSlice(OrderAuditListener listener) {

--- a/jbct/slice-processor-tests/src/main/java/com/example/durabletopicstep/WithAuditRetry.java
+++ b/jbct/slice-processor-tests/src/main/java/com/example/durabletopicstep/WithAuditRetry.java
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2025 Pragmatica Labs - Sergiy Yevtushenko
+// Licensed under Business Source License 1.1. Change Date: 2030-01-01. Change License: Apache-2.0.
+// See LICENSE in the repository root for full terms.
+package com.example.durabletopicstep;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.pragmatica.aether.slice.MethodInterceptor;
+import org.pragmatica.aether.slice.annotation.ResourceQualifier;
+
+/// A method interceptor on the HOST slice's own business method, deliberately placed so this
+/// fixture pairs an interceptor with a context-carrying subscriber that is reached transitively.
+///
+/// The interceptor wrapper is generated per SLICE and walks the slice's OWN methods, so it sees
+/// `report` and never the step's subscriber. That is why this combination is legal while
+/// interceptor-plus-direct-subscriber is refused, and this fixture is what holds that line: a guard
+/// widened bluntly to "slice has interceptors" would refuse this and the module would stop
+/// compiling.
+@ResourceQualifier(type = MethodInterceptor.class, config = "retry.audit")
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface WithAuditRetry {}

--- a/jbct/slice-processor-tests/src/test/java/com/example/durabletopicstep/GeneratedTransitiveContextualSubscriberTest.java
+++ b/jbct/slice-processor-tests/src/test/java/com/example/durabletopicstep/GeneratedTransitiveContextualSubscriberTest.java
@@ -71,4 +71,31 @@ class GeneratedTransitiveContextualSubscriberTest {
         assertThat(factory).contains("delegate::report");
         assertThat(manifest).contains("envelope.version=1000");
     }
+
+    /// THE FALSIFIER for the interceptor rule's scope. `report` carries an interceptor, so the
+    /// wrapper record IS generated for this slice — and the context-carrying subscriber sits beside
+    /// it, reached transitively.
+    ///
+    /// This combination is legal precisely because the wrapper walks the slice's OWN methods and
+    /// never the step's. The proof is that this module compiles at all: were the refusal widened
+    /// bluntly to "the slice declares interceptors", this slice would be rejected and these tests
+    /// would not run. Were the wrapper instead to walk transitive methods, it would emit a one-argument
+    /// override of a two-argument handler and javac would reject the generated file.
+    ///
+    /// So the claim "the wrapper cannot see a transitive contextual subscriber" is held here by a
+    /// build that must succeed, rather than by an argument in a comment.
+    ///
+    /// This falsifier is ONE-DIRECTIONAL and is half of a pair. It catches WIDENING the refusal
+    /// (dropping `site.direct()` fails this module at compile time). It cannot catch NARROWING —
+    /// dropping the model-scope disjunct would leave this fixture green, because this handler carries
+    /// no interceptor of its own. That direction is held by
+    /// `SliceProcessorTest.should_reject_message_context_subscriber_when_interceptor_is_on_another_method`,
+    /// which puts a DIRECT contextual subscriber beside an interceptor on another method. Change
+    /// either side of the guard and one of the two goes red; neither test alone is sufficient.
+    @Test
+    void interceptedHostMethod_coexistsWithTransitiveContextualSubscriber() {
+        assertThat(factory).contains("Wrapper");
+        assertThat(factory).contains("contextual -> listener.onOrderPlaced");
+        assertThat(manifest).contains("reactive.0.context=message");
+    }
 }


### PR DESCRIPTION
Follow-up to #730 (merged). Test-only: no production code changes.

## What this holds

#730's D5 interceptor rule is **precisely** scoped, not bluntly scoped: a context-carrying subscriber is refused when the slice declares method interceptors **and the handler is one of the slice's own methods**. The `site.direct()` qualifier matters, because the generated interceptor wrapper walks `model.methods()` only — a handler reached transitively through a plain-interface step is never placed in it, so refusing it would reject a legal shape.

The review confirmed that by enumerating the sites. This makes it a property the **build** defends rather than one someone checked once.

## The fixture

`OrderAuditSlice.report` now carries a method interceptor (`@WithAuditRetry`), while the same slice picks up a context-carrying subscriber transitively via its `OrderAuditListener` step. That combination is legal and **must compile** — and the load-bearing assertion is that the module compiles at all.

Verified by mutation: dropping `site.direct() &&` from the guard turns this into a **compile-time failure of the whole `slice-processor-tests` module** during annotation processing, with the diagnostic naming the handler and the constraint. It cannot be skipped, ignored, or routed around with `-Dtest=`.

The generated output confirms the two coexist as intended — the wrapper record wraps `report` only, while `methods()` carries the contextual adapter:

```java
record OrderAuditSliceWrapper(Fn1<Promise<AuditReport>, AuditQuery> reportFn) implements OrderAuditSlice { ... }
...
new SliceMethod<>(
    MethodName.methodName("listenerOnOrderPlaced")...,
    contextual -> listener.onOrderPlaced((OrderPlaced) contextual.event(), contextual.context()),
    new TypeToken<Unit>() {},
    new TypeToken<ContextualEvent>() {}
)
```

## It is half of a pair, deliberately

This falsifier is **one-directional** — it catches *widening* the refusal. It cannot catch *narrowing*: dropping the model-scope disjunct would leave it green, since this handler carries no interceptor of its own. That direction is held by `SliceProcessorTest.should_reject_message_context_subscriber_when_interceptor_is_on_another_method`, which pairs a **direct** contextual subscriber with an interceptor on another method (verified red under exactly that mutation during #730).

Change either side of the guard and one of the two goes red; neither is sufficient alone. The pairing is recorded in the test so the next reader does not have to rediscover it.

## Why it was not in #730

It changes generated output for `OrderAuditSlice` (the wrapper record starts being generated), which would have moved assertions and reopened a confirmed diff for reasons unrelated to the two cosmetic nits that were blocking the merge. Held back deliberately and landed separately.

## Testing

`jbct/slice-processor` 346, `jbct/slice-processor-tests` 76 (one new), green, no lint warnings.

Gated with `jbct/slice-processor-tests/target` deleted first — that module silently re-validates stale generated code when only the processor changed, which is filed as #736.
