### PR TITLE
fix: #736 slice-processor-tests always reprocesses fixtures

### DIFF
--- a/jbct/slice-processor-tests/pom.xml
+++ b/jbct/slice-processor-tests/pom.xml
@@ -86,6 +86,45 @@
                     <skipPublishing>true</skipPublishing>
                 </configuration>
             </plugin>
+            <!--
+              This module's whole purpose is to prove slice-processor codegen against real javac, so a
+              green run here must mean "the CURRENT processor generated this". Without the clean below
+              it can mean "a PREVIOUS processor generated this", silently.
+
+              maven-compiler-plugin (3.14.0 here — jbct/pom.xml overrides the root's version) decides
+              staleness from what changed IN THE CURRENT BUILD RUN. The annotation processor is not a
+              tracked input at all: it reaches javac through <annotationProcessorPaths>, and the
+              `provided` dependency does not trigger the dependency-changed path either. So when the
+              processor was rebuilt by an EARLIER run that never reached this module — a gate that died
+              in slice-processor's own test phase, or a build scoped with -pl to the processor alone —
+              the next run sees nothing changed in ITSELF and logs "Nothing to compile - all classes are
+              up to date", leaving the fixtures to re-validate the previous processor's output. Note it
+              is not a disk-timestamp check: at the skip, the processor's classes were NEWER than these
+              outputs and it skipped anyway.
+
+              That sequence is the ordinary edit-fix-gate loop, which is exactly when someone is
+              changing the processor and most needs this module to be telling the truth. Verified live
+              on #386 D5 (PR #730), where a fix looked unapplied because the manifest under test was an
+              hour older than the edit.
+
+              Clearing the module's output makes the skip impossible rather than documented. It costs a
+              full recompile of ~47 fixture sources on every build — measured at roughly two seconds,
+              which is the correct price for a gate that is otherwise able to pass without checking
+              anything. See #736.
+            -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-clean-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>always-reprocess-fixtures</id>
+                        <phase>initialize</phase>
+                        <goals>
+                            <goal>clean</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>

--- a/jbct/slice-processor-tests/src/test/java/com/example/durabletopic/GeneratedContextualSubscriberTest.java
+++ b/jbct/slice-processor-tests/src/test/java/com/example/durabletopic/GeneratedContextualSubscriberTest.java
@@ -27,11 +27,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 /// incorrectly, `DurableOrderSliceFactory` would not compile, the module build would fail, and these
 /// tests would never run.
 ///
-/// ⚠ Running these against a PROCESSOR-ONLY change locally will lie to you. Maven skips annotation
-/// processing here when this module's own sources have not changed, so the fixtures are re-validated
-/// against the artifacts a PREVIOUS processor generated — a green run proving nothing about the
-/// change under test. Delete `jbct/slice-processor-tests/target` before gating a slice-processor
-/// change. CI is unaffected (fresh checkout, nothing to reuse).
+/// That guarantee used to be conditional, and the condition was invisible: the module could skip
+/// annotation processing and re-validate a PREVIOUS processor's output. The module's pom now clears
+/// its own target before every build so the skip cannot happen — see the comment there and #736. It
+/// is a mechanism, not a convention, so nothing here depends on remembering it.
 class GeneratedContextualSubscriberTest {
 
     private static String factory;


### PR DESCRIPTION
Fixes #736.

`jbct/slice-processor-tests` exists so that a wrong slice-processor change is a **build failure**, not a silent gap — its fixtures compile the generated sources with real javac. That guarantee was conditional, and the condition was invisible: the module could skip annotation processing and re-validate the output of a **previous** processor while reporting green.

## The trigger (corrected — the ticket as originally filed was wrong)

Not "when only the processor changes" — that case works. It needs:

1. A run rebuilds `slice-processor` but never reaches this module (died in slice-processor's own test phase, or was scoped `-pl jbct/slice-processor`).
2. The next run has no *further* processor source change, so slice-processor does not recompile.
3. This module logs `Nothing to compile - all classes are up to date` and is skipped.

Step 1 is the ordinary edit-fix-gate loop, so the trap fires exactly when someone is iterating on a processor fix.

maven-compiler-plugin decides staleness from what changed **in the current build run**. The processor is not a tracked input at all — it reaches javac via `<annotationProcessorPaths>`, and the `provided` dependency does not trigger the dependency-changed path. It is not a timestamp check either: at the skip, the processor's classes were *newer* than this module's outputs.

## The fix

`maven-clean-plugin` bound to `initialize`, so the module's output is cleared before every build and the skip becomes impossible rather than documented.

## Verification

The full trap sequence was re-run with the fix in place — a marker injected into the processor's emitted output, the processor rebuilt via `-pl jbct/slice-processor -am` so this module was never reached, then a two-module build with nothing deleted:

- marker **propagates** into the fixture's generated source (previously absent)
- `clean:3.2.0:clean (always-reprocess-fixtures) @ slice-processor-tests` fires
- compile step logs `Recompiling the module` instead of `Nothing to compile`
- `slice-processor` 346, `slice-processor-tests` 76, green

⚠ **On method:** "marker absent" is not evidence on its own — a dead probe and a real skip look identical. Every run above was paired with a **positive control**: identical source, identical command, only the module's target deleted, confirming the marker *can* propagate. Without that control the experiment is unfalsifiable. It was missing from my original protocol and added by the agent executing it; #736 records it, because anyone re-verifying this needs the control more than the sequence.

**Cost:** ~2.0s per build with the fix, versus ~0.06s without (repeats, since `-T 1C` makes single-module timings noisy). That 0.06s is the trap as a number — the cost of a gate doing essentially nothing.

**Collateral check:** surefire reports survive. The clean runs at `initialize`; reports are written later in `test`. 76 report files present after a full run — verified rather than assumed, because the pom comment claims it.

## Also in this PR

The warning I previously added to `GeneratedContextualSubscriberTest` described the **wrong trigger** — it told readers to `rm -rf` for processor-only changes, which demonstrably works fine. Replaced with a pointer to the mechanism. Wrong instructions in a test class are worse than none: they cost attention and buy false confidence.

## Not addressed

`examples/**` and `aether/tests/blueprints/**` also run the processor and are subject to the same skip. They are fixtures and samples rather than gates, so a stale build there misleads nobody about processor correctness. Worth revisiting if one becomes load-bearing.

