### PR TITLE
fix: #740 jbct goals disclose when they examined nothing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,6 +58,15 @@ goal — it fails on formatting drift but does not fix it for you [mechanism:
 `process` goal, which reformats in place. Running `build.sh` locally first means you fix
 formatting issues once, locally, instead of round-tripping through a CI failure.
 
+**What the JBCT gate does and does not cover:** it examines `src/main/java` only. Test sources are
+excluded from every JBCT goal by default (`jbct.includeTests=false`), so a **test-only** module —
+`aether/forge/forge-tests`, for instance — is not format- or lint-checked at all, and running
+`jbct:check` there is a no-op. That is deliberate policy, not an oversight (#624, #740); whether the
+gate should extend to test trees is an open question, not a settled yes. The goals now say so out
+loud rather than reporting a bare success: when files exist but were excluded, they warn that the
+module was **not** examined and name the reason, so a green result is never mistaken for coverage.
+Pass `-Djbct.includeTests=true` to check a test tree by hand.
+
 For quick iteration on a single module: `mvn test -pl <module>`. The full matrix CI actually runs
 is in [`.github/workflows/ci.yml`](.github/workflows/ci.yml) — format+lint check, `mvn install
 -pl '!examples'`, the postgres-async integration suite, an end-to-end `mvn verify` over

--- a/jbct/jbct-maven-plugin/src/main/java/org/pragmatica/jbct/maven/AbstractJbctMojo.java
+++ b/jbct/jbct-maven-plugin/src/main/java/org/pragmatica/jbct/maven/AbstractJbctMojo.java
@@ -1,6 +1,8 @@
 package org.pragmatica.jbct.maven;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 
@@ -67,5 +69,55 @@ public abstract class AbstractJbctMojo extends AbstractMojo {
         }
 
         return false;
+    }
+
+    /// Report an empty file set HONESTLY, distinguishing "nothing to check" from "everything was
+    /// excluded from checking" (#740).
+    ///
+    /// Both states used to render as `No Java files found.` at INFO, followed by a green build. For a
+    /// test-only module under the default `includeTests=false` that sentence is simply untrue — the
+    /// files exist and were skipped by policy — and a reader has no way to tell whether the
+    /// instrument looked and found nothing or never looked at all. A gate that cannot fail must at
+    /// least say so; that is the whole difference between a check that passed and a check that was
+    /// never performed.
+    ///
+    /// Warns only when files were actually excluded, so aggregator modules and genuinely empty source
+    /// trees stay quiet.
+    protected void reportNothingToCheck(String goalName, boolean includeTests) {
+        var excludedTests = includeTests
+                            ? 0
+                            : countJavaFiles(Option.option(testSourceDirectory).map(File::toPath));
+
+        if (excludedTests > 0) {
+            getLog().warn("JBCT " + goalName + " examined NOTHING in " + project.getArtifactId()
+                         + ": no Java files under " + sourceDirectory
+                         + ", and " + excludedTests
+                         + " test file(s) under " + testSourceDirectory
+                         + " were excluded because jbct.includeTests=false."
+                         + " This module is NOT covered by this goal — a green result here is not evidence about those files."
+                         + " Pass -Djbct.includeTests=true to examine them.");
+
+            return;
+        }
+
+        getLog().info("No Java files found.");
+    }
+
+    private static int countJavaFiles(Option<Path> directory) {
+        return directory.filter(Files::exists)
+                        .map(AbstractJbctMojo::countJavaFilesIn)
+                        .or(0);
+    }
+
+    private static int countJavaFilesIn(Path directory) {
+        try (var paths = Files.walk(directory)) {
+            return (int) paths.filter(Files::isRegularFile)
+                              .filter(path -> path.toString().endsWith(".java"))
+                              .count();
+        } catch (IOException _) {
+            // Counting is only ever used to make a message more honest; a failure here must not
+            // turn a reporting path into a build failure.
+            return 0;
+        }
     }
 }

--- a/jbct/jbct-maven-plugin/src/main/java/org/pragmatica/jbct/maven/CheckMojo.java
+++ b/jbct/jbct-maven-plugin/src/main/java/org/pragmatica/jbct/maven/CheckMojo.java
@@ -44,7 +44,7 @@ public class CheckMojo extends AbstractJbctMojo {
         var filesToProcess = collectJavaFiles(jbctConfig.files(), includeTests);
 
         if (filesToProcess.isEmpty()) {
-            getLog().info("No Java files found.");
+            reportNothingToCheck("check", includeTests);
 
             return;
         }

--- a/jbct/jbct-maven-plugin/src/main/java/org/pragmatica/jbct/maven/FormatCheckMojo.java
+++ b/jbct/jbct-maven-plugin/src/main/java/org/pragmatica/jbct/maven/FormatCheckMojo.java
@@ -40,7 +40,7 @@ public class FormatCheckMojo extends AbstractJbctMojo {
         var filesToProcess = collectJavaFiles(config.files(), includeTests);
 
         if (filesToProcess.isEmpty()) {
-            getLog().info("No Java files found.");
+            reportNothingToCheck("format check", includeTests);
 
             return;
         }

--- a/jbct/jbct-maven-plugin/src/main/java/org/pragmatica/jbct/maven/FormatMojo.java
+++ b/jbct/jbct-maven-plugin/src/main/java/org/pragmatica/jbct/maven/FormatMojo.java
@@ -37,7 +37,7 @@ public class FormatMojo extends AbstractJbctMojo {
         var filesToProcess = collectJavaFiles(config.files(), includeTests);
 
         if (filesToProcess.isEmpty()) {
-            getLog().info("No Java files found.");
+            reportNothingToCheck("format", includeTests);
 
             return;
         }

--- a/jbct/jbct-maven-plugin/src/main/java/org/pragmatica/jbct/maven/LintMojo.java
+++ b/jbct/jbct-maven-plugin/src/main/java/org/pragmatica/jbct/maven/LintMojo.java
@@ -42,7 +42,7 @@ public class LintMojo extends AbstractJbctMojo {
         var filesToProcess = collectJavaFiles(jbctConfig.files(), includeTests);
 
         if (filesToProcess.isEmpty()) {
-            getLog().info("No Java files found.");
+            reportNothingToCheck("lint", includeTests);
 
             return;
         }

--- a/jbct/jbct-maven-plugin/src/main/java/org/pragmatica/jbct/maven/ProcessMojo.java
+++ b/jbct/jbct-maven-plugin/src/main/java/org/pragmatica/jbct/maven/ProcessMojo.java
@@ -68,7 +68,7 @@ public class ProcessMojo extends AbstractJbctMojo {
         var filesToProcess = collectJavaFiles(jbctConfig.files(), includeTests);
 
         if (filesToProcess.isEmpty()) {
-            getLog().info("No Java files found.");
+            reportNothingToCheck("process", includeTests);
 
             return;
         }

--- a/jbct/jbct-maven-plugin/src/main/java/org/pragmatica/jbct/maven/ScoreMojo.java
+++ b/jbct/jbct-maven-plugin/src/main/java/org/pragmatica/jbct/maven/ScoreMojo.java
@@ -54,7 +54,7 @@ public class ScoreMojo extends AbstractJbctMojo {
         var filesToProcess = collectJavaFiles(jbctConfig.files(), includeTests);
 
         if (filesToProcess.isEmpty()) {
-            getLog().info("No Java files found.");
+            reportNothingToCheck("score", includeTests);
 
             return;
         }

--- a/jbct/jbct-maven-plugin/src/test/java/org/pragmatica/jbct/maven/NothingToCheckReportingTest.java
+++ b/jbct/jbct-maven-plugin/src/test/java/org/pragmatica/jbct/maven/NothingToCheckReportingTest.java
@@ -1,0 +1,137 @@
+package org.pragmatica.jbct.maven;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.maven.plugin.logging.SystemStreamLog;
+import org.apache.maven.project.MavenProject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/// Regression gate for #740: a goal that examined NOTHING reported it the same way as a goal that
+/// examined everything and found it clean.
+///
+/// `forge-tests` has zero files under `src/main/java` and 41 under `src/test/java`. With the
+/// project-wide `includeTests=false` default, `jbct:check` there collected nothing, logged
+/// `No Java files found.` at INFO, and exited green — while the sentence was flatly untrue, since
+/// the files exist and were excluded by policy. A reader could not distinguish "looked, found
+/// nothing" from "never looked", and the ticket that surfaced it proposed two remedies that would
+/// each have added a second CI step reporting success while examining zero files.
+///
+/// The pin is on the distinction, not on the wording: an empty file set caused by EXCLUSION must
+/// announce itself as uncovered, and a genuinely empty source tree must stay quiet so aggregator
+/// modules do not cry wolf.
+class NothingToCheckReportingTest {
+
+    /// Captures what the goal actually told the reader, which is the whole subject here.
+    private static final class CapturingLog extends SystemStreamLog {
+        private final List<String> warnings = new ArrayList<>();
+        private final List<String> infos = new ArrayList<>();
+
+        @Override
+        public void warn(CharSequence content) {
+            warnings.add(content.toString());
+        }
+
+        @Override
+        public void info(CharSequence content) {
+            infos.add(content.toString());
+        }
+    }
+
+    private static CheckMojo mojoFor(Path mainDir, Path testDir) {
+        var mojo = new CheckMojo();
+        var project = new MavenProject();
+
+        project.setArtifactId("forge-tests");
+        mojo.project = project;
+        mojo.sourceDirectory = mainDir.toFile();
+        mojo.testSourceDirectory = testDir.toFile();
+        mojo.setLog(new CapturingLog());
+
+        return mojo;
+    }
+
+    private static CapturingLog logOf(CheckMojo mojo) {
+        return (CapturingLog) mojo.getLog();
+    }
+
+    private static Path withJavaFiles(Path dir, int count) throws Exception {
+        Files.createDirectories(dir);
+        for (int i = 0; i < count; i++) {
+            Files.writeString(dir.resolve("Sample" + i + ".java"), "class Sample" + i + " {}");
+        }
+
+        return dir;
+    }
+
+    /// The forge-tests shape: files exist, policy excluded them, so the goal covered nothing.
+    @Test
+    void reportNothingToCheck_warnsThatNothingWasExamined_whenTestsWereExcluded(@TempDir Path dir) throws Exception {
+        var mojo = mojoFor(dir.resolve("main"), withJavaFiles(dir.resolve("test"), 41));
+
+        mojo.reportNothingToCheck("check", false);
+
+        var warnings = logOf(mojo).warnings;
+
+        assertThat(warnings).hasSize(1);
+        assertThat(warnings.getFirst()).contains("examined NOTHING")
+                                       .contains("forge-tests")
+                                       .contains("41 test file(s)")
+                                       .contains("jbct.includeTests=false")
+                                       .contains("not evidence");
+    }
+
+    /// It must not claim there are no Java files when there are 41 of them — that was the actual
+    /// falsehood, and the reason a reader trusted the green.
+    @Test
+    void reportNothingToCheck_doesNotClaimAbsence_whenFilesWereMerelyExcluded(@TempDir Path dir) throws Exception {
+        var mojo = mojoFor(dir.resolve("main"), withJavaFiles(dir.resolve("test"), 41));
+
+        mojo.reportNothingToCheck("check", false);
+
+        assertThat(logOf(mojo).infos).noneMatch(line -> line.contains("No Java files found"));
+    }
+
+    /// A genuinely empty module — an aggregator pom, say — must stay quiet, or the warning becomes
+    /// noise and stops being read.
+    @Test
+    void reportNothingToCheck_staysQuiet_whenThereIsGenuinelyNothing(@TempDir Path dir) {
+        var mojo = mojoFor(dir.resolve("main"), dir.resolve("test"));
+
+        mojo.reportNothingToCheck("check", false);
+
+        assertThat(logOf(mojo).warnings).isEmpty();
+        assertThat(logOf(mojo).infos).containsExactly("No Java files found.");
+    }
+
+    /// With tests already included, an empty set really does mean nothing was there — nothing was
+    /// excluded, so there is nothing to disclose.
+    @Test
+    void reportNothingToCheck_staysQuiet_whenTestsWereIncludedAndStillEmpty(@TempDir Path dir) throws Exception {
+        var mojo = mojoFor(dir.resolve("main"), withJavaFiles(dir.resolve("test"), 41));
+
+        mojo.reportNothingToCheck("check", true);
+
+        assertThat(logOf(mojo).warnings).isEmpty();
+        assertThat(logOf(mojo).infos).containsExactly("No Java files found.");
+    }
+
+    /// Counting walks the tree, because sources sit in package directories rather than at the root.
+    @Test
+    void reportNothingToCheck_countsNestedSources(@TempDir Path dir) throws Exception {
+        var nested = dir.resolve("test").resolve("org").resolve("example");
+        var mojo = mojoFor(dir.resolve("main"), dir.resolve("test"));
+
+        withJavaFiles(nested, 3);
+
+        mojo.reportNothingToCheck("check", false);
+
+        assertThat(logOf(mojo).warnings.getFirst()).contains("3 test file(s)");
+    }
+}

--- a/jbct/slice-processor-tests/pom.xml
+++ b/jbct/slice-processor-tests/pom.xml
@@ -86,6 +86,45 @@
                     <skipPublishing>true</skipPublishing>
                 </configuration>
             </plugin>
+            <!--
+              This module's whole purpose is to prove slice-processor codegen against real javac, so a
+              green run here must mean "the CURRENT processor generated this". Without the clean below
+              it can mean "a PREVIOUS processor generated this", silently.
+
+              maven-compiler-plugin (3.14.0 here — jbct/pom.xml overrides the root's version) decides
+              staleness from what changed IN THE CURRENT BUILD RUN. The annotation processor is not a
+              tracked input at all: it reaches javac through <annotationProcessorPaths>, and the
+              `provided` dependency does not trigger the dependency-changed path either. So when the
+              processor was rebuilt by an EARLIER run that never reached this module — a gate that died
+              in slice-processor's own test phase, or a build scoped with -pl to the processor alone —
+              the next run sees nothing changed in ITSELF and logs "Nothing to compile - all classes are
+              up to date", leaving the fixtures to re-validate the previous processor's output. Note it
+              is not a disk-timestamp check: at the skip, the processor's classes were NEWER than these
+              outputs and it skipped anyway.
+
+              That sequence is the ordinary edit-fix-gate loop, which is exactly when someone is
+              changing the processor and most needs this module to be telling the truth. Verified live
+              on #386 D5 (PR #730), where a fix looked unapplied because the manifest under test was an
+              hour older than the edit.
+
+              Clearing the module's output makes the skip impossible rather than documented. It costs a
+              full recompile of ~47 fixture sources on every build — measured at roughly two seconds,
+              which is the correct price for a gate that is otherwise able to pass without checking
+              anything. See #736.
+            -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-clean-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>always-reprocess-fixtures</id>
+                        <phase>initialize</phase>
+                        <goals>
+                            <goal>clean</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>

--- a/jbct/slice-processor-tests/src/test/java/com/example/durabletopic/GeneratedContextualSubscriberTest.java
+++ b/jbct/slice-processor-tests/src/test/java/com/example/durabletopic/GeneratedContextualSubscriberTest.java
@@ -27,11 +27,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 /// incorrectly, `DurableOrderSliceFactory` would not compile, the module build would fail, and these
 /// tests would never run.
 ///
-/// ⚠ Running these against a PROCESSOR-ONLY change locally will lie to you. Maven skips annotation
-/// processing here when this module's own sources have not changed, so the fixtures are re-validated
-/// against the artifacts a PREVIOUS processor generated — a green run proving nothing about the
-/// change under test. Delete `jbct/slice-processor-tests/target` before gating a slice-processor
-/// change. CI is unaffected (fresh checkout, nothing to reuse).
+/// That guarantee used to be conditional, and the condition was invisible: the module could skip
+/// annotation processing and re-validate a PREVIOUS processor's output. The module's pom now clears
+/// its own target before every build so the skip cannot happen — see the comment there and #736. It
+/// is a mechanism, not a convention, so nothing here depends on remembering it.
 class GeneratedContextualSubscriberTest {
 
     private static String factory;


### PR DESCRIPTION
Addresses the second acceptance criterion of #740: *"`jbct:check` on a module it does not examine no longer exits silently green (it should say it examined nothing)."*

The coverage half of that ticket is **deliberately not in this PR** — see below.

## The defect

Six goals shared one line:

```java
if (filesToProcess.isEmpty()) {
    getLog().info("No Java files found.");
    return;
}
```

For `aether/forge/forge-tests` that sentence is **false**. Measured:

```
mvn jbct:check -pl aether/forge/forge-tests -Pwith-e2e
  → [INFO] No Java files found.   → BUILD SUCCESS

  same, plus -Djbct.includeTests=true
  → Check results: 40 format issue(s), 194 lint error(s), 665 warning(s)   → BUILD FAILURE
```

There are **41** Java files. The module has zero under `src/main/java` and 41 under `src/test/java`, and `includeTests` defaults to false for every goal (deliberately, per #624). So the files were excluded by policy — not absent.

Two states a reader must be able to tell apart rendered identically, as one INFO line and a green build:

- **(a)** this module genuinely has nothing to check
- **(b)** this module has files that were excluded from checking

## The fix

One shared `reportNothingToCheck(goal, includeTests)` in `AbstractJbctMojo`; all six goals route through it. When files were excluded it **warns**, naming the count, the directory, the reason, and — the part that matters — that a green result here is not evidence about those files. When there is genuinely nothing, it stays quiet, so aggregator modules and empty trees do not cry wolf.

The defect was one cause at six sites, so the fix is one helper rather than six edits.

## Testing

`jbct-maven-plugin`: 28 tests green, including the pre-existing `IncludeTestsParameterTest` (7) which covers the same six mojos.

New `NothingToCheckReportingTest` (5) pins the **distinction** rather than the wording: excluded-files warns and names the reason; excluded-files must not claim absence; genuinely-empty stays quiet; `includeTests=true` with an empty result stays quiet; counting walks nested package directories.

**Verification boundary, stated plainly:** these are unit tests against the helper, driven with the real forge-tests shape (0 main / 41 test). I have **not** run the end-to-end `jbct:check` on forge-tests with this change, because that needs the modified plugin installed into the isolated repo, and I did not want to mutate this tree's `.m2-local` toolchain without asking. The remaining unverified link is only that the six goals call the helper — six one-line replacements, and `grep` confirms none retains the old call. Happy to install into the isolated repo and produce the end-to-end log if that evidence is wanted.

## What this PR deliberately does NOT do

Extend coverage. The ticket's options 1 and 2 (add a `-Pwith-e2e` gate step; move `forge-tests` into the default reactor) **would not work**: the module would still collect zero files and exit green, because the binding constraint is `includeTests=false`, not the reactor. Either would add a second instrument reporting success while examining nothing — the ticket's own defect, reproduced in its remedy.

Actually gating those files is a project-wide policy change (test sources are excluded everywhere, by design) with a 194-lint-error backlog in this module alone. That is an owner call with stream-data-plane, not something to slide in under a tech-debt ticket. Measurements have been sent so it can be decided on numbers.

Note that after this change, option 3 (document the exclusion) becomes largely redundant: the tool says so itself, at the moment and place someone would otherwise be misled.
