### PR TITLE
fix: pin maven-clean-plugin version introduced unversioned by #744

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,7 @@
 
         <!-- Maven Plugin versions -->
         <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
+        <maven-clean-plugin.version>3.2.0</maven-clean-plugin.version>
         <maven-surefire-plugin.version>3.5.4</maven-surefire-plugin.version>
         <maven-failsafe-plugin.version>3.5.4</maven-failsafe-plugin.version>
         <maven-plugin-api.version>3.9.9</maven-plugin-api.version>
@@ -489,6 +490,14 @@
     <build>
         <pluginManagement>
             <plugins>
+                <!-- Version pinned here because slice-processor-tests binds a clean execution (#736);
+                     an unversioned declaration floats with the Maven distribution and Maven warns
+                     that it "threatens the stability of your build". -->
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-clean-plugin</artifactId>
+                    <version>${maven-clean-plugin.version}</version>
+                </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>


### PR DESCRIPTION
Follow-up to #744 (merged), fixing a defect **I introduced there**.

## What I shipped broken

#744 added a `maven-clean-plugin` execution to `jbct/slice-processor-tests` with **no version**, and no `pluginManagement` entry existed for it anywhere in the repo. Maven now warns on **every build of the reactor**:

```
[WARNING] Some problems were encountered while building the effective model for
          org.pragmatica-lite:slice-processor-tests:jar:1.0.0-rc3
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-clean-plugin
          is missing. @ line 115, column 21
[WARNING] It is highly recommended to fix these problems because they threaten the
          stability of your build.
[WARNING] For this reason, future Maven versions might no longer support building such
          malformed projects.
```

An unversioned plugin floats with whatever the Maven distribution supplies. For a plugin that **deletes a directory on every build**, floating is the wrong property to leave to chance — and #736 exists precisely because build-tool behaviour that varies by invocation is hard to reason about.

## The fix

Pinned to **3.2.0** — the version Maven was already resolving, so no behaviour change — following the repo's existing convention: a `maven-clean-plugin.version` property plus a root `<pluginManagement>` entry, exactly as `maven-compiler-plugin`, `maven-surefire-plugin` and `maven-failsafe-plugin` are handled.

## Verification

- The warning is **gone**. Grepping the full build for `plugin.version' for` and `effective model for` now returns only the pre-existing `org.pragmatica-lite:statemachine` / `maven-jar-plugin` warning, which is not mine and is untouched here.
- The clean execution still runs and still resolves the same version: `--- clean:3.2.0:clean (always-reprocess-fixtures) @ slice-processor-tests ---`.
- `jbct/slice-processor` 346, `jbct/slice-processor-tests` 76, green. No new warnings.

## How it was found

While running the end-to-end verification for #740 (PR #745) on an unrelated module. It had been present on the shared branch since #744 merged, and nothing failed because of it — a warning on every build that no gate treats as an error. Worth noting given the theme of the last few tickets: this is the same shape as the defects those tickets were about, just at low severity — **a signal that is emitted, ignored, and therefore invisible.**
