### PR TITLE
fix(aether-setup): thin main artifact, executable as uber classifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [1.0.0-rc3] - 2026-09-02
 
+### Changed (2026-09-02 — publish-time packaging, one commit after the `v1.0.0-rc3` tag)
+- **`aether-setup` no longer publishes its 30 MB executable as the module artifact.** The shaded jar is
+  now attached under the `uber` classifier (`aether-setup-<version>-uber.jar`), and the thin jar is the
+  main artifact, matching the `peglib-playground` pattern. rc2 shipped the fat jar as the main artifact
+  with a POM that still listed every dependency, so a consumer pulled both. Applied to the Maven Central
+  publish of rc3 from `main` after the tag was cut; the tagged tree carries the old configuration.
+
 ### Fixed (2026-08-31 — the ticketing example could never complete a purchase: seven defects, each found by running the product and reading what it said about itself)
 - **A scalar `@Query` ignored its own `RETURNING` clause.** `FactoryGenerator.inferScalarColumnName`
   derived the result column from the SELECT list and never consulted `RETURNING`, so

--- a/aether/aether-setup/pom.xml
+++ b/aether/aether-setup/pom.xml
@@ -74,6 +74,8 @@
                                     </excludes>
                                 </filter>
                             </filters>
+                            <shadedArtifactAttached>true</shadedArtifactAttached>
+                            <shadedClassifierName>uber</shadedClassifierName>
                             <createDependencyReducedPom>false</createDependencyReducedPom>
                         </configuration>
                     </execution>


### PR DESCRIPTION
`aether-setup` published its 30 MB shaded executable as the module artifact (rc2 did the same, with a POM that still listed every dependency). The shade plugin now attaches the fat jar under the `uber` classifier and the thin jar is the main artifact, matching the `peglib-playground` pattern.

Verified by a module build: `aether-setup-1.0.0-rc3.jar` 0.03 MB (22 entries), `aether-setup-1.0.0-rc3-uber.jar` 30.5 MB with `Main-Class: org.pragmatica.aether.setup.AetherUp`, no `original-` jar. `dead-surface-gate` depends on the module at test scope without a classifier and gets the same classes via the POM.

Applied to the rc3 Maven Central publish from `main`, one commit after the `v1.0.0-rc3` tag; the tag is not moved because the GitHub release and CI artifacts hang on it. Already cherry-picked onto `release-1.0.0-rc4`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Changed**
  - Updated Maven publishing for `aether-setup`.
  - The standard thin JAR is now the primary artifact.
  - The bundled executable JAR is available separately using the `uber` classifier.
  - This prevents consumers from receiving duplicate dependency packaging and enables more predictable dependency resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->