### PR TITLE
docs: first-user fixes from the rc3 clean-install smoke

### DIFF
--- a/aether/README.md
+++ b/aether/README.md
@@ -8,11 +8,14 @@ Unified Application Runtime for Java -- scale horizontally without microservices
 > - **Single trust domain.** Aether assumes all cluster nodes and management clients are
 >   operated by one trusted party. It is **not** hardened for multi-tenant or hostile-network
 >   deployment.
-> - **Security is built in but OFF by default in this RC.** The management API supports
->   API-key auth with role-based access (viewer / operator / admin), and inter-node transport
->   runs over TLS (self-signed by default, or operator-supplied certificates) — but the default
->   `SecurityMode` is `NONE`, so auth must be **explicitly enabled**. Making security default-on
->   is a hard gate for the 1.0.0 (GA) release. Separately, `AETHER_INSECURE_DEV_MODE` is an explicit opt-in that
+> - **Security is on by default in this RC.** The management API supports API-key auth with
+>   role-based access (viewer / operator / admin), and inter-node transport runs over TLS
+>   (self-signed by default, or operator-supplied certificates); the default `SecurityMode` is
+>   `API_KEY`, not `NONE` — a fresh cluster with no configured key mints a one-time ADMIN key and
+>   prints it once in the startup log (look for the `AETHER BOOTSTRAP ADMIN API KEY` banner), or
+>   you can preset one via `AETHER_API_KEYS=<key>` or an `[app-http.api-keys.<name>]` table in
+>   `aether.toml`. For local experiments, set `security_mode = "none"` under `[app-http]` in
+>   `aether.toml` to disable auth entirely. Separately, `AETHER_INSECURE_DEV_MODE` is an explicit opt-in that
 >   enables test-injection endpoints; it is **refused at boot** when operator TLS certificates
 >   are configured, and logs a loud startup warning whenever it is active.
 > - **Not yet production-hardened.** Some background reconcilers are tuned for settled clusters

--- a/aether/docs/operators/current-docker-setup.md
+++ b/aether/docs/operators/current-docker-setup.md
@@ -43,7 +43,7 @@ services:
       - "8080:8080"   # Management API
       - "8090:8090"   # Cluster port
     healthcheck:
-      test: ["CMD", "wget", "--spider", "-q", "http://localhost:8080/health"]
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:8080/health/live"]
       interval: 5s
       timeout: 3s
       retries: 10

--- a/aether/docs/operators/current-docker-setup.md
+++ b/aether/docs/operators/current-docker-setup.md
@@ -6,6 +6,11 @@ Status: **Development/Staging Ready**
 
 Aether includes Docker infrastructure for local development and staging environments. This document describes the current setup and how to use it.
 
+**Note:** In 1.0.0-rc3, a single node is not operational beyond `/health/live` — it reaches
+quorum but never elects a leader, so management routes return 503 and the bootstrap admin key is
+never printed (#782). This is why the compose file below runs three nodes; don't reduce it to
+one until rc4.
+
 ---
 
 ## Components

--- a/aether/docs/operators/current-docker-setup.md
+++ b/aether/docs/operators/current-docker-setup.md
@@ -38,6 +38,8 @@ services:
       CLUSTER_PORT: "8090"
       MANAGEMENT_PORT: "8080"
       PEERS: "node-1:aether-node-1:8090,node-2:aether-node-2:8090,node-3:aether-node-3:8090"
+      AETHER_CLUSTER_NAME: "aether-dev"
+      AETHER_CLUSTER_SECRET: "change-me-dev-secret"
       JAVA_OPTS: "-Xmx256m -XX:+UseZGC"
     ports:
       - "8080:8080"   # Management API

--- a/aether/docs/operators/docker-deployment.md
+++ b/aether/docs/operators/docker-deployment.md
@@ -71,6 +71,8 @@ services:
       CLUSTER_PORT: "8090"
       MANAGEMENT_PORT: "8080"
       PEERS: "node-1:aether-node-1:8090,node-2:aether-node-2:8090,node-3:aether-node-3:8090"
+      AETHER_CLUSTER_NAME: "aether-dev"
+      AETHER_CLUSTER_SECRET: "change-me-dev-secret"
       JAVA_OPTS: "-Xmx256m -XX:+UseZGC"
     ports:
       - "8080:8080"
@@ -78,7 +80,7 @@ services:
     networks:
       - aether-network
     healthcheck:
-      test: ["CMD", "wget", "--spider", "-q", "http://localhost:8080/health"]
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:8080/health/live"]
       interval: 5s
       timeout: 3s
       retries: 10
@@ -101,6 +103,8 @@ networks:
 | `CLUSTER_PORT` | 8090 | Port for cluster communication |
 | `MANAGEMENT_PORT` | 8080 | Port for REST API |
 | `PEERS` | (required) | Cluster peer list |
+| `AETHER_CLUSTER_NAME` | (required) | Cluster name; boot aborts if unset. Lowercase DNS-label format (`[a-z]([-a-z0-9]{0,61}[a-z0-9])?`), e.g. `aether-dev` |
+| `AETHER_CLUSTER_SECRET` | (required) | Shared secret used to generate TLS certificates; boot aborts if unset and no `cluster_secret` is configured in the `[tls]` TOML section |
 | `JAVA_OPTS` | `-Xmx512m` | JVM options |
 
 ### Peer List Format
@@ -133,6 +137,8 @@ docker run -d \
   -e NODE_ID=node-1 \
   -e CLUSTER_PORT=8090 \
   -e PEERS="node-1:localhost:8090" \
+  -e AETHER_CLUSTER_NAME=aether-dev \
+  -e AETHER_CLUSTER_SECRET=change-me-dev-secret \
   -p 8080:8080 \
   -p 8090:8090 \
   aether-node:latest
@@ -148,16 +154,22 @@ docker network create aether-net
 docker run -d --name node1 --network aether-net \
   -e NODE_ID=node-1 \
   -e PEERS="node-1:node1:8090,node-2:node2:8090,node-3:node3:8090" \
+  -e AETHER_CLUSTER_NAME=aether-dev \
+  -e AETHER_CLUSTER_SECRET=change-me-dev-secret \
   -p 8080:8080 aether-node:latest
 
 docker run -d --name node2 --network aether-net \
   -e NODE_ID=node-2 \
   -e PEERS="node-1:node1:8090,node-2:node2:8090,node-3:node3:8090" \
+  -e AETHER_CLUSTER_NAME=aether-dev \
+  -e AETHER_CLUSTER_SECRET=change-me-dev-secret \
   -p 8081:8080 aether-node:latest
 
 docker run -d --name node3 --network aether-net \
   -e NODE_ID=node-3 \
   -e PEERS="node-1:node1:8090,node-2:node2:8090,node-3:node3:8090" \
+  -e AETHER_CLUSTER_NAME=aether-dev \
+  -e AETHER_CLUSTER_SECRET=change-me-dev-secret \
   -p 8082:8080 aether-node:latest
 ```
 
@@ -167,7 +179,7 @@ Containers include health checks:
 
 ```dockerfile
 HEALTHCHECK --interval=10s --timeout=5s --start-period=30s --retries=3 \
-    CMD wget --spider -q http://localhost:8080/health || exit 1
+    CMD wget --spider -q http://localhost:8080/health/live || exit 1
 ```
 
 Check health status:
@@ -329,7 +341,7 @@ jobs:
 
 1. Verify all nodes can reach each other:
    ```bash
-   docker exec aether-node-1 wget -q -O- http://aether-node-2:8080/health
+   docker exec aether-node-1 wget -q -O- http://aether-node-2:8080/health/live
    ```
 2. Check PEERS environment variable format
 3. Ensure health checks are passing

--- a/aether/docs/operators/docker-deployment.md
+++ b/aether/docs/operators/docker-deployment.md
@@ -131,6 +131,10 @@ node-1:aether-node-1:8090,node-2:aether-node-2:8090,node-3:aether-node-3:8090
 
 ### Single Node
 
+**Not operational in 1.0.0-rc3.** A single node reaches quorum but never elects a leader, so
+every management route beyond `/health/live` returns 503, and the bootstrap admin key is never
+printed (#782). Run three nodes (see below), or wait for rc4.
+
 ```bash
 docker run -d \
   --name aether-node-1 \

--- a/core/README.md
+++ b/core/README.md
@@ -44,6 +44,8 @@ Option<String> name = Option.option(user.getName())
 
 ### Safe Error Handling Without Exceptions
 ```java
+// MathError implements org.pragmatica.lang.Cause (message() is the only method a Cause
+// must define); see "Your First Pragmatica Application" below for a full definition.
 Result<Integer> divide(int a, int b) {
     return b == 0
         ? MathError.DIVISION_BY_ZERO.result()
@@ -106,24 +108,45 @@ implementation 'org.pragmatica-lite:core:1.0.0-rc3'
 ### Your First Pragmatica Application
 
 ```java
+package org.pragmatica.examples;
+
 import org.pragmatica.lang.*;
 
+
 public class Example {
+    // A failure cause: implementing org.pragmatica.lang.Cause requires only message().
+    enum MathError implements Cause {
+        DIVISION_BY_ZERO("Division by zero");
+        private final String message;
+        MathError(String message) {
+            this.message = message;
+        }
+        static MathError divisionByZero() {
+            return DIVISION_BY_ZERO;
+        }
+        @Override
+        public String message() {
+            return message;
+        }
+    }
+
     // Safe division that never throws
     public static Result<Double> safeDivide(double a, double b) {
         return b == 0.0
-            ? MathError.divisionByZero().result()
-            : Result.ok(a / b);
+               ? MathError.divisionByZero().result()
+               : Result.ok(a / b);
     }
 
-    // Chaining operations
-    static void main(String[] args) {
-        safeDivide(10.0, 2.0)
-            .map(result -> result * 2)  // Transform success value
-            .fold(
-                error -> "Error: " + error.message(),
-                success -> "Result: " + success
-            );
+    // Chaining operations. JBCT-RET-01 requires business methods to return one of
+    // T / Option<T> / Result<T> / Promise<T>; the JVM entry point is the sanctioned
+    // exception, suppressed the same way as in aether/aether-setup's AetherUp.main.
+    @SuppressWarnings("JBCT-RET-01")
+    public static void main(String[] args) {
+        var message = safeDivide(10.0, 2.0).map(result -> result * 2)  // Transform success value
+                                .fold(error -> "Error: " + error.message(),
+                                      success -> "Result: " + success);
+
+        System.out.println(message);
     }
 }
 ```


### PR DESCRIPTION
First-user defects found by a clean-install smoke of the published 1.0.0-rc3 (fresh Maven repo against Central, release assets with checksums, the GHCR image).

- `core/README.md` "Your First Pragmatica Application" did not compile (`MathError` undefined) and failed JBCT's own check (`void main`). Now defines `MathError` against the real `Cause` interface and uses the JBCT-compliant entry-point shape. Proven by compiling the snippet verbatim from the edited README in an empty Maven repo against `org.pragmatica-lite:core:1.0.0-rc3` (`Result: 10.0`) and running the released, checksum-verified `jbct.jar` on it (0 findings).
- `aether/docs/operators/docker-deployment.md` and `current-docker-setup.md`: the Single Node example did not boot — `AETHER_CLUSTER_NAME` and `AETHER_CLUSTER_SECRET` are required and were undocumented; the healthcheck targeted `/health` (401) instead of `/health/live`. Proven by booting the corrected command to `status: UP`.
- `aether/README.md` said the default `SecurityMode` is `NONE`; since #290 it is `API_KEY` with a one-time bootstrap admin key. The README now states the default, where the key is printed, how to preset one, and how to switch security off for local experiments.

Known and out of scope here: a single-node rc3 cluster cannot elect a leader (consensus defect, fix in progress for rc4), so the Single Node guide is not operational on rc3 even with these corrections; a note referencing the ticket follows once the ticket exists.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified that security is enabled by default, with API-key authentication and options for bootstrapping or configuring keys.
  - Documented how to disable authentication for local experiments.
  - Updated Docker deployment examples to include required cluster identity and secret settings.
  - Updated health checks and troubleshooting commands to use the live-health endpoint.
  - Improved application examples with current error-handling, entry-point, return-type, and output guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->