### PR TITLE
fix(resource): #769 URL overrides take precedence over discrete host/port/database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [1.0.0-rc4] - Unreleased
 
+### Fixed (2026-09-03 — #769: `database.async_url` operator override was ignored by slice stores while the log claimed it was applied)
+- **`DatabaseConnectorConfig.effectiveHost()`/`effectivePort()`/`effectiveDatabase()` gave the
+  discrete `host`/`port`/`database` fields unconditional precedence over a configured URL**,
+  inverting the documented contract (`resource-reference.md`: `jdbc_url`/`r2dbc_url`/`async_url`
+  "replaces host/port/database"). An operator who set only `async_url` to redirect a datastore had
+  the override silently discarded by every consumer of the effective accessors
+  (`AsyncSqlConnectorFactory`, `PgSqlConnectorFactory`, `NotificationListenerFactory`,
+  `AsyncJooqConnectorFactory`), while `effectiveAsyncUrl()` itself was already URL-first and correct.
+- The three accessors now prefer the URL-derived value (via the existing, unchanged
+  jdbc→r2dbc→async internal ordering) and fall back to the discrete field only when no URL yields
+  one. `effectiveType()`, `effectiveUsername()`, and `effectivePassword()` are unchanged — no
+  URL-derivation applies to type/credentials.
+
 ## [1.0.0-rc3] - 2026-09-02
 
 ### Changed (2026-09-02 — publish-time packaging, one commit after the `v1.0.0-rc3` tag)

--- a/aether/docs/slice-developers/resource-reference.md
+++ b/aether/docs/slice-developers/resource-reference.md
@@ -354,6 +354,16 @@ Transport is selected automatically by priority:
 | `async_url` | `String` (optional) | none | Override async URL — selects postgres-async transport (highest priority) |
 | `properties.*` | `Map<String, String>` | empty | Additional driver-specific properties |
 
+**Overrides and precedence (#769):**
+- Each URL override (`jdbc_url`, `r2dbc_url`, `async_url`) takes precedence over the discrete
+  `host`/`port`/`database` fields for the transport it selects — e.g. if `async_url` embeds its
+  own port, that port is used even when a discrete `port` is also set.
+- Setting **two different URL kinds to different hosts** (e.g. `jdbc_url` pointing at one host and
+  `async_url` at another) is **unsupported** today: the effective host/port/database are derived
+  by checking URL kinds in a fixed order (jdbc, then r2dbc, then async) that does not follow the
+  transport-selection priority above. Until this is reconciled, configure only the URL kind for
+  the transport you intend to use.
+
 ### Database Types
 
 | Type | Default Port | JDBC Driver |

--- a/aether/resource/api/src/main/java/org/pragmatica/aether/resource/db/DatabaseConnectorConfig.java
+++ b/aether/resource/api/src/main/java/org/pragmatica/aether/resource/db/DatabaseConnectorConfig.java
@@ -199,25 +199,28 @@ public record DatabaseConnectorConfig(Option<String> name,
                    .or(DatabaseType.POSTGRESQL);
     }
 
+    // #769: a URL (async_url, jdbc_url, r2dbc_url) has the highest priority and replaces
+    // host/port/database — resource-reference.md:337,354. The URL-derived value wins whenever
+    // one of the three URL fields parses to it; discrete fields are the fallback, not the
+    // override. Cross-URL-kind ordering inside firstUrlHost/Port/Database (jdbc, then r2dbc,
+    // then async) is unchanged and out of scope for this fix.
     public String effectiveHost() {
-        return host.orElse(() -> firstUrlHost(jdbcUrl, r2dbcUrl, asyncUrl))
-                   .or("localhost");
+        return firstUrlHost(jdbcUrl, r2dbcUrl, asyncUrl).orElse(() -> host)
+                           .or("localhost");
     }
 
     public int effectivePort() {
-        return port.filter(p -> p > 0)
-                   .or(() -> {
-                           var urlPort = firstUrlPort(jdbcUrl, r2dbcUrl, asyncUrl);
+        var urlPort = firstUrlPort(jdbcUrl, r2dbcUrl, asyncUrl);
 
-                           return urlPort > 0
-                                  ? urlPort
-                                  : effectiveType().defaultPort();
-                       });
+        return urlPort > 0
+               ? urlPort
+               : port.filter(p -> p > 0)
+                     .or(() -> effectiveType().defaultPort());
     }
 
     public String effectiveDatabase() {
-        return database.orElse(() -> firstUrlDatabase(jdbcUrl, r2dbcUrl, asyncUrl))
-                       .or("");
+        return firstUrlDatabase(jdbcUrl, r2dbcUrl, asyncUrl).orElse(() -> database)
+                               .or("");
     }
 
     public String effectiveJdbcUrl() {

--- a/aether/resource/api/src/main/java/org/pragmatica/aether/resource/db/DatabaseConnectorConfig.java
+++ b/aether/resource/api/src/main/java/org/pragmatica/aether/resource/db/DatabaseConnectorConfig.java
@@ -330,6 +330,14 @@ public record DatabaseConnectorConfig(Option<String> name,
                                   .map(_ -> Unit.unit());
     }
 
+    // #769 deferred: firstUrlHost/firstUrlPort/firstUrlDatabase check URL kinds in the order
+    // jdbc -> r2dbc -> async, the REVERSE of the documented transport-selection priority
+    // async > r2dbc > jdbc (AsyncSqlConnectorFactory.priority()=20, R2dbcSqlConnectorFactory.priority()=10,
+    // JDBC default=0). This is deliberate, not an oversight: no shipped aether.toml sets two
+    // different URL kinds to different hosts, so the two orderings currently never disagree in
+    // practice, and reconciling them (deriving from the URL kind the selected transport would
+    // actually use) is a separate, larger change. Unreachable by any shipped config today; tracked
+    // for a follow-up (draft: ticket-url-kind-derivation-follows-transport.md, not yet filed).
     private static Option<String> firstUrlHost(Option<String> jdbcUrl,
                                                Option<String> r2dbcUrl,
                                                Option<String> asyncUrl) {

--- a/aether/resource/api/src/main/java/org/pragmatica/aether/resource/db/DatasourceConnectionProvider.java
+++ b/aether/resource/api/src/main/java/org/pragmatica/aether/resource/db/DatasourceConnectionProvider.java
@@ -134,8 +134,14 @@ class DatasourceConnectionProviderInstance implements DatasourceConnectionProvid
                       factory.priority(),
                       factory.supports(config));
             if (factory.supports(config)) {
-                log.info("Selected factory {} for provisioning",
-                         factory.getClass().getSimpleName());
+                // #769: log the resolved effective connection target (post override precedence),
+                // not the raw config, so a claim that an override was applied is checkable from
+                // the log alone. Credential-free by construction: host/port/database/transport only.
+                log.info("Provisioning datasource via {}: host={}, port={}, database={}",
+                         factory.getClass().getSimpleName(),
+                         config.effectiveHost(),
+                         config.effectivePort(),
+                         config.effectiveDatabase());
 
                 return factory.provision(config);
             }

--- a/aether/resource/api/src/test/java/org/pragmatica/aether/resource/db/DatabaseConnectorConfigTest.java
+++ b/aether/resource/api/src/test/java/org/pragmatica/aether/resource/db/DatabaseConnectorConfigTest.java
@@ -485,4 +485,92 @@ class DatabaseConnectorConfigTest {
             assertThat(str).doesNotContain("user:pass@");
         }
     }
+
+    // #769: resource-reference.md:337,354 documents a URL (async_url, jdbc_url, r2dbc_url) as
+    // highest priority, replacing host/port/database. The effective accessors previously gave
+    // discrete fields unconditional precedence over the URL, so an operator override that only
+    // touched async_url was silently ignored by every consumer of effectiveHost/Port/Database.
+    @Nested
+    class EffectiveComponentsUrlPrecedence {
+
+        @Test
+        void effectiveHost_prefersAsyncUrl_overDiscreteFields_whenBothPresentAndDiffer() {
+            var config = databaseConnectorConfigBuilder()
+                .withName("db")
+                .withHost("intrinsic-host")
+                .withPort(5432)
+                .withDatabase("intrinsic-db")
+                .withAsyncUrl("postgresql://override-host:6543/override-db")
+                .build()
+                .unwrap();
+
+            assertThat(config.effectiveHost()).isEqualTo("override-host");
+            assertThat(config.effectivePort()).isEqualTo(6543);
+            assertThat(config.effectiveDatabase()).isEqualTo("override-db");
+        }
+
+        // Real values from examples/comprehensive-persistence/src/main/resources/resources.toml
+        // [database] section, where discrete fields and async_url agree. Proves the precedence
+        // fix changes nothing for the repo's own resources.toml files.
+        @Test
+        void effectiveHost_staysConsistent_whenDiscreteFieldsAndAsyncUrlAgree_realResourcesTomlValues() {
+            var config = databaseConnectorConfigBuilder()
+                .withName("comprehensive-primary")
+                .withHost("localhost")
+                .withPort(5432)
+                .withDatabase("forge")
+                .withAsyncUrl("postgresql://localhost:5432/forge")
+                .build()
+                .unwrap();
+
+            assertThat(config.effectiveHost()).isEqualTo("localhost");
+            assertThat(config.effectivePort()).isEqualTo(5432);
+            assertThat(config.effectiveDatabase()).isEqualTo("forge");
+        }
+
+        @Test
+        void effectiveHost_usesDiscreteFields_whenNoUrlPresent() {
+            var config = databaseConnectorConfigBuilder()
+                .withName("db")
+                .withType(DatabaseType.POSTGRESQL)
+                .withHost("discrete-host")
+                .withPort(5555)
+                .withDatabase("discrete-db")
+                .build()
+                .unwrap();
+
+            assertThat(config.effectiveHost()).isEqualTo("discrete-host");
+            assertThat(config.effectivePort()).isEqualTo(5555);
+            assertThat(config.effectiveDatabase()).isEqualTo("discrete-db");
+        }
+
+        @Test
+        void effectiveHost_prefersUrl_overDiscreteFields_forJdbcAndR2dbcUrlsToo() {
+            var jdbcConfig = databaseConnectorConfigBuilder()
+                .withName("jdbc-db")
+                .withHost("intrinsic-host")
+                .withPort(5432)
+                .withDatabase("intrinsic-db")
+                .withJdbcUrl("jdbc:postgresql://override-host:6543/override-db")
+                .build()
+                .unwrap();
+
+            assertThat(jdbcConfig.effectiveHost()).isEqualTo("override-host");
+            assertThat(jdbcConfig.effectivePort()).isEqualTo(6543);
+            assertThat(jdbcConfig.effectiveDatabase()).isEqualTo("override-db");
+
+            var r2dbcConfig = databaseConnectorConfigBuilder()
+                .withName("r2dbc-db")
+                .withHost("intrinsic-host")
+                .withPort(5432)
+                .withDatabase("intrinsic-db")
+                .withR2dbcUrl("r2dbc:postgresql://override-host2:6544/override-db2")
+                .build()
+                .unwrap();
+
+            assertThat(r2dbcConfig.effectiveHost()).isEqualTo("override-host2");
+            assertThat(r2dbcConfig.effectivePort()).isEqualTo(6544);
+            assertThat(r2dbcConfig.effectiveDatabase()).isEqualTo("override-db2");
+        }
+    }
 }

--- a/aether/resource/db-async/src/test/java/org/pragmatica/aether/resource/db/async/AsyncSqlConnectorFactoryConfigureConnectionTest.java
+++ b/aether/resource/db-async/src/test/java/org/pragmatica/aether/resource/db/async/AsyncSqlConnectorFactoryConfigureConnectionTest.java
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2025 Pragmatica Labs - Sergiy Yevtushenko
+// Licensed under Business Source License 1.1. Change Date: 2030-01-01. Change License: Apache-2.0.
+// See LICENSE in the repository root for full terms.
+
+package org.pragmatica.aether.resource.db.async;
+
+import java.lang.reflect.Method;
+
+import org.junit.jupiter.api.Test;
+import org.pragmatica.aether.resource.db.DatabaseConnectorConfig;
+import org.pragmatica.postgres.net.ConnectibleBuilder;
+import org.pragmatica.postgres.net.netty.NettyConnectibleBuilder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.pragmatica.aether.resource.db.DatabaseConnectorConfig.databaseConnectorConfigBuilder;
+
+/**
+ * #769 consumer-level pin: {@code AsyncSqlConnectorFactory.configureConnection} must read the
+ * effective (override-resolved) host/port/database from {@code DatabaseConnectorConfig}. Exercised
+ * via reflection since the method is private static (established pattern in this codebase for
+ * testing private helpers without widening production visibility). Goes red if
+ * {@code DatabaseConnectorConfig}'s override-precedence fix (#769) is reverted.
+ */
+class AsyncSqlConnectorFactoryConfigureConnectionTest {
+
+    @Test
+    void configureConnection_withAsyncUrlOverride_appliesTheOverrideHostPortDatabase() {
+        var config = databaseConnectorConfigBuilder()
+                .withName("db")
+                .withHost("discrete-host")
+                .withPort(5432)
+                .withDatabase("discrete-db")
+                .withAsyncUrl("postgresql://override-host:6543/override-db")
+                .build()
+                .unwrap();
+
+        var builder = new InspectableBuilder();
+        invokeConfigureConnection(builder, config);
+
+        var properties = builder.configuration();
+        assertThat(properties.hostname()).isEqualTo("override-host");
+        assertThat(properties.port()).isEqualTo(6543);
+        assertThat(properties.database()).isEqualTo("override-db");
+    }
+
+    private static void invokeConfigureConnection(NettyConnectibleBuilder builder, DatabaseConnectorConfig config) {
+        try {
+            Method method = AsyncSqlConnectorFactory.class.getDeclaredMethod("configureConnection",
+                                                                             NettyConnectibleBuilder.class,
+                                                                             DatabaseConnectorConfig.class);
+            method.setAccessible(true);
+            method.invoke(null, builder, config);
+        } catch (ReflectiveOperationException e) {
+            fail("configureConnection invocation failed: " + e);
+        }
+    }
+
+    private static final class InspectableBuilder extends NettyConnectibleBuilder {
+        ConnectibleBuilder.ConnectibleConfiguration configuration() {
+            return properties;
+        }
+    }
+}

--- a/aether/resource/db-async/src/test/java/org/pragmatica/aether/resource/db/async/DatasourceProvisioningLoggingTest.java
+++ b/aether/resource/db-async/src/test/java/org/pragmatica/aether/resource/db/async/DatasourceProvisioningLoggingTest.java
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2025 Pragmatica Labs - Sergiy Yevtushenko
+// Licensed under Business Source License 1.1. Change Date: 2030-01-01. Change License: Apache-2.0.
+// See LICENSE in the repository root for full terms.
+
+package org.pragmatica.aether.resource.db.async;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.apache.logging.log4j.core.config.LoggerConfig;
+import org.apache.logging.log4j.core.config.Property;
+import org.junit.jupiter.api.Test;
+import org.pragmatica.aether.resource.db.DatasourceConnectionProvider;
+import org.pragmatica.lang.Result;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.pragmatica.aether.resource.db.DatabaseConnectorConfig.databaseConnectorConfigBuilder;
+
+/**
+ * #769: provisioning must log the resolved effective connection target (post override
+ * precedence), not the raw discrete config — otherwise "the log claims the override was
+ * applied" is not actually checkable from the log.
+ */
+class DatasourceProvisioningLoggingTest {
+
+    private static final String PROVIDER_LOGGER = "org.pragmatica.aether.resource.db.DatasourceConnectionProviderInstance";
+
+    @Test
+    void connector_withAsyncUrlOverride_logsTheOverrideHostNotTheDiscreteHost() {
+        var config = databaseConnectorConfigBuilder()
+                .withName("db")
+                .withHost("discrete-host")
+                .withPort(5432)
+                .withDatabase("discrete-db")
+                .withAsyncUrl("postgresql://override-host:6543/override-db")
+                .build()
+                .unwrap();
+
+        var provider = DatasourceConnectionProvider.datasourceConnectionProvider((section, configClass) -> Result.success(config));
+
+        var lines = captureProviderLogLines(() -> {
+            var outcome = provider.connector("db").await();
+            assertThat(outcome.isSuccess()).isTrue();
+        });
+
+        assertThat(lines).anySatisfy(line -> assertThat(line).contains("override-host")
+                                                              .contains("6543")
+                                                              .contains("override-db")
+                                                              .doesNotContain("discrete-host"));
+    }
+
+    private static List<String> captureProviderLogLines(Runnable action) {
+        var attachment = attachAppender();
+        try {
+            action.run();
+            return List.copyOf(attachment.appender().messages());
+        } finally {
+            detachAppender(attachment);
+        }
+    }
+
+    private static Attachment attachAppender() {
+        var ctx = (LoggerContext) LogManager.getContext(false);
+        var config = ctx.getConfiguration();
+        var appender = new CapturingAppender();
+        appender.start();
+        config.addAppender(appender);
+        var loggerConfig = config.getLoggerConfig(PROVIDER_LOGGER);
+        var previousLevel = loggerConfig.getLevel();
+        loggerConfig.addAppender(appender, Level.ALL, null);
+        loggerConfig.setLevel(Level.TRACE);
+        ctx.updateLoggers();
+        return new Attachment(ctx, appender, loggerConfig, previousLevel);
+    }
+
+    private static void detachAppender(Attachment attachment) {
+        attachment.loggerConfig().removeAppender(attachment.appender().getName());
+        attachment.loggerConfig().setLevel(attachment.previousLevel());
+        attachment.ctx().updateLoggers();
+        attachment.appender().stop();
+    }
+
+    private record Attachment(LoggerContext ctx, CapturingAppender appender, LoggerConfig loggerConfig, Level previousLevel) {}
+
+    private static final class CapturingAppender extends AbstractAppender {
+        private final List<String> messages = new CopyOnWriteArrayList<>();
+
+        private CapturingAppender() {
+            super("db-async-provisioning-test-capture", null, null, true, Property.EMPTY_ARRAY);
+        }
+
+        @Override
+        public void append(LogEvent event) {
+            messages.add(event.getMessage().getFormattedMessage());
+        }
+
+        List<String> messages() {
+            return messages;
+        }
+    }
+}


### PR DESCRIPTION
Fixes #769.

`DatabaseConnectorConfig.effectiveHost()/effectivePort()/effectiveDatabase()` gave the discrete `host`/`port`/`database` fields unconditional precedence over a configured URL, inverting the documented contract (`resource-reference.md`: a URL replaces host/port/database). An operator override of `database.async_url` therefore resolved at the config layer, was reported as applied, and was discarded two layers down: migrations used the override, slice stores connected to the intrinsic database.

- Precedence flipped to URL-first with discrete fallback in the shared record, one fix for all four consuming factories. Four pinning tests (two red before the fix), mutation-probed.
- The provisioning choke point (`DatasourceConnectionProvider.selectAndProvision`) now logs the effective host, port, database and transport, credential-free, with a capturing-appender test.
- A consumer-level test pins `AsyncSqlConnectorFactory.configureConnection` to the effective values and goes red if the record fix is reverted.
- The deferred design question (value-derivation order jdbc→r2dbc→async vs. transport selection async>r2dbc>jdbc) is documented in code and in `resource-reference.md`, unreachable by any shipped config, and tracked separately.

Verification: `aether/resource/api` + `db-async` 118 tests, 0 failures; `jbct:check` green on both. Adversarial review: mergeable; its follow-ups are included.
