### PR TITLE
docs: core README metrics snippet uses the real builder API

### DIFF
--- a/core/README.md
+++ b/core/README.md
@@ -228,7 +228,7 @@ Explore comprehensive examples in the [examples](../examples) directory:
 
 ## Integrations
 
-### Jackson JSON (3.0.0)
+### Jackson JSON (3.0+)
 
 Serialize and deserialize Result, Option, and Promise types:
 
@@ -301,21 +301,21 @@ Monitor Result, Option, and Promise operations:
 ```
 
 ```java
-// Wrap operations with metrics
-var wrappedOperation = ResultMetrics.timed(
-    registry,
-    "user.fetch",
-    Tags.of("service", "user-service"),
-    () -> fetchUser(userId)
-);
+// Timer around a Result-returning operation: duration plus success/failure counts
+var fetchMetrics = ResultMetrics.timer("user.fetch")
+    .registry(registry)
+    .tags("service", "user-service")
+    .build();
 
-// Automatic success/failure tracking
-Promise<Data> monitored = PromiseMetrics.counted(
-    registry,
-    "api.call",
-    Tags.of("endpoint", "/users"),
-    apiClient.fetchData()
-);
+Supplier<Result<User>> fetchUser = fetchMetrics.around(() -> userRepository.fetch(userId));
+
+// Counter around a Promise-returning function: success/failure counts only
+var apiMetrics = PromiseMetrics.counter("api.call")
+    .registry(registry)
+    .tags("endpoint", "/users")
+    .build();
+
+Fn1<Promise<Data>, Query> fetchData = apiMetrics.around(apiClient::fetchData);
 ```
 
 ## Contributing


### PR DESCRIPTION
Found by the pre-announce first-reader check of `main` at c61d6bca5.

**Defect.** `core/README.md` "Micrometer Metrics" called `ResultMetrics.timed(registry, name, tags, supplier)` and `PromiseMetrics.counted(registry, name, tags, promise)`. Neither method exists; `git grep 'timed(\|counted('` over `integrations/metrics` returns nothing. The real surface is the builder chain documented in each class's Javadoc: `timer(name)` / `counter(name)` / `combined(name)` → `.registry(..)` → `.tags(..)` → `.build()` → `.around(fn | supplier)`.

**Fix.** The snippet now uses that chain, in the same shape as the classes' own Javadoc examples. Also `### Jackson JSON (3.0.0)` → `(3.0+)`: the root pom pins 3.1.0 and the jackson module README already says 3.0+.

**Verification.** Read against the source at c61d6bca5, not compiled: the snippet is illustrative (`User`, `Data`, `Query`, `userRepository`, `apiClient` are placeholders, as before). Method names and stage order match `ResultMetrics.java` / `PromiseMetrics.java` line for line.

Docs only. Cherry-pick to `release-1.0.0-rc4` after merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Jackson JSON integration documentation to cover version 3.0 and later.
  * Revised the Micrometer Metrics example to demonstrate the builder-style configuration API, including registries, tags, and metric wrappers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->