### PR TITLE
fix: docker-compose boots (#782): required cluster env vars, live healthcheck

### DIFF
--- a/aether/docker/docker-compose.yml
+++ b/aether/docker/docker-compose.yml
@@ -7,8 +7,10 @@ version: "3.9"
 # detection. Host-mapped cluster ports use /udp suffix for explicit protocol binding.
 #
 # Usage:
-#   docker-compose up --build                    # Start 3-node cluster
-#   docker-compose --profile forge up --build   # Start with Forge simulator
+#   export AETHER_CLUSTER_SECRET=<your-secret>    # required, no default is shipped
+#   docker-compose up -d                          # Pull published images, start 3-node cluster
+#   docker-compose up -d --build                  # Build from source instead of pulling
+#   docker-compose --profile forge up --build     # Start with Forge simulator (always built)
 #
 # NOTE — do NOT add `restart: unless-stopped`/`always` to aether-node services.
 # Aether uses a TERMINAL-REMOVAL membership model: a dead NodeId never returns under
@@ -20,6 +22,7 @@ version: "3.9"
 services:
   # Three-node Aether cluster
   aether-node-1:
+    image: ghcr.io/pragmaticalabs/aether-node:${AETHER_VERSION:-1.0.0-rc3}
     build:
       context: ..
       dockerfile: docker/aether-node/Dockerfile
@@ -30,6 +33,8 @@ services:
       CLUSTER_PORT: "8090"
       MANAGEMENT_PORT: "8080"
       PEERS: "node-1:aether-node-1:8090,node-2:aether-node-2:8090,node-3:aether-node-3:8090"
+      AETHER_CLUSTER_NAME: "aether-local"
+      AETHER_CLUSTER_SECRET: "${AETHER_CLUSTER_SECRET:?export AETHER_CLUSTER_SECRET before docker-compose up}"
       JAVA_OPTS: "-Xmx256m -XX:+UseZGC"
     ports:
       - "8080:8080"       # Management API
@@ -37,13 +42,14 @@ services:
     networks:
       - aether-network
     healthcheck:
-      test: ["CMD", "wget", "--spider", "-q", "http://localhost:8080/api/health"]
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:8080/health/live"]
       interval: 5s
       timeout: 3s
       retries: 10
       start_period: 20s
 
   aether-node-2:
+    image: ghcr.io/pragmaticalabs/aether-node:${AETHER_VERSION:-1.0.0-rc3}
     build:
       context: ..
       dockerfile: docker/aether-node/Dockerfile
@@ -54,6 +60,8 @@ services:
       CLUSTER_PORT: "8090"
       MANAGEMENT_PORT: "8080"
       PEERS: "node-1:aether-node-1:8090,node-2:aether-node-2:8090,node-3:aether-node-3:8090"
+      AETHER_CLUSTER_NAME: "aether-local"
+      AETHER_CLUSTER_SECRET: "${AETHER_CLUSTER_SECRET:?export AETHER_CLUSTER_SECRET before docker-compose up}"
       JAVA_OPTS: "-Xmx256m -XX:+UseZGC"
     ports:
       - "8081:8080"
@@ -61,7 +69,7 @@ services:
     networks:
       - aether-network
     healthcheck:
-      test: ["CMD", "wget", "--spider", "-q", "http://localhost:8080/api/health"]
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:8080/health/live"]
       interval: 5s
       timeout: 3s
       retries: 10
@@ -71,6 +79,7 @@ services:
         condition: service_healthy
 
   aether-node-3:
+    image: ghcr.io/pragmaticalabs/aether-node:${AETHER_VERSION:-1.0.0-rc3}
     build:
       context: ..
       dockerfile: docker/aether-node/Dockerfile
@@ -81,6 +90,8 @@ services:
       CLUSTER_PORT: "8090"
       MANAGEMENT_PORT: "8080"
       PEERS: "node-1:aether-node-1:8090,node-2:aether-node-2:8090,node-3:aether-node-3:8090"
+      AETHER_CLUSTER_NAME: "aether-local"
+      AETHER_CLUSTER_SECRET: "${AETHER_CLUSTER_SECRET:?export AETHER_CLUSTER_SECRET before docker-compose up}"
       JAVA_OPTS: "-Xmx256m -XX:+UseZGC"
     ports:
       - "8082:8080"
@@ -88,7 +99,7 @@ services:
     networks:
       - aether-network
     healthcheck:
-      test: ["CMD", "wget", "--spider", "-q", "http://localhost:8080/api/health"]
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:8080/health/live"]
       interval: 5s
       timeout: 3s
       retries: 10

--- a/aether/docs/operators/docker-deployment.md
+++ b/aether/docs/operators/docker-deployment.md
@@ -19,19 +19,6 @@ Two container images are available:
 
 ## Quick Start
 
-### Build Images
-
-```bash
-# Build from project root
-
-# Build JARs first
-mvn package -DskipTests
-
-# Build container images
-docker build -f docker/aether-node/Dockerfile -t aether-node:latest .
-docker build -f docker/aether-forge/Dockerfile -t aether-forge:latest .
-```
-
 ### Run 3-Node Cluster
 
 Requires a cluster secret; there is no shipped default:
@@ -57,6 +44,21 @@ This starts:
 - `aether-node-1` on ports 8080 (API), 8090 (cluster)
 - `aether-node-2` on ports 8081 (API), 8091 (cluster)
 - `aether-node-3` on ports 8082 (API), 8092 (cluster)
+
+### Build images from source (developers)
+
+Only needed for the `--build` path above; the pull path needs neither Java nor Maven.
+
+```bash
+# Build from project root
+
+# Build JARs first
+mvn package -DskipTests
+
+# Build container images
+docker build -f docker/aether-node/Dockerfile -t aether-node:latest .
+docker build -f docker/aether-forge/Dockerfile -t aether-forge:latest .
+```
 
 ### Run with Forge Simulator
 

--- a/aether/docs/operators/docker-deployment.md
+++ b/aether/docs/operators/docker-deployment.md
@@ -34,9 +34,23 @@ docker build -f docker/aether-forge/Dockerfile -t aether-forge:latest .
 
 ### Run 3-Node Cluster
 
+Requires a cluster secret; there is no shipped default:
+
 ```bash
 cd docker
-docker compose up --build
+export AETHER_CLUSTER_SECRET=<your-secret>
+```
+
+Pull the published images (no local build):
+
+```bash
+docker compose up -d
+```
+
+Or build from source instead:
+
+```bash
+docker compose up -d --build
 ```
 
 This starts:
@@ -54,7 +68,7 @@ Access Forge dashboard at http://localhost:8888
 
 ## Docker Compose Configuration
 
-The `docker/docker compose.yml` defines a 3-node cluster:
+The `docker/docker-compose.yml` defines a 3-node cluster:
 
 ```yaml
 version: "3.9"


### PR DESCRIPTION
## Failure seen

`aether/docker/docker-compose.yml` on `main` never got the fix #780 was supposed to bring:
it was missing `AETHER_CLUSTER_NAME`/`AETHER_CLUSTER_SECRET` (both required by the node's
cluster-identity check) and its healthcheck probed the retired `/api/health` route instead
of `/health/live`. The documented three-container quick start in
`aether/docs/operators/docker-deployment.md` did not boot.

## Fix

- Added `AETHER_CLUSTER_NAME` (literal `aether-local`) and a required
  `AETHER_CLUSTER_SECRET` (`${AETHER_CLUSTER_SECRET:?export AETHER_CLUSTER_SECRET before docker-compose up}`
  — never a literal secret in the shipped file, per #684) to all three `aether-node-*`
  services.
- Changed all three healthchecks to `/health/live`.
- Added `image: ghcr.io/pragmaticalabs/aether-node:${AETHER_VERSION:-1.0.0-rc3}` to each
  node service (kept the existing `build:` section for developers) so the compose file can
  boot a reader straight from the published image with no local build.
- Docs: fixed the `docker/docker compose.yml` → `docker/docker-compose.yml` typo at
  `docker-deployment.md:57`; Quick Start now shows the required secret export plus two
  explicit command lines — `docker compose up -d` (pull, no build) and
  `docker compose up -d --build` (build from source).
- No database service added — the shipped `aether.toml`'s hardcoded `forge-postgres`
  datasource is untouched, tracked separately under #786. It did not gate this fix (see
  proof below).

## Proof

Live 3-node run under the project's suite-lock protocol, non-default host ports, project
name `aether-782`, exercising the **pull path** (`docker-compose up -d`, no `--build`)
against the actually-published `ghcr.io/pragmaticalabs/aether-node:1.0.0-rc3`:

- Image pull confirmed (no `Building`/`Step` lines in the log — this was a real pull, not a
  build fallback).
- All three containers reached `healthy`.
- Leader election observed: quorum established (`clusterSize=3, quorumSize=2`), node-1
  became leader; node-2/node-3 logs confirm no split-brain (only node-1 claims leadership).
- Bootstrap admin key banner printed once.
- `GET /api/v1/health` returned `200` on all three mapped ports, each body
  `{"status":"healthy","ready":true,"quorum":true,"nodeCount":3,...}`.
- Grepped all three full node logs for any Postgres/datasource activity
  (`postgres|jdbc|database|datasource|forge-postgres|async_url`) — zero matches. The node
  reaches full cluster health without ever touching the datasource in this proof window; it
  does not gate cluster boot for this ticket's scope.
- Also empirically established (a required precondition for the two-command doc pattern
  above): standalone docker-compose, given both `image:` and `build:` on a service, prefers
  to pull when the image is reachable and only falls back to a local build when it is not;
  `--build` always forces a local build.

Full teardown after the run; suite lock released. Transcript (redacted, verified via
`grep -c 'aeth_[A-Za-z0-9_-]\{10,\}'` returning 0 on every saved log) available on request.

Not fixed here, tracked separately: `current-docker-setup.md` carries a now-further-stale
illustrative YAML sample and the same doc typo (out of scope for this branch); a bundled
Postgres one-command try-it path is #786.