### PR TITLE
fix: #759 a new publish or a delete clears the stale deployment outcome record in the same batch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,40 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [1.0.0-rc4] - Unreleased
 
+### Fixed (2026-09-04 — #759 review: a redeployed blueprint id kept reporting its previous attempt's terminal outcome while the new attempt was converging)
+- **A retry of a previously FAILED/ROLLED_BACK blueprint id read as still-failed until its own
+  terminal write landed.** `DeploymentOutcomeKey` is written only at the four terminal FSM
+  transitions and was never cleared when a new deployment of the same id started —
+  `BlueprintId` wraps the artifact, so a retry reuses the key, and the (now outcome-first)
+  blueprint-status route reported the prior attempt's `FAILED`/`ROLLED_BACK` outcome while the
+  live redeploy was actively converging, a false-negative on deployment health with no code path
+  that would ever clear it on its own.
+- **`BlueprintService.buildAllCommands` now bundles a `KVCommand.Remove` of the publishing id's
+  `DeploymentOutcomeKey` into the SAME consensus batch as the `AppBlueprintKey` Put that starts the
+  new attempt.** The two land atomically, so `outcome(id)` is now: *at any instant, either the
+  blueprint is in flight with no outcome, or terminal with exactly one record for the current
+  attempt — never in flight while reporting a previous attempt's result.* No operator action
+  clears the stale state; every publish clears it for its own id, automatically, as the fix.
+- **No ordering dependency, unlike the `AppBlueprintKey` Put/Remove pair #809 hardens** —
+  `DeploymentOutcomeKey` has no FSM event-dispatch handler wired to it (no
+  `DeploymentOutcomePutReceived`/`RemoveReceived` case exists), so this Remove's position in the
+  batch relative to the blueprint Put is not load-bearing; nothing subscribes to either
+  notification. `DeploymentOutcomeValue` is not fenced (`EpochBearing`/`LeaderValue`), so the
+  witnessless `Remove(key)` form is admitted unconditionally by the KV applier.
+- Javadoc on `BlueprintService.outcome(BlueprintId id)` states the new in-flight-XOR-terminal
+  guarantee directly; it does not resolve the pre-existing crash-orphaned/stuck ambiguity
+  documented there (#760/#724 review round 2 item i) — it only ensures the in-flight case is never
+  confused with a stale terminal record from an earlier attempt of the same id.
+  [mechanism: same consensus batch as the `AppBlueprintKey` Put — see `KVCommand`'s batch-apply
+  semantics; both commands commit together or not at all]
+- Pinning test `BlueprintPublishOwnershipTest.OutcomeClearedAtPublish` drives a real
+  `publishFromArtifact` through the actual command-building path against a seeded FAILED outcome for
+  the same blueprint id, asserting `outcome(id)` is empty after the new publish lands, plus a
+  no-prior-outcome control case. Mutation-probed: red with the `Remove` line dropped (`Expecting
+  value to be true but was false`), green restored — the control case stayed green under the same
+  mutation, as expected, since it has no prior outcome to clear.
+  [verified: aether/aether-deployment/src/test/java/org/pragmatica/aether/deployment/cluster/BlueprintPublishOwnershipTest.java]
+
 ### Fixed (2026-09-04 — #715: Forge/Ember clusters admitted nodes from foreign local processes)
 - **Every `EmberCluster` instance (and therefore every `ForgeServer`, built directly on it) derived
   its cluster QUIC/SWIM identity from one hardcoded literal secret, shared by every process on the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [1.0.0-rc4] - Unreleased
 
-### Fixed (2026-09-04 — #759 review: a redeployed blueprint id kept reporting its previous attempt's terminal outcome while the new attempt was converging)
+### Fixed (2026-09-04 — #759 review: a redeployed or deleted blueprint id kept reporting a stale terminal outcome from a prior attempt)
 - **A retry of a previously FAILED/ROLLED_BACK blueprint id read as still-failed until its own
   terminal write landed.** `DeploymentOutcomeKey` is written only at the four terminal FSM
   transitions and was never cleared when a new deployment of the same id started —
@@ -14,30 +14,59 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   blueprint-status route reported the prior attempt's `FAILED`/`ROLLED_BACK` outcome while the
   live redeploy was actively converging, a false-negative on deployment health with no code path
   that would ever clear it on its own.
-- **`BlueprintService.buildAllCommands` now bundles a `KVCommand.Remove` of the publishing id's
+- **`BlueprintService.buildAllCommands` bundles a `KVCommand.Remove` of the publishing id's
   `DeploymentOutcomeKey` into the SAME consensus batch as the `AppBlueprintKey` Put that starts the
-  new attempt.** The two land atomically, so `outcome(id)` is now: *at any instant, either the
-  blueprint is in flight with no outcome, or terminal with exactly one record for the current
-  attempt — never in flight while reporting a previous attempt's result.* No operator action
-  clears the stale state; every publish clears it for its own id, automatically, as the fix.
+  new attempt** — covers `publishFromArtifact`. The two land atomically, so `outcome(id)` is: *at
+  any instant, either the blueprint is in flight with no outcome, or terminal with exactly one
+  record for the current attempt — never in flight while reporting a previous attempt's result.*
+- **Round 2: the same gap existed on two more live paths that write or remove `AppBlueprintKey`
+  without going through `buildAllCommands`.** DSL `publish(String)` (`SliceRoutes.handleBlueprint`)
+  went through `storeBlueprintWithKey`, and `delete(id)` through `removeFromStore` — both applied a
+  single-command batch touching only `AppBlueprintKey`, so a DSL republish left a prior
+  FAILED/ROLLED_BACK outcome in place until the new attempt's own terminal write, and a `delete`'s
+  orphaned outcome record never cleared at all (nothing ever writes that id's `AppBlueprintKey`
+  again to trigger it). Both methods now bundle the same `DeploymentOutcomeKey` Remove into their
+  own batch, so the guarantee above now holds for all three ways `AppBlueprintKey` changes on a
+  live path: `publishFromArtifact`, DSL `publish`, and `delete`. [mechanism: same-batch
+  `cluster.apply` in `buildAllCommands`, `storeBlueprintWithKey`, `removeFromStore` — all commands
+  passed to one `apply(...)` call commit together or not at all]
+- **One documented exception, out of scope for this fix: `ClusterDeploymentState.restorePreviousBlueprint`.**
+  An ALL_OR_NOTHING rollback with a previous blueprint re-Puts `previous.id()`'s `AppBlueprintKey`
+  (making it live again) in the same batch as a ROLLED_BACK outcome Put keyed by `inflight.id()` —
+  the FAILING id, not `previous.id()`. `previous.id()`'s own `DeploymentOutcomeKey` is untouched,
+  and `restoringBlueprints` suppresses `previous.id()`'s normal in-flight FSM tracking while the
+  restore is pending, so no later terminal write ever supersedes whatever `outcome(previous.id())`
+  already held from an earlier attempt of that id. A restored blueprint can therefore be live and
+  serving while `outcome(previous.id())` still reports a stale, unrelated terminal record; recovery
+  is the same shape as the pre-existing crash-orphaned/stuck cases documented on this method —
+  consult `get(previous.id())`'s presence, not `outcome()` alone. [mechanism:
+  `ClusterDeploymentState.restorePreviousBlueprint` / `rolledBackOutcomeCommand` keys the outcome
+  Put on `inflight.id()`, never `previous.id()`; `restoringBlueprints` gates the two in-flight-
+  tracking checks that would otherwise produce a new terminal write for `previous.id()`]
+- No operator action is needed for the three covered paths — a publish or a delete of `id` clears
+  its own stale outcome automatically. (Corrects the round-1 wording above, which claimed this held
+  for every publish before `delete` was covered and before the `restorePreviousBlueprint` exception
+  was documented.)
 - **No ordering dependency, unlike the `AppBlueprintKey` Put/Remove pair #809 hardens** —
   `DeploymentOutcomeKey` has no FSM event-dispatch handler wired to it (no
   `DeploymentOutcomePutReceived`/`RemoveReceived` case exists), so this Remove's position in the
-  batch relative to the blueprint Put is not load-bearing; nothing subscribes to either
+  batch relative to the blueprint Put/Remove is not load-bearing; nothing subscribes to either
   notification. `DeploymentOutcomeValue` is not fenced (`EpochBearing`/`LeaderValue`), so the
   witnessless `Remove(key)` form is admitted unconditionally by the KV applier.
-- Javadoc on `BlueprintService.outcome(BlueprintId id)` states the new in-flight-XOR-terminal
-  guarantee directly; it does not resolve the pre-existing crash-orphaned/stuck ambiguity
-  documented there (#760/#724 review round 2 item i) — it only ensures the in-flight case is never
-  confused with a stale terminal record from an earlier attempt of the same id.
-  [mechanism: same consensus batch as the `AppBlueprintKey` Put — see `KVCommand`'s batch-apply
-  semantics; both commands commit together or not at all]
-- Pinning test `BlueprintPublishOwnershipTest.OutcomeClearedAtPublish` drives a real
-  `publishFromArtifact` through the actual command-building path against a seeded FAILED outcome for
-  the same blueprint id, asserting `outcome(id)` is empty after the new publish lands, plus a
-  no-prior-outcome control case. Mutation-probed: red with the `Remove` line dropped (`Expecting
-  value to be true but was false`), green restored — the control case stayed green under the same
-  mutation, as expected, since it has no prior outcome to clear.
+- A new test pins the atomicity property directly on the recorded consensus batch, not just its
+  eventual effect: the `AppBlueprintKey` write/remove and the `DeploymentOutcomeKey` Remove must
+  land in ONE `cluster.apply` call — red if the fix were (hypothetically) split into two separate
+  calls, a shape every existing effect-based assertion would still pass.
+- Javadoc on `BlueprintService.outcome(BlueprintId id)` states the in-flight-XOR-terminal guarantee
+  scoped to the three covered paths, and documents the `restorePreviousBlueprint` exception above;
+  it does not resolve the pre-existing crash-orphaned/stuck ambiguity documented there (#760/#724
+  review round 2 item i) — it only ensures the in-flight case is never confused with a stale
+  terminal record from an earlier attempt of the same id.
+- Pinning tests in `BlueprintPublishOwnershipTest.OutcomeClearedAtPublish` drive the real
+  `publishFromArtifact`, DSL `publish`, and `delete` paths against a seeded FAILED outcome for the
+  same blueprint id, asserting `outcome(id)` is empty after each; a no-prior-outcome control case;
+  and a same-batch assertion pinning atomicity for each path. Mutation-probed: red with each
+  `Remove` line dropped, green restored.
   [verified: aether/aether-deployment/src/test/java/org/pragmatica/aether/deployment/cluster/BlueprintPublishOwnershipTest.java]
 
 ### Fixed (2026-09-04 — #715: Forge/Ember clusters admitted nodes from foreign local processes)

--- a/aether/aether-deployment/src/main/java/org/pragmatica/aether/deployment/cluster/BlueprintService.java
+++ b/aether/aether-deployment/src/main/java/org/pragmatica/aether/deployment/cluster/BlueprintService.java
@@ -22,6 +22,7 @@ import org.pragmatica.aether.slice.blueprint.ResolvedSlice;
 import org.pragmatica.aether.slice.kvstore.AetherKey;
 import org.pragmatica.aether.slice.kvstore.AetherKey.AppBlueprintKey;
 import org.pragmatica.aether.slice.kvstore.AetherKey.BlueprintStreamBindingsKey;
+import org.pragmatica.aether.slice.kvstore.AetherKey.DeploymentOutcomeKey;
 import org.pragmatica.aether.slice.kvstore.AetherKey.SchemaVersionKey;
 import org.pragmatica.aether.slice.kvstore.AetherValue;
 import org.pragmatica.aether.slice.kvstore.AetherValue.AppBlueprintValue;
@@ -100,6 +101,17 @@ public interface BlueprintService {
     /// A caller needing to tell "will complete soon" (case 2) apart from "permanently stuck, needs
     /// intervention" (cases 3-4) must consult additional state — e.g. `get(id)`'s presence plus how
     /// long the blueprint has been in that state — `outcome()` alone cannot make that distinction.
+    ///
+    /// #759 review, BLOCKING 3 (fix): `publishFromArtifact` bundles a `KVCommand.Remove` of this key
+    /// into the SAME consensus batch as the `AppBlueprintKey` Put that starts the new attempt, so the
+    /// two land atomically. This closes the retry gap above case 2: before this fix, publishing a new
+    /// attempt of an `id` that had already reached a terminal FAILED/ROLLED_BACK outcome left the STALE
+    /// prior record in place until the new attempt's own terminal write, so a caller polling mid-flight
+    /// saw the LAST attempt's failure while the new one was actively converging. The guarantee is now:
+    /// at any instant, `id` is either in flight with `outcome(id)` empty, or terminal with exactly one
+    /// record for the CURRENT attempt — never in flight while this method still reports a previous
+    /// attempt's result. This does not resolve cases 3-4 above; it only ensures case 2 is never
+    /// confused with a stale case-3/4-shaped terminal record from an earlier attempt of the same id.
     Option<AetherValue.DeploymentOutcomeValue> outcome(BlueprintId id);
     List<ExpandedBlueprint> list();
     Promise<Unit> delete(BlueprintId id);
@@ -379,6 +391,19 @@ class BlueprintServiceInstance implements BlueprintService {
         var commands = new ArrayList<KVCommand<AetherKey>>();
 
         commands.add(buildBlueprintPutCommand(expanded, registerOnly));
+        // #759 review, BLOCKING: a fresh publish reuses `expanded.id()` on a retry after a prior
+        // FAILED/ROLLED_BACK attempt of the SAME blueprint id, and `outcome(id)` otherwise keeps
+        // returning that stale terminal record — indistinguishable from the new attempt already
+        // having failed — until the new attempt itself reaches a terminal transition. Bundling this
+        // Remove into the SAME consensus batch as the AppBlueprintKey Put above makes the two land
+        // atomically, so at any instant `id` is either in flight with no outcome, or terminal with
+        // exactly one, never "in flight" while `outcome(id)` still shows the LAST attempt's result.
+        // `DeploymentOutcomeValue` is not fenced (no `EpochBearing`/`LeaderValue`), so the witnessless
+        // `Remove(key)` constructor is admitted unconditionally by the applier. No FSM event is wired
+        // for `DeploymentOutcomeKey` changes (unlike `AppBlueprintKey`'s `handleAppBlueprintChange`/
+        // `handleAppBlueprintRemoval`), so this Remove's position in the batch relative to the Put
+        // above is NOT load-bearing — nothing subscribes to either notification.
+        commands.add(new Remove<>(DeploymentOutcomeKey.deploymentOutcomeKey(expanded.id())));
         // Slice META-INF/resources.toml is intentionally NOT published to KV — it is local to
         // each node and applied via the per-slice intrinsic config layer at slice load
         // (see SliceStore.loadSlice). The resourcesConfig parameter is kept here because the

--- a/aether/aether-deployment/src/main/java/org/pragmatica/aether/deployment/cluster/BlueprintService.java
+++ b/aether/aether-deployment/src/main/java/org/pragmatica/aether/deployment/cluster/BlueprintService.java
@@ -112,6 +112,32 @@ public interface BlueprintService {
     /// record for the CURRENT attempt — never in flight while this method still reports a previous
     /// attempt's result. This does not resolve cases 3-4 above; it only ensures case 2 is never
     /// confused with a stale case-3/4-shaped terminal record from an earlier attempt of the same id.
+    ///
+    /// #759 review round 2, BLOCKING 1/2 (scope extended): the same-batch Remove above originally
+    /// covered only `buildAllCommands` (`publishFromArtifact`). Two other live paths write or remove
+    /// `AppBlueprintKey` without going through it — DSL `publish(String)` (`SliceRoutes.handleBlueprint`)
+    /// via `storeBlueprintWithKey`, and `delete(id)` via `removeFromStore` — and both left the same
+    /// stale-outcome gap open (a deleted id's outcome record never clears at all, since nothing ever
+    /// writes that id's `AppBlueprintKey` again to trigger it). Both methods now bundle the same
+    /// `DeploymentOutcomeKey` Remove into their own single-`apply` batch, so the guarantee above holds
+    /// for all three ways `AppBlueprintKey` changes on a live path: `publishFromArtifact`, DSL
+    /// `publish`, and `delete`. [mechanism: same-batch `cluster.apply` in `buildAllCommands`,
+    /// `storeBlueprintWithKey`, `removeFromStore`]
+    ///
+    /// **Scope — one documented exception:** `ClusterDeploymentState.restorePreviousBlueprint`. An
+    /// ALL_OR_NOTHING rollback with a previous blueprint re-Puts `previous.id()`'s `AppBlueprintKey`
+    /// (making it live again) in the SAME batch as a ROLLED_BACK outcome Put keyed by `inflight.id()`
+    /// — the FAILING id, not `previous.id()`. `previous.id()`'s own `DeploymentOutcomeKey` is
+    /// untouched by that batch, and `restoringBlueprints` suppresses `previous.id()`'s normal
+    /// in-flight FSM tracking while the restore is pending, so no later terminal write ever
+    /// supersedes whatever `outcome(previous.id())` already held from an earlier deployment attempt
+    /// of that same id. A restored blueprint can therefore be live and actively serving while
+    /// `outcome(previous.id())` still reports a stale, unrelated-in-time terminal record — this is
+    /// the same recovery shape as cases 3-4 above: an operator (or caller) must consult
+    /// `get(previous.id())`'s presence alongside this method, not this method alone. [mechanism:
+    /// `ClusterDeploymentState.restorePreviousBlueprint` / `rolledBackOutcomeCommand` keys the
+    /// outcome Put on `inflight.id()`, never `previous.id()`; `restoringBlueprints` gates the
+    /// in-flight-tracking checks that would otherwise produce a new terminal write for `previous.id()`]
     Option<AetherValue.DeploymentOutcomeValue> outcome(BlueprintId id);
     List<ExpandedBlueprint> list();
     Promise<Unit> delete(BlueprintId id);
@@ -572,15 +598,29 @@ class BlueprintServiceInstance implements BlueprintService {
                                                              ExpandedBlueprint expanded) {
         var value = AppBlueprintValue.appBlueprintValue(expanded);
         KVCommand<AetherKey> command = new Put<>(key, value);
+        // #759 review round 2, BLOCKING 1: `publish(String dsl)` is a live republish path
+        // (SliceRoutes.handleBlueprint) that bypasses buildAllCommands, so without this it kept the
+        // same stale-outcome gap buildAllCommands already closed for publishFromArtifact — a DSL
+        // republish of a previously FAILED/ROLLED_BACK id left that terminal record in place until
+        // the new attempt's own terminal write. Bundled into the SAME batch as the Put for the same
+        // reason as buildAllCommands's Remove: no FSM event is wired to DeploymentOutcomeKey, so
+        // position within the batch is not load-bearing.
+        var outcomeClear = new Remove<AetherKey>(DeploymentOutcomeKey.deploymentOutcomeKey(expanded.id()));
 
-        return cluster.apply(List.of(command))
+        return cluster.apply(List.of(command, outcomeClear))
                       .map(_ -> expanded);
     }
 
     private Promise<Unit> removeFromStore(AetherKey.AppBlueprintKey key) {
         KVCommand<AetherKey> command = new Remove<>(key);
+        // #759 review round 2, BLOCKING 2: without this, a deleted blueprint's outcome record
+        // survived forever — nothing ever clears DeploymentOutcomeKey for an id once its
+        // AppBlueprintKey is removed, so a deleted id's last terminal outcome orphans permanently
+        // and a later re-publish of the same id would (until BLOCKING 1/buildAllCommands) have
+        // inherited it. Same batch as the AppBlueprintKey Remove for the same atomicity reason.
+        var outcomeClear = new Remove<AetherKey>(DeploymentOutcomeKey.deploymentOutcomeKey(key.blueprintId()));
 
-        return cluster.apply(List.of(command))
+        return cluster.apply(List.of(command, outcomeClear))
                       .mapToUnit();
     }
 

--- a/aether/aether-deployment/src/test/java/org/pragmatica/aether/deployment/cluster/BlueprintPublishOwnershipTest.java
+++ b/aether/aether-deployment/src/test/java/org/pragmatica/aether/deployment/cluster/BlueprintPublishOwnershipTest.java
@@ -194,6 +194,48 @@ class BlueprintPublishOwnershipTest {
         }
     }
 
+    /// #759 review: `DeploymentOutcomeKey` is written only at the four terminal FSM transitions and
+    /// was never cleared when a NEW deployment of the same blueprint id started. `BlueprintId` wraps
+    /// the artifact, so a retry reuses the key, and `BlueprintService.outcome(id)` — the outcome-first
+    /// status route's read path — kept reporting the PREVIOUS attempt's terminal outcome while the new
+    /// attempt was actively converging. `buildAllCommands` now bundles a `Remove` of this key into the
+    /// SAME consensus batch as the `AppBlueprintKey` Put that starts the new attempt.
+    @Nested
+    class OutcomeClearedAtPublish {
+        @Test
+        void publishFromArtifact_clearsStaleOutcome_fromPriorFailedAttempt_ofSameBlueprintId() {
+            seedFailedOutcome(OWNER);
+
+            publish(OWNER_COORDS, withoutMigrations(OWNER_COORDS)).onFailure(BlueprintPublishOwnershipTest::failOnUnexpectedFailure);
+
+            assertThat(recordedOutcome().isEmpty())
+                    .as("a fresh publish of a previously FAILED id must clear the stale outcome — outcome(id) "
+                        + "must be empty until the NEW attempt's own terminal write, never carry the PREVIOUS "
+                        + "attempt's result forward")
+                    .isTrue();
+        }
+
+        @Test
+        void publishFromArtifact_leavesNoOutcome_whenIdNeverHadOne() {
+            publish(OWNER_COORDS, withoutMigrations(OWNER_COORDS)).onFailure(BlueprintPublishOwnershipTest::failOnUnexpectedFailure);
+
+            assertThat(recordedOutcome().isEmpty()).as("a first-ever publish has no prior outcome to clear; the "
+                                                        + "Remove of an absent key is a no-op")
+                                                    .isTrue();
+        }
+
+        private void seedFailedOutcome(BlueprintId id) {
+            store.processCommand(new KVCommand.Put<>(AetherKey.DeploymentOutcomeKey.deploymentOutcomeKey(id),
+                                                      AetherValue.DeploymentOutcomeValue.failed(List.of("orders-api"),
+                                                                                                "prior attempt failed",
+                                                                                                1L)));
+        }
+
+        private Option<AetherValue> recordedOutcome() {
+            return store.get(AetherKey.DeploymentOutcomeKey.deploymentOutcomeKey(OWNER));
+        }
+    }
+
     // --- helpers ---
 
     /// The cause must reach the caller UNWRAPPED. `ProblemResponses.resolveStatus` keys the response

--- a/aether/aether-deployment/src/test/java/org/pragmatica/aether/deployment/cluster/BlueprintPublishOwnershipTest.java
+++ b/aether/aether-deployment/src/test/java/org/pragmatica/aether/deployment/cluster/BlueprintPublishOwnershipTest.java
@@ -9,6 +9,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -200,6 +201,12 @@ class BlueprintPublishOwnershipTest {
     /// status route's read path — kept reporting the PREVIOUS attempt's terminal outcome while the new
     /// attempt was actively converging. `buildAllCommands` now bundles a `Remove` of this key into the
     /// SAME consensus batch as the `AppBlueprintKey` Put that starts the new attempt.
+    ///
+    /// Round 2 review widened the scope: `storeBlueprintWithKey` (DSL `publish`) and `removeFromStore`
+    /// (`delete`) write/remove `AppBlueprintKey` on their OWN single-command batches, bypassing
+    /// `buildAllCommands` entirely — so the same stale-outcome gap was still open on both live paths.
+    /// Both now bundle the same `DeploymentOutcomeKey` Remove into their own batch. [[AtomicityPin]]
+    /// below pins the batch-boundary property directly for all three paths.
     @Nested
     class OutcomeClearedAtPublish {
         @Test
@@ -224,15 +231,95 @@ class BlueprintPublishOwnershipTest {
                                                     .isTrue();
         }
 
-        private void seedFailedOutcome(BlueprintId id) {
-            store.processCommand(new KVCommand.Put<>(AetherKey.DeploymentOutcomeKey.deploymentOutcomeKey(id),
-                                                      AetherValue.DeploymentOutcomeValue.failed(List.of("orders-api"),
-                                                                                                "prior attempt failed",
-                                                                                                1L)));
+        /// #759 review round 2, BLOCKING 1: `publish(String dsl)` — the live path behind
+        /// `SliceRoutes.handleBlueprint` — went through `storeBlueprintWithKey`, a single-command
+        /// batch touching only `AppBlueprintKey`, bypassing `buildAllCommands` and its Remove
+        /// entirely.
+        @Test
+        void publishDsl_clearsStaleOutcome_fromPriorFailedAttempt_ofSameBlueprintId() {
+            seedFailedOutcome(OWNER);
+
+            publishDsl(OWNER_COORDS).onFailure(BlueprintPublishOwnershipTest::failOnUnexpectedFailure);
+
+            assertThat(recordedOutcome().isEmpty())
+                    .as("a DSL republish of a previously FAILED id must clear the stale outcome too — the "
+                        + "SliceRoutes.handleBlueprint live path must give the same guarantee "
+                        + "publishFromArtifact already does")
+                    .isTrue();
+        }
+
+        /// #759 review round 2, BLOCKING 2: `delete(id)` went through `removeFromStore`, a
+        /// single-command batch removing only `AppBlueprintKey` — the outcome record was never
+        /// cleared and orphaned permanently, since no later write to the deleted id would ever touch
+        /// it again.
+        @Test
+        void delete_clearsStaleOutcome_fromPriorFailedAttempt() {
+            seedFailedOutcome(OWNER);
+
+            BlueprintService.blueprintService(cluster, store, repository())
+                            .delete(OWNER)
+                            .await();
+
+            assertThat(recordedOutcome().isEmpty())
+                    .as("deleting a blueprint id must clear its outcome record too — an orphaned "
+                        + "terminal record must not survive the blueprint id it described")
+                    .isTrue();
         }
 
         private Option<AetherValue> recordedOutcome() {
             return store.get(AetherKey.DeploymentOutcomeKey.deploymentOutcomeKey(OWNER));
+        }
+    }
+
+    /// #759 review round 2, BLOCKING 3: pins that each fix lands its `AppBlueprintKey`
+    /// write/remove and its `DeploymentOutcomeKey` Remove in ONE recorded consensus batch — the
+    /// property the outcome-first status route depends on (at any instant, in flight XOR terminal,
+    /// never both). Every assertion in [[OutcomeClearedAtPublish]] is effect-based (checks the FINAL
+    /// state of the store) and would stay green even if a fix were split into two separate
+    /// `cluster.apply` calls; these tests check the batch boundary directly, mirroring
+    /// `ClusterDeploymentStateTransactionalTest.restorePreviousBlueprint_recordsRolledBackOutcomeAtomicallyWithRestore`.
+    @Nested
+    class AtomicityPin {
+        @Test
+        void publishFromArtifact_putsBlueprintAndClearsOutcome_inOneBatch() {
+            seedFailedOutcome(OWNER);
+
+            publish(OWNER_COORDS, withoutMigrations(OWNER_COORDS)).onFailure(BlueprintPublishOwnershipTest::failOnUnexpectedFailure);
+
+            assertThat(landedInSameBatch(AppBlueprintKey.appBlueprintKey(OWNER),
+                                         AetherKey.DeploymentOutcomeKey.deploymentOutcomeKey(OWNER)))
+                    .as("buildAllCommands's AppBlueprintKey Put and its DeploymentOutcomeKey Remove "
+                        + "must land in the SAME cluster.apply batch, not merely both somewhere in "
+                        + "this node's apply history")
+                    .isTrue();
+        }
+
+        @Test
+        void publishDsl_putsBlueprintAndClearsOutcome_inOneBatch() {
+            seedFailedOutcome(OWNER);
+
+            publishDsl(OWNER_COORDS).onFailure(BlueprintPublishOwnershipTest::failOnUnexpectedFailure);
+
+            assertThat(landedInSameBatch(AppBlueprintKey.appBlueprintKey(OWNER),
+                                         AetherKey.DeploymentOutcomeKey.deploymentOutcomeKey(OWNER)))
+                    .as("storeBlueprintWithKey's Put and its DeploymentOutcomeKey Remove must land in "
+                        + "the SAME batch")
+                    .isTrue();
+        }
+
+        @Test
+        void delete_removesBlueprintAndClearsOutcome_inOneBatch() {
+            seedFailedOutcome(OWNER);
+
+            BlueprintService.blueprintService(cluster, store, repository())
+                            .delete(OWNER)
+                            .await();
+
+            assertThat(landedInSameBatch(AppBlueprintKey.appBlueprintKey(OWNER),
+                                         AetherKey.DeploymentOutcomeKey.deploymentOutcomeKey(OWNER)))
+                    .as("removeFromStore's AppBlueprintKey Remove and its DeploymentOutcomeKey Remove "
+                        + "must land in the SAME batch")
+                    .isTrue();
         }
     }
 
@@ -259,6 +346,35 @@ class BlueprintPublishOwnershipTest {
         return BlueprintService.blueprintService(cluster, store, repository(), artifactStore(blueprintJar))
                                .publishFromArtifact(coords + ":blueprint")
                                .await();
+    }
+
+    /// #759 review round 2: the DSL `publish(String)` path (`SliceRoutes.handleBlueprint`) parses
+    /// this TOML directly — no jar, no `ArtifactStore` — but still resolves the declared slice
+    /// through `repository()`, same as [#publish].
+    private Result<ExpandedBlueprint> publishDsl(String blueprintId) {
+        var dsl = "id = \"" + blueprintId + "\"\n" + SLICE_STANZA;
+
+        return BlueprintService.blueprintService(cluster, store, repository())
+                               .publish(dsl)
+                               .await();
+    }
+
+    /// #759 review round 2, BLOCKING 3: true only when SOME recorded `cluster.apply` batch contains
+    /// both keys — proves the two commands committed atomically in one consensus round, not merely
+    /// both somewhere across this node's apply history (which two separate `apply` calls would also
+    /// satisfy).
+    private boolean landedInSameBatch(AetherKey keyA, AetherKey keyB) {
+        return cluster.batches
+                      .stream()
+                      .anyMatch(batch -> batch.stream().anyMatch(c -> c.key().equals(keyA))
+                                       && batch.stream().anyMatch(c -> c.key().equals(keyB)));
+    }
+
+    private void seedFailedOutcome(BlueprintId id) {
+        store.processCommand(new KVCommand.Put<>(AetherKey.DeploymentOutcomeKey.deploymentOutcomeKey(id),
+                                                  AetherValue.DeploymentOutcomeValue.failed(List.of("orders-api"),
+                                                                                            "prior attempt failed",
+                                                                                            1L)));
     }
 
     private void seedSchemaOwnedBy(BlueprintId owner) {
@@ -388,7 +504,19 @@ class BlueprintPublishOwnershipTest {
         };
     }
 
-    private record TestClusterNode(TestKVStore store) implements ClusterNode<KVCommand<AetherKey>> {
+    private static final class TestClusterNode implements ClusterNode<KVCommand<AetherKey>> {
+        private final TestKVStore store;
+        // #759 review round 2, BLOCKING 3: tracks each apply() call's batch verbatim (mirrors
+        // ClusterDeploymentStateTransactionalTest's RecordingClusterNode) so a test can pin that a
+        // Put and a Remove landed in the SAME consensus batch, not merely both somewhere in this
+        // node's history — splitting the fix into two separate apply() calls would leave every
+        // effect-based assertion in OutcomeClearedAtPublish green while breaking atomicity.
+        final List<List<KVCommand<AetherKey>>> batches = new ArrayList<>();
+
+        TestClusterNode(TestKVStore store) {
+            this.store = store;
+        }
+
         @Override
         public NodeId self() {
             return NodeId.nodeId("test-node").unwrap();
@@ -412,6 +540,8 @@ class BlueprintPublishOwnershipTest {
         @Override
         @SuppressWarnings("unchecked")
         public <R> Promise<List<R>> apply(List<KVCommand<AetherKey>> commands) {
+            batches.add(List.copyOf(commands));
+
             return Promise.success(commands.stream()
                                            .map(command -> (R) store.processCommand(command))
                                            .toList());


### PR DESCRIPTION
## Mechanism
`DeploymentOutcomeKey` (keyed by `BlueprintId`) is written only at terminal FSM transitions and was never cleared when a new deployment of the same id began, so `BlueprintService.outcome(id)` could keep reporting a previous attempt's terminal result while a new attempt was live. Round 1 (already merged into this branch) fixed the primary path, `buildAllCommands` (used by `publishFromArtifact`), by bundling a `Remove` of `DeploymentOutcomeKey` into the same `cluster.apply` batch as the `AppBlueprintKey` Put.

This round (review round 2) extends the same fix to the two remaining live paths that write or remove `AppBlueprintKey` without going through `buildAllCommands`:
- `storeBlueprintWithKey` (backing DSL `publish(String)`, i.e. `SliceRoutes.handleBlueprint`) now bundles the same `DeploymentOutcomeKey` Remove into its own single `cluster.apply` batch.
- `removeFromStore` (backing `delete(BlueprintId)`) now bundles a `DeploymentOutcomeKey` Remove into its own batch too — previously a deleted blueprint's outcome record was never cleared and orphaned permanently.

Both fixes preserve atomicity: the Put/Remove of `AppBlueprintKey` and the Remove of `DeploymentOutcomeKey` are submitted as ONE list to a single `cluster.apply(...)` call, so they commit together or not at all. No FSM event is wired to `DeploymentOutcomeKey`, so ordering within the batch is not load-bearing — only the batch boundary is.

## Scoped guarantee, with one documented exception
`outcome(id)` now gives its XOR guarantee (in flight XOR terminal, never both, never a stale terminal record from a prior attempt) for all three live ways `AppBlueprintKey` changes: `publishFromArtifact`, DSL `publish`, and `delete`.

**Exception, out of scope for this fix:** `ClusterDeploymentState.restorePreviousBlueprint`. An ALL_OR_NOTHING rollback re-Puts `previous.id()`'s `AppBlueprintKey` (making it live again) in the same batch as a ROLLED_BACK outcome Put keyed by `inflight.id()` — the failing id, not `previous.id()`. `previous.id()`'s own `DeploymentOutcomeKey` is untouched by that batch, and `restoringBlueprints` suppresses `previous.id()`'s normal in-flight FSM tracking while the restore is pending, so no later terminal write ever supersedes whatever `outcome(previous.id())` already held from an earlier attempt. A restored blueprint can therefore be live while `outcome(previous.id())` reports a stale, unrelated terminal record — callers must consult `get(previous.id())`'s presence alongside `outcome()`, not `outcome()` alone. This is documented in the `outcome(BlueprintId id)` Javadoc and in CHANGELOG.md; it is not fixed here because it is a distinct recovery-path question, not a regression of this round's scope.

The round-1 CHANGELOG sentence "every publish clears it for its own id, automatically" has been removed as no longer universally accurate (it predates the `delete` fix and the documented `restorePreviousBlueprint` exception).

## Tests, with red lines
All new/changed tests live in `BlueprintPublishOwnershipTest`. Full class: 19/19 pass; full `aether-deployment` module: 926/926 pass; `mvn jbct:check -pl aether/aether-deployment` passes (0 errors).

Three separate mutation-probe runs produced red-before evidence:
1. Reverting `storeBlueprintWithKey` and `removeFromStore` to their pre-fix single-command batches (dropping the `DeploymentOutcomeKey` Remove) turns exactly 4 tests red: `OutcomeClearedAtPublish.publishDsl_clearsStaleOutcome_fromPriorFailedAttempt_ofSameBlueprintId`, `OutcomeClearedAtPublish.delete_clearsStaleOutcome_fromPriorFailedAttempt`, `AtomicityPin.publishDsl_putsBlueprintAndClearsOutcome_inOneBatch`, `AtomicityPin.delete_removesBlueprintAndClearsOutcome_inOneBatch`. All 15 other tests stay green. Restored, 19/19 green again.
2. Splitting `storeBlueprintWithKey`'s single `cluster.apply` batch into two separate sequential `apply` calls (same eventual effect, broken atomicity) turns exactly 1 test red: `AtomicityPin.publishDsl_putsBlueprintAndClearsOutcome_inOneBatch`. Critically, `OutcomeClearedAtPublish.publishDsl_clearsStaleOutcome_fromPriorFailedAttempt_ofSameBlueprintId` (effect-based) stays GREEN under this mutation — proving the new `AtomicityPin` tests catch a non-atomic split that every effect-based assertion misses. Restored, 19/19 green again.

`AtomicityPin` mirrors the pattern from `ClusterDeploymentStateTransactionalTest.restorePreviousBlueprint_recordsRolledBackOutcomeAtomicallyWithRestore`: it asserts the Put and the Remove appear together in ONE recorded `cluster.apply` batch, not merely both somewhere in the node's apply history.

## Review
Addresses all 3 BLOCKING findings and item 4 (non-blocking, guarantee scoping) from round-2 review of #759.

Note: CHANGELOG.md conflict with #817 is expected on merge (informational, not a defect in this PR).