### PR TITLE
chore: #819 per-PR changelog fragments with release-prep assembly and a CI check

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,23 @@
+name: Changelog fragment
+
+# CHANGELOG.md is assembled from changelog.d/ at release prep; a feature PR adds a fragment and never
+# edits the file. See changelog.d/README.md. Labels: `no-changelog` waives the fragment,
+# `release-prep` allows the CHANGELOG.md edit.
+on:
+  pull_request:
+    branches: [main, release-*]
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+
+jobs:
+  fragment:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check the changelog fragment
+        env:
+          PR_LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
+        run: scripts/changelog-check.sh "origin/${{ github.base_ref }}"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,6 +108,9 @@ branch, and the diagnosis.
   expected of contributors).
 - Open the PR against `main`. A maintainer will review, request changes if needed, and choose the
   merge strategy at merge time.
+- Do not edit `CHANGELOG.md`. Add your entry as `changelog.d/<issue-number>-<slug>.md` in the format
+  described in [`changelog.d/README.md`](changelog.d/README.md); the file is assembled at release
+  prep, and a CI check refuses a direct edit. Documentation-only PRs need no fragment.
 
 ### Sign-off
 

--- a/changelog.d/819-changelog-fragments.md
+++ b/changelog.d/819-changelog-fragments.md
@@ -1,0 +1,8 @@
+### Changed (2026-09-04 — #819: per-PR changelog fragments assembled at release prep)
+- **`CHANGELOG.md` is no longer edited by feature pull requests.** Each pull request adds
+  `changelog.d/<number>-<slug>.md` holding its entry in the existing format;
+  `scripts/changelog-assemble.sh` folds the fragments into the `Unreleased` section at release prep.
+  Every rc4 pull request had been conflicting on the one file all of them appended to.
+- **A CI check** (`.github/workflows/changelog.yml`, `scripts/changelog-check.sh`) fails a pull request
+  that edits `CHANGELOG.md` without the `release-prep` label, or that changes sources without a
+  well-formed fragment and without the `no-changelog` label. Documentation-only pull requests are exempt.

--- a/changelog.d/README.md
+++ b/changelog.d/README.md
@@ -1,0 +1,51 @@
+# changelog.d — one fragment per pull request
+
+`CHANGELOG.md` is assembled, not edited. A pull request that changes sources adds one file here and
+leaves `CHANGELOG.md` alone; `scripts/changelog-assemble.sh` folds the fragments into the `Unreleased`
+section at release prep and deletes them. The published file keeps its current shape.
+
+Why: every pull request used to append under the same unreleased heading, so the first merge put every
+other open pull request into conflict and each needed a re-merge round before it could land.
+
+## File name
+
+`<number>-<slug>.md` — the issue number the pull request fixes (the pull request number when there is
+no issue), a dash, a short lowercase slug. Examples: `684-compose-secret-out-of-env.md`,
+`726-network-metrics-honest-home.md`.
+
+## Content
+
+Exactly the block that would have gone into `CHANGELOG.md`: one `###` sub-heading in the existing
+style, then the bullets. The sub-heading names the section, the date, the issue and its title:
+
+```markdown
+### Fixed (2026-09-04 — #684: generated docker-compose wrote the cluster secret in plaintext)
+- **What was wrong**, in one bold lead.
+- What changed, with `[verified: <test path>]` for claims a live-path test pins and
+  `[mechanism: ...]` for claims traced through the code.
+```
+
+Sections: `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `Security`, `Performance`. One section
+per fragment; a change that needs two sections uses two fragments (`684-compose-secret-fixed.md`,
+`684-compose-secret-security.md`).
+
+## The check
+
+`scripts/changelog-check.sh <base-ref>` runs on every pull request (`.github/workflows/changelog.yml`).
+It fails when:
+
+- the pull request edits `CHANGELOG.md` and does not carry the `release-prep` label;
+- the pull request touches something other than documentation, workflows or this directory, and adds
+  no well-formed fragment, and does not carry the `no-changelog` label.
+
+Documentation-only pull requests (`*.md`, `docs/`, `.github/`) need no fragment.
+
+## Release prep
+
+```sh
+scripts/changelog-assemble.sh            # writes CHANGELOG.md, git-removes the fragments
+scripts/changelog-assemble.sh --dry-run  # prints the assembled section, changes nothing
+```
+
+Fragments are inserted at the top of the `Unreleased` section, newest date first, so the section reads
+the way it always has. The pull request that runs the assembly carries the `release-prep` label.

--- a/scripts/changelog-assemble.sh
+++ b/scripts/changelog-assemble.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Fold changelog.d/*.md fragments into the Unreleased section of CHANGELOG.md.
+#
+#   scripts/changelog-assemble.sh            writes CHANGELOG.md, git-removes the fragments
+#   scripts/changelog-assemble.sh --dry-run  prints the assembled Unreleased section, changes nothing
+#
+# Fragments go in at the top of the section, newest date first (ties by descending number), so the
+# section keeps its existing newest-first order. See changelog.d/README.md for the fragment format.
+set -euo pipefail
+
+root="$(git rev-parse --show-toplevel)"
+changelog="$root/CHANGELOG.md"
+dir="$root/changelog.d"
+dry_run=false
+[[ "${1:-}" == "--dry-run" ]] && dry_run=true
+
+shopt -s nullglob
+fragments=("$dir"/[0-9]*-*.md)
+if (( ${#fragments[@]} == 0 )); then
+    echo "changelog-assemble: no fragments in changelog.d/" >&2
+    exit 0
+fi
+
+heading_line="$(grep -n -m1 '^## \[.*\] - Unreleased$' "$changelog" | cut -d: -f1 || true)"
+if [[ -z "$heading_line" ]]; then
+    echo "changelog-assemble: CHANGELOG.md has no '## [<version>] - Unreleased' heading" >&2
+    exit 1
+fi
+
+# Sort key per fragment: date from the sub-heading (YYYY-MM-DD, 0000-00-00 when absent), then the
+# leading number of the file name; both descending.
+keyed=()
+for f in "${fragments[@]}"; do
+    first="$(grep -m1 '^### ' "$f" || true)"
+    if [[ -z "$first" ]]; then
+        echo "changelog-assemble: $f has no '### <Section>' sub-heading" >&2
+        exit 1
+    fi
+    date="$(grep -o '[0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\}' <<<"$first" | head -1 || true)"
+    number="$(basename "$f" | grep -o '^[0-9]*')"
+    keyed+=("${date:-0000-00-00} $number $f")
+done
+
+assembled="$(mktemp)"
+trap 'rm -f "$assembled"' EXIT
+printf '%s\n' "${keyed[@]}" | sort -k1,1r -k2,2nr | while read -r _ _ f; do
+    # Drop leading and trailing blank lines, keep inner ones, then one separating blank line.
+    # awk rather than sed: the GNU and BSD seds disagree on the multi-line idioms.
+    awk 'NF { for (i = 0; i < blank; i++) print ""; blank = 0; print; next } { blank++ }' "$f"
+    echo
+done > "$assembled"
+
+output="$(mktemp)"
+trap 'rm -f "$assembled" "$output"' EXIT
+{
+    # The heading and the blank line under it, then the fragments, then the rest of the file
+    # without the blank line that followed the heading.
+    sed -n "1,${heading_line}p" "$changelog"
+    echo
+    cat "$assembled"
+    awk -v s="$((heading_line + 1))" 'NR >= s && !(NR == s && $0 == "")' "$changelog"
+} > "$output"
+
+if $dry_run; then
+    next_heading="$(awk -v start="$((heading_line + 1))" 'NR > start && /^## \[/ {print NR; exit}' "$output")"
+    sed -n "${heading_line},$(( ${next_heading:-$(wc -l < "$output")} - 1 ))p" "$output"
+    exit 0
+fi
+
+cp "$output" "$changelog"
+git -C "$root" rm -q -- "${fragments[@]}"
+echo "changelog-assemble: folded ${#fragments[@]} fragment(s) into CHANGELOG.md"

--- a/scripts/changelog-check.sh
+++ b/scripts/changelog-check.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Pull-request check for changelog fragments. See changelog.d/README.md.
+#
+#   scripts/changelog-check.sh <base-ref>
+#
+# PR_LABELS (comma-separated) may carry `no-changelog` (no fragment required) or `release-prep`
+# (CHANGELOG.md may be edited). Fails when CHANGELOG.md is edited without `release-prep`, or when
+# non-documentation files change without a well-formed fragment and without `no-changelog`.
+set -euo pipefail
+
+base="${1:?usage: changelog-check.sh <base-ref>}"
+labels=",${PR_LABELS:-},"
+root="$(git rev-parse --show-toplevel)"
+cd "$root"
+
+has_label() { [[ "$labels" == *",$1,"* ]]; }
+
+# No mapfile: macOS ships bash 3.2 and this runs locally too.
+changed=()
+while IFS= read -r line; do changed+=("$line"); done < <(git diff --name-only --diff-filter=ACDMR "$base...HEAD")
+if (( ${#changed[@]} == 0 )); then
+    echo "changelog-check: no changes against $base"
+    exit 0
+fi
+
+status=0
+
+if printf '%s\n' "${changed[@]}" | grep -qx 'CHANGELOG.md' && ! has_label release-prep; then
+    echo "changelog-check: CHANGELOG.md is assembled at release prep; put the entry in changelog.d/<number>-<slug>.md instead (or label the PR release-prep)" >&2
+    status=1
+fi
+
+# Paths that never need a fragment.
+is_exempt() {
+    case "$1" in
+        changelog.d/*|*.md|docs/*|.github/*|LICENSE*|.gitignore|.gitattributes) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+needs_fragment=false
+for path in "${changed[@]}"; do
+    is_exempt "$path" || { needs_fragment=true; break; }
+done
+
+fragments=()
+while IFS= read -r line; do [[ -n "$line" ]] && fragments+=("$line"); done < <(git diff --name-only --diff-filter=AM "$base...HEAD" -- 'changelog.d/*.md' | grep -v '/README.md$' || true)
+
+section_re='^### (Added|Changed|Deprecated|Removed|Fixed|Security|Performance)( \(.*\))?$'
+well_formed=0
+# ${arr[@]+"${arr[@]}"}: bash 3.2 treats an empty array as unbound under set -u.
+for f in ${fragments[@]+"${fragments[@]}"}; do
+    name="$(basename "$f")"
+    if ! [[ "$name" =~ ^[0-9]+-[a-z0-9-]+\.md$ ]]; then
+        echo "changelog-check: $f: file name must be <number>-<slug>.md (lowercase, digits, dashes)" >&2
+        status=1
+        continue
+    fi
+    first="$(grep -m1 -v '^[[:space:]]*$' "$f" || true)"
+    if ! [[ "$first" =~ $section_re ]]; then
+        echo "changelog-check: $f: first line must be '### <Section> (...)' with Section one of Added, Changed, Deprecated, Removed, Fixed, Security, Performance" >&2
+        status=1
+        continue
+    fi
+    if ! grep -q '^- ' "$f"; then
+        echo "changelog-check: $f: needs at least one '- ' bullet under the sub-heading" >&2
+        status=1
+        continue
+    fi
+    well_formed=$((well_formed + 1))
+done
+
+if $needs_fragment && (( well_formed == 0 )) && ! has_label no-changelog; then
+    echo "changelog-check: sources changed but no well-formed changelog.d/<number>-<slug>.md fragment was added (label the PR no-changelog if it truly needs no entry)" >&2
+    status=1
+fi
+
+if (( status == 0 )); then
+    echo "changelog-check: ok (${well_formed} fragment(s), needs_fragment=$needs_fragment)"
+fi
+exit $status


### PR DESCRIPTION
Closes #819. Owner ruling 2026-09-04 (`know:` commit `a4d849028` on rc4).

Every rc4 PR this week conflicted on CHANGELOG.md because each one appended under the same unreleased heading. From this PR on, a feature PR adds `changelog.d/<number>-<slug>.md` and leaves CHANGELOG.md alone; `scripts/changelog-assemble.sh` folds the fragments into the `Unreleased` section at release prep (newest date first, then higher number first, matching the file's existing order) and git-removes them. The published file keeps its shape.

CI check `.github/workflows/changelog.yml` runs `scripts/changelog-check.sh origin/<base>` on every PR to `main` and `release-*`:
- fails when CHANGELOG.md is edited without the `release-prep` label;
- fails when non-documentation paths change without a well-formed fragment and without the `no-changelog` label;
- validates file name (`<number>-<slug>.md`), the `### <Section> (...)` first line (Added, Changed, Deprecated, Removed, Fixed, Security, Performance) and at least one bullet.

Evidence, all run locally on macOS bash 3.2 in a throwaway worktree (the scripts avoid `mapfile` and the GNU/BSD sed idioms for that reason):
- `[verified: scripts/changelog-check.sh]` positive: this branch vs rc4 → ok (1 fragment). Negative: no fragment → fail; same with `no-changelog` → ok; CHANGELOG.md edited → fail; same with `release-prep` → ok; malformed section, bad file name, no bullet → fail each with the specific message; docs-only change → ok without a fragment.
- `[verified: scripts/changelog-assemble.sh]` dry-run and write mode with three fragments (dates 2026-09-01 and 2026-09-04, numbers 100/819/900): inserted at the top of `Unreleased` in order #900, #819, #100; fragments git-removed; second run is a no-op.
- This PR carries its own fragment (`changelog.d/819-changelog-fragments.md`), so the new workflow's run on this PR is the check's first live execution.

Open PRs that already edit CHANGELOG.md (#817) merge before this one; PRs opened after it carry fragments (the live streams have been told). `main` receives this with the rc4 release.
