### PR TITLE
fix: add explicit partition parameter to Management-API publish (#524)

### DIFF
--- a/aether/cli/src/main/java/org/pragmatica/aether/cli/AetherCli.java
+++ b/aether/cli/src/main/java/org/pragmatica/aether/cli/AetherCli.java
@@ -4295,6 +4295,13 @@ public class AetherCli implements Runnable {
             @Parameters(index = "1", description = "Message content")
             private String message;
 
+            /// #524: Management-API publish writes untyped bytes, so it cannot extract an
+            /// `@PartitionKey` the way an app publish does — an explicit `--partition` here is the
+            /// operator choosing a target directly, not key-based routing. Omitted keeps the
+            /// unchanged default: partition 0.
+            @CommandLine.Option(names = "--partition", description = "Target partition (default: 0). Management-API publish does no key-based routing -- it writes untyped bytes with no event to extract a key from, so this is a direct, deliberate target choice.")
+            private Integer partition;
+
             @Override
             public Integer call() {
                 return resolveStreamAddress(address).fold(StreamCommand::handleAddressError, this::publish);
@@ -4302,7 +4309,9 @@ public class AetherCli implements Runnable {
 
             private int publish(ResourceAddress addr) {
                 var encoded = Base64.getEncoder().encodeToString(message.getBytes());
-                var body = "{\"data\":\"" + encoded + "\"}";
+                var body = partition == null
+                           ? "{\"data\":\"" + encoded + "\"}"
+                           : "{\"data\":\"" + encoded + "\",\"partition\":" + partition + "}";
                 var response = streamParent.parent.post(STREAMS_PUBLISH,
                                                         List.of(addr.namespace().value(),
                                                                 addr.name().value(),

--- a/aether/docs/reference/cli.md
+++ b/aether/docs/reference/cli.md
@@ -1605,15 +1605,22 @@ on: partitions no node can consume because the declaring slice is `ACTIVE` nowhe
 
 See [Management API — Declarative Stream Consumers](management-api.md#declarative-stream-consumers).
 
-### `aether streams publish <name-or-address> <message>`
+### `aether streams publish <name-or-address> <message> [--partition N]`
 
 Publish a text message to a stream. The message is base64-encoded automatically. Bare name
 defaults to `system:<name>:1.0.0`; a `namespace:stream:version` address targets any stream.
 Wraps `POST /api/v1/streams/{namespace}/{stream}/{version}/publish`.
 
+`--partition N` targets a specific partition; omitted, it defaults to **partition 0** (unchanged
+behavior). This command does no key-based routing — Management-API publish writes untyped bytes
+with no event to extract an `@PartitionKey` from (unlike an app publish, #507), so `--partition`
+is a direct, deliberate target choice, not a routing key. Naming a partition outside the stream's
+declared range fails with `400 Bad Request` naming the valid range.
+
 ```bash
 aether streams publish my-events "Hello, world!"
 aether streams publish orders:order-events:1.0.0 "Hello, world!"
+aether streams publish my-events "Hello, world!" --partition 2
 ```
 
 ### `aether streams read <name-or-address> <partition>`

--- a/aether/docs/reference/management-api.md
+++ b/aether/docs/reference/management-api.md
@@ -5267,6 +5267,15 @@ POST /api/v1/streams/{namespace}/{stream}/{version}/publish-batch
 **Auth:** OPERATOR_AND_ABOVE. Publishes one event (or a batch). **Writes to `system:*` streams
 are rejected with `405 Method Not Allowed`** — see below.
 
+Body: `{"data": "<base64>", "partition": <int>}`. `partition` is optional; omitted, it defaults
+to **partition 0** (unchanged pre-#524 behavior). **This path does no key-based routing** — unlike
+an app publish (#507), which extracts `@PartitionKey` from a typed event, Management-API publish
+writes untyped bytes with no event class to read a key from, so an explicit `partition` here is
+the operator naming a target directly. A `partition` outside `[0, partitionCount)` for the stream
+is rejected with `400 Bad Request`, naming the valid range — never a silent write to partition 0,
+never `500`. `[mechanism: ManagementServerError.InvalidPartition, ProblemResponses HttpStatusAware
+dispatch]`
+
 ### Delete Stream Version
 
 ```

--- a/aether/docs/reference/management-api.md
+++ b/aether/docs/reference/management-api.md
@@ -5276,6 +5276,19 @@ is rejected with `400 Bad Request`, naming the valid range — never a silent wr
 never `500`. `[mechanism: ManagementServerError.InvalidPartition, ProblemResponses HttpStatusAware
 dispatch]`
 
+When the stream's partition count cannot be determined — the auto-create guard could not
+materialize the stream locally (capacity exhausted, or `STRONG` consistency requiring AHSE
+storage) — the request is rejected with `409 Conflict`, naming the stream and the underlying
+cause, rather than validated against a guessed count. `[mechanism: ManagementServerError.StreamUnavailable,
+ProblemResponses HttpStatusAware dispatch]`
+
+**Batch publish is not atomic.** `publish-batch` validates and writes each item independently and
+concurrently; when one item names an out-of-range `partition`, items before it (and possibly after
+it) may already be durably written before the batch call fails. The response on failure names only
+the first invalid item — it does not report which of the other items committed. `[mechanism:
+publishMany fires every item concurrently via Promise.allOf with no short-circuit, then
+Result.allOf surfaces only the first Result failure]`
+
 ### Delete Stream Version
 
 ```

--- a/aether/node/src/main/java/org/pragmatica/aether/api/ManagementServerError.java
+++ b/aether/node/src/main/java/org/pragmatica/aether/api/ManagementServerError.java
@@ -48,6 +48,25 @@ public sealed interface ManagementServerError extends Cause, HttpStatusAware {
         }
     }
 
+    /// #524 SHOULD-FIX 1: the Management-API publish auto-create guard (`ensureStreamExists`) could
+    /// not materialize the stream -- a genuine failure (capacity exhausted, or STRONG consistency
+    /// requiring AHSE storage), never a transient config-visibility race, which the manager resolves
+    /// internally and never surfaces here. The declared partition count is therefore genuinely
+    /// unknown at the route, so `validatePartition` must never guess one (e.g. against a hardcoded
+    /// default) -- this reports 409 naming the stream and the underlying cause instead of silently
+    /// accepting an invalid partition or rejecting a valid one against a fabricated count.
+    record StreamUnavailable(String streamName, String reason) implements ManagementServerError {
+        @Override
+        public String message() {
+            return "Stream '" + streamName + "' is not available: " + reason;
+        }
+
+        @Override
+        public HttpStatus httpStatus() {
+            return HttpStatus.CONFLICT;
+        }
+    }
+
     /// #524: an explicit `partition` on a Management-API publish named a partition the stream does not
     /// declare. Names the valid range rather than silently writing to partition 0 or 500ing.
     record InvalidPartition(int requested, int partitionCount) implements ManagementServerError {

--- a/aether/node/src/main/java/org/pragmatica/aether/api/ManagementServerError.java
+++ b/aether/node/src/main/java/org/pragmatica/aether/api/ManagementServerError.java
@@ -48,6 +48,21 @@ public sealed interface ManagementServerError extends Cause, HttpStatusAware {
         }
     }
 
+    /// #524: an explicit `partition` on a Management-API publish named a partition the stream does not
+    /// declare. Names the valid range rather than silently writing to partition 0 or 500ing.
+    record InvalidPartition(int requested, int partitionCount) implements ManagementServerError {
+        @Override
+        public String message() {
+            return "Partition %d is out of range; this stream has partitions [0, %d)".formatted(requested,
+                                                                                                partitionCount);
+        }
+
+        @Override
+        public HttpStatus httpStatus() {
+            return HttpStatus.BAD_REQUEST;
+        }
+    }
+
     record NotLeader(String leaderId) implements ManagementServerError {
         @Override
         public String message() {

--- a/aether/node/src/main/java/org/pragmatica/aether/api/routes/StreamApiRoutes.java
+++ b/aether/node/src/main/java/org/pragmatica/aether/api/routes/StreamApiRoutes.java
@@ -40,6 +40,7 @@ import org.pragmatica.lang.Cause;
 import org.pragmatica.lang.Option;
 import org.pragmatica.lang.Promise;
 import org.pragmatica.lang.Result;
+import org.pragmatica.lang.Unit;
 import org.pragmatica.lang.utils.Causes;
 
 
@@ -634,18 +635,21 @@ public final class StreamApiRoutes implements RouteSource {
     }
 
     /// #524 guard: an out-of-range `partition` on a Management-API publish must fail 4xx naming the
-    /// valid range — never a silent write to partition 0, never a 500. Reads the LOCAL materialized
-    /// partition count (same source [#ensureStreamExists] just guaranteed is present); falls back to
-    /// the management default only in the pathological case where materialization was swallowed by
-    /// `ensureStreamExists`'s `.recover`, so this check itself never 500s.
-    private Result<org.pragmatica.lang.Unit> validatePartition(String streamName, int partition) {
-        var partitionCount = streamManager().streamInfo(streamName)
-                                          .map(StreamPartitionManager.StreamInfo::partitions)
-                                          .or(DEFAULT_PARTITIONS);
-
-        return partition >= 0 && partition < partitionCount
-               ? Result.unitResult()
-               : new ManagementServerError.InvalidPartition(partition, partitionCount).result();
+    /// valid range — never a silent write to partition 0, never a 500. Reads the committed config's
+    /// DECLARED partition count (`StreamInfo#partitions`, backed by `declaredPartitions()` — the
+    /// committed `StreamConfig`'s count, not the partition rings actually materialized locally).
+    /// `ensureStreamExists` (run first in [#publishOne]) guarantees this entry is present on success,
+    /// so an empty `streamInfo()` here means that guarantee did not hold; never guess a count in that
+    /// case — report the stream unavailable instead of validating against a fabricated default.
+    private Result<Unit> validatePartition(String streamName, int partition) {
+        return streamManager().streamInfo(streamName)
+                            .map(StreamPartitionManager.StreamInfo::partitions)
+                            .toResult(new ManagementServerError.StreamUnavailable(streamName,
+                                                                                  "partition count is not known"))
+                            .flatMap(partitionCount -> partition >= 0 && partition < partitionCount
+                                                       ? Result.unitResult()
+                                                       : new ManagementServerError.InvalidPartition(partition,
+                                                                                                    partitionCount).result());
     }
 
     /// Adapter boundary: JSON `data` may legally be absent (null on the wire). Wrap into Option,
@@ -668,7 +672,14 @@ public final class StreamApiRoutes implements RouteSource {
     /// materialization preserves the replication factor rather than fabricating a `replicas=1/min-sync=0`
     /// management default over it. Falls back to the management default only for a genuinely
     /// management-only stream with no committed entry.
-    private Result<org.pragmatica.lang.Unit> ensureStreamExists(String streamName) {
+    ///
+    /// #524 SHOULD-FIX 1: a materialization failure here is never a transient race — the only failure
+    /// modes `ensureStreamMaterialized` can return are permanent (capacity exhausted, or STRONG
+    /// consistency requiring AHSE storage); the transient config-visibility race belongs to a different
+    /// call path entirely. So it must never be swallowed: on success `streams` is guaranteed to hold
+    /// the entry (making [#validatePartition]'s read safe), and on failure this reports a typed 409
+    /// naming the stream and cause instead of silently proceeding with an unknown partition count.
+    private Result<Unit> ensureStreamExists(String streamName) {
         var config = nodeSupplier.get()
                                  .kvStore()
                                  .getTyped(StreamConfigKey.streamConfigKey(streamName),
@@ -680,7 +691,8 @@ public final class StreamApiRoutes implements RouteSource {
                                                                      "latest"));
 
         return streamManager().ensureStreamMaterialized(config)
-                            .recover(_ -> org.pragmatica.lang.Unit.unit());
+                            .mapError(cause -> new ManagementServerError.StreamUnavailable(streamName,
+                                                                                           cause.message()));
     }
 
     private Result<GroupResponse> createGroup(String namespace,

--- a/aether/node/src/main/java/org/pragmatica/aether/api/routes/StreamApiRoutes.java
+++ b/aether/node/src/main/java/org/pragmatica/aether/api/routes/StreamApiRoutes.java
@@ -13,6 +13,7 @@ import java.util.function.Supplier;
 import java.util.stream.Stream;
 
 import org.pragmatica.aether.api.ManagementApiResponses.StreamReplicasResponse;
+import org.pragmatica.aether.api.ManagementServerError;
 import org.pragmatica.aether.management.route.ManagementRoute;
 import org.pragmatica.aether.node.ManageableNode;
 import org.pragmatica.aether.slice.ReadPreference;
@@ -55,6 +56,9 @@ public final class StreamApiRoutes implements RouteSource {
     private static final Cause STREAM_NOT_FOUND = Causes.cause("Stream not found");
     private static final Cause GROUP_NOT_FOUND = Causes.cause("Consumer group not found");
     private static final int DEFAULT_PARTITIONS = 4;
+    /// #524: pre-fix hardwired publish target, preserved as the explicit default for an omitted
+    /// `partition` field so existing callers see unchanged behavior.
+    private static final int DEFAULT_PUBLISH_PARTITION = 0;
 
     private static final RetentionPolicy MANAGEMENT_API_RETENTION = RetentionPolicy.retentionPolicy(10_000,
                                                                                                     4 * 1024 * 1024L,
@@ -129,7 +133,11 @@ public final class StreamApiRoutes implements RouteSource {
         }
     }
 
-    public record PublishRequest(String data) {}
+    /// `partition` is optional (absent/`null` on the wire keeps the pre-#524 default: partition 0).
+    /// Management-API publish writes UNTYPED bytes — there is no event class to read an
+    /// `@PartitionKey` from, so unlike the app publish path (#507) an explicit partition here is the
+    /// operator choosing a target directly, never key-based routing.
+    public record PublishRequest(String data, Integer partition) {}
 
     public record PublishResponse(String address, long offset) {}
 
@@ -603,9 +611,11 @@ public final class StreamApiRoutes implements RouteSource {
                      .async();
     }
 
-    /// Owner-routed publish to partition 0. When this node is metadata-only (#265) the write is
-    /// forwarded to the partition owner via [StreamWriteRouter] instead of failing PARTITION_NOT_LOCAL
-    /// on a local append; an owner node appends locally (and awaits the min-sync barrier).
+    /// Owner-routed publish to an explicit `partition` (#524: default 0 — unchanged from the earlier
+    /// hardwired behavior — when the request omits it). When this node is metadata-only (#265) the
+    /// write is forwarded to the partition owner via [StreamWriteRouter] instead of failing
+    /// PARTITION_NOT_LOCAL on a local append; an owner node appends locally (and awaits the min-sync
+    /// barrier).
     ///
     /// Engine key via [StreamManager#engineKey], not `addr.asString()`: a `system`-namespace address
     /// must resolve to the bare name the engine keys operator-created flat streams by, or this publish
@@ -613,12 +623,29 @@ public final class StreamApiRoutes implements RouteSource {
     private Promise<Long> publishOne(ResourceAddress addr, PublishRequest request) {
         var streamName = StreamManager.engineKey(addr);
         var payload = decodePayload(request.data());
+        var partition = Option.option(request.partition()).or(DEFAULT_PUBLISH_PARTITION);
 
         return ensureStreamExists(streamName).async()
+                                 .flatMap(_ -> validatePartition(streamName, partition).async())
                                  .flatMap(_ -> streamWriteRouter().publish(streamName,
-                                                                           0,
+                                                                           partition,
                                                                            payload,
                                                                            System.currentTimeMillis()));
+    }
+
+    /// #524 guard: an out-of-range `partition` on a Management-API publish must fail 4xx naming the
+    /// valid range — never a silent write to partition 0, never a 500. Reads the LOCAL materialized
+    /// partition count (same source [#ensureStreamExists] just guaranteed is present); falls back to
+    /// the management default only in the pathological case where materialization was swallowed by
+    /// `ensureStreamExists`'s `.recover`, so this check itself never 500s.
+    private Result<org.pragmatica.lang.Unit> validatePartition(String streamName, int partition) {
+        var partitionCount = streamManager().streamInfo(streamName)
+                                          .map(StreamPartitionManager.StreamInfo::partitions)
+                                          .or(DEFAULT_PARTITIONS);
+
+        return partition >= 0 && partition < partitionCount
+               ? Result.unitResult()
+               : new ManagementServerError.InvalidPartition(partition, partitionCount).result();
     }
 
     /// Adapter boundary: JSON `data` may legally be absent (null on the wire). Wrap into Option,

--- a/aether/node/src/test/java/org/pragmatica/aether/api/routes/StreamApiRoutesPublishPartitionTest.java
+++ b/aether/node/src/test/java/org/pragmatica/aether/api/routes/StreamApiRoutesPublishPartitionTest.java
@@ -30,10 +30,12 @@ import static org.pragmatica.aether.stream.StreamPartitionManager.streamPartitio
 /// publish writes untyped bytes with no event class to extract a key from, so the fix is an
 /// explicit `partition` on [StreamApiRoutes.PublishRequest] — never key-based routing — validated
 /// against the stream's actual partition count before ever reaching [StreamWriteRouter#publish].
-/// This file pins three properties: (1) an omitted `partition` still targets 0 (unchanged
-/// behavior), (2) an explicit in-range `partition` targets THAT partition and no other, and (3) an
+/// This file pins four properties: (1) an omitted `partition` still targets 0 (unchanged
+/// behavior), (2) an explicit in-range `partition` targets THAT partition and no other, (3) an
 /// out-of-range `partition` fails 4xx naming the valid range instead of silently writing to
-/// partition 0 or 500ing.
+/// partition 0 or 500ing, and (4) when the stream's partition count cannot be determined (a genuine
+/// materialization failure, not a race) the route reports the stream unavailable rather than
+/// validating against a guessed count.
 class StreamApiRoutesPublishPartitionTest {
     private static final String NAMESPACE = "com.example.app";
     private static final String STREAM = "orders";
@@ -134,6 +136,34 @@ class StreamApiRoutesPublishPartitionTest {
                    .onSuccess(events -> assertThat(events).as("a rejected out-of-range partition must never silently "
                                                               + "fall back to writing partition 0")
                                                           .isEmpty());
+        } finally {
+            manager.close();
+        }
+    }
+
+    /// #524 SHOULD-FIX 1 review finding: `ensureStreamExists`'s prior `.recover(_ -> Unit.unit())`
+    /// swallowed a genuine materialization failure, leaving `streamInfo()` empty and letting
+    /// `validatePartition` guess a hardcoded partition count instead. A zero-capacity manager forces
+    /// `ensureStreamMaterialized`'s very first reservation to fail deterministically (never a
+    /// transient race, so this pins a real failure, not a flake) — the route must surface a typed 4xx
+    /// naming the stream, never guess a count and either wrongly accept or wrongly reject the request.
+    @Test
+    void publish_streamMaterializationFails_reportsStreamUnavailable_neverGuessesPartitionCount() {
+        var manager = streamPartitionManager(0);
+        try {
+            routesFor(manager).publishEvent(NAMESPACE, STREAM, VERSION, new StreamApiRoutes.PublishRequest("payload", null))
+                              .await()
+                              .onSuccess(response -> fail("materialization must fail when capacity is exhausted, not "
+                                                          + "publish at offset " + response.offset()))
+                              .onFailure(cause -> {
+                                  assertThat(cause).isInstanceOf(ManagementServerError.StreamUnavailable.class);
+                                  assertThat(((ManagementServerError.StreamUnavailable) cause).httpStatus())
+                                          .isEqualTo(HttpStatus.CONFLICT);
+                              });
+
+            assertThat(manager.streamInfo(STREAM_ADDRESS).isEmpty())
+                    .as("a failed materialization must never leave a partition count to guess")
+                    .isTrue();
         } finally {
             manager.close();
         }

--- a/aether/node/src/test/java/org/pragmatica/aether/api/routes/StreamApiRoutesPublishPartitionTest.java
+++ b/aether/node/src/test/java/org/pragmatica/aether/api/routes/StreamApiRoutesPublishPartitionTest.java
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2025 Pragmatica Labs - Sergiy Yevtushenko
+// Licensed under Business Source License 1.1. Change Date: 2030-01-01. Change License: Apache-2.0.
+// See LICENSE in the repository root for full terms.
+package org.pragmatica.aether.api.routes;
+
+import org.junit.jupiter.api.Test;
+import org.pragmatica.aether.api.ManagementServerError;
+import org.pragmatica.aether.node.ManageableNode;
+import org.pragmatica.aether.slice.RetentionPolicy;
+import org.pragmatica.aether.slice.StreamConfig;
+import org.pragmatica.aether.slice.kvstore.AetherKey;
+import org.pragmatica.aether.slice.kvstore.AetherValue;
+import org.pragmatica.aether.slice.stream.StreamNamespacesService;
+import org.pragmatica.aether.stream.StreamPartitionManager;
+import org.pragmatica.aether.stream.StreamWriteRouter;
+import org.pragmatica.aether.stream.consumer.ConsumerGroupCoordinator;
+import org.pragmatica.aether.stream.consumer.ConsumerGroupRegistry;
+import org.pragmatica.cluster.state.kvstore.KVStore;
+import org.pragmatica.http.HttpStatus;
+
+import java.lang.reflect.Proxy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.pragmatica.aether.stream.StreamPartitionManager.streamPartitionManager;
+
+/// #524: Management-API publish (`StreamApiRoutes#publishOne`) hardwired every write to partition
+/// 0, diverging from the app-publish path (#507), which routes by `@PartitionKey`. Management-API
+/// publish writes untyped bytes with no event class to extract a key from, so the fix is an
+/// explicit `partition` on [StreamApiRoutes.PublishRequest] — never key-based routing — validated
+/// against the stream's actual partition count before ever reaching [StreamWriteRouter#publish].
+/// This file pins three properties: (1) an omitted `partition` still targets 0 (unchanged
+/// behavior), (2) an explicit in-range `partition` targets THAT partition and no other, and (3) an
+/// out-of-range `partition` fails 4xx naming the valid range instead of silently writing to
+/// partition 0 or 500ing.
+class StreamApiRoutesPublishPartitionTest {
+    private static final String NAMESPACE = "com.example.app";
+    private static final String STREAM = "orders";
+    private static final String VERSION = "1.0.0";
+    private static final String STREAM_ADDRESS = NAMESPACE + ":" + STREAM + ":" + VERSION;
+    private static final int PARTITIONS = 4;
+
+    private static ManageableNode nodeWith(StreamPartitionManager manager) {
+        return (ManageableNode) Proxy.newProxyInstance(ManageableNode.class.getClassLoader(),
+                                                       new Class[]{ManageableNode.class},
+                                                       (_, method, _) -> stubbed(method.getName(), manager));
+    }
+
+    /// `publishOne`'s auto-create guard reads `kvStore()` before falling back to the management
+    /// default, and `streamWriteRouter()` needs a real router over the SAME manager to append
+    /// locally — both additional to the single `streamPartitionManager()` stub the delete-only
+    /// proxy in `StreamApiRoutesDeleteStreamTest` required.
+    private static Object stubbed(String method, StreamPartitionManager manager) {
+        return switch (method) {
+            case "streamPartitionManager" -> manager;
+            case "kvStore" -> new KVStore<AetherKey, AetherValue>(null, null, null);
+            case "streamWriteRouter" -> StreamWriteRouter.localOnly(manager);
+            default -> throw new UnsupportedOperationException("Not stubbed in test proxy: " + method);
+        };
+    }
+
+    private static StreamApiRoutes routesFor(StreamPartitionManager manager) {
+        return StreamApiRoutes.streamApiRoutes(() -> nodeWith(manager),
+                                               StreamNamespacesService.inMemory(),
+                                               ConsumerGroupCoordinator.noOp(),
+                                               ConsumerGroupRegistry.consumerGroupRegistry());
+    }
+
+    @Test
+    void publish_partitionOmitted_targetsPartitionZero_unchangedBehavior() {
+        var manager = streamPartitionManager(Long.MAX_VALUE);
+        try {
+            manager.createStream(StreamConfig.streamConfig(STREAM_ADDRESS, PARTITIONS, retention(), "latest"))
+                   .onFailure(cause -> fail("stream create must succeed: " + cause));
+
+            routesFor(manager).publishEvent(NAMESPACE, STREAM, VERSION, new StreamApiRoutes.PublishRequest("payload", null))
+                              .await()
+                              .onFailure(cause -> fail("publish with an omitted partition must succeed: " + cause))
+                              .onSuccess(response -> assertThat(response.offset()).isEqualTo(0L));
+
+            manager.readLocal(STREAM_ADDRESS, 0, 0, 10)
+                   .onFailure(cause -> fail("partition 0 must hold the event: " + cause))
+                   .onSuccess(events -> assertThat(events).hasSize(1));
+        } finally {
+            manager.close();
+        }
+    }
+
+    @Test
+    void publish_explicitInRangePartition_targetsThatPartitionOnly() {
+        var manager = streamPartitionManager(Long.MAX_VALUE);
+        try {
+            manager.createStream(StreamConfig.streamConfig(STREAM_ADDRESS, PARTITIONS, retention(), "latest"))
+                   .onFailure(cause -> fail("stream create must succeed: " + cause));
+
+            routesFor(manager).publishEvent(NAMESPACE, STREAM, VERSION, new StreamApiRoutes.PublishRequest("payload", 2))
+                              .await()
+                              .onFailure(cause -> fail("publish to an in-range partition must succeed: " + cause))
+                              .onSuccess(response -> assertThat(response.offset()).isEqualTo(0L));
+
+            manager.readLocal(STREAM_ADDRESS, 2, 0, 10)
+                   .onFailure(cause -> fail("partition 2 must hold the event: " + cause))
+                   .onSuccess(events -> assertThat(events).hasSize(1));
+
+            manager.readLocal(STREAM_ADDRESS, 0, 0, 10)
+                   .onFailure(cause -> fail("partition 0 read must succeed even when empty: " + cause))
+                   .onSuccess(events -> assertThat(events).as("an explicit partition must not ALSO write partition 0")
+                                                          .isEmpty());
+        } finally {
+            manager.close();
+        }
+    }
+
+    @Test
+    void publish_outOfRangePartition_fails400NamingValidRange_neverPartitionZeroNever500() {
+        var manager = streamPartitionManager(Long.MAX_VALUE);
+        try {
+            manager.createStream(StreamConfig.streamConfig(STREAM_ADDRESS, PARTITIONS, retention(), "latest"))
+                   .onFailure(cause -> fail("stream create must succeed: " + cause));
+
+            routesFor(manager).publishEvent(NAMESPACE, STREAM, VERSION, new StreamApiRoutes.PublishRequest("payload", PARTITIONS))
+                              .await()
+                              .onSuccess(response -> fail("an out-of-range partition must fail, not publish at offset "
+                                                          + response.offset()))
+                              .onFailure(cause -> {
+                                  assertThat(cause).isInstanceOf(ManagementServerError.InvalidPartition.class);
+                                  assertThat(((ManagementServerError.InvalidPartition) cause).httpStatus())
+                                          .isEqualTo(HttpStatus.BAD_REQUEST);
+                              });
+
+            manager.readLocal(STREAM_ADDRESS, 0, 0, 10)
+                   .onFailure(cause -> fail("partition 0 read must succeed even when empty: " + cause))
+                   .onSuccess(events -> assertThat(events).as("a rejected out-of-range partition must never silently "
+                                                              + "fall back to writing partition 0")
+                                                          .isEmpty());
+        } finally {
+            manager.close();
+        }
+    }
+
+    private static RetentionPolicy retention() {
+        return RetentionPolicy.retentionPolicy();
+    }
+}

--- a/aether/node/src/test/java/org/pragmatica/aether/api/routes/StreamRoutesEngineKeyRoundTripTest.java
+++ b/aether/node/src/test/java/org/pragmatica/aether/api/routes/StreamRoutesEngineKeyRoundTripTest.java
@@ -75,7 +75,7 @@ class StreamRoutesEngineKeyRoundTripTest {
             apiRoutes.publishEvent(StreamManager.SYSTEM_NAMESPACE,
                                    STREAM_NAME,
                                    VERSION,
-                                   new StreamApiRoutes.PublishRequest("payload"))
+                                   new StreamApiRoutes.PublishRequest("payload", null))
                      .await()
                      .onFailure(cause -> fail("publish against the system-namespace address must resolve to the "
                                               + "stream CREATE minted: " + cause))

--- a/changelog.d/524-mgmt-publish-partition.md
+++ b/changelog.d/524-mgmt-publish-partition.md
@@ -1,0 +1,22 @@
+### Added (2026-09-04 — #524: explicit `partition` on Management-API publish)
+
+- Added an optional `partition` field to `StreamApiRoutes.PublishRequest` (REST body and CLI
+  `aether streams publish --partition N`). Management-API publish writes untyped bytes with no
+  event class to extract an `@PartitionKey` from, so unlike an app publish (#507) an explicit
+  partition here is the operator naming a target directly — never key-based routing. Omitted,
+  it defaults to partition 0, the unchanged pre-#524 behavior; both single (`publish`) and batch
+  (`publish-batch`) publish inherit this via the shared `PublishRequest` DTO.
+  [verified: `aether/node/src/test/java/org/pragmatica/aether/api/routes/StreamApiRoutesPublishPartitionTest.java#publish_partitionOmitted_targetsPartitionZero_unchangedBehavior`,
+  `#publish_explicitInRangePartition_targetsThatPartitionOnly`]
+- Added `ManagementServerError.InvalidPartition`: a `partition` outside `[0, partitionCount)` for
+  the target stream now fails `400 Bad Request` naming the valid range, resolved via the existing
+  `HttpStatusAware`/`ProblemResponses` dispatch — never a silent write to partition 0, never `500`.
+  [verified: `aether/node/src/test/java/org/pragmatica/aether/api/routes/StreamApiRoutesPublishPartitionTest.java#publish_outOfRangePartition_fails400NamingValidRange_neverPartitionZeroNever500`]
+- Documented the no-key-based-routing rationale and the 4xx validation behavior in
+  `aether/docs/reference/management-api.md` (Publish section) and
+  `aether/docs/reference/cli.md` (`aether streams publish`).
+  [mechanism: docs updated alongside the route/CLI code in the same change]
+- Dashboard quad-rule check: `aether/dashboard/src/main/resources/dashboard/index.html` has no
+  publish action of any kind (grepped for "publish" — only an unrelated "No desired topology
+  published" table cell matched), so no dashboard change applies here.
+  [mechanism: grep of the dashboard HTML found no publish UI surface to update]

--- a/changelog.d/524-mgmt-publish-partition.md
+++ b/changelog.d/524-mgmt-publish-partition.md
@@ -20,3 +20,24 @@
   publish action of any kind (grepped for "publish" — only an unrelated "No desired topology
   published" table cell matched), so no dashboard change applies here.
   [mechanism: grep of the dashboard HTML found no publish UI surface to update]
+
+### Fixed (PR #836 review round 1)
+
+- `validatePartition` no longer guesses a partition count when the stream's declared count is
+  unknown at the route. The prior `.or(DEFAULT_PARTITIONS)` fallback fired whenever
+  `ensureStreamExists`'s `.recover` had swallowed a genuine (never transient) materialization
+  failure, validating against a hardcoded default instead — a stream with more partitions got
+  valid requests wrongly refused, and one with fewer got an invalid partition wrongly accepted and
+  forwarded, failing later with a different status than the one promised. `ensureStreamExists` now
+  surfaces that failure as `ManagementServerError.StreamUnavailable` (`409 Conflict`, naming the
+  stream and the underlying cause) instead of swallowing it, so `validatePartition`'s own
+  empty-`streamInfo()` branch is a defensive backstop, not the primary guard — and it, too, answers
+  `StreamUnavailable` rather than a guessed count.
+  [verified: `aether/node/src/test/java/org/pragmatica/aether/api/routes/StreamApiRoutesPublishPartitionTest.java#publish_streamMaterializationFails_reportsStreamUnavailable_neverGuessesPartitionCount`]
+- Documented that `publish-batch` is not atomic: items before the first invalid partition are
+  already durably written when the batch call fails. Pre-existing property of the concurrent
+  per-item write, newly reachable now that per-item partition validation can fail.
+  [mechanism: `publishMany` fires every item concurrently via `Promise.allOf` with no
+  short-circuit, then `Result.allOf` surfaces only the first `Result` failure — documented in
+  `aether/docs/reference/management-api.md` (Publish section)]
+


### PR DESCRIPTION
## Summary

Addresses #524 (this repo merges to a release branch, so "Fixes" does not auto-close here — see CLAUDE.md). Management-API publish (`StreamApiRoutes#publishOne`) hardwired every write to
partition 0, diverging from the app-publish path (#507), which routes by `@PartitionKey`.

**Note on the ticket text:** the ticket cites `StreamRoutes.publishAndAwaitSync`, which does not
exist anywhere in the current codebase. The real, equivalent defect is in
`StreamApiRoutes.publishOne` (package `org.pragmatica.aether.api.routes`) — confirmed by premise
check before starting this fix.

## What changed (quad rule: route + CLI + docs + dashboard)

- **Route:** `StreamApiRoutes.PublishRequest` gains an optional `partition` field (REST body:
  `{"data": "<base64>", "partition": <int>}`). Omitted, it defaults to partition 0 — unchanged
  pre-#524 behavior. Both single (`publish`) and batch (`publish-batch`) inherit this via the
  shared DTO. A new `ManagementServerError.InvalidPartition` rejects any `partition` outside
  `[0, partitionCount)` with `400 Bad Request` naming the valid range, dispatched through the
  existing `HttpStatusAware`/`ProblemResponses` mechanism — never a silent write to partition 0,
  never `500`.
  [verified: `aether/node/src/test/java/org/pragmatica/aether/api/routes/StreamApiRoutesPublishPartitionTest.java`]
- **CLI:** `aether streams publish <name-or-address> <message> [--partition N]` in `AetherCli.java`
  — same optional/default semantics, forwarded verbatim into the REST body.
  [verified: `mvn compile -pl aether/cli -am` clean; CLI flag wires directly into the same
  `PublishRequest` JSON shape the route test pins]
- **Docs:** `aether/docs/reference/management-api.md` (Publish section) and
  `aether/docs/reference/cli.md` (`aether streams publish`) both document that Management-API
  publish does **no key-based routing** — it writes untyped bytes with no event class to extract
  an `@PartitionKey` from, so `partition` is a direct, deliberate target choice, not a routing key.
  [mechanism: docs updated alongside the route/CLI code in the same change]
- **Dashboard:** grepped `aether/dashboard/src/main/resources/dashboard/index.html` for any
  publish UI surface — none exists (only an unrelated "No desired topology published" table cell
  matched). No dashboard change applies.
  [mechanism: grep found no publish action in the dashboard to update]

## Test evidence (red-before / green-after)

Reverted only the `publishOne` production hunk (hardwired `partition = 0`, dropped the
`validatePartition` call) and re-ran the new test class:

```
tests="3" errors="0" skipped="0" failures="2"
```
- `publish_partitionOmitted_targetsPartitionZero_unchangedBehavior` — PASS (irrelevant to the bug)
- `publish_explicitInRangePartition_targetsThatPartitionOnly` — FAIL: `Expected size: 1 but was: 0`
  (everything landed on partition 0 instead of 2)
- `publish_outOfRangePartition_fails400NamingValidRange_neverPartitionZeroNever500` — FAIL:
  silently succeeded at offset 0 instead of failing (exactly the forbidden behavior)

Restored the fix: all 13 testcases across 4 classes pass, 0 failures/0 errors, counted from
surefire XML —
`StreamApiRoutesPublishPartitionTest` (3, new), `StreamRoutesEngineKeyRoundTripTest` (1, updated
call site for the new DTO shape), `StreamApiRoutesDeleteStreamTest` (3, regression),
`StreamApiRoutesEventsTest` (6 incl. `@Nested`, regression).

## JBCT gate

`env -u HCLOUD_TOKEN mvn jbct:check -pl aether/node,aether/cli -fae` — initially failed on 2
formatting-only issues (`ManagementServerError.java`, `StreamApiRoutes.java`); fixed via
`jbct:format -pl aether/node` (Formatted: 2, Unchanged: 147, Errors: 0), re-verified clean on both
modules, and re-ran the full test suite afterward to confirm the format pass caused zero
behavioral change (still 13/13 green).

## Changelog

`changelog.d/524-mgmt-publish-partition.md` added; `CHANGELOG.md` itself untouched (CI-fragment
workflow).
