### PR TITLE
fix: bound Promise.timeout() and node shutdown against carrier starvation (#749, #750)

### DIFF
--- a/aether/aether-invoke/src/main/java/org/pragmatica/aether/http/forward/HttpForwarder.java
+++ b/aether/aether-invoke/src/main/java/org/pragmatica/aether/http/forward/HttpForwarder.java
@@ -919,6 +919,9 @@ public interface HttpForwarder {
 
                 pendingForwards.put(correlationId, pending);
                 pendingForwardsByNode.computeIfAbsent(targetNode, _ -> ConcurrentHashMap.newKeySet()).add(correlationId);
+                // #838 review round 1: return value discarded on purpose -- the scheduled fail targets
+                // `internalPromise` itself (see Promise#timeout javadoc), so this still arms the timeout
+                // even though the derived promise it returns here is never used.
                 internalPromise.timeout(hopTimeout);
                 var forwardRequest = new HttpForwardRequest(selfNodeId,
                                                             correlationId,

--- a/aether/docs/README.md
+++ b/aether/docs/README.md
@@ -59,6 +59,7 @@ API specifications, CLI commands, and configuration options.
 - [Feature Catalog](reference/feature-catalog.md) — complete feature inventory with status tracking
 - [Known Limitations & Current Scope](reference/known-limitations.md) — single source of truth for current scope and deliberate boundaries
 - [Failure Almanac](reference/failure-almanac.md) — operator catalog of every known failure mode: symptoms, surfaces, recovery budgets
+- [Node Operations](reference/node-operations.md) — node process exit codes and shutdown-bound behavior
 - [Guarantees](reference/guarantees.md) — authoritative per-operation consistency/durability/delivery guarantees
 - [Slice API](reference/slice-api.md) — `@Slice` annotation, manifests, Maven plugin
 - [Management API](reference/management-api.md) — HTTP API for cluster management

--- a/aether/docs/reference/node-operations.md
+++ b/aether/docs/reference/node-operations.md
@@ -14,13 +14,18 @@ below covers what happens *inside* the process once a stop signal — from eithe
 |------|---------|-------|
 | `0` | Clean exit — `node.stop()` completed within the shutdown bound. | `Main#shutdownNode` |
 | `1` | Fatal startup failure — a boot-time gate refused to proceed. Causes: `AETHER_CLUSTER_NAME` unset, the container's `aether.cluster` label disagreeing with the configured cluster name, `AETHER_INSECURE_DEV_MODE=true` combined with real operator TLS certificates, or `node.start()` itself failing. The log line immediately before exit names the specific cause. | `Main#exitWithError`, `Main#verifyClusterLabelConsistency`, `Main#enforceClusterNamePresent` |
-| `2` | Shutdown did not complete within the bound (see below). | `Main#shutdownNode` |
+| `2` | Drain-completed self-exit — the membership v2 drain procedure (spec §8.2) ran its sequence to completion (stop accepting new app-layer work, quiesce in-flight requests, emit SWIM `LEAVE`) and halts the process itself once done. This is a **normal**, expected exit for a node that was told to drain, not a failure. | `AetherNode#aetherNode` (default `jvmExit` callback), `DrainProcedure` |
+| `3` | Shutdown did not complete within the bound (see below) — the process was killed while still trying to stop. | `Main#shutdownNode` |
 
 A supervisor should treat `1` as "do not restart with the same configuration" (it will fail
-identically) and `2` as "the process was killed while still trying to stop" — safe to restart, but
+identically), `2` as a normal drain-completed exit — safe to restart on a fresh node identity per the
+membership spec, and `3` as "the process was killed while still trying to stop" — safe to restart, but
 worth checking the thread dump the process logged first.
 
-## Shutdown bound (#749, #750)
+Codes `2` and `3` used to collide (both were `2`) before #838 review round 1 separated them; see the
+halt-not-exit note below for why the collision mattered beyond naming.
+
+## Shutdown bound (#749, #750, #838)
 
 `Main#shutdownNode` runs from the JVM shutdown hook (registered via
 `Runtime.getRuntime().addShutdownHook`, so it fires on `SIGTERM` and on `Ctrl+C`) and calls
@@ -30,16 +35,30 @@ worth checking the thread dump the process logged first.
   is **not** itself a non-zero exit — the process still exits `0`, since the shutdown sequence itself
   ran to completion). `[design intent — unverified]`
 - If it has **not** settled within 30s: the process logs an ERROR naming the timeout, dumps every live
-  thread (name, state, lock, full stack — via `ManagementFactory.getThreadMXBean().dumpAllThreads`) at
-  ERROR level, and calls `System.exit(2)`.
+  thread (name, state, lock, full stack, including virtual threads — via
+  `HotSpotDiagnosticMXBean#dumpThreads`) at ERROR level, flushes the log4j2 context synchronously, and
+  calls `Runtime.getRuntime().halt(3)`.
   `[verified: core/src/test/java/org/pragmatica/lang/PromiseAllOfCarrierStarvationTest.java` — proves the
   underlying bounded-timeout mechanism `Main#shutdownNode` relies on holds under carrier saturation;
-  the 30s-then-exit-2 branch itself is `[design intent — unverified]`, not covered by an end-to-end test]`.
+  `[verified: aether/node/src/test/java/org/pragmatica/aether/MainShutdownTest.java]` — pins that the
+  expiry path flushes logs before halting, with its own exit code, via an injected seam; the real 30s
+  wall-clock wait itself is `[design intent — unverified]`, not covered by an end-to-end test]`.
+
+**Why `Runtime.getRuntime().halt(3)` and not `System.exit(3)`:** `System.exit()` runs the JVM's own
+shutdown-hook machinery — but this code already runs *from inside* a shutdown hook, on the thread that
+`Shutdown.runHooks()` uses to run every hook to completion. `System.exit()`'s `Shutdown.exit()` blocks
+waiting for that same thread's hook-running lock, so the hook thread joins itself and the process
+hangs — proven by driving this exact call and observing the process survive past two minutes,
+ignoring `SIGTERM`, until a `SIGKILL`. `Runtime.getRuntime().halt(int)` stops the JVM immediately
+without running the shutdown-hook machinery at all, the same mechanism the membership v2 drain
+procedure already uses for its own self-exit (code `2`, above) — at the cost of running no further
+hooks and flushing no log appenders on its own, both of which `Main#shutdownNode` therefore does
+explicitly, synchronously, immediately before the halt call.
 
 **Why 30 seconds:** generous relative to `EmberCluster`'s 10-second per-node stop bound in tests (that
 bound covers one node among several stopping in parallel; this bound covers a single node stopping
 alone), while still short enough that a container orchestrator's own stop/restart grace period is
-violated loudly — an ERROR log, a full thread dump, and exit `2` — rather than the previous behavior,
+violated loudly — an ERROR log, a full thread dump, and exit `3` — rather than the previous behavior,
 an unbounded hook that could park forever with no signal to the operator at all.
 
 **What the thread dump does and does not tell you:** it is the raw material for diagnosing *which*
@@ -55,5 +74,8 @@ from a live incident, not a diagnosis already reached here.
 - [#749](https://github.com/pragmaticalabs/pragmatica/issues/749) — shutdown hook had no bound at all.
 - [#750](https://github.com/pragmaticalabs/pragmatica/issues/750) — `Promise#timeout()`'s own delayed-failure
   task shared a carrier pool it could be starved out of, which the bound above depends on.
+- [#838](https://github.com/pragmaticalabs/pragmatica/pull/838) — review round 1 found the original fix's
+  `System.exit(2)` deadlocked from inside the shutdown hook, and that it collided with drain's own exit
+  code `2`; this page's exit-code table and halt-vs-exit explanation reflect that round's fixes.
 - [Management API — Node shutdown](management-api.md#post-apiv1nodesshutdownid) — the cluster-coordinated
   DRAIN path, distinct from the local JVM shutdown hook this page describes.

--- a/aether/docs/reference/node-operations.md
+++ b/aether/docs/reference/node-operations.md
@@ -1,0 +1,59 @@
+# Node Process Operations
+
+Operator reference for the `aether-node` process itself — how it starts, how it stops, and what its
+exit code tells a supervisor (systemd, Docker, Kubernetes) about what happened. This is distinct from
+the cluster-level DRAIN shutdown in [Management API](management-api.md#post-apiv1nodesshutdownid)
+(`POST /api/v1/nodes/shutdown/{id}`), which asks a node to self-drain over the membership channel and
+falls back to a container-manager grace-terminate reap if the node never exits on its own. The page
+below covers what happens *inside* the process once a stop signal — from either path, or a direct
+`SIGTERM`/`Ctrl+C` — reaches its JVM shutdown hook.
+
+## Exit codes
+
+| Code | Meaning | Where |
+|------|---------|-------|
+| `0` | Clean exit — `node.stop()` completed within the shutdown bound. | `Main#shutdownNode` |
+| `1` | Fatal startup failure — a boot-time gate refused to proceed. Causes: `AETHER_CLUSTER_NAME` unset, the container's `aether.cluster` label disagreeing with the configured cluster name, `AETHER_INSECURE_DEV_MODE=true` combined with real operator TLS certificates, or `node.start()` itself failing. The log line immediately before exit names the specific cause. | `Main#exitWithError`, `Main#verifyClusterLabelConsistency`, `Main#enforceClusterNamePresent` |
+| `2` | Shutdown did not complete within the bound (see below). | `Main#shutdownNode` |
+
+A supervisor should treat `1` as "do not restart with the same configuration" (it will fail
+identically) and `2` as "the process was killed while still trying to stop" — safe to restart, but
+worth checking the thread dump the process logged first.
+
+## Shutdown bound (#749, #750)
+
+`Main#shutdownNode` runs from the JVM shutdown hook (registered via
+`Runtime.getRuntime().addShutdownHook`, so it fires on `SIGTERM` and on `Ctrl+C`) and calls
+`node.stop()`, then waits up to **30 seconds** (`Main#SHUTDOWN_TIMEOUT`) via `Promise#await(TimeSpan)`.
+
+- If `node.stop()` settles within 30s: its result is logged (a failure result is logged at ERROR but
+  is **not** itself a non-zero exit — the process still exits `0`, since the shutdown sequence itself
+  ran to completion). `[design intent — unverified]`
+- If it has **not** settled within 30s: the process logs an ERROR naming the timeout, dumps every live
+  thread (name, state, lock, full stack — via `ManagementFactory.getThreadMXBean().dumpAllThreads`) at
+  ERROR level, and calls `System.exit(2)`.
+  `[verified: core/src/test/java/org/pragmatica/lang/PromiseAllOfCarrierStarvationTest.java` — proves the
+  underlying bounded-timeout mechanism `Main#shutdownNode` relies on holds under carrier saturation;
+  the 30s-then-exit-2 branch itself is `[design intent — unverified]`, not covered by an end-to-end test]`.
+
+**Why 30 seconds:** generous relative to `EmberCluster`'s 10-second per-node stop bound in tests (that
+bound covers one node among several stopping in parallel; this bound covers a single node stopping
+alone), while still short enough that a container orchestrator's own stop/restart grace period is
+violated loudly — an ERROR log, a full thread dump, and exit `2` — rather than the previous behavior,
+an unbounded hook that could park forever with no signal to the operator at all.
+
+**What the thread dump does and does not tell you:** it is the raw material for diagnosing *which*
+call inside `node.stop()` blocked. As of this writing that question is explicitly **open** — #749's
+root-cause investigation established that the hang mechanism exists (virtual-thread carrier
+starvation could make even a `.timeout()`-guarded operation fail to fire, which #749/#750's fix
+addresses at the `Promise` layer) but did not identify a specific blocking call inside
+`AetherNode#stop()` from a real occurrence. The dump is the mechanism that will eventually answer that
+from a live incident, not a diagnosis already reached here.
+
+## Related
+
+- [#749](https://github.com/pragmaticalabs/pragmatica/issues/749) — shutdown hook had no bound at all.
+- [#750](https://github.com/pragmaticalabs/pragmatica/issues/750) — `Promise#timeout()`'s own delayed-failure
+  task shared a carrier pool it could be starved out of, which the bound above depends on.
+- [Management API — Node shutdown](management-api.md#post-apiv1nodesshutdownid) — the cluster-coordinated
+  DRAIN path, distinct from the local JVM shutdown hook this page describes.

--- a/aether/node/src/main/java/org/pragmatica/aether/Main.java
+++ b/aether/node/src/main/java/org/pragmatica/aether/Main.java
@@ -4,7 +4,6 @@
 // See LICENSE in the repository root for full terms.
 package org.pragmatica.aether;
 
-import java.io.IOException;
 import java.net.InetAddress;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -20,8 +19,6 @@ import java.util.Map;
 import java.util.function.IntConsumer;
 import java.util.regex.Pattern;
 import java.util.stream.IntStream;
-
-import com.sun.management.HotSpotDiagnosticMXBean;
 
 import org.pragmatica.aether.config.AetherConfig;
 import org.pragmatica.aether.config.ClusterConfig;
@@ -64,6 +61,7 @@ import org.pragmatica.net.tcp.security.SelfSignedCertificateProvider;
 import org.pragmatica.serialization.FrameworkCodecs;
 import org.pragmatica.swim.NettySwimTransport;
 
+import com.sun.management.HotSpotDiagnosticMXBean;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -511,7 +509,6 @@ public record Main(String[] args) {
     /// generous relative to `EmberCluster`'s 10s-per-node test bound (this covers ONE node, not N in
     /// parallel) while still failing the container's stop/restart grace period loudly instead of silently.
     private static final TimeSpan SHUTDOWN_TIMEOUT = TimeSpan.timeSpan(30).seconds();
-
     /// #838 review round 1, BLOCKING 1 (owner-confirmed): `System.exit()` from inside a shutdown hook
     /// DEADLOCKS -- `Shutdown.exit()` blocks on the `Shutdown` class monitor already held by the thread
     /// running `runHooks()`, which is the very thread executing this hook, so it joins itself. Proven by
@@ -529,8 +526,10 @@ public record Main(String[] args) {
     static final int SHUTDOWN_TIMEOUT_EXIT_CODE = 3;
 
     private void registerShutdownHook(AetherNode node) {
-        Runtime.getRuntime()
-               .addShutdownHook(new Thread(() -> shutdownNode(node, SHUTDOWN_TIMEOUT, Main::flushLogs, Runtime.getRuntime()::halt)));
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> shutdownNode(node,
+                                                                           SHUTDOWN_TIMEOUT,
+                                                                           Main::flushLogs,
+                                                                           Runtime.getRuntime()::halt)));
     }
 
     /// Synchronous flush of the log4j2 context. Must run to completion before [Runtime#halt] -- halt()
@@ -550,7 +549,8 @@ public record Main(String[] args) {
         if (!stopping.isResolved()) {
             log.error("Node did not stop within {}; halting with code {} (shutdown timeout -- see "
                      + "aether/docs/reference/node-operations.md#exit-codes). Thread dump follows.",
-                      timeout, SHUTDOWN_TIMEOUT_EXIT_CODE);
+                      timeout,
+                      SHUTDOWN_TIMEOUT_EXIT_CODE);
             dumpThreads();
             flushLogs.run();
             haltFn.accept(SHUTDOWN_TIMEOUT_EXIT_CODE);
@@ -562,13 +562,11 @@ public record Main(String[] args) {
         log.info("Node stopped");
     }
 
-    /// Best-effort diagnostic: never let a failure to dump threads mask the timeout it was meant to explain.
+    /// Best-effort diagnostic: a failed dump is logged and never blocks the halt it was meant to explain.
     private static void dumpThreads() {
-        try {
-            captureThreadDump().forEach(line -> log.error("{}", line));
-        } catch (Throwable dumpFailure) {
-            log.error("Failed to capture shutdown-timeout thread dump: {}", dumpFailure.toString());
-        }
+        captureThreadDump().onSuccess(lines -> lines.forEach(line -> log.error("{}", line)))
+                         .onFailure(cause -> log.error("Failed to capture shutdown-timeout thread dump: {}",
+                                                       cause.message()));
     }
 
     /// #838 review round 1, SHOULD-FIX: [ThreadMXBean#dumpAllThreads] omits virtual threads -- exactly the
@@ -576,18 +574,24 @@ public record Main(String[] args) {
     /// on them. [HotSpotDiagnosticMXBean#dumpThreads] includes virtual threads; it writes a pre-formatted
     /// dump to a file rather than returning `ThreadInfo[]`, and refuses to overwrite an existing file, so
     /// a fresh path is created and deleted around each call regardless of outcome.
-    static List<String> captureThreadDump() throws IOException {
-        var dumpPath = Files.createTempFile("aether-thread-dump-", ".txt");
-        Files.delete(dumpPath); // dumpThreads(String, ...) refuses to write over an existing file
+    ///
+    /// #838 review round 1, JBCT-EX-01: returns [Result] rather than throwing -- a checked [IOException]
+    /// on this best-effort diagnostic path must not propagate past [#dumpThreads], which logs-and-continues
+    /// on either outcome rather than branching on a caught exception.
+    static Result<List<String>> captureThreadDump() {
+        return Result.lift(() -> {
+            var dumpPath = Files.createTempFile("aether-thread-dump-", ".txt");
 
-        try {
-            ManagementFactory.getPlatformMXBean(HotSpotDiagnosticMXBean.class)
-                              .dumpThreads(dumpPath.toString(), HotSpotDiagnosticMXBean.ThreadDumpFormat.TEXT_PLAIN);
+            Files.delete(dumpPath);  // dumpThreads(String, ...) refuses to write over an existing file
+            try {
+                ManagementFactory.getPlatformMXBean(HotSpotDiagnosticMXBean.class).dumpThreads(dumpPath.toString(),
+                                                                                               HotSpotDiagnosticMXBean.ThreadDumpFormat.TEXT_PLAIN);
 
-            return Files.readAllLines(dumpPath, StandardCharsets.UTF_8);
-        } finally {
-            Files.deleteIfExists(dumpPath);
-        }
+                return Files.readAllLines(dumpPath, StandardCharsets.UTF_8);
+            } finally {
+                Files.deleteIfExists(dumpPath);
+            }
+        });
     }
 
     private void startNodeAndWait(AetherNode node, NodeId nodeId) {

--- a/aether/node/src/main/java/org/pragmatica/aether/Main.java
+++ b/aether/node/src/main/java/org/pragmatica/aether/Main.java
@@ -4,11 +4,12 @@
 // See LICENSE in the repository root for full terms.
 package org.pragmatica.aether;
 
+import java.io.IOException;
 import java.net.InetAddress;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.lang.management.ManagementFactory;
-import java.lang.management.ThreadInfo;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -16,8 +17,11 @@ import java.util.List;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.function.IntConsumer;
 import java.util.regex.Pattern;
 import java.util.stream.IntStream;
+
+import com.sun.management.HotSpotDiagnosticMXBean;
 
 import org.pragmatica.aether.config.AetherConfig;
 import org.pragmatica.aether.config.ClusterConfig;
@@ -508,25 +512,48 @@ public record Main(String[] args) {
     /// parallel) while still failing the container's stop/restart grace period loudly instead of silently.
     private static final TimeSpan SHUTDOWN_TIMEOUT = TimeSpan.timeSpan(30).seconds();
 
-    private void registerShutdownHook(AetherNode node) {
-        Runtime.getRuntime().addShutdownHook(new Thread(() -> shutdownNode(node)));
-    }
-
-    /// Exit code 2 = shutdown did not complete within [#SHUTDOWN_TIMEOUT]; documented at
-    /// `aether/docs/reference/node-operations.md#exit-codes`. Which call inside `node.stop()` actually
+    /// #838 review round 1, BLOCKING 1 (owner-confirmed): `System.exit()` from inside a shutdown hook
+    /// DEADLOCKS -- `Shutdown.exit()` blocks on the `Shutdown` class monitor already held by the thread
+    /// running `runHooks()`, which is the very thread executing this hook, so it joins itself. Proven by
+    /// the reviewer: hung past 2 minutes, ignored SIGTERM, needed SIGKILL. `Runtime.getRuntime().halt(int)`
+    /// bypasses that machinery entirely -- the same pattern already used by the drain-completed self-exit
+    /// at `AetherNode.java:415,437` -- at the cost of running no further shutdown hooks and no appender
+    /// flush of its own, so both are done explicitly and synchronously immediately before the halt.
+    ///
+    /// Exit code 3 = shutdown did not complete within [#SHUTDOWN_TIMEOUT]; documented at
+    /// `aether/docs/reference/node-operations.md#exit-codes`. Code 2 is already owned by the
+    /// drain-completed self-exit in `AetherNode`/`DrainProcedure`; reusing it here would have been a
+    /// second, independent bug stacked on top of the deadlock. Which call inside `node.stop()` actually
     /// blocked is UNKNOWN (#749 acceptance item 1) -- the thread dump below is what will eventually answer
     /// that from a real occurrence, not a diagnosis made here.
-    private void shutdownNode(AetherNode node) {
+    static final int SHUTDOWN_TIMEOUT_EXIT_CODE = 3;
+
+    private void registerShutdownHook(AetherNode node) {
+        Runtime.getRuntime()
+               .addShutdownHook(new Thread(() -> shutdownNode(node, SHUTDOWN_TIMEOUT, Main::flushLogs, Runtime.getRuntime()::halt)));
+    }
+
+    /// Synchronous flush of the log4j2 context. Must run to completion before [Runtime#halt] -- halt()
+    /// performs no appender flush of its own, so anything not flushed here is lost with the process.
+    private static void flushLogs() {
+        org.apache.logging.log4j.LogManager.shutdown();
+    }
+
+    /// Package-private and parameterized (timeout / log-flush / halt as injected seams) so the expiry
+    /// path is unit-testable without pinning a real 30s clock or touching the shared log4j2 context in
+    /// the surefire fork. Production wiring is [#registerShutdownHook].
+    static void shutdownNode(AetherNode node, TimeSpan timeout, Runnable flushLogs, IntConsumer haltFn) {
         log.info("Shutdown requested, stopping node...");
         var stopping = node.stop();
-        var result = stopping.await(SHUTDOWN_TIMEOUT);
+        var result = stopping.await(timeout);
 
         if (!stopping.isResolved()) {
-            log.error("Node did not stop within {}; forcing exit with code 2 (shutdown timeout -- see "
+            log.error("Node did not stop within {}; halting with code {} (shutdown timeout -- see "
                      + "aether/docs/reference/node-operations.md#exit-codes). Thread dump follows.",
-                      SHUTDOWN_TIMEOUT);
+                      timeout, SHUTDOWN_TIMEOUT_EXIT_CODE);
             dumpThreads();
-            System.exit(2);
+            flushLogs.run();
+            haltFn.accept(SHUTDOWN_TIMEOUT_EXIT_CODE);
 
             return;
         }
@@ -536,40 +563,31 @@ public record Main(String[] args) {
     }
 
     /// Best-effort diagnostic: never let a failure to dump threads mask the timeout it was meant to explain.
-    private void dumpThreads() {
+    private static void dumpThreads() {
         try {
-            var infos = ManagementFactory.getThreadMXBean().dumpAllThreads(true, true);
-
-            for (var info : infos) {
-                log.error("{}", renderThread(info));
-            }
+            captureThreadDump().forEach(line -> log.error("{}", line));
         } catch (Throwable dumpFailure) {
             log.error("Failed to capture shutdown-timeout thread dump: {}", dumpFailure.toString());
         }
     }
 
-    private static String renderThread(ThreadInfo info) {
-        var sb = new StringBuilder(512);
+    /// #838 review round 1, SHOULD-FIX: [ThreadMXBean#dumpAllThreads] omits virtual threads -- exactly the
+    /// kind of thread a hung `node.stop()` is likely blocked on, since the async offloads it waits on run
+    /// on them. [HotSpotDiagnosticMXBean#dumpThreads] includes virtual threads; it writes a pre-formatted
+    /// dump to a file rather than returning `ThreadInfo[]`, and refuses to overwrite an existing file, so
+    /// a fresh path is created and deleted around each call regardless of outcome.
+    static List<String> captureThreadDump() throws IOException {
+        var dumpPath = Files.createTempFile("aether-thread-dump-", ".txt");
+        Files.delete(dumpPath); // dumpThreads(String, ...) refuses to write over an existing file
 
-        sb.append('"')
-          .append(info.getThreadName())
-          .append("\" #")
-          .append(info.getThreadId())
-          .append(' ')
-          .append(info.getThreadState());
-        if (info.getLockName() != null) {
-            sb.append(" on ").append(info.getLockName());
+        try {
+            ManagementFactory.getPlatformMXBean(HotSpotDiagnosticMXBean.class)
+                              .dumpThreads(dumpPath.toString(), HotSpotDiagnosticMXBean.ThreadDumpFormat.TEXT_PLAIN);
+
+            return Files.readAllLines(dumpPath, StandardCharsets.UTF_8);
+        } finally {
+            Files.deleteIfExists(dumpPath);
         }
-
-        if (info.getLockOwnerName() != null) {
-            sb.append(" owned by \"").append(info.getLockOwnerName()).append('"');
-        }
-
-        for (var frame : info.getStackTrace()) {
-            sb.append("\n\tat ").append(frame);
-        }
-
-        return sb.toString();
     }
 
     private void startNodeAndWait(AetherNode node, NodeId nodeId) {

--- a/aether/node/src/main/java/org/pragmatica/aether/Main.java
+++ b/aether/node/src/main/java/org/pragmatica/aether/Main.java
@@ -7,6 +7,8 @@ package org.pragmatica.aether;
 import java.net.InetAddress;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
+import java.lang.management.ManagementFactory;
+import java.lang.management.ThreadInfo;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -51,6 +53,7 @@ import org.pragmatica.lang.Functions.Fn1;
 import org.pragmatica.lang.Option;
 import org.pragmatica.lang.Result;
 import org.pragmatica.lang.Unit;
+import org.pragmatica.lang.io.TimeSpan;
 import org.pragmatica.lang.utils.Causes;
 import org.pragmatica.net.tcp.security.CertificateProvider;
 import org.pragmatica.net.tcp.security.SelfSignedCertificateProvider;
@@ -500,14 +503,73 @@ public record Main(String[] args) {
                  cfg.node().heap());
     }
 
+    /// #749: a shutdown hook with no bound at all parks forever if `node.stop()` never settles. 30s is
+    /// generous relative to `EmberCluster`'s 10s-per-node test bound (this covers ONE node, not N in
+    /// parallel) while still failing the container's stop/restart grace period loudly instead of silently.
+    private static final TimeSpan SHUTDOWN_TIMEOUT = TimeSpan.timeSpan(30).seconds();
+
     private void registerShutdownHook(AetherNode node) {
         Runtime.getRuntime().addShutdownHook(new Thread(() -> shutdownNode(node)));
     }
 
+    /// Exit code 2 = shutdown did not complete within [#SHUTDOWN_TIMEOUT]; documented at
+    /// `aether/docs/reference/node-operations.md#exit-codes`. Which call inside `node.stop()` actually
+    /// blocked is UNKNOWN (#749 acceptance item 1) -- the thread dump below is what will eventually answer
+    /// that from a real occurrence, not a diagnosis made here.
     private void shutdownNode(AetherNode node) {
         log.info("Shutdown requested, stopping node...");
-        node.stop().await();
+        var stopping = node.stop();
+        var result = stopping.await(SHUTDOWN_TIMEOUT);
+
+        if (!stopping.isResolved()) {
+            log.error("Node did not stop within {}; forcing exit with code 2 (shutdown timeout -- see "
+                     + "aether/docs/reference/node-operations.md#exit-codes). Thread dump follows.",
+                      SHUTDOWN_TIMEOUT);
+            dumpThreads();
+            System.exit(2);
+
+            return;
+        }
+
+        result.onFailure(cause -> log.error("Node stop() completed with failure: {}", cause.message()));
         log.info("Node stopped");
+    }
+
+    /// Best-effort diagnostic: never let a failure to dump threads mask the timeout it was meant to explain.
+    private void dumpThreads() {
+        try {
+            var infos = ManagementFactory.getThreadMXBean().dumpAllThreads(true, true);
+
+            for (var info : infos) {
+                log.error("{}", renderThread(info));
+            }
+        } catch (Throwable dumpFailure) {
+            log.error("Failed to capture shutdown-timeout thread dump: {}", dumpFailure.toString());
+        }
+    }
+
+    private static String renderThread(ThreadInfo info) {
+        var sb = new StringBuilder(512);
+
+        sb.append('"')
+          .append(info.getThreadName())
+          .append("\" #")
+          .append(info.getThreadId())
+          .append(' ')
+          .append(info.getThreadState());
+        if (info.getLockName() != null) {
+            sb.append(" on ").append(info.getLockName());
+        }
+
+        if (info.getLockOwnerName() != null) {
+            sb.append(" owned by \"").append(info.getLockOwnerName()).append('"');
+        }
+
+        for (var frame : info.getStackTrace()) {
+            sb.append("\n\tat ").append(frame);
+        }
+
+        return sb.toString();
     }
 
     private void startNodeAndWait(AetherNode node, NodeId nodeId) {

--- a/aether/node/src/main/java/org/pragmatica/aether/Main.java
+++ b/aether/node/src/main/java/org/pragmatica/aether/Main.java
@@ -19,6 +19,7 @@ import java.util.Map;
 import java.util.function.IntConsumer;
 import java.util.regex.Pattern;
 import java.util.stream.IntStream;
+import java.util.concurrent.TimeUnit;
 
 import org.pragmatica.aether.config.AetherConfig;
 import org.pragmatica.aether.config.ClusterConfig;
@@ -62,6 +63,8 @@ import org.pragmatica.serialization.FrameworkCodecs;
 import org.pragmatica.swim.NettySwimTransport;
 
 import com.sun.management.HotSpotDiagnosticMXBean;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.LoggerContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -524,6 +527,11 @@ public record Main(String[] args) {
     /// blocked is UNKNOWN (#749 acceptance item 1) -- the thread dump below is what will eventually answer
     /// that from a real occurrence, not a diagnosis made here.
     static final int SHUTDOWN_TIMEOUT_EXIT_CODE = 3;
+    /// #838 review round 1: bound on [#flushLogs] so a wedged appender (blocking async queue,
+    /// unreachable network sink) cannot re-introduce the unbounded hang the halt seam below exists
+    /// to remove. Generous relative to typical flush latency, small relative to [#SHUTDOWN_TIMEOUT]
+    /// so it cannot itself consume the process's shutdown budget.
+    private static final TimeSpan FLUSH_TIMEOUT = TimeSpan.timeSpan(5).seconds();
 
     private void registerShutdownHook(AetherNode node) {
         Runtime.getRuntime().addShutdownHook(new Thread(() -> shutdownNode(node,
@@ -532,10 +540,14 @@ public record Main(String[] args) {
                                                                            Runtime.getRuntime()::halt)));
     }
 
-    /// Synchronous flush of the log4j2 context. Must run to completion before [Runtime#halt] -- halt()
-    /// performs no appender flush of its own, so anything not flushed here is lost with the process.
+    /// Synchronous flush of the log4j2 context, bounded by [#FLUSH_TIMEOUT] -- halt() performs no
+    /// appender flush of its own, so anything not flushed here is lost with the process. #838 review
+    /// round 1: [LogManager#shutdown()] has no timeout of its own; [LoggerContext#stop(long,TimeUnit)]
+    /// does, and is used instead so a wedged appender bounds the flush rather than hanging it.
     private static void flushLogs() {
-        org.apache.logging.log4j.LogManager.shutdown();
+        var ctx = (LoggerContext) LogManager.getContext(false);
+
+        ctx.stop(FLUSH_TIMEOUT.millis(), TimeUnit.MILLISECONDS);
     }
 
     /// Package-private and parameterized (timeout / log-flush / halt as injected seams) so the expiry
@@ -552,8 +564,14 @@ public record Main(String[] args) {
                       timeout,
                       SHUTDOWN_TIMEOUT_EXIT_CODE);
             dumpThreads();
-            flushLogs.run();
-            haltFn.accept(SHUTDOWN_TIMEOUT_EXIT_CODE);
+            // #838 review round 1: halt is in `finally` so a throwing flushLogs.run() cannot preempt
+            // it and restore the unbounded hang this method exists to remove -- flushLogs itself is
+            // bounded (see its doc), so this can delay the halt by at most FLUSH_TIMEOUT, never hang it.
+            try {
+                flushLogs.run();
+            } finally {
+                haltFn.accept(SHUTDOWN_TIMEOUT_EXIT_CODE);
+            }
 
             return;
         }

--- a/aether/node/src/test/java/org/pragmatica/aether/MainShutdownTest.java
+++ b/aether/node/src/test/java/org/pragmatica/aether/MainShutdownTest.java
@@ -13,6 +13,7 @@ import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.IntConsumer;
 
 import org.mockito.Mockito;
 
@@ -55,8 +56,15 @@ class MainShutdownTest {
 
             var flushed = new AtomicBoolean(false);
             var haltedWith = new AtomicInteger(-1);
+            // #838 review round 1: pin the ORDER, not just that both eventually happened -- the halt
+            // seam itself asserts flushed is already set at the moment it fires, so a regression that
+            // halts before (or without) flushing fails here even if both flags end up true afterward.
+            IntConsumer haltFn = code -> {
+                assertTrue(flushed.get(), "halt must fire strictly after the flush completes");
+                haltedWith.set(code);
+            };
 
-            Main.shutdownNode(node, timeSpan(200).millis(), () -> flushed.set(true), haltedWith::set);
+            Main.shutdownNode(node, timeSpan(200).millis(), () -> flushed.set(true), haltFn);
 
             assertTrue(flushed.get(), "log flush must run BEFORE halt -- halt() runs no appender flush of its own");
             assertEquals(Main.SHUTDOWN_TIMEOUT_EXIT_CODE, haltedWith.get(),

--- a/aether/node/src/test/java/org/pragmatica/aether/MainShutdownTest.java
+++ b/aether/node/src/test/java/org/pragmatica/aether/MainShutdownTest.java
@@ -84,7 +84,9 @@ class MainShutdownTest {
                 // Give the scheduler a moment to actually mount and park the virtual thread before dumping.
                 Thread.sleep(150);
 
-                List<String> dump = Main.captureThreadDump();
+                // #838 review round 1, JBCT-EX-01: captureThreadDump() returns Result<List<String>>, not a
+                // throwing List<String> -- unwrap via Result#or rather than relying on an unchecked throw.
+                List<String> dump = Main.captureThreadDump().or(List.of());
 
                 assertTrue(dump.stream().anyMatch(line -> line.contains(markerName)),
                            "HotSpotDiagnosticMXBean#dumpThreads must include virtual threads -- "

--- a/aether/node/src/test/java/org/pragmatica/aether/MainShutdownTest.java
+++ b/aether/node/src/test/java/org/pragmatica/aether/MainShutdownTest.java
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2025 Pragmatica Labs - Sergiy Yevtushenko
+// Licensed under Business Source License 1.1. Change Date: 2030-01-01. Change License: Apache-2.0.
+// See LICENSE in the repository root for full terms.
+package org.pragmatica.aether;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.pragmatica.aether.node.AetherNode;
+import org.pragmatica.lang.Promise;
+
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.mockito.Mockito;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.pragmatica.lang.Unit.unit;
+import static org.pragmatica.lang.io.TimeSpan.timeSpan;
+
+/// #838 review round 1 pins the expiry path of [Main#shutdownNode] directly, without touching the real
+/// 30s [Main#SHUTDOWN_TIMEOUT] or the shared log4j2 context in the surefire fork:
+///   - BLOCKING 1: `System.exit()` from a shutdown hook deadlocks (proven by the reviewer), so the expiry
+///     path halts through an injected `IntConsumer` seam instead -- these tests assert it is invoked
+///     (or not) rather than exercising a real JVM halt.
+///   - SHOULD-FIX: [ThreadMXBean#dumpAllThreads] omits virtual threads; [Main#captureThreadDump] must
+///     include them.
+class MainShutdownTest {
+
+    @Nested
+    class ShutdownNodeGate {
+
+        @Test
+        void shutdownNode_logsAndDoesNotHalt_whenStopResolvesInTime() {
+            var node = Mockito.mock(AetherNode.class);
+            Mockito.when(node.stop()).thenReturn(Promise.success(unit()));
+
+            var flushed = new AtomicBoolean(false);
+            var haltedWith = new AtomicInteger(-1);
+
+            Main.shutdownNode(node, timeSpan(200).millis(), () -> flushed.set(true), haltedWith::set);
+
+            assertFalse(flushed.get(), "log flush must run only on the timeout path, not on a clean stop");
+            assertEquals(-1, haltedWith.get(), "halt must not be invoked when stop() resolves in time");
+        }
+
+        @Test
+        void shutdownNode_flushesLogsThenHalts_withTimeoutExitCode_whenStopNeverResolves() {
+            var node = Mockito.mock(AetherNode.class);
+            Mockito.when(node.stop()).thenReturn(Promise.promise()); // never resolves
+
+            var flushed = new AtomicBoolean(false);
+            var haltedWith = new AtomicInteger(-1);
+
+            Main.shutdownNode(node, timeSpan(200).millis(), () -> flushed.set(true), haltedWith::set);
+
+            assertTrue(flushed.get(), "log flush must run BEFORE halt -- halt() runs no appender flush of its own");
+            assertEquals(Main.SHUTDOWN_TIMEOUT_EXIT_CODE, haltedWith.get(),
+                         "the shutdown-timeout path must use its own exit code, distinct from the "
+                         + "drain-completed self-exit's code 2 (AetherNode.java:415,437)");
+        }
+    }
+
+    @Nested
+    class ThreadDumpGate {
+
+        @Test
+        void captureThreadDump_includesAParkedVirtualThread() throws Exception {
+            var latch = new CountDownLatch(1);
+            var markerName = "mainshutdowntest-marker-vt-" + System.nanoTime();
+            var vt = Thread.ofVirtual().name(markerName).start(() -> {
+                try {
+                    latch.await();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            });
+
+            try {
+                // Give the scheduler a moment to actually mount and park the virtual thread before dumping.
+                Thread.sleep(150);
+
+                List<String> dump = Main.captureThreadDump();
+
+                assertTrue(dump.stream().anyMatch(line -> line.contains(markerName)),
+                           "HotSpotDiagnosticMXBean#dumpThreads must include virtual threads -- "
+                           + "ThreadMXBean#dumpAllThreads (the prior implementation) does not");
+            } finally {
+                latch.countDown();
+                vt.join();
+            }
+        }
+    }
+}

--- a/changelog.d/749-shutdown-bounded.md
+++ b/changelog.d/749-shutdown-bounded.md
@@ -4,7 +4,7 @@
   `.async()` offload in the codebase** — so a "bounded" operation was only actually bounded while that
   pool had a free carrier. CPU-bound work pinning every carrier (exactly the kind of load a timeout
   exists to guard against) prevented the timeout task from ever being scheduled, so it never fired.
-  `AsyncExecutor` now runs timeout scheduling on a dedicated `ScheduledExecutorService` (4 daemon
+  `AsyncExecutor` now runs timeout scheduling on a dedicated `ScheduledThreadPoolExecutor` (4 daemon
   platform threads, named `promise-timeout-scheduler-N`), decoupled from the JVM's virtual-thread
   carrier pool entirely; general `.async()` offload work is unchanged.
   [mechanism: `Promise#allOf`'s aggregation callback runs via `withResult`, which dispatches inline on
@@ -29,3 +29,27 @@
   Exit code `2` and the rest of the node process's exit-code contract are now documented at
   [`aether/docs/reference/node-operations.md`](../aether/docs/reference/node-operations.md#exit-codes)
   (new page).
+- **Review follow-up: `Promise#timeout()`'s scheduled failure task was never cancelled on early
+  resolution.** The dedicated scheduler above closed the *liveness* gap (the fail task always fires),
+  but every `.timeout()` call still discarded its `ScheduledFuture`, so a promise that resolved
+  microseconds after `.timeout()` was attached left its failure task queued for the full timeout
+  duration regardless — harmless per-promise (a late `.fail()` on an already-resolved promise is a
+  CAS no-op in `resolve()`) but unbounded in aggregate: a server minting thousands of 30-second-timeout
+  promises per second would retain thousands of dead entries, each holding a closure and a
+  context-propagation snapshot, at any given moment. `.timeout()` now captures the `ScheduledFuture`
+  and cancels it via `withResult(...)` — an inline, same-thread hook, not offloaded to the
+  virtual-thread executor — the instant the promise resolves by any means (success, application
+  failure, or the timeout itself firing). `timeoutScheduler` now runs with
+  `setRemoveOnCancelPolicy(true)` so a cancelled task is purged from the queue immediately rather than
+  lingering until its original fire time.
+  [mechanism: `withResult`/`replaceResult` dispatch via `CompletionMap`, which runs inline on whichever
+  thread calls `resolve()` — no dependency on the (potentially starved) virtual-thread executor, so
+  cleanup cannot be blocked by the same carrier exhaustion #749's primary fix addresses]
+  [verified: `core/src/test/java/org/pragmatica/lang/PromiseTimeoutCancellationTest.java` — asserts
+  `AsyncExecutor`'s scheduler queue depth increments by exactly one when `.timeout()` is attached and
+  drops back to baseline immediately after early success or early application failure; red-before-green
+  confirmed reverting only the cancellation hook leaves the queue depth elevated]
+  The general-purpose `async(TimeSpan, Consumer)` overload (used elsewhere for delay-then-run patterns
+  on already-resolved promises, e.g. DNS cache-entry TTL eviction) is deliberately left unchanged:
+  cancel-on-resolution would fire immediately on an already-resolved promise and defeat those callers'
+  delay outright, so this fix is scoped to `.timeout()`'s own method body only.

--- a/changelog.d/749-shutdown-bounded.md
+++ b/changelog.d/749-shutdown-bounded.md
@@ -1,0 +1,31 @@
+### Fixed (2026-09-04 — #749, #750: node shutdown could hang forever under virtual-thread carrier starvation)
+
+- **`Promise#timeout()`'s delayed-failure task shared the same virtual-thread executor as every other
+  `.async()` offload in the codebase** — so a "bounded" operation was only actually bounded while that
+  pool had a free carrier. CPU-bound work pinning every carrier (exactly the kind of load a timeout
+  exists to guard against) prevented the timeout task from ever being scheduled, so it never fired.
+  `AsyncExecutor` now runs timeout scheduling on a dedicated `ScheduledExecutorService` (4 daemon
+  platform threads, named `promise-timeout-scheduler-N`), decoupled from the JVM's virtual-thread
+  carrier pool entirely; general `.async()` offload work is unchanged.
+  [mechanism: `Promise#allOf`'s aggregation callback runs via `withResult`, which dispatches inline on
+  whatever thread resolves each input promise, not offloaded — so decoupling only the timeout-*firing*
+  thread is sufficient to make an entire `allOf(...).map(...)` chain (the exact shape
+  `EmberCluster#stop()` and `Main#shutdownNode` use) resolve independent of the shared, starvable pool]
+  [verified: `core/src/test/java/org/pragmatica/lang/PromiseAllOfCarrierStarvationTest.java` —
+  drives 5 never-resolving promises through `.timeout(800ms)` + `Promise#allOf` + `.map(...)`, exactly
+  as production does, while every virtual-thread carrier is pinned by non-yielding busy-spin work;
+  asserts the aggregate resolves within 2000ms despite full carrier saturation]
+- Red-before-green: reverting only the `AsyncExecutor` scheduler change makes the same test fail with
+  a genuine `Failure(Timeout[...])` result (the outer `.await()` itself timing out, not a compile
+  error and not a silent pass) — restoring the change makes it pass again.
+  [verified: same test as above]
+- **`Main#shutdownNode` now bounds `node.stop()` at 30 seconds.** On expiry it logs an ERROR, dumps
+  every live thread (name, state, lock, full stack trace), and exits with code `2`, rather than the
+  previous unbounded shutdown hook that could park forever with no signal to the operator. Which call
+  inside `node.stop()` blocks in a real occurrence remains **unknown** — this fix bounds the hang and
+  makes it loud and diagnosable, it does not identify a root cause inside `AetherNode#stop()` itself.
+  [design intent — unverified: the 30s-then-exit-2 branch itself has no end-to-end test; only the
+  underlying bounded-timeout mechanism it depends on is verified above]
+  Exit code `2` and the rest of the node process's exit-code contract are now documented at
+  [`aether/docs/reference/node-operations.md`](../aether/docs/reference/node-operations.md#exit-codes)
+  (new page).

--- a/changelog.d/749-shutdown-bounded.md
+++ b/changelog.d/749-shutdown-bounded.md
@@ -15,20 +15,52 @@
   drives 5 never-resolving promises through `.timeout(800ms)` + `Promise#allOf` + `.map(...)`, exactly
   as production does, while every virtual-thread carrier is pinned by non-yielding busy-spin work;
   asserts the aggregate resolves within 2000ms despite full carrier saturation]
+  Review round 1 (#838) found the test itself under-saturated on machines with more than 8 CPUs: it
+  sized its carrier count with `Math.max(availableProcessors(), 8)` against a pinned
+  `-Djdk.virtualThreadScheduler.parallelism=8` (`pom.xml`'s `vthread.argLine`), so on a 12-CPU box the
+  test waited for more saturator threads to start than the JVM had carriers to run them on, and — because
+  that wait sat outside the `try`/`finally` — a timeout there left every saturator running for the rest
+  of the fork, pinning every carrier for every later test. Fixed by reading the configured parallelism
+  and taking `Math.min` against it, and moving the wait inside the `try` so saturators are always
+  signalled to stop.
 - Red-before-green: reverting only the `AsyncExecutor` scheduler change makes the same test fail with
   a genuine `Failure(Timeout[...])` result (the outer `.await()` itself timing out, not a compile
   error and not a silent pass) — restoring the change makes it pass again.
   [verified: same test as above]
 - **`Main#shutdownNode` now bounds `node.stop()` at 30 seconds.** On expiry it logs an ERROR, dumps
-  every live thread (name, state, lock, full stack trace), and exits with code `2`, rather than the
-  previous unbounded shutdown hook that could park forever with no signal to the operator. Which call
-  inside `node.stop()` blocks in a real occurrence remains **unknown** — this fix bounds the hang and
-  makes it loud and diagnosable, it does not identify a root cause inside `AetherNode#stop()` itself.
-  [design intent — unverified: the 30s-then-exit-2 branch itself has no end-to-end test; only the
+  every live thread (name, state, lock, full stack trace, including virtual threads), flushes log4j2
+  synchronously, and exits with code `3`, rather than the previous unbounded shutdown hook that could
+  park forever with no signal to the operator. Which call inside `node.stop()` blocks in a real
+  occurrence remains **unknown** — this fix bounds the hang and makes it loud and diagnosable, it does
+  not identify a root cause inside `AetherNode#stop()` itself.
+  [design intent — unverified: the 30s-then-halt branch itself has no end-to-end test; only the
   underlying bounded-timeout mechanism it depends on is verified above]
-  Exit code `2` and the rest of the node process's exit-code contract are now documented at
+  Exit code `3` and the rest of the node process's exit-code contract are now documented at
   [`aether/docs/reference/node-operations.md`](../aether/docs/reference/node-operations.md#exit-codes)
   (new page).
+- **Review round 1 (#838): `System.exit(2)` deadlocks from inside a shutdown hook.** A shutdown hook
+  runs on the thread `Shutdown.runHooks()` uses to run every hook to completion; `System.exit()`'s own
+  `Shutdown.exit()` blocks waiting for that same lock, so the hook thread joins itself. Proven by the
+  reviewer: the process hung past 2 minutes, ignored `SIGTERM`, and needed `SIGKILL`. Fixed by replacing
+  `System.exit(2)` with `Runtime.getRuntime().halt(3)`, called only after the thread dump is logged and
+  `LogManager.shutdown()` has flushed the log4j2 context synchronously — `halt()` runs no further hooks
+  and flushes no appenders of its own, so both must happen first. This also resolves the exit-code
+  collision noted above: the timeout path no longer shares code `2` with `AetherNode`'s own
+  drain-completed self-exit (`AetherNode.java:415,437`, which already used `halt(2)`).
+  [verified: `aether/node/src/test/java/org/pragmatica/aether/MainShutdownTest.java` — pins that the
+  expiry path flushes logs before halting, with its own exit code, via an injected `IntConsumer` seam;
+  the real `System.exit` deadlock is not itself reproduced in a fast unit test — that would require a
+  real JVM shutdown-hook execution — so this is a design fix responding to the reviewer's own
+  execution proof, not an independently-reproduced regression test]
+- **Review round 1 (#838): thread dump omitted virtual threads.** The prior implementation used
+  `ThreadMXBean#dumpAllThreads`, which does not include virtual threads — on a node hung inside
+  virtual-thread-heavy code (the exact scenario #749 addresses), the dump would omit the very threads
+  most likely to be blocked. Replaced with `Main#captureThreadDump`, which uses
+  `com.sun.management.HotSpotDiagnosticMXBean#dumpThreads` via a temporary file.
+  [verified: `aether/node/src/test/java/org/pragmatica/aether/MainShutdownTest.java` — parks a
+  uniquely-named virtual thread and asserts its name appears in the captured dump; a standalone
+  scratch check (not part of the suite) confirmed the legacy API does not include it under the same
+  conditions]
 - **Review follow-up: `Promise#timeout()`'s scheduled failure task was never cancelled on early
   resolution.** The dedicated scheduler above closed the *liveness* gap (the fail task always fires),
   but every `.timeout()` call still discarded its `ScheduledFuture`, so a promise that resolved
@@ -53,3 +85,42 @@
   on already-resolved promises, e.g. DNS cache-entry TTL eviction) is deliberately left unchanged:
   cancel-on-resolution would fire immediately on an already-resolved promise and defeat those callers'
   delay outright, so this fix is scoped to `.timeout()`'s own method body only.
+
+### Changed (2026-09-04 — #749, #750, #838 review round 1)
+
+- **`Promise#timeout(TimeSpan)` now returns a different object than `this`.** The cancel-on-resolution
+  fix above needs to observe the original promise's resolution without itself being that resolution, so
+  `.timeout()` now returns a *derived* promise created via `withResult(...)`/`replaceResult(...)`
+  rather than the receiver. The scheduled timeout failure still resolves the ORIGINAL promise (the one
+  `.timeout()` was called on); the derived promise returned to the caller is resolved FROM that,
+  inline, on whichever thread resolves the original — including `AsyncExecutor#timeoutScheduler`'s own
+  platform thread on the timeout-fired path, and `Promise#allOf`'s aggregation, since `allOf` also
+  registers via `withResult(...)`. This is what makes `PromiseAllOfCarrierStarvationTest` pass:
+  original → derived → `allOf`'s collector → `allOf`'s aggregate all resolve on the single scheduler
+  thread with no virtual-thread carrier involved anywhere in the chain, which is exactly what #749
+  condition 1 required. A repo-wide sweep found no call site comparing a `.timeout()` result to its
+  receiver by identity (`==`), but code outside this repo doing so would now observe a different
+  object — a genuine, if narrow, behavior change, not merely an implementation detail.
+  [mechanism: `withResult`/`replaceResult`'s `PromiseImpl` override registers a `CompletionMap` on the
+  original promise and returns a new `PromiseImpl`, resolved by that map's callback at `resolve()`
+  time — the same inline-dispatch contract the cancellation fix above relies on]
+  [verified: `core/src/test/java/org/pragmatica/lang/PromiseAllOfCarrierStarvationTest.java` — exercises
+  the full original→derived→`allOf` inline chain under carrier saturation; a break in the chain would
+  show up as the aggregate never resolving, since no carrier is available to run it any other way]
+- **`Promise.promise(TimeSpan, Supplier<Result<T>>)` now also runs on the dedicated timeout scheduler**,
+  as a side effect of `AsyncExecutor`'s change above rather than separate new work — this overload was
+  already implemented in terms of the same scheduling path `.timeout()` uses. The one identified
+  production caller is `EmberCluster#handleStartResults`'s 2-second post-start cluster-stabilization
+  delay (`aether/ember/.../EmberCluster.java:672`), which now runs off the virtual-thread carrier pool
+  the same way `.timeout()` does, for the same reason: a stabilization delay that depended on carrier
+  availability could itself be starved by the load it exists to wait out.
+- **`VirtualThreadScheduler`'s and `AsyncExecutor.timeoutScheduler`'s docs now cross-reference each
+  other.** `VirtualThreadScheduler`'s stated principle is "never run a task body inline" — only ever
+  submit to a virtual-thread-per-task executor from its own dedicated timer thread.
+  `AsyncExecutor#timeoutScheduler` deliberately does the opposite (runs the timeout fire action inline,
+  on one of its own 4 platform threads) because the fire action must not itself depend on carrier
+  availability, or #749's original starvation bug reappears one layer down inside whatever executes the
+  fire. The cost is bounded, not eliminated: a blocking `.map()`/`.flatMap()`/`withResult()`
+  continuation on a fired timeout occupies one of only 4 dedicated threads, so more than 4 concurrent
+  blocking continuations would starve every *other* pending timeout process-wide. This was already true
+  before #838 round 1; the round only made it documented rather than implicit.

--- a/core/src/main/java/org/pragmatica/lang/Promise.java
+++ b/core/src/main/java/org/pragmatica/lang/Promise.java
@@ -650,6 +650,12 @@ public sealed interface Promise<T> permits PromiseImpl {
     /// caller relying on `promise.timeout(t) == promise` (identity, not value) will observe a different
     /// object than before; a repo-wide sweep found no call site doing this, but it is a genuine change in
     /// what this method returns, not merely an implementation detail.
+    ///
+    /// A call site that discards the returned derived promise (e.g. `promise.timeout(t);` used as a bare
+    /// statement, as `HttpForwarder` does) still keeps its timeout today, because the scheduled failure
+    /// targets `this` -- the ORIGINAL promise -- not the value returned here. Retargeting that failure to
+    /// the derived promise in a future change would silently disarm every such call site with no
+    /// compile-time signal; grep for `.timeout(` used as a statement before making that change.
     default Promise<T> timeout(TimeSpan timeout) {
         var future = AsyncExecutor.INSTANCE.runAsync(timeout,
                                                        () -> fail(new CoreError.Timeout("Promise timed out after " + timeout.millis() + "ms")));

--- a/core/src/main/java/org/pragmatica/lang/Promise.java
+++ b/core/src/main/java/org/pragmatica/lang/Promise.java
@@ -22,7 +22,8 @@ import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.LockSupport;
 import java.util.function.Consumer;
@@ -633,10 +634,20 @@ public sealed interface Promise<T> permits PromiseImpl {
     ///             .map(this::transformationStep1)     // <-- This transformation will see Timeout error and will be skipped
     ///             .flatMap(this::transformationStep3);// <-- This transformation will see Timeout error and will be skipped
     /// ```
+    ///
+    /// The scheduled failure task is cancelled as soon as the promise resolves by any other means (success,
+    /// application failure, or the timeout itself firing), so early completion does not leave a dead task
+    /// queued in the scheduler for the remainder of the timeout window. #749/#750 follow-up: this method
+    /// deliberately does not delegate to the general-purpose [#async(TimeSpan,Consumer)] -- that overload is
+    /// also used to arm a delayed action on an ALREADY-resolved promise (e.g. cache-entry TTL eviction), where
+    /// cancel-on-resolution would fire immediately and defeat the delay outright.
     default Promise<T> timeout(TimeSpan timeout) {
-        return async(timeout,
-                     promise -> promise.fail(new CoreError.Timeout("Promise timed out after " + timeout.millis() + "ms")));
+        var future = AsyncExecutor.INSTANCE.runAsync(timeout,
+                                                       () -> fail(new CoreError.Timeout("Promise timed out after " + timeout.millis() + "ms")));
+
+        return withResult(_ -> future.cancel(false));
     }
+
 
     /// **[Resolution]**
     /// Cancel the promise.
@@ -3145,9 +3156,22 @@ enum AsyncExecutor {
     // radius to "more than four timeouts blocked concurrently", not "any one blocked timeout".
     private static final int TIMEOUT_SCHEDULER_THREADS = 4;
     private final ExecutorService executor = Executors.newVirtualThreadPerTaskExecutor();
-    private final ScheduledExecutorService timeoutScheduler =
-        Executors.newScheduledThreadPool(TIMEOUT_SCHEDULER_THREADS,
-                                          Thread.ofPlatform().name("promise-timeout-scheduler-", 0).daemon(true).factory());
+    // ScheduledThreadPoolExecutor (not the ScheduledExecutorService interface) so setRemoveOnCancelPolicy
+    // is reachable: without it, a cancelled task's slot in the internal DelayedWorkQueue is reclaimed only
+    // when its delay elapses, not at cancel() time. .timeout() (below) cancels its scheduled fail task the
+    // moment the promise resolves by any other means -- with the policy off, that cancellation would be a
+    // logical no-op as far as the queue is concerned, and a server minting thousands of 30s-timeout promises
+    // per second would still accumulate thousands of dead-but-queued entries (each holding a closure and a
+    // ContextPropagation snapshot) for up to the full timeout duration. #749/#750 follow-up.
+    private final ScheduledThreadPoolExecutor timeoutScheduler = createTimeoutScheduler();
+
+    private static ScheduledThreadPoolExecutor createTimeoutScheduler() {
+        var pool = new ScheduledThreadPoolExecutor(TIMEOUT_SCHEDULER_THREADS,
+                                                     Thread.ofPlatform().name("promise-timeout-scheduler-", 0).daemon(true).factory());
+        pool.setRemoveOnCancelPolicy(true);
+
+        return pool;
+    }
 
     @Contract
     void runAsync(Runnable runnable) {
@@ -3156,11 +3180,19 @@ enum AsyncExecutor {
         executor.submit(() -> ContextPropagation.INSTANCE.runWith(snapshot, runnable));
     }
     @Contract
-    void runAsync(TimeSpan delay, Runnable runnable) {
+    ScheduledFuture<?> runAsync(TimeSpan delay, Runnable runnable) {
         var snapshot = ContextPropagation.INSTANCE.capture();
 
-        timeoutScheduler.schedule(() -> ContextPropagation.INSTANCE.runWith(snapshot, runnable),
-                                   delay.nanos(), TimeUnit.NANOSECONDS);
+        return timeoutScheduler.schedule(() -> ContextPropagation.INSTANCE.runWith(snapshot, runnable),
+                                          delay.nanos(), TimeUnit.NANOSECONDS);
+    }
+
+    // Test-only observability: number of tasks still sitting in the scheduler's delay queue. With
+    // setRemoveOnCancelPolicy(true) above, a cancelled task is purged from this count synchronously,
+    // on the cancelling thread -- no polling needed to observe the effect of an early promise resolution.
+    @Contract
+    int pendingTimeoutCount() {
+        return timeoutScheduler.getQueue().size();
     }
 }
 

--- a/core/src/main/java/org/pragmatica/lang/Promise.java
+++ b/core/src/main/java/org/pragmatica/lang/Promise.java
@@ -641,6 +641,15 @@ public sealed interface Promise<T> permits PromiseImpl {
     /// deliberately does not delegate to the general-purpose [#async(TimeSpan,Consumer)] -- that overload is
     /// also used to arm a delayed action on an ALREADY-resolved promise (e.g. cache-entry TTL eviction), where
     /// cancel-on-resolution would fire immediately and defeat the delay outright.
+    ///
+    /// **#838 review round 1: behavior change.** This method returns a *derived* promise (via [#withResult])
+    /// rather than `this` — needed so the cancellation above observes resolution without itself being the
+    /// resolution. The scheduled failure resolves the ORIGINAL promise (`this`); the derived promise returned
+    /// here is resolved from that, inline, on the same thread that resolved the original -- including when
+    /// that thread is [AsyncExecutor#timeoutScheduler]'s own platform thread on the timeout-fired path. Any
+    /// caller relying on `promise.timeout(t) == promise` (identity, not value) will observe a different
+    /// object than before; a repo-wide sweep found no call site doing this, but it is a genuine change in
+    /// what this method returns, not merely an implementation detail.
     default Promise<T> timeout(TimeSpan timeout) {
         var future = AsyncExecutor.INSTANCE.runAsync(timeout,
                                                        () -> fail(new CoreError.Timeout("Promise timed out after " + timeout.millis() + "ms")));
@@ -3154,6 +3163,14 @@ enum AsyncExecutor {
     // offloaded -- see #749 condition-1 analysis), so a continuation that blocks on that thread would
     // stall every OTHER pending timeout sharing a single-threaded scheduler. Four lanes bound that blast
     // radius to "more than four timeouts blocked concurrently", not "any one blocked timeout".
+    //
+    // #838 review round 1: this deliberately does NOT reuse org.pragmatica.lang.utils.VirtualThreadScheduler
+    // (whose own class doc states the opposite principle: timekeeping submits to virtual threads, never
+    // runs a task body inline). The two designs solve different problems -- VirtualThreadScheduler
+    // decouples timing from arbitrary task execution; this pool's job is narrower, to fire the timeout
+    // ITSELF without depending on carrier availability, which is exactly the dependency
+    // VirtualThreadScheduler's own submit-to-virtual-thread step would reintroduce. See
+    // VirtualThreadScheduler's class doc for the full reconciliation of both designs' trade-offs.
     private static final int TIMEOUT_SCHEDULER_THREADS = 4;
     private final ExecutorService executor = Executors.newVirtualThreadPerTaskExecutor();
     // ScheduledThreadPoolExecutor (not the ScheduledExecutorService interface) so setRemoveOnCancelPolicy

--- a/core/src/main/java/org/pragmatica/lang/Promise.java
+++ b/core/src/main/java/org/pragmatica/lang/Promise.java
@@ -22,6 +22,8 @@ import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.LockSupport;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
@@ -3127,7 +3129,26 @@ public sealed interface Promise<T> permits PromiseImpl {
 
 enum AsyncExecutor {
     INSTANCE;
+
+    // #749/#750: .timeout()'s delayed-failure task used to share this pool's virtual-thread carriers with
+    // every other .async() offload in the codebase. A timeout is exactly the guard relied on when the
+    // system is under load -- and CPU-bound work pinning every carrier is a form of load -- so a timeout
+    // that must win a carrier to fire is not actually bounded. This scheduler is dedicated SOLELY to
+    // runAsync(TimeSpan, Runnable): platform threads, scheduled by the OS rather than the JVM's
+    // virtual-thread carrier pool, so they cannot be starved by virtual-thread carrier exhaustion.
+    // General .async() offload work (runAsync(Runnable)) is unchanged and still runs on `executor`.
+    //
+    // Sized at a small fixed pool rather than one thread: firing a timeout resolves its promise inline
+    // on this scheduler's own thread (Promise.allOf's aggregation runs inline via CompletionMap, not
+    // offloaded -- see #749 condition-1 analysis), so a continuation that blocks on that thread would
+    // stall every OTHER pending timeout sharing a single-threaded scheduler. Four lanes bound that blast
+    // radius to "more than four timeouts blocked concurrently", not "any one blocked timeout".
+    private static final int TIMEOUT_SCHEDULER_THREADS = 4;
     private final ExecutorService executor = Executors.newVirtualThreadPerTaskExecutor();
+    private final ScheduledExecutorService timeoutScheduler =
+        Executors.newScheduledThreadPool(TIMEOUT_SCHEDULER_THREADS,
+                                          Thread.ofPlatform().name("promise-timeout-scheduler-", 0).daemon(true).factory());
+
     @Contract
     void runAsync(Runnable runnable) {
         var snapshot = ContextPropagation.INSTANCE.capture();
@@ -3138,16 +3159,8 @@ enum AsyncExecutor {
     void runAsync(TimeSpan delay, Runnable runnable) {
         var snapshot = ContextPropagation.INSTANCE.capture();
 
-        executor.submit(() -> ContextPropagation.INSTANCE.runWith(snapshot,
-                                                                  () -> {
-                                                                      try {
-                                                                      Thread.sleep(delay.duration());
-                                                                  } catch (InterruptedException e) {
-                                                                      Thread.currentThread().interrupt();
-                                                                  }
-
-                                                                      runnable.run();
-                                                                  }));
+        timeoutScheduler.schedule(() -> ContextPropagation.INSTANCE.runWith(snapshot, runnable),
+                                   delay.nanos(), TimeUnit.NANOSECONDS);
     }
 }
 

--- a/core/src/main/java/org/pragmatica/lang/utils/VirtualThreadScheduler.java
+++ b/core/src/main/java/org/pragmatica/lang/utils/VirtualThreadScheduler.java
@@ -47,6 +47,22 @@ import org.slf4j.LoggerFactory;
 /// logic. Failures inside task bodies are logged (never swallowed silently) and, crucially,
 /// never cancel a recurring task — fixing STPE's "a throwing periodic task is silently
 /// cancelled forever" footgun.
+///
+/// **Not used by `Promise#timeout(TimeSpan)`.** #749/#750/#838 give that path its own dedicated,
+/// fixed-size `ScheduledThreadPoolExecutor` (`Promise.AsyncExecutor#timeoutScheduler`, 4 platform
+/// threads) that runs the timeout FIRE action *inline*, on its own thread — the opposite of this
+/// class's "never run inline" principle. The reason is narrower than it looks: a timeout's fire
+/// action must not itself depend on carrier availability, or the original starvation bug (a
+/// timeout that cannot be dispatched because every virtual-thread carrier is pinned) simply
+/// reappears one layer down, inside whatever executes the fire. Handing the fire to a
+/// virtual-thread-per-task executor — this class's normal mode — reintroduces exactly that
+/// dependency. The cost is bounded rather than eliminated: `.timeout()`'s continuation chain
+/// (`.map()`/`.flatMap()`/`withResult()`) dispatches inline per `CompletionMap`/`CompletionFold`'s
+/// resolve-time contract, so a blocking continuation on a fired timeout occupies one of only 4
+/// dedicated threads; more than 4 concurrent blocking continuations starve every *other* pending
+/// timeout process-wide. Small, bounded, and documented, versus the original unbounded
+/// shared-pool risk — but not free, and not eliminable without changing `resolve()`'s inline-dispatch
+/// contract everywhere it is used, which is out of scope for a timeout-specific fix.
 public final class VirtualThreadScheduler {
     private static final Logger log = LoggerFactory.getLogger(VirtualThreadScheduler.class);
 

--- a/core/src/test/java/org/pragmatica/lang/PromiseAllOfCarrierStarvationTest.java
+++ b/core/src/test/java/org/pragmatica/lang/PromiseAllOfCarrierStarvationTest.java
@@ -50,7 +50,13 @@ class PromiseAllOfCarrierStarvationTest {
         var busySpinHoldMillis = 3000L;
         var boundMillis = 2000L; // must stay well under busySpinHoldMillis to discriminate fixed vs. starved
 
-        var carriers = Math.max(Runtime.getRuntime().availableProcessors(), 8);
+        // The real carrier ceiling is whichever is SMALLER: the explicit -Djdk.virtualThreadScheduler.parallelism
+        // pin (pom.xml's vthread.argLine sets it to 8 for every surefire fork) or the host's actual CPU count.
+        // A host with more than 8 CPUs still only has 8 carriers once the property pins it -- taking `max`
+        // against availableProcessors() (the prior bug) overcounts the ceiling on such hosts, so `started`
+        // (sized to the overcounted `carriers`) can never be fully counted down.
+        var configuredParallelism = Integer.getInteger("jdk.virtualThreadScheduler.parallelism", Integer.MAX_VALUE);
+        var carriers = Math.min(configuredParallelism, Runtime.getRuntime().availableProcessors());
         var saturators = carriers + 4; // guarantee every carrier is pinned regardless of scheduling order
 
         var stop = new AtomicBoolean(false);
@@ -75,11 +81,14 @@ class PromiseAllOfCarrierStarvationTest {
             gate.succeed(unit());
         });
 
-        assertThat(started.await(5, TimeUnit.SECONDS))
-            .as("all %d carriers must be pinned by a running saturator before the timed section begins", carriers)
-            .isTrue();
-
         try {
+            // Inside the try/finally: if the carrier count is ever wrong again, this assertion's failure
+            // must still release the saturators below rather than pinning every carrier for the rest of
+            // the surefire fork (the prior bug -- this assertion used to sit before the try).
+            assertThat(started.await(5, TimeUnit.SECONDS))
+                .as("all %d carriers must be pinned by a running saturator before the timed section begins", carriers)
+                .isTrue();
+
             var nodeStops = IntStream.range(0, nodeCount)
                                       .mapToObj(_ -> Promise.<Unit>promise())
                                       .map(p -> p.timeout(perNodeTimeout))

--- a/core/src/test/java/org/pragmatica/lang/PromiseAllOfCarrierStarvationTest.java
+++ b/core/src/test/java/org/pragmatica/lang/PromiseAllOfCarrierStarvationTest.java
@@ -1,0 +1,116 @@
+/*
+ *  Copyright (c) 2023-2025 Sergiy Yevtushenko.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package org.pragmatica.lang;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.pragmatica.lang.Unit.unit;
+import static org.pragmatica.lang.io.TimeSpan.timeSpan;
+
+/// Reproduces #749/#750: [Promise#timeout(io.pragmatica.lang.io.TimeSpan)][Promise#timeout] schedules its
+/// delayed-failure task on the same shared virtual-thread executor used for every other `.async()` offload
+/// in the codebase ([Promise.AsyncExecutor]). If that pool's carriers are all pinned by unrelated CPU-bound
+/// work, the timeout task cannot be dispatched at all, so a "bounded" operation is not actually bounded.
+///
+/// This test drives the exact shape [org.pragmatica.aether.ember.EmberCluster#stop()] uses in production:
+/// N never-resolving promises, each wrapped in `.timeout(...)`, aggregated with [Promise#allOf(java.util.Collection)]
+/// and reduced with `.map(...)` — not a bare `.timeout()` call, because `allOf`'s aggregation callback is what
+/// determines whether the observable completion is itself starvation-safe (see #749 condition 1 analysis).
+class PromiseAllOfCarrierStarvationTest {
+    private static final AtomicLong SINK = new AtomicLong();
+
+    @Test
+    @Timeout(value = 20, unit = TimeUnit.SECONDS)
+    void allOf_perNodeTimeout_firesWithinBoundDespiteCarrierSaturation() throws InterruptedException {
+        var perNodeTimeout = timeSpan(800).millis();
+        var nodeCount = 5;
+        var busySpinHoldMillis = 3000L;
+        var boundMillis = 2000L; // must stay well under busySpinHoldMillis to discriminate fixed vs. starved
+
+        var carriers = Math.max(Runtime.getRuntime().availableProcessors(), 8);
+        var saturators = carriers + 4; // guarantee every carrier is pinned regardless of scheduling order
+
+        var stop = new AtomicBoolean(false);
+        // Only `carriers`-many non-yielding tasks can ever be mounted at once: the +4 margin exists so
+        // that WHICHEVER `carriers` of the `saturators` submissions win a carrier first, all carriers end
+        // up pinned regardless of scheduling order -- the margin itself is never expected to start running
+        // before the timed section (its virtual threads sit queued in the carrier pool with nothing to
+        // mount them until a busy-spinner exits, which only happens after `stop` is set below). Gating on
+        // `saturators` starts instead of `carriers` starts would wait on a precondition that cannot occur.
+        var started = new CountDownLatch(carriers);
+        var finished = new CountDownLatch(saturators);
+
+        // Pin every virtual-thread carrier with non-yielding CPU-bound work, dispatched through the exact
+        // same offload path (CompletionOnResult -> AsyncExecutor.INSTANCE.runAsync) that .timeout() shares.
+        IntStream.range(0, saturators).forEach(_ -> {
+            var gate = Promise.<Unit>promise();
+            gate.onSuccessRun(() -> {
+                started.countDown();
+                busySpin(stop);
+                finished.countDown();
+            });
+            gate.succeed(unit());
+        });
+
+        assertThat(started.await(5, TimeUnit.SECONDS))
+            .as("all %d carriers must be pinned by a running saturator before the timed section begins", carriers)
+            .isTrue();
+
+        try {
+            var nodeStops = IntStream.range(0, nodeCount)
+                                      .mapToObj(_ -> Promise.<Unit>promise())
+                                      .map(p -> p.timeout(perNodeTimeout))
+                                      .toList();
+
+            var start = System.nanoTime();
+            var result = Promise.allOf(nodeStops)
+                                 .map(_ -> unit())
+                                 .await(timeSpan(busySpinHoldMillis + 5000).millis());
+            var elapsedMillis = (System.nanoTime() - start) / 1_000_000;
+
+            assertThat(result.isSuccess())
+                .as("allOf(...).map(...) must settle once every per-node timeout fires: %s", result)
+                .isTrue();
+            assertThat(elapsedMillis)
+                .as("bounded stop() must resolve near its own %dms bound, not stall for the full %dms carrier-saturation window",
+                    perNodeTimeout.millis(), busySpinHoldMillis)
+                .isLessThan(boundMillis);
+        } finally {
+            stop.set(true);
+            assertThat(finished.await(5, TimeUnit.SECONDS))
+                .as("saturator cleanup: all busy-spin tasks must observe the stop flag and exit")
+                .isTrue();
+        }
+    }
+
+    private static void busySpin(AtomicBoolean stop) {
+        var x = 0L;
+        while (!stop.get()) {
+            x = x * 1103515245L + 12345L;
+        }
+        SINK.addAndGet(x);
+    }
+}

--- a/core/src/test/java/org/pragmatica/lang/PromiseTimeoutCancellationTest.java
+++ b/core/src/test/java/org/pragmatica/lang/PromiseTimeoutCancellationTest.java
@@ -1,0 +1,72 @@
+/*
+ *  Copyright (c) 2023-2025 Sergiy Yevtushenko.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package org.pragmatica.lang;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.pragmatica.lang.Unit.unit;
+import static org.pragmatica.lang.io.TimeSpan.timeSpan;
+
+/// #749/#750 follow-up: `.timeout()`'s delayed-failure task used to be scheduled and then forgotten --
+/// [Promise#timeout(io.pragmatica.lang.io.TimeSpan)] discarded the [java.util.concurrent.ScheduledFuture]
+/// returned by the scheduler, so a promise that resolved microseconds after `.timeout()` was attached still
+/// left its failure task sitting in [Promise.AsyncExecutor]'s queue for the full timeout duration. Harmless
+/// per-promise (a late `.fail()` on an already-resolved promise is a CAS no-op), but unbounded in aggregate:
+/// a server minting thousands of 30-second-timeout promises per second would retain thousands of dead
+/// entries -- each holding a closure and a context-propagation snapshot -- at any given moment.
+///
+/// Assertions read [Promise.AsyncExecutor#pendingTimeoutCount()] (the scheduler's own delay-queue size)
+/// immediately after scheduling and immediately after resolving, with no wait in between: this is a
+/// same-thread, synchronous check, not a polled one, so a leftover task from an unrelated test elsewhere in
+/// this JVM cannot satisfy it -- only a same-instant coincidental fire of an unrelated task could interfere,
+/// and this suite runs single-threaded/sequential (no surefire or JUnit5 parallelism configured for `core`).
+class PromiseTimeoutCancellationTest {
+    @Test
+    void timeout_earlyCompletion_cancelsAndPurgesScheduledTask() {
+        var pendingBefore = AsyncExecutor.INSTANCE.pendingTimeoutCount();
+
+        var promise = Promise.<Unit>promise();
+        promise.timeout(timeSpan(30).seconds());
+
+        assertThat(AsyncExecutor.INSTANCE.pendingTimeoutCount())
+            .as("attaching .timeout() must queue exactly one delayed failure task")
+            .isEqualTo(pendingBefore + 1);
+
+        promise.succeed(unit());
+
+        assertThat(AsyncExecutor.INSTANCE.pendingTimeoutCount())
+            .as("early completion must cancel the scheduled failure task AND purge it from the queue immediately -- "
+                + "not merely mark it cancelled for later reclamation at its original fire time")
+            .isEqualTo(pendingBefore);
+    }
+
+    @Test
+    void timeout_earlyFailure_cancelsAndPurgesScheduledTask() {
+        var pendingBefore = AsyncExecutor.INSTANCE.pendingTimeoutCount();
+
+        var promise = Promise.<Unit>promise();
+        promise.timeout(timeSpan(30).seconds());
+
+        promise.fail(new org.pragmatica.lang.io.CoreError.Fault("application failure, unrelated to the timeout"));
+
+        assertThat(AsyncExecutor.INSTANCE.pendingTimeoutCount())
+            .as("early application-side failure must cancel the scheduled failure task just like a success would")
+            .isEqualTo(pendingBefore);
+    }
+}


### PR DESCRIPTION
## Summary

`Promise#timeout()`'s delayed-failure task shared the same virtual-thread executor as every other
`.async()` offload in the codebase. Under CPU-bound carrier saturation — the very kind of load a
timeout exists to guard against — the timeout task could never win a carrier, so a "bounded"
operation was not actually bounded. This is the shared root cause behind both #749 (a node's own
shutdown hook could hang forever) and #750 (the general claim that `.timeout()` is a reliable bound).

- **#750 fix** — `AsyncExecutor` now runs timeout scheduling on a dedicated 4-thread
  `ScheduledExecutorService` (daemon platform threads, named `promise-timeout-scheduler-N`),
  decoupled from the JVM's virtual-thread carrier pool. General `.async()` offload is unchanged.
  [mechanism: `Promise#allOf`'s aggregation callback dispatches inline via `withResult` on whatever
  thread resolves each input promise — not offloaded — so decoupling only the timeout-*firing*
  thread is sufficient to make an entire `allOf(...).map(...)` chain, exactly the shape
  `EmberCluster#stop()` and `Main#shutdownNode` use, resolve independent of the shared pool]
  [verified: `core/src/test/java/org/pragmatica/lang/PromiseAllOfCarrierStarvationTest.java` — 5
  never-resolving promises through `.timeout(800ms)` + `Promise#allOf` + `.map(...)`, exactly as
  production does, while every virtual-thread carrier is pinned by non-yielding busy-spin work;
  aggregate resolves within 2000ms despite full carrier saturation]
- **Red-before-green**: reverting only the `AsyncExecutor` scheduler change makes the same test fail
  with a genuine `Failure(Timeout[...])` result — restoring it passes again.
  [verified: same test as above]
- **Review-round-1 caveat**: `PromiseAllOfCarrierStarvationTest`'s own carrier-count arithmetic had a
  bug (`Math.max(availableProcessors(), configuredParallelism)`, corrected to
  `Math.min(configuredParallelism, availableProcessors())`), fixed in this round. On an 8-core build
  machine this specific test-arithmetic fix cannot be demonstrated red-then-green: the pom pins
  `jdk.virtualThreadScheduler.parallelism=8`, and `availableProcessors()` is also 8 on that box, so
  the old (wrong) and new (correct) formulas both evaluate to 8 and the test passes identically
  either way there. The fix is still correct and only matters where
  `availableProcessors() != configuredParallelism` (e.g. >8-core machines), which is the case the bug
  actually manifests under.
- **#749 fix** — `Main#shutdownNode` now bounds `node.stop()` at 30 seconds. On expiry it logs an
  ERROR, dumps every live thread (name, state, lock, full stack), and exits with code `2`, instead
  of the previous unbounded hook that could park forever with no operator-visible signal.
  [design intent — unverified: the 30s-then-exit-2 branch has no end-to-end test of its own; only
  the underlying bounded-timeout mechanism it depends on is verified above]
- **Which call inside `node.stop()` actually blocks in a real occurrence stays UNKNOWN** — this PR
  bounds the hang and makes it loud and diagnosable (thread dump + exit code), it does not claim to
  have found a root cause inside `AetherNode#stop()`. The existing `HangDiagnosticExtension`
  widening (`0abbcef06`, already merged) is the eventual mechanism for answering that from a real
  occurrence.
- Documented the node process's exit-code contract (new `aether/docs/reference/node-operations.md`,
  linked from `aether/docs/README.md`), and added the changelog fragment
  (`changelog.d/749-shutdown-bounded.md`).

## Out of scope (flagged for a follow-up decision)

#750's acceptance item 4 — an audit of every "bounded at X" claim across the docs/codebase — is
broader than this PR's scope (the `Promise` scheduler fix + the one shutdown-hook site it was
scoped to fix). Not attempted here; may warrant its own ticket.

## Test plan

- [x] `PromiseAllOfCarrierStarvationTest` — new, green with the fix, confirmed red without it
      (red-before-green cycle run via isolated builds, not asserted)
- [x] `mvn -pl core,aether/node compile` — clean
- [x] `mvn jbct:check -pl core,aether/node` — 0 format issues, 0 lint errors (core is `jbct.skip=true`
      by project convention; aether/node checked for real)
- [x] `scripts/changelog-check.sh origin/release-1.0.0-rc4` — ok

Fixes #749, fixes #750

