### PR TITLE
docs: branching section describes the reviewed PR-per-ticket practice on the release branch

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,13 +48,20 @@ The only valid use of `-Djbct.skip=true` is building `jbct/` itself during boots
 
 ```
 main (stable — latest published release only)
-  └── release-X.Y.Z (active development — commit directly)
+  └── release-X.Y.Z (active development — short-lived PR branches, reviewed, merged by the owner)
 ```
 
-- **NEVER create feature branches on a release branch.** Commit directly — the branch exists to prevent divergence.
+- **One PR branch per ticket, off the release branch, merged back within the day.** Name it
+  `fix/<issue>-<slug>` (or `feat/`, `chore/`, `docs/`). Every PR gets an adversarial review before the
+  owner's merge (owner ruling 2026-09-05; the reviews found blocking defects in most PRs of the first
+  week, which is the reason for the step). No long-lived branches: a branch that outlives its review
+  round is rebased or re-merged onto the release tip, never left to diverge. Empty `know:` commits
+  recording rulings go straight onto the release branch.
+- **Never edit `CHANGELOG.md` in a PR.** Add `changelog.d/<issue>-<slug>.md` (see
+  [`changelog.d/README.md`](changelog.d/README.md)); the CI check refuses a direct edit and a source
+  change without a fragment.
 - **"Fixes #N" never auto-closes here** — GitHub only auto-closes on the default branch, and all work merges to the release branch. Close referenced issues manually (with a PR-citing comment) as part of every merge round.
 - **Closing comments name the stale surfaces.** When a fix lands, the closing comment must name (and the fix should sweep) the docstrings, comments, and docs that described the OLD behavior — stale descriptions mint wrong tickets. Evidence: 2026-08-27, four tickets in one day carried materially wrong premises because fixes landed and the describing surfaces did not move; one stale docstring propagated its obsolete model into its ticket's own diagnosis.
-- `feat/*` / `fix/*` branches are allowed only when working off `main` with no active release branch.
 - Release branch merges to `main` when ready → tag `vX.Y.Z` → publish to Maven Central.
 - Slash commands: `/new-release-branch`, `/pre-release-check`, `/release-check`, `/release`, `/wrap-up`.
 


### PR DESCRIPTION
Owner ruling 2026-09-05 (item 2 of the open-items pass): the project CLAUDE.md said never to branch on a release branch and to commit directly, while the practice since rc4 is one short-lived PR branch per ticket, an adversarial review, and the owner's admin merge. The paragraph now describes that practice, forbids long-lived branches, notes that `know:` commits go straight onto the release branch, and points at the changelog fragment rule (#819). Docs-only; no fragment required.