### PR TITLE
evidence: #610 routing maps are never written in production; DHT FULL has no repair

### DIFF
--- a/integrations/dht/src/test/java/org/pragmatica/dht/DHTFullReplicationConvergenceTest.java
+++ b/integrations/dht/src/test/java/org/pragmatica/dht/DHTFullReplicationConvergenceTest.java
@@ -1,0 +1,190 @@
+/*
+ *  Copyright (c) 2020-2025 Sergiy Yevtushenko.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.pragmatica.dht;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.pragmatica.consensus.NodeId;
+import org.pragmatica.consensus.ProtocolMessage;
+import org.pragmatica.lang.Option;
+import org.pragmatica.lang.io.TimeSpan;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.pragmatica.dht.DHTAntiEntropy.dhtAntiEntropy;
+import static org.pragmatica.dht.DHTNode.dhtNode;
+import static org.pragmatica.dht.DistributedDHTClient.distributedDHTClient;
+import static org.pragmatica.dht.storage.MemoryStorageEngine.memoryStorageEngine;
+
+/// #610: endpoints / per-node slice state / HTTP routes are DHT `ReplicatedMap`s run at
+/// `DHTConfig.FULL` (W=1/R=1, eventually consistent) with anti-entropy and rebalancing disabled.
+/// [DHTAntiEntropy#runAntiEntropy] bails immediately on `config.isFullReplication()`, so a node
+/// that misses a write holds a stale value with nothing to reconcile it until the key is next
+/// written. This is the ticket's required first step: drop ONE node's copy of a SINGLE write at
+/// the transport level (no crash, no partition — a plain lost message, the ordinary case a
+/// fire-and-forget replica write can suffer) and assert convergence WITHOUT any subsequent write
+/// to that key, bounded by a short timeout.
+///
+/// Three-node in-process cluster over a shared in-memory dispatch network, mirroring the
+/// `DHTChurnSurvivalTest` harness — no full aether topology needed to reach this bug.
+class DHTFullReplicationConvergenceTest {
+    private static byte[] key(String s) {
+        return s.getBytes(StandardCharsets.UTF_8);
+    }
+
+    private static byte[] value(String s) {
+        return s.getBytes(StandardCharsets.UTF_8);
+    }
+
+    @Test
+    @Timeout(30)
+    void fullReplicationWrite_droppedOnOneNode_convergesWithoutSubsequentWrite() {
+        var cluster = new FullReplicationCluster(3);
+        var missingHolder = new NodeId("node-2");
+        var k = key("endpoints/svc-a");
+        var v = value("node-7");
+
+        cluster.dropNextPutTo(missingHolder);
+        cluster.member(new NodeId("node-0")).client().put(k, v).await();
+
+        // Prerequisite: the write actually succeeded overall (quorum=1 under FULL is satisfied by
+        // the other two nodes) while the targeted node genuinely never received it.
+        assertThat(cluster.holds(missingHolder, k)).as("write was dropped on the target node").isFalse();
+
+        cluster.startAntiEntropy(TimeSpan.timeSpan(50).millis());
+        try {
+            var converged = cluster.awaitConvergence(k, v, TimeSpan.timeSpan(3).seconds());
+
+            assertThat(converged)
+                .as("#610: a write dropped on one node under DHTConfig.FULL must self-heal via " +
+                    "anti-entropy without a subsequent write to the same key — today " +
+                    "DHTAntiEntropy.runAntiEntropy() returns immediately for " +
+                    "config.isFullReplication(), so the dropped node never converges")
+                .isTrue();
+        } finally {
+            cluster.stopAntiEntropy();
+        }
+    }
+
+    // --- in-process multi-node harness (pattern shared with DHTChurnSurvivalTest) ---
+
+    private record Member(NodeId id, DHTNode node, DistributedDHTClient client, DHTAntiEntropy antiEntropy) {}
+
+    private static final class FullReplicationCluster {
+        private final Map<NodeId, Member> members = new LinkedHashMap<>();
+        private final Set<NodeId> dropNextPutTo = ConcurrentHashMap.newKeySet();
+
+        FullReplicationCluster(int size) {
+            var ring = ConsistentHashRing.<NodeId>consistentHashRing();
+            for (int i = 0; i < size; i++) {
+                ring.addNode(new NodeId("node-" + i));
+            }
+            for (int i = 0; i < size; i++) {
+                var id = new NodeId("node-" + i);
+                var storage = memoryStorageEngine();
+                var node = dhtNode(id, storage, ring, DHTConfig.FULL);
+                DHTNetwork network = this::deliver;
+                var client = distributedDHTClient(node, network, DHTConfig.FULL);
+                var antiEntropy = dhtAntiEntropy(node, network, DHTConfig.FULL, TimeSpan.timeSpan(50).millis());
+
+                members.put(id, new Member(id, node, client, antiEntropy));
+            }
+        }
+
+        Member member(NodeId id) {
+            return members.get(id);
+        }
+
+        /// One-shot: the NEXT `PutRequest` delivered to `target` is silently dropped, simulating a
+        /// lost replica write. Delivery to every other node, and every later write to `target`, is
+        /// unaffected.
+        void dropNextPutTo(NodeId target) {
+            dropNextPutTo.add(target);
+        }
+
+        boolean holds(NodeId id, byte[] key) {
+            return matches(members.get(id), key, null, false);
+        }
+
+        void startAntiEntropy(TimeSpan interval) {
+            members.values().forEach(m -> m.antiEntropy().start());
+        }
+
+        void stopAntiEntropy() {
+            members.values().forEach(m -> m.antiEntropy().stop());
+        }
+
+        boolean awaitConvergence(byte[] key, byte[] expected, TimeSpan bound) {
+            var deadline = System.currentTimeMillis() + bound.millis();
+
+            while (System.currentTimeMillis() < deadline) {
+                if (members.values().stream().allMatch(m -> matches(m, key, expected, true))) {
+                    return true;
+                }
+
+                sleepQuietly(20);
+            }
+
+            return members.values().stream().allMatch(m -> matches(m, key, expected, true));
+        }
+
+        private static void sleepQuietly(long millis) {
+            try {
+                Thread.sleep(millis);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        }
+
+        private static boolean matches(Member member, byte[] key, byte[] expected, boolean compareValue) {
+            var stored = member.node().getLocal(key).await().or(Option.<byte[]> none());
+
+            if (!compareValue) {
+                return stored.isPresent();
+            }
+
+            return stored.map(actual -> Arrays.equals(actual, expected)).or(false);
+        }
+
+        private void deliver(NodeId target, ProtocolMessage message) {
+            var member = members.get(target);
+            if (member == null) {
+                return; // target has departed — dropped, as on a real halted node
+            }
+
+            switch (message) {
+                case DHTMessage.PutRequest req -> {
+                    if (dropNextPutTo.remove(target)) {
+                        return; // simulated lost write — no response, matching a dropped datagram
+                    }
+                    member.node().handlePutRequest(req, resp -> deliver(req.sender(), resp));
+                }
+                case DHTMessage.PutResponse resp -> member.client().onPutResponse(resp);
+                case DHTMessage.DigestRequest req -> member.node().handleDigestRequest(req, resp -> deliver(req.sender(), resp));
+                case DHTMessage.DigestResponse resp -> member.antiEntropy().onDigestResponse(resp);
+                case DHTMessage.MigrationDataRequest req -> member.node().handleMigrationDataRequest(req, resp -> deliver(req.sender(), resp));
+                case DHTMessage.MigrationDataResponse resp -> member.antiEntropy().onMigrationDataResponse(resp);
+                default -> { }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## What this is

A draft, non-mergeable evidence PR for #610. It contains one failing test and no production code. Opened to make the investigation record public and reviewable; per team decision this closes as a dead-surface finding rather than a repair.

## #610's premise, as filed

`endpoints`, `slice-nodes`, and `http-routes` are DHT `ReplicatedMap`s at `DHTConfig.FULL` (W=1/R=1, eventually consistent, anti-entropy explicitly disabled for that config). The ticket's claim: a node that misses a write holds a stale copy until the key is next written, with nothing to reconcile it.

## What the test proves

`integrations/dht/src/test/java/org/pragmatica/dht/DHTFullReplicationConvergenceTest.java` drives a 3-node in-process `DHTClient` cluster directly at `DHTConfig.FULL`, drops one node's copy of a put, and asserts convergence without a further write. It fails on its 3-second bound, every time — burning the full timeout, not erroring out. **This confirms the DHT-level mechanism has no repair, exactly as the ticket describes.** `[mechanism: DHTAntiEntropy.runAntiEntropy() returns immediately when config.isFullReplication() — hard-guarded off by design]`

## What further investigation found: the mechanism has no production trigger

None of the three named maps has a single `.put()` call site in production code anywhere in the repo.

- `endpoints()` / `sliceNodes()` / `httpRoutes()` (`aether/aether-dht/.../AetherMaps.java:22-24`) have zero non-test callers outside their own declarations.
- `EndpointRegistry.registerEndpoint` (`aether/aether-invoke/.../EndpointRegistry.java:129`) writes a **local in-memory** `Map<EndpointKey,Endpoint>` — never reaches the DHT map.
- `ClusterDeploymentState.trackSliceState` (`aether/aether-deployment/.../ClusterDeploymentState.java:1391-1393`) writes a **plain in-process** `Map<SliceNodeKey,SliceState>` field — never reaches the DHT map.
- HTTP route publication (`aether/aether-invoke/.../HttpRoutePublisher.java:305-315`) goes through **Rabia consensus** (`KVCommand.Put` against `NodeRoutesKey`, a different key type) — never reaches the DHT map.
- The only two classes that reference these DHT maps directly for read/write — `DhtNodeCleanup` and `CachedReplicatedMap` (both `aether/aether-dht`) — are themselves never instantiated in production.
- The only live wiring for all three maps is the **receive side**: `AetherNode.java:2637-2651` (message-router entries for `PutRequest`/`RemoveRequest`) → `AetherNode.java:5363-5380` (`handleRemotePutResponse`/`handleRemoteRemoveResponse`) → `aetherMaps.dispatchRemotePut`/`dispatchRemoteRemove` → `NamespacedReplicatedMap.onRemotePut`/`onRemoteRemove`. Every node can accept a replicated write for these namespaces; no node ever originates one.
- `DHTConfig.FULL` has exactly one other non-test reference, `aether/ember/.../EmberCluster.java:1027` — it passes the same config into the same `AetherNodeConfig`/`AetherNode` construction path, not a separate consumer.

The authoritative, linearizable state for this data lives entirely in `KVStore` (`integrations/cluster/.../kvstore/KVStore.java`, implements `StateMachine<KVCommand<K>>`, Rabia-backed) and in-process structures — a different subsystem, with no bridge class connecting it to `aether-dht`'s eventually-consistent maps.

## Conclusion

The three DHT maps are permanently empty in production, so the ticket's specific failure mode ("stale until next write") cannot occur via them today — there is no first write either. The underlying DHT-level defect is real (see the committed test) but has no live surface. Recommend closing #610 on this evidence and tracking removal of the three dead maps plus their receive-side wiring as a separate dead-surface cleanup.

## Scope

- 1 commit, 1 file: a failing test only.
- No production code.
- Not for merge.