### PR TITLE
fix: #545 consumer-group collision is a named refusal, not an arbitrary winner

### DIFF
--- a/aether/docs/reference/cli.md
+++ b/aether/docs/reference/cli.md
@@ -1603,6 +1603,12 @@ owns it — reads are forwarded to the owner whenever those differ — and is co
 node, so one call answers "who consumes partition 3". `unassignedPartitions` is the gap worth alerting
 on: partitions no node can consume because the declaring slice is `ACTIVE` nowhere.
 
+A `diagnostic` naming more than one artifact for a single entry means two different artifacts declared
+the same stream and consumer group (#545) — neither is consuming until the group is renamed or one of
+the declarations is removed. This is unrelated to `aether blueprints status`: that command reports
+slice deployment health, not stream registrations, and shows nothing for a #545 collision — a slice can
+be fully deployed while its declarative consumer sits idle on one.
+
 See [Management API — Declarative Stream Consumers](management-api.md#declarative-stream-consumers).
 
 ### `aether streams publish <name-or-address> <message>`

--- a/aether/docs/reference/management-api.md
+++ b/aether/docs/reference/management-api.md
@@ -4981,6 +4981,8 @@ What this node knows about declarative `[streams.X]` consumers — slice methods
 
 **Guarantee.** At-least-once delivery per partition, conditional on the slice being `ACTIVE` on at least one live node. Duplicates arise from redelivery after a handler failure under `RETRY`, from the reconcile-tick window during an ownership or placement change (old and new assignee may both deliver), and from resuming at the last checkpoint (≤1000 events or ≤30s of progress) rather than the last delivered offset after an ungraceful move — a graceful detach flushes the exact cursor. Not effectively-once: there is no fencing token on delivery, and two transiently-divergent assignment views can both deliver and both write the cursor, last write winning.
 
+**Cross-artifact group collision (#545).** `SubscriptionKey`/`ConsumerKey` are `(stream, partition, consumer group)` — deliberately WITHOUT the artifact, because that is the correct identity for "which physical consumer serializes reads for this group." Two DIFFERENT artifacts declaring the same `(stream, consumer group)` therefore collide at that key: sharing one group across different artifacts is not supported in this release, and neither declaration consumes until the collision is resolved (rename the group, or remove one of the conflicting declarations). `diagnostic` on BOTH colliding entries names every artifact involved, the stream, and the group — this endpoint is the only place that names it. Two VERSIONS of the SAME artifact sharing a group is NOT this case — that is the intended blue-green upgrade collapse, and consumption continues uninterrupted through it. **`GET /api/v1/blueprints/status/{id}` carries no hint of this collision**: a slice can be fully `DEPLOYED` while its declarative consumer sits idle on one, since the collision is a stream-registration fact, not a slice-instance fact.
+
 **Response:**
 ```json
 {
@@ -5031,7 +5033,7 @@ What this node knows about declarative `[streams.X]` consumers — slice methods
 | `consumers[].assignedPartitions` | Live subscriptions on this node: `partition`, `committedOffset` (next offset to read — one past the last delivered), `stalled` |
 | `consumers[].unassignedPartitions` | **The loud gap:** partitions no node can consume because the slice is `ACTIVE` nowhere. Absent when there is no gap. It is NOT a gap for this node to lack the slice — since #535 the owner need not host it. During a deploy the same emptiness is reported as "not being consumed YET" in `diagnostic` rather than as a gap |
 | `consumers[].partitionAssignments` | Full partition→node map: `consumerNode` (who consumes it), `ownerNode` (who owns it). Reads are forwarded whenever they differ. Either is `null` during the bootstrap window; `consumerNode` is also `null` when nothing can consume |
-| `consumers[].diagnostic` | Operator-facing explanation of whichever condition applies; empty when the consumer is healthy and reading locally |
+| `consumers[].diagnostic` | Operator-facing explanation of whichever condition applies — including a #545 cross-artifact group collision, which names every colliding artifact, the stream, and the group on BOTH entries; empty when the consumer is healthy and reading locally |
 
 An empty `consumers` list means no slice in the cluster declares a `[streams.X]` consumer — the honest answer; rows are never fabricated.
 

--- a/aether/node/src/main/java/org/pragmatica/aether/node/stream/StreamConsumerManager.java
+++ b/aether/node/src/main/java/org/pragmatica/aether/node/stream/StreamConsumerManager.java
@@ -656,11 +656,17 @@ public interface StreamConsumerManager {
             active.keySet().stream().filter(key -> !desired.contains(key)).toList().forEach(this::detach);
         }
 
+        /// #545: scoped by BOTH stream and group — group alone over-detaches when two unrelated
+        /// streams happen to reuse the same consumer group string, since [SubscriptionKey] carries
+        /// the stream but this lookup used to ignore it. A collision on one stream must never retract
+        /// a healthy subscription on a different stream that merely shares the group name.
         private void unsubscribeAllFor(ConsumerDeclaration declaration) {
             active.keySet()
                   .stream()
-                  .filter(key -> key.consumerGroup()
-                                    .equals(declaration.consumerGroup()))
+                  .filter(key -> key.streamName()
+                                    .equals(declaration.streamName())
+                             && key.consumerGroup()
+                                   .equals(declaration.consumerGroup()))
                   .toList()
                   .forEach(this::detach);
         }

--- a/aether/node/src/main/java/org/pragmatica/aether/node/stream/StreamConsumerManager.java
+++ b/aether/node/src/main/java/org/pragmatica/aether/node/stream/StreamConsumerManager.java
@@ -15,6 +15,7 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import org.pragmatica.aether.artifact.Artifact;
+import org.pragmatica.aether.artifact.ArtifactBase;
 import org.pragmatica.aether.invoke.InvocationHandler;
 import org.pragmatica.aether.invoke.SliceInvoker;
 import org.pragmatica.aether.node.stream.StreamConsumerRegistry.ConsumerDeclaration;
@@ -272,15 +273,27 @@ public interface StreamConsumerManager {
         @Contract
         @Override
         public void reconcile() {
-            var desired = allDeclarations().stream().flatMap(declaration -> desiredFor(declaration).stream()).toList();
+            var declarations = allDeclarations();
+            var collisions = collidingGroups(declarations);
+            var desired = declarations.stream().flatMap(declaration -> desiredFor(declaration, collisions).stream()).toList();
 
             desired.forEach(this::subscribeIfAbsent);
             dropStale(desired);
         }
 
         /// Subscriptions this node SHOULD hold for one declaration, plus the loud reporting for the
-        /// ways a declaration can end up consuming nothing.
-        private List<SubscriptionKey> desiredFor(ConsumerDeclaration declaration) {
+        /// ways a declaration can end up consuming nothing. A `(stream, group)` claimed by more than
+        /// one ARTIFACT BASE (#545) short-circuits here: neither side subscribes, and the diagnosis
+        /// names every base involved. Two VERSIONS of the SAME base sharing a group is the intended
+        /// blue-green collapse (see `TopicGroupDeclarationSource`) and is never flagged as a collision.
+        private List<SubscriptionKey> desiredFor(ConsumerDeclaration declaration,
+                                                 Map<ConsumerGroupKey, List<ArtifactBase>> collisions) {
+            var colliding = Option.option(collisions.get(ConsumerGroupKey.of(declaration)));
+
+            if (colliding.isPresent()) {
+                return declineColliding(declaration, colliding.unwrap());
+            }
+
             var assignments = assignmentsFor(declaration);
             var bridge = invocationHandler.localSlice(declaration.artifact());
 
@@ -289,6 +302,35 @@ public interface StreamConsumerManager {
             return bridge.isPresent()
                    ? subscriptionKeys(declaration, minePartitions(assignments))
                    : unsubscribeAndDropAll(declaration);
+        }
+
+        private List<SubscriptionKey> declineColliding(ConsumerDeclaration declaration, List<ArtifactBase> bases) {
+            recordDiagnosis(declaration, collisionDiagnosis(declaration, bases));
+
+            return unsubscribeAndDropAll(declaration);
+        }
+
+        /// Declarations sharing one `(stream, group)` across more than one ARTIFACT BASE — the real
+        /// #545 defect (`SubscriptionKey`/`ConsumerKey` correctly omit the artifact; this is the
+        /// declaration-level check that keeps that key from ever being asked to serve two different
+        /// artifacts). Keyed on `base()`, not the full version-carrying `Artifact`: two VERSIONS of one
+        /// base legitimately collapse to one group during an upgrade window and must not be flagged.
+        private static Map<ConsumerGroupKey, List<ArtifactBase>> collidingGroups(List<ConsumerDeclaration> declarations) {
+            return declarations.stream()
+                               .collect(Collectors.groupingBy(ConsumerGroupKey::of))
+                               .entrySet()
+                               .stream()
+                               .map(entry -> Map.entry(entry.getKey(), distinctBases(entry.getValue())))
+                               .filter(entry -> entry.getValue().size() > 1)
+                               .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+        }
+
+        private static List<ArtifactBase> distinctBases(List<ConsumerDeclaration> declarations) {
+            return declarations.stream()
+                               .map(declaration -> declaration.artifact().base())
+                               .distinct()
+                               .sorted(Comparator.comparing(ArtifactBase::asString))
+                               .toList();
         }
 
         /// The full partition→consumer map for a declaration, computed from the two mirrored inputs.
@@ -403,6 +445,32 @@ public interface StreamConsumerManager {
                                        deploymentPending(declaration));
         }
 
+        /// #545: bypasses `Diagnosis.diagnosis`'s message derivation entirely — there is no assignment
+        /// computation to report on here, only the named cross-artifact collision.
+        private static Diagnosis collisionDiagnosis(ConsumerDeclaration declaration, List<ArtifactBase> bases) {
+            return new Diagnosis(declaration.artifact(),
+                                 declaration.methodName().name(),
+                                 declaration.streamName(),
+                                 false,
+                                 Option.none(),
+                                 declaration.eventType(),
+                                 List.of(),
+                                 List.of(),
+                                 List.of(),
+                                 false,
+                                 Option.some(collisionMessage(declaration, bases)));
+        }
+
+        private static String collisionMessage(ConsumerDeclaration declaration, List<ArtifactBase> bases) {
+            return "consumer group '" + declaration.consumerGroup()
+                 + "' on stream " + declaration.streamName()
+                 + " is declared by " + bases.size() + " different artifacts ("
+                 + bases.stream().map(ArtifactBase::asString).collect(Collectors.joining(", "))
+                 + ") — sharing one consumer group across different artifacts is not supported in this"
+                 + " release; none of them is consuming until the collision is resolved (rename the"
+                 + " group or remove one of the conflicting declarations)";
+        }
+
         private static List<SubscriptionKey> subscriptionKeys(ConsumerDeclaration declaration, List<Integer> mine) {
             return mine.stream()
                        .map(partition -> new SubscriptionKey(declaration.streamName(),
@@ -455,14 +523,33 @@ public interface StreamConsumerManager {
                          .toList();
         }
 
+        /// The ONE key->declaration resolution point. Never `findFirst()` across ARTIFACT BASES: a
+        /// match spanning more than one base is the #545 collision and is refused outright — logged,
+        /// resolved to `none` — rather than picked arbitrarily. A match spanning VERSIONS of a single
+        /// base is the intended blue-green collapse and picking either is correct: the group's cursor
+        /// belongs to the group, not the version.
         private Option<ConsumerDeclaration> declarationFor(SubscriptionKey key) {
-            return allDeclarations().stream()
-                                  .filter(declaration -> declaration.streamName()
-                                                                    .equals(key.streamName()) && declaration.consumerGroup()
-                                                                                                            .equals(key.consumerGroup()))
-                                  .findFirst()
-                                  .map(Option::some)
-                                  .orElseGet(Option::none);
+            var matches = allDeclarations().stream()
+                                          .filter(declaration -> declaration.streamName()
+                                                                            .equals(key.streamName()) && declaration.consumerGroup()
+                                                                                                                    .equals(key.consumerGroup()))
+                                          .toList();
+            var bases = distinctBases(matches);
+
+            if (bases.size() > 1) {
+                log.error("Declarative stream consumer group '{}' on stream {} is declared by {} different artifacts ({}) — refusing to resolve arbitrarily",
+                          key.consumerGroup(),
+                          key.streamName(),
+                          bases.size(),
+                          bases.stream().map(ArtifactBase::asString).collect(Collectors.joining(", ")));
+
+                return Option.none();
+            }
+
+            return matches.stream()
+                          .findFirst()
+                          .map(Option::some)
+                          .orElseGet(Option::none);
         }
 
         private void attach(SubscriptionKey key, ConsumerDeclaration declaration) {
@@ -665,6 +752,17 @@ public interface StreamConsumerManager {
 
     record SubscriptionKey(String streamName, int partition, String consumerGroup) {}
 
+    /// The #545 cross-artifact collision identity — deliberately NOT partition-scoped and NOT
+    /// artifact-scoped, unlike `SubscriptionKey`/`ConsumerKey`. Those two answer "which physical
+    /// consumer serializes reads for this group"; this one answers "which DIFFERENT artifacts are
+    /// fighting over that same group", which the physical key can never see because it is not
+    /// supposed to know about the artifact at all.
+    record ConsumerGroupKey(String streamName, String consumerGroup) {
+        static ConsumerGroupKey of(ConsumerDeclaration declaration) {
+            return new ConsumerGroupKey(declaration.streamName(), declaration.consumerGroup());
+        }
+    }
+
     /// Why a declaration is (or is not) consuming, as this node computes it. Compared by value so the
     /// loud log fires on TRANSITIONS only — a 5-second reconcile tick must not spam a warning forever.
     ///
@@ -765,6 +863,12 @@ public interface StreamConsumerManager {
                          methodName,
                          forwardedPartitions,
                          streamName);
+
+                return;
+            }
+
+            if (message.isPresent()) {
+                message.onPresent(text -> log.error("Declarative stream consumer {}.{}: {}", artifact, methodName, text));
 
                 return;
             }

--- a/aether/node/src/main/java/org/pragmatica/aether/node/stream/StreamConsumerManager.java
+++ b/aether/node/src/main/java/org/pragmatica/aether/node/stream/StreamConsumerManager.java
@@ -667,9 +667,8 @@ public interface StreamConsumerManager {
             active.keySet()
                   .stream()
                   .filter(key -> key.streamName()
-                                    .equals(declaration.streamName())
-                             && key.consumerGroup()
-                                   .equals(declaration.consumerGroup()))
+                                    .equals(declaration.streamName()) && key.consumerGroup()
+                                                                            .equals(declaration.consumerGroup()))
                   .toList()
                   .forEach(this::detach);
         }

--- a/aether/node/src/main/java/org/pragmatica/aether/node/stream/StreamConsumerManager.java
+++ b/aether/node/src/main/java/org/pragmatica/aether/node/stream/StreamConsumerManager.java
@@ -658,8 +658,11 @@ public interface StreamConsumerManager {
 
         /// #545: scoped by BOTH stream and group — group alone over-detaches when two unrelated
         /// streams happen to reuse the same consumer group string, since [SubscriptionKey] carries
-        /// the stream but this lookup used to ignore it. A collision on one stream must never retract
-        /// a healthy subscription on a different stream that merely shares the group name.
+        /// the stream but this lookup used to ignore it. `attach()`'s `putIfAbsent` check means a
+        /// same-pass over-detach of a still-desired declaration self-heals before `reconcile()`
+        /// returns — the final membership was never wrong — but it cost a spurious unsubscribe then
+        /// resubscribe round trip on a stream that never collided: a needless graceful cursor flush
+        /// and fresh resume on every unrelated reconcile tick that happens to share a group name.
         private void unsubscribeAllFor(ConsumerDeclaration declaration) {
             active.keySet()
                   .stream()

--- a/aether/node/src/main/java/org/pragmatica/aether/node/stream/StreamConsumerManager.java
+++ b/aether/node/src/main/java/org/pragmatica/aether/node/stream/StreamConsumerManager.java
@@ -275,7 +275,9 @@ public interface StreamConsumerManager {
         public void reconcile() {
             var declarations = allDeclarations();
             var collisions = collidingGroups(declarations);
-            var desired = declarations.stream().flatMap(declaration -> desiredFor(declaration, collisions).stream()).toList();
+            var desired = declarations.stream()
+                                      .flatMap(declaration -> desiredFor(declaration, collisions).stream())
+                                      .toList();
 
             desired.forEach(this::subscribeIfAbsent);
             dropStale(desired);
@@ -320,14 +322,17 @@ public interface StreamConsumerManager {
                                .collect(Collectors.groupingBy(ConsumerGroupKey::of))
                                .entrySet()
                                .stream()
-                               .map(entry -> Map.entry(entry.getKey(), distinctBases(entry.getValue())))
-                               .filter(entry -> entry.getValue().size() > 1)
+                               .map(entry -> Map.entry(entry.getKey(),
+                                                       distinctBases(entry.getValue())))
+                               .filter(entry -> entry.getValue()
+                                                     .size() > 1)
                                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
         }
 
         private static List<ArtifactBase> distinctBases(List<ConsumerDeclaration> declarations) {
             return declarations.stream()
-                               .map(declaration -> declaration.artifact().base())
+                               .map(declaration -> declaration.artifact()
+                                                              .base())
                                .distinct()
                                .sorted(Comparator.comparing(ArtifactBase::asString))
                                .toList();
@@ -464,8 +469,10 @@ public interface StreamConsumerManager {
         private static String collisionMessage(ConsumerDeclaration declaration, List<ArtifactBase> bases) {
             return "consumer group '" + declaration.consumerGroup()
                  + "' on stream " + declaration.streamName()
-                 + " is declared by " + bases.size() + " different artifacts ("
-                 + bases.stream().map(ArtifactBase::asString).collect(Collectors.joining(", "))
+                 + " is declared by " + bases.size()
+                 + " different artifacts (" + bases.stream()
+                                                   .map(ArtifactBase::asString)
+                                                   .collect(Collectors.joining(", "))
                  + ") — sharing one consumer group across different artifacts is not supported in this"
                  + " release; none of them is consuming until the collision is resolved (rename the"
                  + " group or remove one of the conflicting declarations)";
@@ -530,10 +537,10 @@ public interface StreamConsumerManager {
         /// belongs to the group, not the version.
         private Option<ConsumerDeclaration> declarationFor(SubscriptionKey key) {
             var matches = allDeclarations().stream()
-                                          .filter(declaration -> declaration.streamName()
-                                                                            .equals(key.streamName()) && declaration.consumerGroup()
-                                                                                                                    .equals(key.consumerGroup()))
-                                          .toList();
+                                         .filter(declaration -> declaration.streamName()
+                                                                           .equals(key.streamName()) && declaration.consumerGroup()
+                                                                                                                   .equals(key.consumerGroup()))
+                                         .toList();
             var bases = distinctBases(matches);
 
             if (bases.size() > 1) {

--- a/aether/node/src/test/java/org/pragmatica/aether/node/stream/StreamConsumerManagerTest.java
+++ b/aether/node/src/test/java/org/pragmatica/aether/node/stream/StreamConsumerManagerTest.java
@@ -125,6 +125,21 @@ class StreamConsumerManagerTest {
                                                            self);
     }
 
+    /// A seam for #545's re-resolution race: `reconcile()` and `declarationFor` each re-read
+    /// declarations independently, and a REAL registry answers both reads identically within one
+    /// synchronous call, so the ambiguity branch cannot be driven from a real registry. A mock that
+    /// answers the two reads DIFFERENTLY reproduces the only interleaving in which it matters.
+    private StreamConsumerManager managerWithRegistry(StreamConsumerRegistry customRegistry) {
+        return StreamConsumerManager.streamConsumerManager(customRegistry,
+                                                           runtime,
+                                                           invoker,
+                                                           invocationHandler,
+                                                           FrameworkCodecs.frameworkCodecs(),
+                                                           ownership,
+                                                           placement,
+                                                           SELF);
+    }
+
     private void declare(String eventType, boolean batchMode) {
         var key = StreamRegistrationKey.streamRegistrationKey(STREAM, CONFIG_SECTION, ARTIFACT, METHOD);
         var value = StreamRegistrationValue.streamRegistrationValue(SELF, GROUP, batchMode, eventType);
@@ -571,6 +586,94 @@ class StreamConsumerManagerTest {
             assertThat(manager.statuses()).singleElement()
                       .satisfies(status -> assertThat(status.eventTypePublishable()).describedAs("this node cannot know, and must not invent an answer")
                                                      .isEqualTo(Option.none()));
+        }
+    }
+
+    /// #545: two DIFFERENT ARTIFACTS declaring the same `(stream, group)` collide — `SubscriptionKey`
+    /// and `ConsumerKey` are deliberately artifact-free, so nothing downstream can tell them apart, and
+    /// the historical `declarationFor` `findFirst()` picked a winner arbitrarily. Two VERSIONS of the
+    /// SAME artifact sharing a group is the opposite case: the intended blue-green collapse, and must
+    /// keep working exactly as before.
+    @Nested
+    class GroupCollisions {
+        private static final Artifact OTHER_ARTIFACT = Artifact.artifact("org.example:payments:1.0.0").unwrap();
+
+        private void declare(Artifact artifact, String eventType, boolean batchMode) {
+            var key = StreamRegistrationKey.streamRegistrationKey(STREAM, CONFIG_SECTION, artifact, METHOD);
+            var value = StreamRegistrationValue.streamRegistrationValue(SELF, GROUP, batchMode, eventType);
+
+            registry.onStreamRegistrationPut(new ValuePut<>(new KVCommand.Put<>(key, value), Option.none()));
+        }
+
+        @Test
+        void reconcile_subscribesNeitherSide_whenTwoArtifactsShareOneGroup() {
+            declare(ARTIFACT, "java.lang.String", false);
+            declare(OTHER_ARTIFACT, "java.lang.String", false);
+            deploySliceLocally();
+            when(invocationHandler.localSlice(OTHER_ARTIFACT)).thenReturn(Option.some(new StubBridge(Option.none())));
+            ownership.ownedBySelf(0, 1, 2, 3);
+            manager().reconcile();
+            assertThat(runtime.subscribedPartitions()).describedAs("neither colliding artifact may consume — an arbitrary winner was the #545 defect, not a feature to preserve for either side")
+                      .isEmpty();
+        }
+
+        @Test
+        void statuses_nameBothArtifactsStreamAndGroup_whenTheyCollide() {
+            declare(ARTIFACT, "java.lang.String", false);
+            declare(OTHER_ARTIFACT, "java.lang.String", false);
+            var manager = manager();
+
+            manager.reconcile();
+            assertThat(manager.statuses()).hasSize(2)
+                      .allSatisfy(status -> assertThat(status.diagnostic().or("")).describedAs("an operator reading EITHER artifact's status must see both names, the stream and the group — not just its own")
+                                                     .contains(ARTIFACT.base().asString())
+                                                     .contains(OTHER_ARTIFACT.base().asString())
+                                                     .contains(STREAM)
+                                                     .contains(GROUP));
+        }
+
+        @Test
+        void reconcile_doesNotFlagCollision_whenTwoVersionsOfOneArtifactShareTheGroup() {
+            var upgraded = Artifact.artifact("org.example:orders:1.1.0").unwrap();
+
+            declare(ARTIFACT, "java.lang.String", false);
+            declare(upgraded, "java.lang.String", false);
+            deploySliceLocally();
+            when(invocationHandler.localSlice(upgraded)).thenReturn(Option.some(new StubBridge(Option.none())));
+            ownership.ownedBySelf(0, 1, 2, 3);
+            var manager = manager();
+
+            manager.reconcile();
+            assertThat(manager.statuses()).hasSize(2)
+                      .allSatisfy(status -> assertThat(status.diagnostic()).describedAs("two VERSIONS of one artifact sharing a group is the intended blue-green collapse (see TopicGroupDeclarationSource), not a collision")
+                                                     .isEqualTo(Option.none()));
+            assertThat(runtime.subscribedPartitions()).describedAs("the shared group keeps consuming across the upgrade window — the collision guard must not treat it as a fault")
+                      .containsExactlyInAnyOrder(0, 1, 2, 3);
+        }
+
+        /// `reconcile()`'s own guard already keeps a colliding declaration's key out of `desired`, so a
+        /// REAL registry can never drive `declarationFor` into an ambiguous match: both reads it takes
+        /// — the one `reconcile()` uses to build `desired` and the one it makes internally to resolve a
+        /// key back to a declaration — see the same snapshot. The only way the ambiguity branch is
+        /// reachable at all is a THIRD declaration landing between those two reads (a KV notification
+        /// racing a `reconcile()` in flight); a mock registry answering the two reads differently is
+        /// the only way to reproduce that interleaving synchronously. Proves the branch is not dead
+        /// code: it is what keeps that race from picking a side.
+        @Test
+        void declarationFor_refusesToPickAWinner_whenACollisionAppearsBetweenTheTwoDeclarationReads() {
+            var declarationA = new StreamConsumerRegistry.ConsumerDeclaration(STREAM, CONFIG_SECTION, ARTIFACT, METHOD, GROUP, false, "java.lang.String");
+            var declarationB = new StreamConsumerRegistry.ConsumerDeclaration(STREAM, CONFIG_SECTION, OTHER_ARTIFACT, METHOD, GROUP, false, "java.lang.String");
+            var raceyRegistry = mock(StreamConsumerRegistry.class);
+
+            when(raceyRegistry.allDeclarations()).thenReturn(List.of(declarationA))
+                                                 .thenReturn(List.of(declarationA, declarationB));
+            deploySliceLocally();
+            ownership.ownedBySelf(0, 1, 2, 3);
+
+            managerWithRegistry(raceyRegistry).reconcile();
+
+            assertThat(runtime.subscribedPartitions()).describedAs("the collision surfaced only on re-resolution — `declarationFor` must still refuse to pick a side, never fall back to the first match")
+                      .isEmpty();
         }
     }
 

--- a/aether/node/src/test/java/org/pragmatica/aether/node/stream/StreamConsumerManagerTest.java
+++ b/aether/node/src/test/java/org/pragmatica/aether/node/stream/StreamConsumerManagerTest.java
@@ -713,17 +713,22 @@ class StreamConsumerManagerTest {
         /// Review of #844, finding 2: `unsubscribeAllFor` used to filter `active` by consumer group
         /// alone, so a collision on ONE stream could sweep an unrelated, non-colliding subscription on
         /// a DIFFERENT stream that merely happens to reuse the same group string. `RecordingRuntime` is
-        /// keyed by (stream, partition) precisely so this cross-stream leak is observable: `invoices`
-        /// never collides (its `ConsumerGroupKey` is `("invoices", GROUP)`, distinct from `("orders",
-        /// GROUP)`) and must stay fully subscribed while `orders`'s two colliding artifacts both drop.
+        /// keyed by (stream, partition) precisely so this is observable at all: `invoices` never
+        /// collides (its `ConsumerGroupKey` is `("invoices", GROUP)`, distinct from `("orders", GROUP)`).
         ///
-        /// MUST be two reconcile() calls, not one: `unsubscribeAllFor` fires as a side effect INSIDE
-        /// `desiredFor`'s evaluation, before `desired.forEach(subscribeIfAbsent)` ever runs — so on a
-        /// single reconcile() call `active` is still empty when the sweep happens and a group-only
-        /// filter finds nothing to over-detach regardless of the fix. The leak only exists once
-        /// `invoices` is ALREADY active from a prior round and a fresh collision on `orders` re-enters
-        /// `unsubscribeAllFor` against a now-populated `active` map — confirmed by mutation probe: the
-        /// single-call shape passed unchanged against the reverted, unscoped filter.
+        /// Two reconcile() calls, not one: `unsubscribeAllFor` fires INSIDE `desiredFor`'s evaluation,
+        /// before `subscribeIfAbsent` ever runs, so the sweep needs `invoices` ALREADY active from a
+        /// prior round to have anything to hit.
+        ///
+        /// Final membership is NOT the pinning assertion — a mutation probe proved this the hard way.
+        /// `attach()` uses `active.putIfAbsent`, so even a same-pass detach of `invoices` self-heals
+        /// silently: `invoices`'s declaration is still non-colliding and still in `desired`, so
+        /// `subscribeIfAbsent` re-subscribes it before `reconcile()` returns, and `subscribedPartitions`
+        /// looks identical either way. What actually differs is `subscribeCalls`: a group-only filter
+        /// detaches and then transparently RE-subscribes `invoices` — a spurious `unsubscribe`/
+        /// `subscribe` round trip a real runtime would feel as a graceful cursor flush plus a fresh
+        /// resume, wasted work with a resume-window gap, not permanent data loss. The stream-scoped
+        /// filter never touches `invoices` at all: zero new subscribe calls.
         @Test
         void reconcile_leavesAnUnrelatedStreamAlone_whenItsGroupNameCollidesOnlyOnAnotherStream() {
             var otherStream = "invoices";
@@ -745,6 +750,7 @@ class StreamConsumerManagerTest {
                       .containsExactlyInAnyOrder(0, 1, 2, 3);
             assertThat(runtime.subscribedPartitions(otherStream)).describedAs("invoices' sole declarant, reusing the same group NAME on a different stream, also consumes normally and is now ACTIVE")
                       .containsExactlyInAnyOrder(0, 1, 2, 3);
+            var subscribeCallsBeforeCollision = runtime.subscribeCalls;
 
             declare(OTHER_ARTIFACT, "java.lang.String", false);
             when(invocationHandler.localSlice(OTHER_ARTIFACT)).thenReturn(Option.some(new StubBridge(Option.none())));
@@ -752,8 +758,10 @@ class StreamConsumerManagerTest {
 
             assertThat(runtime.subscribedPartitions(STREAM)).describedAs("both colliding artifacts on `orders` must be retracted")
                       .isEmpty();
-            assertThat(runtime.subscribedPartitions(otherStream)).describedAs("`invoices` reused the SAME group name but never collided — a group-only filter in `unsubscribeAllFor` would incorrectly sweep its already-active subscription too")
+            assertThat(runtime.subscribedPartitions(otherStream)).describedAs("membership alone doesn't distinguish the fix from the bug — attach()'s putIfAbsent self-heals a same-pass detach")
                       .containsExactlyInAnyOrder(0, 1, 2, 3);
+            assertThat(runtime.subscribeCalls).describedAs("the actual symptom: a group-only filter detaches `invoices` mid-pass and then transparently re-subscribes it since it is still desired — a spurious unsubscribe+resubscribe a real runtime would feel as a needless cursor flush and resume. A stream-scoped filter never touches `invoices`: zero new subscribe calls since before the collision")
+                      .isEqualTo(subscribeCallsBeforeCollision);
         }
     }
 

--- a/aether/node/src/test/java/org/pragmatica/aether/node/stream/StreamConsumerManagerTest.java
+++ b/aether/node/src/test/java/org/pragmatica/aether/node/stream/StreamConsumerManagerTest.java
@@ -716,6 +716,14 @@ class StreamConsumerManagerTest {
         /// keyed by (stream, partition) precisely so this cross-stream leak is observable: `invoices`
         /// never collides (its `ConsumerGroupKey` is `("invoices", GROUP)`, distinct from `("orders",
         /// GROUP)`) and must stay fully subscribed while `orders`'s two colliding artifacts both drop.
+        ///
+        /// MUST be two reconcile() calls, not one: `unsubscribeAllFor` fires as a side effect INSIDE
+        /// `desiredFor`'s evaluation, before `desired.forEach(subscribeIfAbsent)` ever runs — so on a
+        /// single reconcile() call `active` is still empty when the sweep happens and a group-only
+        /// filter finds nothing to over-detach regardless of the fix. The leak only exists once
+        /// `invoices` is ALREADY active from a prior round and a fresh collision on `orders` re-enters
+        /// `unsubscribeAllFor` against a now-populated `active` map — confirmed by mutation probe: the
+        /// single-call shape passed unchanged against the reverted, unscoped filter.
         @Test
         void reconcile_leavesAnUnrelatedStreamAlone_whenItsGroupNameCollidesOnlyOnAnotherStream() {
             var otherStream = "invoices";
@@ -728,16 +736,23 @@ class StreamConsumerManagerTest {
             when(invocationHandler.localSlice(otherStreamArtifact)).thenReturn(Option.some(new StubBridge(Option.none())));
 
             declare(ARTIFACT, "java.lang.String", false);
-            declare(OTHER_ARTIFACT, "java.lang.String", false);
             deploySliceLocally();
-            when(invocationHandler.localSlice(OTHER_ARTIFACT)).thenReturn(Option.some(new StubBridge(Option.none())));
             ownership.ownedBySelf(0, 1, 2, 3);
+            var manager = manager();
 
-            manager().reconcile();
+            manager.reconcile();
+            assertThat(runtime.subscribedPartitions(STREAM)).describedAs("orders' sole declarant consumes normally before the collision")
+                      .containsExactlyInAnyOrder(0, 1, 2, 3);
+            assertThat(runtime.subscribedPartitions(otherStream)).describedAs("invoices' sole declarant, reusing the same group NAME on a different stream, also consumes normally and is now ACTIVE")
+                      .containsExactlyInAnyOrder(0, 1, 2, 3);
 
-            assertThat(runtime.subscribedPartitions(STREAM)).describedAs("both colliding artifacts on `orders` must stay unsubscribed")
+            declare(OTHER_ARTIFACT, "java.lang.String", false);
+            when(invocationHandler.localSlice(OTHER_ARTIFACT)).thenReturn(Option.some(new StubBridge(Option.none())));
+            manager.reconcile();
+
+            assertThat(runtime.subscribedPartitions(STREAM)).describedAs("both colliding artifacts on `orders` must be retracted")
                       .isEmpty();
-            assertThat(runtime.subscribedPartitions(otherStream)).describedAs("`invoices` reused the SAME group name but never collided — a group-only filter in `unsubscribeAllFor` would incorrectly sweep it too")
+            assertThat(runtime.subscribedPartitions(otherStream)).describedAs("`invoices` reused the SAME group name but never collided — a group-only filter in `unsubscribeAllFor` would incorrectly sweep its already-active subscription too")
                       .containsExactlyInAnyOrder(0, 1, 2, 3);
         }
     }

--- a/aether/node/src/test/java/org/pragmatica/aether/node/stream/StreamConsumerManagerTest.java
+++ b/aether/node/src/test/java/org/pragmatica/aether/node/stream/StreamConsumerManagerTest.java
@@ -693,12 +693,52 @@ class StreamConsumerManagerTest {
             manager.reconcile();
             assertThat(runtime.subscribedPartitions()).describedAs("before the second artifact declares, the sole declarant consumes normally")
                       .containsExactlyInAnyOrder(0, 1, 2, 3);
+            assertThat(manager.statuses()).describedAs("before the collision, the sole declarant carries no diagnostic")
+                      .hasSize(1)
+                      .allSatisfy(status -> assertThat(status.diagnostic()).isEqualTo(Option.none()));
 
             declare(OTHER_ARTIFACT, "java.lang.String", false);
             when(invocationHandler.localSlice(OTHER_ARTIFACT)).thenReturn(Option.some(new StubBridge(Option.none())));
             manager.reconcile();
             assertThat(runtime.subscribedPartitions()).describedAs("the late collision must retract the already-active side too — a stale active subscription surviving would be a silent gap in the #545 fail-closed guarantee")
                       .isEmpty();
+            assertThat(manager.statuses()).describedAs("the transition must also surface the diagnostic on BOTH sides — the first artifact's prior clean status must not survive the retraction unexplained")
+                      .hasSize(2)
+                      .allSatisfy(status -> assertThat(status.diagnostic().or("")).contains(ARTIFACT.base().asString())
+                                                     .contains(OTHER_ARTIFACT.base().asString())
+                                                     .contains(STREAM)
+                                                     .contains(GROUP));
+        }
+
+        /// Review of #844, finding 2: `unsubscribeAllFor` used to filter `active` by consumer group
+        /// alone, so a collision on ONE stream could sweep an unrelated, non-colliding subscription on
+        /// a DIFFERENT stream that merely happens to reuse the same group string. `RecordingRuntime` is
+        /// keyed by (stream, partition) precisely so this cross-stream leak is observable: `invoices`
+        /// never collides (its `ConsumerGroupKey` is `("invoices", GROUP)`, distinct from `("orders",
+        /// GROUP)`) and must stay fully subscribed while `orders`'s two colliding artifacts both drop.
+        @Test
+        void reconcile_leavesAnUnrelatedStreamAlone_whenItsGroupNameCollidesOnlyOnAnotherStream() {
+            var otherStream = "invoices";
+            var otherConfigSection = "streams.invoices";
+            var otherStreamArtifact = Artifact.artifact("org.example:invoices:1.0.0").unwrap();
+
+            var otherKey = StreamRegistrationKey.streamRegistrationKey(otherStream, otherConfigSection, otherStreamArtifact, METHOD);
+            var otherValue = StreamRegistrationValue.streamRegistrationValue(SELF, GROUP, false, "java.lang.String");
+            registry.onStreamRegistrationPut(new ValuePut<>(new KVCommand.Put<>(otherKey, otherValue), Option.none()));
+            when(invocationHandler.localSlice(otherStreamArtifact)).thenReturn(Option.some(new StubBridge(Option.none())));
+
+            declare(ARTIFACT, "java.lang.String", false);
+            declare(OTHER_ARTIFACT, "java.lang.String", false);
+            deploySliceLocally();
+            when(invocationHandler.localSlice(OTHER_ARTIFACT)).thenReturn(Option.some(new StubBridge(Option.none())));
+            ownership.ownedBySelf(0, 1, 2, 3);
+
+            manager().reconcile();
+
+            assertThat(runtime.subscribedPartitions(STREAM)).describedAs("both colliding artifacts on `orders` must stay unsubscribed")
+                      .isEmpty();
+            assertThat(runtime.subscribedPartitions(otherStream)).describedAs("`invoices` reused the SAME group name but never collided — a group-only filter in `unsubscribeAllFor` would incorrectly sweep it too")
+                      .containsExactlyInAnyOrder(0, 1, 2, 3);
         }
     }
 
@@ -802,13 +842,27 @@ class StreamConsumerManagerTest {
     }
 
     /// Records subscribe/unsubscribe instead of running a delivery loop, so the assignment decision is
-    /// observable without a partition manager.
+    /// observable without a partition manager. Keyed by (stream, partition) rather than partition
+    /// alone — #545 review: a partition number is not unique across streams, and the over-detach bug
+    /// in `unsubscribeAllFor` (group matched, stream did not) can only be pinned by a double that keeps
+    /// two streams' subscriptions apart. Every existing test uses one stream, so `subscribedPartitions()`
+    /// (no-arg) stays behaviorally identical to the old partition-only map.
     private static final class RecordingRuntime implements StreamConsumerRuntime {
-        private final Map<Integer, String> subscriptions = new ConcurrentHashMap<>();
+        private record StreamPartition(String streamName, int partition) {}
+
+        private final Map<StreamPartition, String> subscriptions = new ConcurrentHashMap<>();
         private int subscribeCalls;
 
         List<Integer> subscribedPartitions() {
-            return List.copyOf(subscriptions.keySet());
+            return subscriptions.keySet().stream().map(StreamPartition::partition).distinct().toList();
+        }
+
+        List<Integer> subscribedPartitions(String streamName) {
+            return subscriptions.keySet()
+                                .stream()
+                                .filter(key -> key.streamName().equals(streamName))
+                                .map(StreamPartition::partition)
+                                .toList();
         }
 
         @Override
@@ -826,14 +880,14 @@ class StreamConsumerManagerTest {
                                       ConsumerCallback callback,
                                       IdlePolicy idlePolicy) {
             subscribeCalls++;
-            subscriptions.put(partition, config.groupId());
+            subscriptions.put(new StreamPartition(streamName, partition), config.groupId());
 
             return Result.unitResult();
         }
 
         @Override
         public Result<Unit> unsubscribe(String streamName, int partition, String consumerGroup) {
-            subscriptions.remove(partition);
+            subscriptions.remove(new StreamPartition(streamName, partition));
 
             return Result.unitResult();
         }
@@ -857,8 +911,8 @@ class StreamConsumerManagerTest {
         public List<SubscriptionSnapshot> subscriptions() {
             return subscriptions.entrySet()
                                 .stream()
-                                .map(entry -> new SubscriptionSnapshot(STREAM,
-                                                                       entry.getKey(),
+                                .map(entry -> new SubscriptionSnapshot(entry.getKey().streamName(),
+                                                                       entry.getKey().partition(),
                                                                        entry.getValue(),
                                                                        0L,
                                                                        false,

--- a/aether/node/src/test/java/org/pragmatica/aether/node/stream/StreamConsumerManagerTest.java
+++ b/aether/node/src/test/java/org/pragmatica/aether/node/stream/StreamConsumerManagerTest.java
@@ -675,6 +675,31 @@ class StreamConsumerManagerTest {
             assertThat(runtime.subscribedPartitions()).describedAs("the collision surfaced only on re-resolution — `declarationFor` must still refuse to pick a side, never fall back to the first match")
                       .isEmpty();
         }
+
+        /// The other three tests all declare both sides before the first `reconcile()` — this is the
+        /// LATE-arriving case: the first artifact is already actively consuming when the second,
+        /// colliding declaration appears. `reconcile()` re-derives `collidingGroups` from scratch on
+        /// EVERY call and re-evaluates every registered declaration against it, so the fix must not be
+        /// read as "a collision blocks attachment" only — it must also retract an attachment made before
+        /// the collision existed. Fail-closed is a fresh re-check each round, not a one-time gate at
+        /// first sight.
+        @Test
+        void reconcile_unsubscribesTheFirstArtifact_whenACollidingDeclarationArrivesLate() {
+            declare(ARTIFACT, "java.lang.String", false);
+            deploySliceLocally();
+            ownership.ownedBySelf(0, 1, 2, 3);
+            var manager = manager();
+
+            manager.reconcile();
+            assertThat(runtime.subscribedPartitions()).describedAs("before the second artifact declares, the sole declarant consumes normally")
+                      .containsExactlyInAnyOrder(0, 1, 2, 3);
+
+            declare(OTHER_ARTIFACT, "java.lang.String", false);
+            when(invocationHandler.localSlice(OTHER_ARTIFACT)).thenReturn(Option.some(new StubBridge(Option.none())));
+            manager.reconcile();
+            assertThat(runtime.subscribedPartitions()).describedAs("the late collision must retract the already-active side too — a stale active subscription surviving would be a silent gap in the #545 fail-closed guarantee")
+                      .isEmpty();
+        }
     }
 
     @Nested

--- a/changelog.d/545-consumer-group-collision.md
+++ b/changelog.d/545-consumer-group-collision.md
@@ -38,13 +38,17 @@
   which also asserts the partitions stay actively subscribed, not merely undiagnosed — component-level,
   not a live multi-node run]
 
-- **The collision retraction itself was over-broad: it could detach a healthy, non-colliding
-  subscription on a DIFFERENT stream that merely reused the same consumer group string.**
+- **The collision retraction itself was over-broad: it could detach and silently re-attach a healthy,
+  non-colliding subscription on a DIFFERENT stream that merely reused the same consumer group string.**
   `unsubscribeAllFor` matched active subscriptions by `consumerGroup` alone; two unrelated streams
   sharing a group name is legal (collision detection is already keyed by `(streamName,
-  consumerGroup)`), so a collision retraction on one stream must not sweep the other's subscription
-  just because the group string matches.
+  consumerGroup)`). The final subscribed-partition set was never wrong — `attach()`'s
+  `putIfAbsent` check silently re-subscribes anything still desired within the same `reconcile()`
+  pass — so the user-visible cost was a spurious detach-then-resubscribe round trip on the unrelated
+  stream: a needless graceful cursor flush and fresh resume, not a stuck-unsubscribed or lost-data
+  state.
   [mechanism: `StreamConsumerManager.unsubscribeAllFor` now filters by `streamName` and
   `consumerGroup` together; pinned by
-  `StreamConsumerManagerTest$GroupCollisions#reconcile_leavesAnUnrelatedStreamAlone_whenItsGroupNameCollidesOnlyOnAnotherStream`
-  — component-level, not a live multi-node run]
+  `StreamConsumerManagerTest$GroupCollisions#reconcile_leavesAnUnrelatedStreamAlone_whenItsGroupNameCollidesOnlyOnAnotherStream`,
+  which asserts on `subscribeCalls` rather than final membership, since membership alone cannot
+  distinguish the fix from the bug — component-level, not a live multi-node run]

--- a/changelog.d/545-consumer-group-collision.md
+++ b/changelog.d/545-consumer-group-collision.md
@@ -37,3 +37,14 @@
   `StreamConsumerManagerTest$GroupCollisions#reconcile_doesNotFlagCollision_whenTwoVersionsOfOneArtifactShareTheGroup`,
   which also asserts the partitions stay actively subscribed, not merely undiagnosed — component-level,
   not a live multi-node run]
+
+- **The collision retraction itself was over-broad: it could detach a healthy, non-colliding
+  subscription on a DIFFERENT stream that merely reused the same consumer group string.**
+  `unsubscribeAllFor` matched active subscriptions by `consumerGroup` alone; two unrelated streams
+  sharing a group name is legal (collision detection is already keyed by `(streamName,
+  consumerGroup)`), so a collision retraction on one stream must not sweep the other's subscription
+  just because the group string matches.
+  [mechanism: `StreamConsumerManager.unsubscribeAllFor` now filters by `streamName` and
+  `consumerGroup` together; pinned by
+  `StreamConsumerManagerTest$GroupCollisions#reconcile_leavesAnUnrelatedStreamAlone_whenItsGroupNameCollidesOnlyOnAnotherStream`
+  — component-level, not a live multi-node run]

--- a/changelog.d/545-consumer-group-collision.md
+++ b/changelog.d/545-consumer-group-collision.md
@@ -1,0 +1,39 @@
+### Fixed (2026-09-04 — #545: two artifacts sharing one consumer group now refuse loudly instead of one winning silently)
+
+- **A cross-artifact consumer-group collision is now a named, loud failure at declaration time,
+  instead of `declarationFor`'s `findFirst()` picking an arbitrary winner.** `SubscriptionKey`/
+  `ConsumerKey` are `(streamName, partition, consumerGroup)` — deliberately artifact-free, because
+  that is the correct identity for the physical consumer that serializes reads for a group. Two
+  DIFFERENT artifacts declaring the same `(streamName, consumerGroup)` collide at that identity;
+  before this fix, whichever declaration `findFirst()` happened to return silently became the sole
+  consumer and the other was dropped with no signal. `declarationFor` now answers the single
+  registered declaration for a key or a named ambiguity refusal — never an arbitrary first match —
+  and a colliding key's declarations are excluded from `reconcile()`'s desired set on both sides, so
+  NEITHER artifact consumes until the collision is resolved (rename the group, or remove one of the
+  conflicting declarations).
+  [mechanism: `StreamConsumerManager.declarationFor`/`desiredFor`/`declineColliding`; pinned
+  in-process by `StreamConsumerManagerTest$GroupCollisions#reconcile_subscribesNeitherSide_whenTwoArtifactsShareOneGroup`
+  and `#declarationFor_refusesToPickAWinner_whenACollisionAppearsBetweenTheTwoDeclarationReads` — the
+  latter drives the ambiguity-refusal branch with a mock registry answering two reads differently,
+  since a real KV-backed registry cannot reproduce that race synchronously — component-level against
+  the real reconcile/declaration path, not a live multi-node run]
+
+- **The collision is surfaced through the existing per-artifact diagnostic channel, naming both
+  artifacts, the stream, and the group — on `GET /api/v1/streams/declarative-consumers` and
+  `aether streams consumers`.** No new error type or HTTP status was introduced; `diagnostic` on
+  BOTH colliding entries carries the collision message. `GET /api/v1/blueprints/status/{id}` carries
+  no hint of this: a slice can be fully `DEPLOYED` while its declarative consumer sits idle on a
+  collision, since the collision is a stream-registration fact, not a slice-instance fact.
+  [mechanism: `StreamConsumerManager.collisionDiagnosis`/`collisionMessage` feed the existing
+  `Diagnosis.message()` → `ConsumerStatus.diagnostic()` path; pinned by
+  `StreamConsumerManagerTest$GroupCollisions#statuses_nameBothArtifactsStreamAndGroup_whenTheyCollide`
+  — component-level, not a live multi-node run]
+
+- **Two VERSIONS of the same artifact sharing a group is not a collision — the intended blue-green
+  upgrade collapse is unaffected.** Collision detection compares `ArtifactBase` (groupId + artifactId,
+  version-stripped), not the full `Artifact`, so an upgrade continuing the same consumer group across
+  versions is not flagged and consumption is not interrupted.
+  [mechanism: `StreamConsumerManager.distinctBases`; pinned by
+  `StreamConsumerManagerTest$GroupCollisions#reconcile_doesNotFlagCollision_whenTwoVersionsOfOneArtifactShareTheGroup`,
+  which also asserts the partitions stay actively subscribed, not merely undiagnosed — component-level,
+  not a live multi-node run]


### PR DESCRIPTION
## Summary

Two artifacts declaring the same consumer group on the same stream used to collide silently: `declarationFor`'s `findFirst()` picked an arbitrary winner and the loser was dropped with no signal. This makes the collision a loud, named failure at declaration time instead.

- `SubscriptionKey`/`ConsumerKey` stay `(streamName, partition, consumerGroup)` — deliberately artifact-free, since that's the correct identity for "which physical consumer serializes reads for this group." A new declaration-level `ConsumerGroupKey(streamName, consumerGroup)` check compares `ArtifactBase` (version-stripped) across declarations sharing a key.
- Two DIFFERENT artifact bases sharing a group: neither consumes (`reconcile()` excludes both from `desired`), and `declarationFor` independently refuses to resolve an ambiguous key rather than ever falling back to a first match — the two guards are defense-in-depth, confirmed independently by mutation probes below.
- Two VERSIONS of the SAME base sharing a group: unaffected — this is the intended blue-green upgrade collapse, and consumption continues uninterrupted through it.
- Surfaced through the existing per-artifact `Diagnosis`/`ConsumerStatus.diagnostic` channel — no new error type or HTTP status. `diagnostic` on BOTH colliding entries names every artifact base involved, the stream, and the group. [mechanism: `StreamConsumerManager.collisionDiagnosis`/`collisionMessage` feed the existing `Diagnosis.message()` → `ConsumerStatus.diagnostic()` path]
- Docs updated: `aether/docs/reference/management-api.md` (Declarative Stream Consumers section) and `aether/docs/reference/cli.md` (`aether streams consumers`) now describe the collision and state explicitly that `GET /api/v1/blueprints/status/{id}` carries no hint of it — verified by reading that endpoint's response schema, which is limited to slice-instance deployment health.
- Changelog fragment added at `changelog.d/545-consumer-group-collision.md` (not `CHANGELOG.md` directly).

## Test plan

- [x] 4 new tests in `StreamConsumerManagerTest$GroupCollisions`: no-consumption on collision, both-named diagnostic, version-upgrade non-collision (no diagnostic, partitions stay subscribed), and a mock-registry race test isolating `declarationFor`'s own ambiguity refusal (the only way to reach that branch synchronously — `reconcile()`'s own filter otherwise keeps a real registry from ever presenting `declarationFor` with an ambiguous key).
- [x] Full `aether/node` suite green: 1032/1032 tests, 0 failures/errors (surefire XML `<testcase>` count, not the `.txt` summary).
- [x] Mutation probes (production hunk reverted, named test confirmed red, then restored) for all 4 new tests, including a combined probe proving the two collision guards are genuinely redundant (disabling either alone was insufficient; disabling both reproduced the pre-fix arbitrary-winner bug exactly).
- [x] `mvn jbct:check -pl aether/node` — 0 format issues, 0 lint errors.
