### PR TITLE
fix: dashboard live alerts, event key, and polling gate (#292, #304, #294)

### DIFF
--- a/aether/dashboard/src/main/resources/dashboard/index.html
+++ b/aether/dashboard/src/main/resources/dashboard/index.html
@@ -312,9 +312,9 @@
                     <div class="panel">
                         <h2>LIVE EVENTS</h2>
                         <div class="event-feed" x-ref="eventFeed">
-                            <template x-for="event in $store.events.recent.slice(0, 10)" :key="event.timestamp + event.type">
+                            <template x-for="event in $store.events.recent.slice(0, 10)" :key="$store.events.eventKey(event)">
                                 <div class="event-item" :class="'severity-' + (event.severity || 'INFO').toLowerCase()">
-                                    <span class="event-time" x-text="formatTime(event.timestamp)"></span>
+                                    <span class="event-time" x-text="formatTime($store.events.eventMillis(event))"></span>
                                     <span class="event-type" x-text="event.type"></span>
                                     <span class="event-summary" x-text="event.summary || event.message"></span>
                                 </div>

--- a/aether/dashboard/src/main/resources/dashboard/js/app.js
+++ b/aether/dashboard/src/main/resources/dashboard/js/app.js
@@ -173,23 +173,35 @@ document.addEventListener('alpine:init', function() {
             },
 
             async checkHealth() {
-                // #294: bare '/health' matches what Forge actually serves and what this dashboard is
-                // demonstrably run against today; the real node's Management API has already migrated
-                // to '/api/v1/health' in code (ManagementRoute, #300) without a corresponding dashboard
-                // update — a pre-existing, systemic, tracked mismatch across every dashboard endpoint,
-                // not something this ticket fixes. Against an already-migrated node this probe 404s
-                // like every other call here does today.
+                // #294/#300: try the versioned path FIRST — it is the ONLY health path the real node's
+                // Management API serves (ManagementRoute has no bare '/health' route at all, per #300's
+                // path-versioning gap), then fall back to bare '/health', which is what Forge actually
+                // serves and has never migrated. Probing versioned-first is what makes this gate work
+                // against a real node, not just Forge; probing bare-only (the original #294 fix) meant
+                // the gate silently never engaged against a real node at all.
                 //
                 // 'degraded' is keyed on the semantic `status !== 'healthy'`, not a literal 'degraded'
                 // wire value — none exists. The real node's HealthResponse.status is only ever
                 // "healthy"/"unhealthy"; Forge's is hardcoded to always "healthy" and can never signal
                 // degradation, an honest limit on this gate against Forge.
-                var health = await RestClient.get('/health');
+                var health = await RestClient.get('/api/v1/health');
+                if (!health) {
+                    health = await RestClient.get('/health');
+                }
                 if (health && health.status) {
                     Alpine.store('cluster').degraded = health.status !== 'healthy';
+                    return;
                 }
-                // A missing/unreachable health endpoint leaves `degraded` at its last known value —
-                // never fabricate a health verdict from a failed probe.
+                // Fail-open: neither path answered (both 404, or the network call itself failed).
+                // This is UNKNOWN health, not degraded health — a probe failure must never set
+                // degraded=true, or any target that serves neither health path would wedge every
+                // OTHER poll behind a health check that can never succeed. Treat unknown as healthy
+                // and keep polling; warn once, not on every 2s tick.
+                Alpine.store('cluster').degraded = false;
+                if (!this._healthProbeUnreachableWarned) {
+                    this._healthProbeUnreachableWarned = true;
+                    console.warn('[Dashboard] health probe failed on both /api/v1/health and /health; treating as healthy (fail-open) and continuing to poll');
+                }
             },
 
             async pollStatus() {

--- a/aether/dashboard/src/main/resources/dashboard/js/app.js
+++ b/aether/dashboard/src/main/resources/dashboard/js/app.js
@@ -1,3 +1,29 @@
+// #294/#300 (three-state health gate, corrected after #846 review): a pure decision function,
+// kept separate from checkHealth()'s store-mutation and warn-once side effects, so the health
+// classification is one small reviewable unit. Inputs are probeHealth() results ({reachable, json}
+// for each of the versioned and bare paths); output is either `{unknown: true}` — deliberately
+// OMITTING `degraded` so the caller has nothing to assign and a prior verdict survives untouched —
+// or `{unknown: false, degraded: <bool>}` once at least one path proved the server is reachable.
+//
+// No JS test runner exists anywhere in this repo (confirmed: no GraalJS/Nashorn/javax.script
+// dependency in any pom.xml or test source) and adding one is out of scope for this fix, so this
+// stays pinned by structural Java contract-test assertions on the extracted body — the same honest,
+// disclosed technique already used for the rest of this file's coverage — rather than by executing
+// it. Extracting it as a standalone pure function is still worth doing on its own terms: it is
+// reviewable in isolation, and it makes "unknown never overwrites degraded" a structural property
+// of the object shape instead of something checkHealth() has to remember to preserve.
+function decideHealthState(v1, bare) {
+    var reachable = v1.reachable || bare.reachable;
+    if (!reachable) {
+        return { unknown: true };
+    }
+    var health = (v1.json && v1.json.status) ? v1 : bare;
+    return {
+        unknown: false,
+        degraded: !!(health.json && health.json.status) && health.json.status !== 'healthy'
+    };
+}
+
 document.addEventListener('alpine:init', function() {
     Alpine.data('app', function() {
         return {
@@ -146,10 +172,16 @@ document.addEventListener('alpine:init', function() {
                 // Always poll REST for full state (loadTargets, slices, etc.)
                 // WS provides incremental metrics but REST has the complete picture
                 this.pollTimer = setInterval(function() {
-                    // #294: health is probed on every tick, ungated, so the gate itself can detect
-                    // recovery — every OTHER poll below is skipped while the cluster is degraded.
+                    var cluster = Alpine.store('cluster');
+                    // #294 (three states): while the server is UNREACHABLE (network error on both
+                    // health paths, not merely reachable-and-unhealthy), every timer — including the
+                    // health probe itself — backs off to a shared slow 10s retry instead of hammering
+                    // a dead backend at full 2s/3s cadence. `unknownRetryDue()` is a no-op false when
+                    // healthUnknown is already false, so the known-reachable case (healthy OR
+                    // degraded) is unaffected and still probes every tick to catch recovery fast.
+                    if (cluster.healthUnknown && !cluster.unknownRetryDue()) return;
                     self.checkHealth();
-                    if (Alpine.store('cluster').degraded) return;
+                    if (cluster.degraded) return;
                     self.pollStatus();
                     Alpine.store('events').refresh();
                     Alpine.store('alerts').refresh();
@@ -158,7 +190,9 @@ document.addEventListener('alpine:init', function() {
                 // Secondary stores: poll at lower frequency as fallback
                 // for when WS misses INITIAL_STATE or drops connection
                 this.secondaryPollTimer = setInterval(function() {
-                    if (Alpine.store('cluster').degraded) return;
+                    var cluster = Alpine.store('cluster');
+                    if (cluster.degraded) return;
+                    if (cluster.healthUnknown && !cluster.unknownRetryDue()) return;
                     Alpine.store('topology').refresh();
                     Alpine.store('desiredTopology').refresh();
                     Alpine.store('governors').refresh();
@@ -173,35 +207,44 @@ document.addEventListener('alpine:init', function() {
             },
 
             async checkHealth() {
-                // #294/#300: try the versioned path FIRST — it is the ONLY health path the real node's
-                // Management API serves (ManagementRoute has no bare '/health' route at all, per #300's
-                // path-versioning gap), then fall back to bare '/health', which is what Forge actually
-                // serves and has never migrated. Probing versioned-first is what makes this gate work
-                // against a real node, not just Forge; probing bare-only (the original #294 fix) meant
-                // the gate silently never engaged against a real node at all.
+                // #294/#300 (three-state gate, corrected after #846 review): try the versioned path
+                // FIRST — it is the ONLY health path the real node's Management API serves
+                // (ManagementRoute has no bare '/health' route at all, per #300's path-versioning
+                // gap) — then fall back to bare '/health', which is what Forge actually serves and
+                // has never migrated. probeHealth() (not the shared RestClient.get()) is used here
+                // because it alone distinguishes "reachable, no route" (any HTTP response, 404
+                // included) from "unreachable" (a fetch-level network error) — a distinction
+                // RestClient.get() collapses to an identical null for both, which is exactly the gap
+                // the #846 review found: this method's PREVIOUS revision could not tell a real total
+                // outage apart from a harmless 404 and fail-opened on both alike.
                 //
+                // decideHealthState() (module scope, top of this file) is the pure decision; this
+                // method only applies it and owns the once-only warning side effect.
+                var v1 = await RestClient.probeHealth('/api/v1/health');
+                var bare = (v1.json && v1.json.status) ? { reachable: false, json: null } : await RestClient.probeHealth('/health');
+                var decision = decideHealthState(v1, bare);
+                var cluster = Alpine.store('cluster');
+
+                cluster.healthUnknown = decision.unknown;
+                if (decision.unknown) {
+                    // Both paths were genuinely UNREACHABLE (refused/timeout), not merely 404 — the
+                    // 404 case is folded into `degraded` below via decideHealthState's fail-open.
+                    // `degraded` is deliberately left untouched: a prior known-degraded verdict must
+                    // not read back as healthy just because the network to check it also died.
+                    if (!this._healthProbeUnreachableWarned) {
+                        this._healthProbeUnreachableWarned = true;
+                        console.warn('[Dashboard] health probe unreachable on both /api/v1/health and /health; backing off to a slow 10s retry and holding the last known health state');
+                    }
+                    return;
+                }
+                this._healthProbeUnreachableWarned = false;
                 // 'degraded' is keyed on the semantic `status !== 'healthy'`, not a literal 'degraded'
                 // wire value — none exists. The real node's HealthResponse.status is only ever
                 // "healthy"/"unhealthy"; Forge's is hardcoded to always "healthy" and can never signal
-                // degradation, an honest limit on this gate against Forge.
-                var health = await RestClient.get('/api/v1/health');
-                if (!health) {
-                    health = await RestClient.get('/health');
-                }
-                if (health && health.status) {
-                    Alpine.store('cluster').degraded = health.status !== 'healthy';
-                    return;
-                }
-                // Fail-open: neither path answered (both 404, or the network call itself failed).
-                // This is UNKNOWN health, not degraded health — a probe failure must never set
-                // degraded=true, or any target that serves neither health path would wedge every
-                // OTHER poll behind a health check that can never succeed. Treat unknown as healthy
-                // and keep polling; warn once, not on every 2s tick.
-                Alpine.store('cluster').degraded = false;
-                if (!this._healthProbeUnreachableWarned) {
-                    this._healthProbeUnreachableWarned = true;
-                    console.warn('[Dashboard] health probe failed on both /api/v1/health and /health; treating as healthy (fail-open) and continuing to poll');
-                }
+                // degradation, an honest limit on this gate against Forge. A path that answered but
+                // has no health route here (404 on both) fails OPEN via decideHealthState — reachable
+                // is not the same claim as degraded.
+                cluster.degraded = decision.degraded;
             },
 
             async pollStatus() {

--- a/aether/dashboard/src/main/resources/dashboard/js/app.js
+++ b/aether/dashboard/src/main/resources/dashboard/js/app.js
@@ -146,13 +146,19 @@ document.addEventListener('alpine:init', function() {
                 // Always poll REST for full state (loadTargets, slices, etc.)
                 // WS provides incremental metrics but REST has the complete picture
                 this.pollTimer = setInterval(function() {
+                    // #294: health is probed on every tick, ungated, so the gate itself can detect
+                    // recovery — every OTHER poll below is skipped while the cluster is degraded.
+                    self.checkHealth();
+                    if (Alpine.store('cluster').degraded) return;
                     self.pollStatus();
                     Alpine.store('events').refresh();
+                    Alpine.store('alerts').refresh();
                 }, 2000);
 
                 // Secondary stores: poll at lower frequency as fallback
                 // for when WS misses INITIAL_STATE or drops connection
                 this.secondaryPollTimer = setInterval(function() {
+                    if (Alpine.store('cluster').degraded) return;
                     Alpine.store('topology').refresh();
                     Alpine.store('desiredTopology').refresh();
                     Alpine.store('governors').refresh();
@@ -164,6 +170,26 @@ document.addEventListener('alpine:init', function() {
                     Alpine.store('deployments').refreshRoutes();
                     Alpine.store('schema').refresh();
                 }, 10000);
+            },
+
+            async checkHealth() {
+                // #294: bare '/health' matches what Forge actually serves and what this dashboard is
+                // demonstrably run against today; the real node's Management API has already migrated
+                // to '/api/v1/health' in code (ManagementRoute, #300) without a corresponding dashboard
+                // update — a pre-existing, systemic, tracked mismatch across every dashboard endpoint,
+                // not something this ticket fixes. Against an already-migrated node this probe 404s
+                // like every other call here does today.
+                //
+                // 'degraded' is keyed on the semantic `status !== 'healthy'`, not a literal 'degraded'
+                // wire value — none exists. The real node's HealthResponse.status is only ever
+                // "healthy"/"unhealthy"; Forge's is hardcoded to always "healthy" and can never signal
+                // degradation, an honest limit on this gate against Forge.
+                var health = await RestClient.get('/health');
+                if (health && health.status) {
+                    Alpine.store('cluster').degraded = health.status !== 'healthy';
+                }
+                // A missing/unreachable health endpoint leaves `degraded` at its last known value —
+                // never fabricate a health verdict from a failed probe.
             },
 
             async pollStatus() {

--- a/aether/dashboard/src/main/resources/dashboard/js/app.js
+++ b/aether/dashboard/src/main/resources/dashboard/js/app.js
@@ -173,15 +173,25 @@ document.addEventListener('alpine:init', function() {
                 // WS provides incremental metrics but REST has the complete picture
                 this.pollTimer = setInterval(function() {
                     var cluster = Alpine.store('cluster');
-                    // #294 (three states): while the server is UNREACHABLE (network error on both
-                    // health paths, not merely reachable-and-unhealthy), every timer — including the
-                    // health probe itself — backs off to a shared slow 10s retry instead of hammering
-                    // a dead backend at full 2s/3s cadence. `unknownRetryDue()` is a no-op false when
+                    // #294/#846 (three states, throttle split after review): while the server is
+                    // UNREACHABLE, the health re-probe backs off to its OWN fixed ~10s cadence via
+                    // `healthProbeRetryDue()` — dedicated to this call alone, never shared with the
+                    // data-poll timers below. It used to share `unknownRetryDue()` with them, and
+                    // being a read-and-consume throttle, whichever timer's tick called it first in a
+                    // window won the slot; when that wasn't this one, checkHealth() silently skipped
+                    // a whole cycle and recovery detection slipped past 10s by an amount that
+                    // depended on interval drift. `healthProbeRetryDue()` is a no-op true when
                     // healthUnknown is already false, so the known-reachable case (healthy OR
-                    // degraded) is unaffected and still probes every tick to catch recovery fast.
-                    if (cluster.healthUnknown && !cluster.unknownRetryDue()) return;
-                    self.checkHealth();
+                    // degraded) is unaffected and still probes every tick to catch a fresh outage
+                    // fast.
+                    if (!cluster.healthUnknown || cluster.healthProbeRetryDue()) {
+                        self.checkHealth();
+                    }
                     if (cluster.degraded) return;
+                    // Data polls (below) still share `unknownRetryDue()` with the secondary timer
+                    // and requests.js's timer — one shared slow retry cadence for data staleness,
+                    // decoupled from the health re-probe above.
+                    if (cluster.healthUnknown && !cluster.unknownRetryDue()) return;
                     self.pollStatus();
                     Alpine.store('events').refresh();
                     Alpine.store('alerts').refresh();

--- a/aether/dashboard/src/main/resources/dashboard/js/app.js
+++ b/aether/dashboard/src/main/resources/dashboard/js/app.js
@@ -125,7 +125,11 @@ document.addEventListener('alpine:init', function() {
                         this.updateSparklines();
                         this.updateCharts();
                     } else if (data.type === 'ALERT' || data.type === 'ALERT_RESOLVED') {
-                        Alpine.store('alerts').updateFromWs(data.data || data);
+                        // #292: the discriminator lives at the TOP level only (AlertManager.buildAlertMessage
+                        // sends {"type":"ALERT","data":{...}}, never duplicated inside data) — pass the whole
+                        // envelope through so the store can read `type` itself instead of an already-unwrapped
+                        // payload that never carries it.
+                        Alpine.store('alerts').updateFromWs(data);
                     } else if (data.type === 'HISTORY') {
                         Alpine.store('alerts').updateFromWsHistory(data.data || data);
                     }

--- a/aether/dashboard/src/main/resources/dashboard/js/lib/rest-client.js
+++ b/aether/dashboard/src/main/resources/dashboard/js/lib/rest-client.js
@@ -34,6 +34,14 @@ window.RestClient = {
     // is a narrow carve-out for one status code, not general failure suppression.
     _warned404: {},
 
+    // #294 (three-state health gate, corrected after #846 review): while the cluster's OWN health
+    // probe cannot reach the server at all (Alpine.store('cluster').healthUnknown), every OTHER
+    // poller failing with the SAME network error is not new information — toasting each one
+    // individually is the exact toast storm the health gate exists to prevent. Log once per
+    // method+path instead, the same carve-out shape as the 404 case above. A reachable server that
+    // later returns an application error still toasts normally: that path never sets healthUnknown.
+    _warnedUnreachable: {},
+
     _reportFailure: function(method, path, status) {
         if (status === 404) {
             var key = method + ' ' + path;
@@ -44,6 +52,39 @@ window.RestClient = {
             return;
         }
         Notifications.show(method + ' ' + path + ' failed: ' + status, 'error');
+    },
+
+    _reportNetworkFailure: function(method, path, message) {
+        var cluster = window.Alpine && Alpine.store('cluster');
+        if (cluster && cluster.healthUnknown) {
+            var key = method + ' ' + path;
+            if (!this._warnedUnreachable[key]) {
+                this._warnedUnreachable[key] = true;
+                console.warn('[RestClient] ' + key + ' -> network error while cluster health is unknown (' + message + '); further network-error toasts on this endpoint are suppressed until health is known again');
+            }
+            return;
+        }
+        Notifications.show(method + ' ' + path + ': ' + message, 'error');
+    },
+
+    // #294/#300 (three-state health gate): a dedicated probe used ONLY by checkHealth(). It never
+    // toasts — health probing runs on every poll tick by design — and it reports HOW a probe failed,
+    // which the shared get()/post()/put()/del() cannot: any HTTP response at all (a 404 included)
+    // means the server is reachable, just without this route; only a fetch-level exception (refused,
+    // timeout, DNS failure) means the server could not be reached. Those are different claims and the
+    // three-state gate needs both.
+    probeHealth: function(path) {
+        var self = this;
+        return fetch(path, { headers: self.getHeaders() }).then(function(response) {
+            if (!response.ok) return { reachable: true, json: null };
+            return response.json().then(function(json) {
+                return { reachable: true, json: json };
+            }).catch(function() {
+                return { reachable: true, json: null };
+            });
+        }).catch(function() {
+            return { reachable: false, json: null };
+        });
     },
 
     // #293/G7: API key is read from sessionStorage (set by the auth overlay) or a cookie — never the
@@ -70,7 +111,7 @@ window.RestClient = {
             }
             return response.json();
         }).catch(function(e) {
-            Notifications.show('GET ' + path + ': ' + e.message, 'error');
+            self._reportNetworkFailure('GET', path, e.message);
             return null;
         });
     },
@@ -99,7 +140,7 @@ window.RestClient = {
                 try { return JSON.parse(text); } catch(e) { return text; }
             });
         }).catch(function(e) {
-            Notifications.show('POST ' + path + ': ' + e.message, 'error');
+            self._reportNetworkFailure('POST', path, e.message);
             return null;
         });
     },
@@ -117,7 +158,7 @@ window.RestClient = {
             }
             return response.ok;
         }).catch(function(e) {
-            Notifications.show('PUT ' + path + ': ' + e.message, 'error');
+            self._reportNetworkFailure('PUT', path, e.message);
             return false;
         });
     },
@@ -134,7 +175,7 @@ window.RestClient = {
             }
             return response.ok;
         }).catch(function(e) {
-            Notifications.show('DELETE ' + path + ': ' + e.message, 'error');
+            self._reportNetworkFailure('DELETE', path, e.message);
             return false;
         });
     }

--- a/aether/dashboard/src/main/resources/dashboard/js/lib/rest-client.js
+++ b/aether/dashboard/src/main/resources/dashboard/js/lib/rest-client.js
@@ -28,6 +28,24 @@ window.Notifications = {
 };
 
 window.RestClient = {
+    // #294: an endpoint the server has no route for (Forge stand-ins, or a dashboard path not yet
+    // migrated to /api/v1 — #300) 404s on every poll tick. Toasting that every 2-3s is just noise;
+    // log it once per method+path instead. Every OTHER failure status still toasts every time — this
+    // is a narrow carve-out for one status code, not general failure suppression.
+    _warned404: {},
+
+    _reportFailure: function(method, path, status) {
+        if (status === 404) {
+            var key = method + ' ' + path;
+            if (!this._warned404[key]) {
+                this._warned404[key] = true;
+                console.warn('[RestClient] ' + key + ' -> 404 (endpoint not implemented by this server; further 404s on this endpoint are suppressed)');
+            }
+            return;
+        }
+        Notifications.show(method + ' ' + path + ' failed: ' + status, 'error');
+    },
+
     // #293/G7: API key is read from sessionStorage (set by the auth overlay) or a cookie — never the
     // URL, since keys in URLs leak into access logs, proxies and browser history. Always sent as the
     // X-API-Key header.
@@ -47,7 +65,7 @@ window.RestClient = {
         return fetch(path, { headers: self.getHeaders() }).then(function(response) {
             if (response.status === 401) { self.handleUnauthorized(); return null; }
             if (!response.ok) {
-                Notifications.show('GET ' + path + ' failed: ' + response.status, 'error');
+                self._reportFailure('GET', path, response.status);
                 return null;
             }
             return response.json();
@@ -74,7 +92,7 @@ window.RestClient = {
         return fetch(path, opts).then(function(response) {
             if (response.status === 401) { self.handleUnauthorized(); return null; }
             if (!response.ok) {
-                Notifications.show('POST ' + path + ' failed: ' + response.status, 'error');
+                self._reportFailure('POST', path, response.status);
                 return null;
             }
             return response.text().then(function(text) {
@@ -95,7 +113,7 @@ window.RestClient = {
         };
         return fetch(path, opts).then(function(response) {
             if (!response.ok) {
-                Notifications.show('PUT ' + path + ' failed: ' + response.status, 'error');
+                self._reportFailure('PUT', path, response.status);
             }
             return response.ok;
         }).catch(function(e) {
@@ -112,7 +130,7 @@ window.RestClient = {
         var self = this;
         return fetch(path, { method: 'DELETE', headers: self.getHeaders() }).then(function(response) {
             if (!response.ok) {
-                Notifications.show('DELETE ' + path + ' failed: ' + response.status, 'error');
+                self._reportFailure('DELETE', path, response.status);
             }
             return response.ok;
         }).catch(function(e) {

--- a/aether/dashboard/src/main/resources/dashboard/js/stores/alerts.js
+++ b/aether/dashboard/src/main/resources/dashboard/js/stores/alerts.js
@@ -4,16 +4,20 @@ document.addEventListener('alpine:init', function() {
         history: [],
         thresholds: [],
 
-        updateFromWs(data) {
-            if (data.type === 'ALERT') {
-                this.active.push(data);
-            } else if (data.type === 'ALERT_RESOLVED') {
-                var metric = data.metric;
-                var nodeId = data.nodeId;
+        // #292: the WS envelope discriminator lives at the TOP level only (`{"type":"ALERT","data":{...}}`,
+        // AlertManager.buildAlertMessage) — never duplicated inside `data`. This handler is passed the raw,
+        // still-wrapped envelope (see app.js onWsMessage) and reads `type` there, not on the unwrapped payload.
+        updateFromWs(envelope) {
+            var payload = envelope.data || envelope;
+            if (envelope.type === 'ALERT') {
+                this.active.push(payload);
+            } else if (envelope.type === 'ALERT_RESOLVED') {
+                var metric = payload.metric;
+                var nodeId = payload.nodeId;
                 this.active = this.active.filter(function(a) {
                     return !(a.metric === metric && a.nodeId === nodeId);
                 });
-                this.history.unshift(data);
+                this.history.unshift(payload);
             }
         },
 

--- a/aether/dashboard/src/main/resources/dashboard/js/stores/cluster.js
+++ b/aether/dashboard/src/main/resources/dashboard/js/stores/cluster.js
@@ -21,14 +21,36 @@ document.addEventListener('alpine:init', function() {
         // RestClient suppresses the resulting network-error toasts (see rest-client.js).
         healthUnknown: false,
         _lastUnknownRetryAt: 0,
+        _lastHealthProbeRetryAt: 0,
 
-        // Shared throttle so every poll timer (app.js's two, requests.js's own) agrees on when the
-        // next attempt during an unknown-health outage is due, rather than each independently
-        // retrying at its own cadence and recreating the storm this state exists to avoid.
+        // Shared throttle for the DATA-poll timers only (app.js's secondary timer and its primary
+        // timer's post-checkHealth batch, requests.js's own) so they agree on one slow retry cadence
+        // during an unknown-health outage instead of each independently hammering a dead backend.
+        // Deliberately NOT used to gate the health re-probe itself (see healthProbeRetryDue below):
+        // this is a read-and-consume throttle, so whichever timer's tick calls it first in a window
+        // wins the slot and the others skip that tick — fine for data staleness, but when the
+        // primary timer's checkHealth() call shared this same slot (#846 review), a different
+        // timer winning the slot first could make checkHealth() skip an entire cycle, pushing
+        // recovery detection past the intended 10s bound by an amount that depended on interval
+        // drift between the timers.
         unknownRetryDue() {
             var now = Date.now();
             if (!this._lastUnknownRetryAt || now - this._lastUnknownRetryAt >= 10000) {
                 this._lastUnknownRetryAt = now;
+                return true;
+            }
+            return false;
+        },
+
+        // Dedicated to the health re-probe (app.js's primary timer's checkHealth() call) alone.
+        // No other timer reads or consumes this throttle, so the re-probe fires on a fixed ~10s
+        // cadence regardless of what the data-poll timers above are doing in the same window —
+        // giving recovery detection a fixed bound instead of one that depends on which timer's
+        // tick happens to consume unknownRetryDue()'s shared slot first.
+        healthProbeRetryDue() {
+            var now = Date.now();
+            if (!this._lastHealthProbeRetryAt || now - this._lastHealthProbeRetryAt >= 10000) {
+                this._lastHealthProbeRetryAt = now;
                 return true;
             }
             return false;

--- a/aether/dashboard/src/main/resources/dashboard/js/stores/cluster.js
+++ b/aether/dashboard/src/main/resources/dashboard/js/stores/cluster.js
@@ -4,6 +4,9 @@ document.addEventListener('alpine:init', function() {
         leaderId: '',
         targetClusterSize: 0,
         healthy: true,
+        // #294: never fabricate a degraded verdict before the first /health probe returns —
+        // only app.js's checkHealth() flips this, and only when a response actually reports status.
+        degraded: false,
         uptimeSeconds: 0,
         controllerConfig: null,
         ttmStatus: 'DISABLED',

--- a/aether/dashboard/src/main/resources/dashboard/js/stores/cluster.js
+++ b/aether/dashboard/src/main/resources/dashboard/js/stores/cluster.js
@@ -4,8 +4,10 @@ document.addEventListener('alpine:init', function() {
         leaderId: '',
         targetClusterSize: 0,
         healthy: true,
-        // #294: never fabricate a degraded verdict before the first /health probe returns —
-        // only app.js's checkHealth() flips this, and only when a response actually reports status.
+        // #294: never fabricate a degraded verdict before the first health probe returns — only
+        // app.js's checkHealth() flips this, and it fails OPEN to false whenever a probe reports
+        // healthy OR whenever neither health path answers at all; only an explicit "unhealthy"
+        // status sets this true.
         degraded: false,
         uptimeSeconds: 0,
         controllerConfig: null,

--- a/aether/dashboard/src/main/resources/dashboard/js/stores/cluster.js
+++ b/aether/dashboard/src/main/resources/dashboard/js/stores/cluster.js
@@ -5,10 +5,34 @@ document.addEventListener('alpine:init', function() {
         targetClusterSize: 0,
         healthy: true,
         // #294: never fabricate a degraded verdict before the first health probe returns — only
-        // app.js's checkHealth() flips this, and it fails OPEN to false whenever a probe reports
-        // healthy OR whenever neither health path answers at all; only an explicit "unhealthy"
-        // status sets this true.
+        // app.js's checkHealth() flips this. `degraded` means an explicit "unhealthy" status was
+        // RECEIVED; a probe that answers with a 404 (reachable, no health route here) fails OPEN
+        // and never touches this. See `healthUnknown` below for the third state: a probe that could
+        // not reach the server at all leaves `degraded` exactly as it was.
         degraded: false,
+        // #294 (three-state health gate, corrected after #846 review): distinct from `degraded`.
+        // Set true only when BOTH health paths fail with a network-level error (refused, timeout) —
+        // the server could not be reached at all, as opposed to being reached and found unhealthy,
+        // or reached and found to have no health route (both of those are `degraded`/false, never
+        // this). checkHealth() never overwrites a prior `degraded=true` when this is set — an
+        // outage on top of a known-degraded cluster must not read back as "healthy". Cleared the
+        // moment either probe answers anything, even a 404. While true, pollers back off to a slow
+        // 10s retry via `unknownRetryDue()` instead of hammering a dead backend at full cadence, and
+        // RestClient suppresses the resulting network-error toasts (see rest-client.js).
+        healthUnknown: false,
+        _lastUnknownRetryAt: 0,
+
+        // Shared throttle so every poll timer (app.js's two, requests.js's own) agrees on when the
+        // next attempt during an unknown-health outage is due, rather than each independently
+        // retrying at its own cadence and recreating the storm this state exists to avoid.
+        unknownRetryDue() {
+            var now = Date.now();
+            if (!this._lastUnknownRetryAt || now - this._lastUnknownRetryAt >= 10000) {
+                this._lastUnknownRetryAt = now;
+                return true;
+            }
+            return false;
+        },
         uptimeSeconds: 0,
         controllerConfig: null,
         ttmStatus: 'DISABLED',

--- a/aether/dashboard/src/main/resources/dashboard/js/stores/events.js
+++ b/aether/dashboard/src/main/resources/dashboard/js/stores/events.js
@@ -11,6 +11,9 @@ document.addEventListener('alpine:init', function() {
             if (event.at && typeof event.at.packed === 'number') {
                 return Math.floor(event.at.packed / 65536);
             }
+            // Neither `at` nor `timestamp` present collapses eventKey() to a constant "0:TYPE" for
+            // every event of that type — an honest limit, not a bug: no known payload shape reaches
+            // this branch today, so it has never needed a real fallback.
             return event.timestamp || 0;
         },
 

--- a/aether/dashboard/src/main/resources/dashboard/js/stores/events.js
+++ b/aether/dashboard/src/main/resources/dashboard/js/stores/events.js
@@ -4,13 +4,26 @@ document.addEventListener('alpine:init', function() {
         maxEvents: 200,
         severityFilter: 'ALL',
 
+        // #304: node-mode ClusterEventView carries its HLC time under `at` (packed physical-ms/counter,
+        // HlcTimestamp.pack), never `timestamp` — that field belongs to Forge-mode ForgeEvent only.
+        // These helpers read whichever the payload actually carries instead of assuming `timestamp`.
+        eventMillis(event) {
+            if (event.at && typeof event.at.packed === 'number') {
+                return Math.floor(event.at.packed / 65536);
+            }
+            return event.timestamp || 0;
+        },
+
+        eventKey(event) {
+            return this.eventMillis(event) + ':' + event.type;
+        },
+
         addEvents(events) {
             if (!Array.isArray(events)) return;
             var self = this;
             events.forEach(function(event) {
-                var exists = self.recent.some(function(e) {
-                    return e.timestamp === event.timestamp && e.type === event.type;
-                });
+                var key = self.eventKey(event);
+                var exists = self.recent.some(function(e) { return self.eventKey(e) === key; });
                 if (!exists) {
                     self.recent.unshift(event);
                 }

--- a/aether/dashboard/src/main/resources/dashboard/js/stores/requests.js
+++ b/aether/dashboard/src/main/resources/dashboard/js/stores/requests.js
@@ -56,8 +56,15 @@ document.addEventListener('alpine:init', function() {
             this.refreshAll();
             this.refreshTimer = setInterval(function() {
                 // #294: skip this tick while the cluster health probe reports not-healthy — don't
-                // hammer a degraded/unreachable backend every 3s.
-                if (Alpine.store('cluster').degraded) return;
+                // hammer a degraded backend every 3s.
+                var cluster = Alpine.store('cluster');
+                if (cluster.degraded) return;
+                // #294 (three states, corrected after #846 review): a genuinely UNREACHABLE server
+                // (network error on both health paths) backs this timer off to the same shared slow
+                // 10s retry as app.js's pollers, rather than continuing to hammer a dead backend
+                // every 3s — coordinated via cluster.unknownRetryDue() so only one timer's tick
+                // actually fires per outage window.
+                if (cluster.healthUnknown && !cluster.unknownRetryDue()) return;
                 self.refreshAll();
             }, 3000);
         },

--- a/aether/dashboard/src/main/resources/dashboard/js/stores/requests.js
+++ b/aether/dashboard/src/main/resources/dashboard/js/stores/requests.js
@@ -55,6 +55,9 @@ document.addEventListener('alpine:init', function() {
             var self = this;
             this.refreshAll();
             this.refreshTimer = setInterval(function() {
+                // #294: skip this tick while the cluster health probe reports not-healthy — don't
+                // hammer a degraded/unreachable backend every 3s.
+                if (Alpine.store('cluster').degraded) return;
                 self.refreshAll();
             }, 3000);
         },

--- a/aether/docs/architecture/12-management.md
+++ b/aether/docs/architecture/12-management.md
@@ -218,22 +218,25 @@ Every dashboard poll timer (status, events, alerts, requests, topology, schema, 
 rest of the secondary-store refreshes) is gated on a client-side `degraded` flag, checked
 on every tick:
 
-- The gate is refreshed by an ungated health probe (`GET /health`) that runs on every
-  primary-timer tick regardless of the current gate state, so the dashboard can detect
-  recovery as well as degradation. `degraded` is keyed semantically on
-  `status !== 'healthy'` — there is no literal `"degraded"` wire value in either health
-  shape. A missing or unreachable probe response leaves `degraded` at its last known
-  value; the dashboard never fabricates a health verdict from a failed fetch.
-- **`/health` is bare, not `/api/health` or `/api/v1/health`.** This is a deliberate,
-  narrow scope boundary, not a fix for the versioning gap below: it is the path Forge's
-  `StatusRoutes` actually serves, and what this dashboard is demonstrably run against
-  today. The real node's Management API has no bare `/health` route at all — only
-  `/api/v1/health`, `/health/live`, and `/health/ready` (see
-  [management-api.md](../reference/management-api.md)) — so against a real node this
-  probe 404s like every other dashboard call does today (see the versioning gap, below).
-  Forge's own `HealthResponse` is hardcoded to always report `"healthy"` and can never
-  signal degradation, an honest limit on this gate's real-world triggerability against
-  Forge.
+- The gate is refreshed by an ungated health probe that runs on every primary-timer tick
+  regardless of the current gate state, so the dashboard can detect recovery as well as
+  degradation. `degraded` is keyed semantically on `status !== 'healthy'` — there is no
+  literal `"degraded"` wire value in either health shape.
+- **The probe tries `GET /api/v1/health` first, falling back to bare `GET /health`.** The
+  versioned path is the only health route the real node's Management API serves — bare
+  `/health` does not exist there at all (only `/api/v1/health`, `/health/live`, and
+  `/health/ready`, see [management-api.md](../reference/management-api.md)). Bare `/health`
+  remains as the fallback because it's what Forge actually serves; Forge's own
+  `HealthResponse` is hardcoded to always report `"healthy"` and can never signal
+  degradation, an honest limit on this gate's real-world triggerability against Forge.
+  Probing versioned-first (rather than bare-only, the original cut of this fix) is what
+  makes the gate actually engage against a real node — bare-only meant every probe 404'd
+  there and the gate silently never left its default.
+- **A probe failure (neither path answers) fails open to healthy, never wedges on
+  `degraded = true`.** Unknown health is not the same claim as degraded health: treating
+  the two as one would let a target that answers neither health path permanently gate off
+  every other poll, since the very probe meant to detect recovery could never itself
+  succeed. The failure is warned once per session, not re-logged on every tick.
 - **A 404 from an endpoint the server has no route for is logged once per endpoint, not
   toasted on every tick.** Every other failure status (5xx, network error) still toasts
   on every occurrence — this is a narrow carve-out for the specific, expected case of
@@ -242,9 +245,9 @@ on every tick:
 
 **Known gap, out of scope here (tracked in #300):** the dashboard and Forge speak the
 unversioned `/api/...` convention throughout, while the real node's Management API has
-already migrated most routes to `/api/v1/...` (`ManagementRoute`). This predates and is
-independent of the polling-gate work above; closing it requires updating every dashboard
-REST call, not just the health probe.
+already migrated most routes to `/api/v1/...` (`ManagementRoute`). The health probe above
+now bridges this for `/health` specifically; every other dashboard REST call still needs
+updating to close the gap fully.
 
 ## E2E Testing
 

--- a/aether/docs/architecture/12-management.md
+++ b/aether/docs/architecture/12-management.md
@@ -216,7 +216,9 @@ events, `timestamp` for Forge-mode events), never assumed to be one or the other
 
 Every dashboard poll timer (status, events, alerts, requests, topology, schema, and the
 rest of the secondary-store refreshes) is gated on a client-side `degraded` flag, checked
-on every tick:
+on every tick. The gate tracks three states, not two — `healthy`, `degraded`, and
+`unknown` — because a probe that fails to answer at all is a materially different claim
+from a probe that answers and reports trouble:
 
 - The gate is refreshed by an ungated health probe that runs on every primary-timer tick
   regardless of the current gate state, so the dashboard can detect recovery as well as
@@ -231,17 +233,38 @@ on every tick:
   degradation, an honest limit on this gate's real-world triggerability against Forge.
   Probing versioned-first (rather than bare-only, the original cut of this fix) is what
   makes the gate actually engage against a real node — bare-only meant every probe 404'd
-  there and the gate silently never left its default.
-- **A probe failure (neither path answers) fails open to healthy, never wedges on
-  `degraded = true`.** Unknown health is not the same claim as degraded health: treating
-  the two as one would let a target that answers neither health path permanently gate off
-  every other poll, since the very probe meant to detect recovery could never itself
-  succeed. The failure is warned once per session, not re-logged on every tick.
+  there and the gate silently never left its default. The probe itself
+  (`RestClient.probeHealth()`) is a dedicated method distinct from the shared
+  `RestClient.get()`: it reports reachability separately from the parsed body, and never
+  toasts on any outcome.
+- **A probe that answers, but with no usable health payload — a 404 on both paths — fails
+  open to `healthy`, never to `degraded`.** The server is reachable, it just doesn't
+  implement a health route here; that is not evidence of trouble.
+- **A probe that fails to answer at all on BOTH paths (connection refused, timeout — a
+  fetch-level exception, not an HTTP response) is `unknown`, a state distinct from both
+  `healthy` and `degraded`.** Collapsing "unreachable" into the same fail-open as "reachable,
+  no route" was tried first and found to be a BLOCKING defect: `RestClient.get()`'s shared
+  error handling returns an identical `null` for a 404 and for a network exception, so a
+  total backend outage looked exactly like a harmless missing route, the gate cleared, and
+  every other poller resumed hammering the dead backend every 2-3s with network-error
+  toasts the 404 suppression never covered — reintroducing this document's own toast-storm
+  problem in the worst case, an outage. `unknown` fixes this by construction: the pure
+  `decideHealthState()` function's unreachable branch returns `{unknown: true}` with no
+  `degraded` key at all, so a prior `degraded = true` verdict is never overwritten by an
+  outage — a total outage on top of a known-degraded cluster must not read back as healthy.
+  `unknown` clears the moment either probe answers anything, even a 404. While unknown,
+  every poll timer (all three in this document, plus `checkHealth()` itself) backs off to a
+  shared slow 10s retry cadence via `cluster.unknownRetryDue()`, instead of continuing to
+  retry every 2-3s. `RestClient` routes every network-exception `.catch()` through
+  `_reportNetworkFailure()`, which suppresses the toast (warning once instead, mirroring the
+  404 handling below) for as long as `healthUnknown` stays true; a genuine, isolated network
+  blip while the server is otherwise known-reachable still toasts normally, since the
+  suppression is conditioned on cluster state, not on the error itself.
 - **A 404 from an endpoint the server has no route for is logged once per endpoint, not
-  toasted on every tick.** Every other failure status (5xx, network error) still toasts
-  on every occurrence — this is a narrow carve-out for the specific, expected case of
-  polling an endpoint the target server doesn't implement, not general failure
-  suppression.
+  toasted on every tick.** Every other failure status (5xx, or a network error while the
+  server is otherwise known-reachable) still toasts on every occurrence — this is a narrow
+  carve-out for the specific, expected case of polling an endpoint the target server
+  doesn't implement, not general failure suppression.
 
 **Known gap, out of scope here (tracked in #300):** the dashboard and Forge speak the
 unversioned `/api/...` convention throughout, while the real node's Management API has

--- a/aether/docs/architecture/12-management.md
+++ b/aether/docs/architecture/12-management.md
@@ -192,6 +192,60 @@ graph TB
 - Throughput and latency per slice method
 - Success/failure rates
 
+### Alert Delivery
+
+Alerts reach the dashboard two ways, and both must agree on the wire shape:
+
+- **WebSocket push.** `AlertManager` broadcasts `{"type":"ALERT","data":{...}}` (or
+  `ALERT_RESOLVED`) over `/ws/dashboard` — the discriminator lives at the top level only,
+  never duplicated inside `data`. The client dispatches the whole envelope to the alerts
+  store and reads `type` there, not on an already-unwrapped payload.
+- **REST poll fallback.** The alerts store is also refreshed from the same gated
+  2-second poll timer that drives cluster status and events, so a missed or dropped WS
+  message self-heals within one poll cycle rather than leaving the panel stale until the
+  next alert fires.
+
+### Live Event Feed
+
+`ClusterEventView` carries its Hybrid Logical Clock time under `at` (packed
+physical-ms/counter), never `timestamp` — the dashboard's event dedup/display key is
+computed from whichever time field the payload actually carries (`at` for node-mode
+events, `timestamp` for Forge-mode events), never assumed to be one or the other.
+
+### Polling Behavior Under Degraded Health
+
+Every dashboard poll timer (status, events, alerts, requests, topology, schema, and the
+rest of the secondary-store refreshes) is gated on a client-side `degraded` flag, checked
+on every tick:
+
+- The gate is refreshed by an ungated health probe (`GET /health`) that runs on every
+  primary-timer tick regardless of the current gate state, so the dashboard can detect
+  recovery as well as degradation. `degraded` is keyed semantically on
+  `status !== 'healthy'` — there is no literal `"degraded"` wire value in either health
+  shape. A missing or unreachable probe response leaves `degraded` at its last known
+  value; the dashboard never fabricates a health verdict from a failed fetch.
+- **`/health` is bare, not `/api/health` or `/api/v1/health`.** This is a deliberate,
+  narrow scope boundary, not a fix for the versioning gap below: it is the path Forge's
+  `StatusRoutes` actually serves, and what this dashboard is demonstrably run against
+  today. The real node's Management API has no bare `/health` route at all — only
+  `/api/v1/health`, `/health/live`, and `/health/ready` (see
+  [management-api.md](../reference/management-api.md)) — so against a real node this
+  probe 404s like every other dashboard call does today (see the versioning gap, below).
+  Forge's own `HealthResponse` is hardcoded to always report `"healthy"` and can never
+  signal degradation, an honest limit on this gate's real-world triggerability against
+  Forge.
+- **A 404 from an endpoint the server has no route for is logged once per endpoint, not
+  toasted on every tick.** Every other failure status (5xx, network error) still toasts
+  on every occurrence — this is a narrow carve-out for the specific, expected case of
+  polling an endpoint the target server doesn't implement, not general failure
+  suppression.
+
+**Known gap, out of scope here (tracked in #300):** the dashboard and Forge speak the
+unversioned `/api/...` convention throughout, while the real node's Management API has
+already migrated most routes to `/api/v1/...` (`ManagementRoute`). This predates and is
+independent of the polling-gate work above; closing it requires updating every dashboard
+REST call, not just the health probe.
+
 ## E2E Testing
 
 Testing is split across three layers:

--- a/aether/node/src/test/java/org/pragmatica/aether/api/AlertWsEnvelopeContractTest.java
+++ b/aether/node/src/test/java/org/pragmatica/aether/api/AlertWsEnvelopeContractTest.java
@@ -121,12 +121,28 @@ class AlertWsEnvelopeContractTest {
     }
 
     /// #292 fix, "alerts included in the poll fallback" (CTO scope ruling): the alerts store must be
-    /// refreshed from the same gated poll loop that drives events/status, not left WS-only.
+    /// refreshed from the same gated REPEATING poll timer that drives events/status, not left WS-only.
+    ///
+    /// Scoped to `startPolling()`'s own body, not the whole file: `loadInitialData()` already calls
+    /// `Alpine.store('alerts').refresh()` exactly once, on page load — that pre-existing call would
+    /// make a whole-file `contains` check pass vacuously whether or not the repeating timer was ever
+    /// touched, and self-healing after a missed/dropped WS message is exactly what a one-time
+    /// initial-load call cannot provide.
     @Test
-    void appJs_pollFallback_refreshesAlertsStore() {
+    void appJs_startPolling_refreshesAlertsStoreOnTheRepeatingTimer_notOnlyOnce() {
         var appJs = resource("/dashboard/js/app.js");
+        var start = appJs.indexOf("startPolling() {");
+        var end = appJs.indexOf("async pollStatus() {", start);
 
-        assertThat(appJs).contains("Alpine.store('alerts').refresh()");
+        assertThat(start).as("startPolling() must exist in app.js").isNotNegative();
+        assertThat(end).as("pollStatus() must follow startPolling() so its body is boundable").isGreaterThan(start);
+
+        var startPollingBody = appJs.substring(start, end);
+
+        assertThat(startPollingBody)
+                .as("alerts must be refreshed from the REPEATING poll timer inside startPolling(), not only "
+                    + "once from loadInitialData()")
+                .contains("Alpine.store('alerts').refresh()");
     }
 
     /// #292 fix, half 2: `alerts.js` must read the discriminator off the still-wrapped envelope

--- a/aether/node/src/test/java/org/pragmatica/aether/api/AlertWsEnvelopeContractTest.java
+++ b/aether/node/src/test/java/org/pragmatica/aether/api/AlertWsEnvelopeContractTest.java
@@ -9,9 +9,6 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.function.BiConsumer;
 
-import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
-
 import org.pragmatica.aether.slice.kvstore.AetherKey;
 import org.pragmatica.aether.slice.kvstore.AetherKey.AlertThresholdKey;
 import org.pragmatica.aether.slice.kvstore.AetherValue;
@@ -23,9 +20,13 @@ import org.pragmatica.lang.NullReturn;
 import org.pragmatica.lang.Result;
 import org.pragmatica.lang.utils.Causes;
 
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+
 
 /// Pins the wire contract behind #292 (live alerts never render): the WS envelope
 /// `AlertManager.buildAlertMessage` produces is `{"type":"ALERT","timestamp":…,"data":{…}}` — the
@@ -55,12 +56,17 @@ class AlertWsEnvelopeContractTest {
         var kvStore = (KVStore<AetherKey, AetherValue>) Mockito.mock(KVStore.class);
 
         Mockito.doAnswer(invocation -> {
-                    BiConsumer<AlertThresholdKey, AlertThresholdValue> consumer = invocation.getArgument(2);
-                    consumer.accept(new AlertThresholdKey(metric), AlertThresholdValue.alertThresholdValue(metric, warning, critical));
-                    return null;
-                })
-                .when(kvStore)
-                .forEach(eq(AlertThresholdKey.class), eq(AlertThresholdValue.class), any());
+                             BiConsumer<AlertThresholdKey, AlertThresholdValue> consumer = invocation.getArgument(2);
+
+                             consumer.accept(new AlertThresholdKey(metric),
+                                             AlertThresholdValue.alertThresholdValue(metric, warning, critical));
+
+                             return null;
+                         })
+               .when(kvStore)
+               .forEach(eq(AlertThresholdKey.class),
+                        eq(AlertThresholdValue.class),
+                        any());
 
         return AlertManager.readOnly(kvStore);
     }
@@ -70,6 +76,7 @@ class AlertWsEnvelopeContractTest {
             if (in == null) {
                 return Result.failure(Causes.cause("Dashboard resource not found on classpath: " + path));
             }
+
             return Result.success(new String(in.readAllBytes(), StandardCharsets.UTF_8));
         } catch (IOException e) {
             return Result.failure(Causes.fromThrowable(e));
@@ -79,24 +86,21 @@ class AlertWsEnvelopeContractTest {
     @Test
     void checkThreshold_valueAboveCritical_returnsEnvelopeWithTopLevelTypeAndUnwrappedData() {
         var manager = managerWithThreshold("cpu.usage", 0.7, 0.9);
-
-        var json = manager.checkThreshold("cpu.usage", new NodeId("node-1"), 0.95)
-                          .or("");
+        var json = manager.checkThreshold("cpu.usage", new NodeId("node-1"), 0.95).or("");
 
         assertThat(json).as("a value above the critical threshold must produce an alert message").isNotEmpty();
-
         var parsed = MAPPER.readTree(json);
 
         assertThat(parsed.isSuccess()).as("alert message must be valid JSON").isTrue();
-
         parsed.onSuccess(tree -> {
-            assertThat(tree.has("type")).as("discriminator must live at the top level").isTrue();
+            assertThat(tree.has("type")).as("discriminator must live at the top level")
+                      .isTrue();
             assertThat(tree.get("type").asString()).isEqualTo("ALERT");
             assertThat(tree.has("data")).isTrue();
-
             var data = tree.get("data");
 
-            assertThat(data.has("type")).as("'type' must never be duplicated inside 'data'").isFalse();
+            assertThat(data.has("type")).as("'type' must never be duplicated inside 'data'")
+                      .isFalse();
             assertThat(data.get("metric").asString()).isEqualTo("cpu.usage");
             assertThat(data.get("nodeId").asString()).isEqualTo("node-1");
             assertThat(data.get("severity").asString()).isEqualTo("CRITICAL");
@@ -106,9 +110,7 @@ class AlertWsEnvelopeContractTest {
     @Test
     void checkThreshold_valueBelowWarning_returnsEmpty() {
         var manager = managerWithThreshold("cpu.usage", 0.7, 0.9);
-
-        var json = manager.checkThreshold("cpu.usage", new NodeId("node-1"), 0.1)
-                          .or("");
+        var json = manager.checkThreshold("cpu.usage", new NodeId("node-1"), 0.1).or("");
 
         assertThat(json).as("a value below every threshold must trigger no alert").isEmpty();
     }
@@ -119,11 +121,10 @@ class AlertWsEnvelopeContractTest {
     void appJs_dispatchesWholeEnvelopeToAlertsStore_notUnwrappedPayload() {
         var appJs = resource("/dashboard/js/app.js").unwrap();
 
-        assertThat(appJs)
-                .as("app.js must pass the whole ALERT/ALERT_RESOLVED envelope to the alerts store")
-                .contains("Alpine.store('alerts').updateFromWs(data);")
-                .as("the old unwrap-before-dispatch must be gone")
-                .doesNotContain("Alpine.store('alerts').updateFromWs(data.data || data);");
+        assertThat(appJs).as("app.js must pass the whole ALERT/ALERT_RESOLVED envelope to the alerts store")
+                  .contains("Alpine.store('alerts').updateFromWs(data);")
+                  .as("the old unwrap-before-dispatch must be gone")
+                  .doesNotContain("Alpine.store('alerts').updateFromWs(data.data || data);");
     }
 
     /// #292 fix, "alerts included in the poll fallback" (CTO scope ruling): the alerts store must be
@@ -142,13 +143,11 @@ class AlertWsEnvelopeContractTest {
 
         assertThat(start).as("startPolling() must exist in app.js").isNotNegative();
         assertThat(end).as("pollStatus() must follow startPolling() so its body is boundable").isGreaterThan(start);
-
         var startPollingBody = appJs.substring(start, end);
 
-        assertThat(startPollingBody)
-                .as("alerts must be refreshed from the REPEATING poll timer inside startPolling(), not only "
-                    + "once from loadInitialData()")
-                .contains("Alpine.store('alerts').refresh()");
+        assertThat(startPollingBody).as("alerts must be refreshed from the REPEATING poll timer inside startPolling(), not only "
+                                       + "once from loadInitialData()")
+                  .contains("Alpine.store('alerts').refresh()");
     }
 
     /// #292 fix, half 2: `alerts.js` must read the discriminator off the still-wrapped envelope
@@ -159,10 +158,9 @@ class AlertWsEnvelopeContractTest {
     void alertsJs_readsDiscriminatorOnTheEnvelope_notOnTheUnwrappedPayload() {
         var alertsJs = resource("/dashboard/js/stores/alerts.js").unwrap();
 
-        assertThat(alertsJs)
-                .as("alerts.js must check the envelope-level discriminator")
-                .contains("envelope.type === 'ALERT'")
-                .as("the old payload-level check must be gone")
-                .doesNotContain("data.type === 'ALERT'");
+        assertThat(alertsJs).as("alerts.js must check the envelope-level discriminator")
+                  .contains("envelope.type === 'ALERT'")
+                  .as("the old payload-level check must be gone")
+                  .doesNotContain("data.type === 'ALERT'");
     }
 }

--- a/aether/node/src/test/java/org/pragmatica/aether/api/AlertWsEnvelopeContractTest.java
+++ b/aether/node/src/test/java/org/pragmatica/aether/api/AlertWsEnvelopeContractTest.java
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2025 Pragmatica Labs - Sergiy Yevtushenko
+// Licensed under Business Source License 1.1. Change Date: 2030-01-01. Change License: Apache-2.0.
+// See LICENSE in the repository root for full terms.
+package org.pragmatica.aether.api;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.util.function.BiConsumer;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import org.pragmatica.aether.slice.kvstore.AetherKey;
+import org.pragmatica.aether.slice.kvstore.AetherKey.AlertThresholdKey;
+import org.pragmatica.aether.slice.kvstore.AetherValue;
+import org.pragmatica.aether.slice.kvstore.AetherValue.AlertThresholdValue;
+import org.pragmatica.cluster.state.kvstore.KVStore;
+import org.pragmatica.consensus.NodeId;
+import org.pragmatica.json.JsonMapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+
+/// Pins the wire contract behind #292 (live alerts never render): the WS envelope
+/// `AlertManager.buildAlertMessage` produces is `{"type":"ALERT","timestamp":…,"data":{…}}` — the
+/// discriminator lives ONLY at the top level, never duplicated inside `data`
+/// (`DashboardMetricsPublisher.checkAndBroadcastAlerts` broadcasts `checkThreshold`'s return value
+/// verbatim, so this IS the wire message, not a stand-in for it).
+///
+/// The pre-fix client bug was two-sided and both sides are pinned here as JS-source-text
+/// assertions, since neither `app.js` nor `alerts.js` has a Java-side seam to exercise directly:
+///   - `app.js` unwrapped the envelope before dispatch (`data.data || data`), so the handler that
+///     reads `type` never saw it.
+///   - `alerts.js` then read `data.type === 'ALERT'` on that already-unwrapped payload, which never
+///     carries a `type` field — so the check was always false and nothing rendered.
+///
+/// `ALERT_RESOLVED` (`AlertManager.broadcastAlertResolved`) is a private, directly-broadcasting
+/// method with no return-value seam — its envelope shape is confirmed by source inspection only
+/// (`[design intent — unverified]` in the changelog fragment), not executed here.
+class AlertWsEnvelopeContractTest {
+    private static final JsonMapper MAPPER = JsonMapper.defaultJsonMapper();
+
+    @SuppressWarnings("unchecked")
+    private static AlertManager managerWithThreshold(String metric, double warning, double critical) {
+        var kvStore = (KVStore<AetherKey, AetherValue>) Mockito.mock(KVStore.class);
+
+        Mockito.doAnswer(invocation -> {
+                    BiConsumer<AlertThresholdKey, AlertThresholdValue> consumer = invocation.getArgument(2);
+                    consumer.accept(new AlertThresholdKey(metric), AlertThresholdValue.alertThresholdValue(metric, warning, critical));
+                    return null;
+                })
+                .when(kvStore)
+                .forEach(eq(AlertThresholdKey.class), eq(AlertThresholdValue.class), any());
+
+        return AlertManager.readOnly(kvStore);
+    }
+
+    private static String resource(String path) {
+        try (InputStream in = AlertWsEnvelopeContractTest.class.getResourceAsStream(path)) {
+            if (in == null) {
+                throw new IllegalStateException("Dashboard resource not found on classpath: " + path);
+            }
+            return new String(in.readAllBytes(), StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    @Test
+    void checkThreshold_valueAboveCritical_returnsEnvelopeWithTopLevelTypeAndUnwrappedData() {
+        var manager = managerWithThreshold("cpu.usage", 0.7, 0.9);
+
+        var json = manager.checkThreshold("cpu.usage", new NodeId("node-1"), 0.95)
+                          .or("");
+
+        assertThat(json).as("a value above the critical threshold must produce an alert message").isNotEmpty();
+
+        var parsed = MAPPER.readTree(json);
+
+        assertThat(parsed.isSuccess()).as("alert message must be valid JSON").isTrue();
+
+        parsed.onSuccess(tree -> {
+            assertThat(tree.has("type")).as("discriminator must live at the top level").isTrue();
+            assertThat(tree.get("type").asString()).isEqualTo("ALERT");
+            assertThat(tree.has("data")).isTrue();
+
+            var data = tree.get("data");
+
+            assertThat(data.has("type")).as("'type' must never be duplicated inside 'data'").isFalse();
+            assertThat(data.get("metric").asString()).isEqualTo("cpu.usage");
+            assertThat(data.get("nodeId").asString()).isEqualTo("node-1");
+            assertThat(data.get("severity").asString()).isEqualTo("CRITICAL");
+        });
+    }
+
+    @Test
+    void checkThreshold_valueBelowWarning_returnsEmpty() {
+        var manager = managerWithThreshold("cpu.usage", 0.7, 0.9);
+
+        var json = manager.checkThreshold("cpu.usage", new NodeId("node-1"), 0.1)
+                          .or("");
+
+        assertThat(json).as("a value below every threshold must trigger no alert").isEmpty();
+    }
+
+    /// #292 fix, half 1: `onWsMessage` must forward the WHOLE envelope to the alerts store, not the
+    /// unwrapped `data.data || data` payload — the store is what needs to read `type`.
+    @Test
+    void appJs_dispatchesWholeEnvelopeToAlertsStore_notUnwrappedPayload() {
+        var appJs = resource("/dashboard/js/app.js");
+
+        assertThat(appJs)
+                .as("app.js must pass the whole ALERT/ALERT_RESOLVED envelope to the alerts store")
+                .contains("Alpine.store('alerts').updateFromWs(data);")
+                .as("the old unwrap-before-dispatch must be gone")
+                .doesNotContain("Alpine.store('alerts').updateFromWs(data.data || data);");
+    }
+
+    /// #292 fix, "alerts included in the poll fallback" (CTO scope ruling): the alerts store must be
+    /// refreshed from the same gated poll loop that drives events/status, not left WS-only.
+    @Test
+    void appJs_pollFallback_refreshesAlertsStore() {
+        var appJs = resource("/dashboard/js/app.js");
+
+        assertThat(appJs).contains("Alpine.store('alerts').refresh()");
+    }
+
+    /// #292 fix, half 2: `alerts.js` must read the discriminator off the still-wrapped envelope
+    /// (`envelope.type`), not off the unwrapped payload (`data.type`) — the two halves of this test
+    /// class exist because the bug required both a client-dispatch fix and a store-handler fix; either
+    /// alone leaves alerts un-rendered.
+    @Test
+    void alertsJs_readsDiscriminatorOnTheEnvelope_notOnTheUnwrappedPayload() {
+        var alertsJs = resource("/dashboard/js/stores/alerts.js");
+
+        assertThat(alertsJs)
+                .as("alerts.js must check the envelope-level discriminator")
+                .contains("envelope.type === 'ALERT'")
+                .as("the old payload-level check must be gone")
+                .doesNotContain("data.type === 'ALERT'");
+    }
+}

--- a/aether/node/src/test/java/org/pragmatica/aether/api/AlertWsEnvelopeContractTest.java
+++ b/aether/node/src/test/java/org/pragmatica/aether/api/AlertWsEnvelopeContractTest.java
@@ -6,7 +6,6 @@ package org.pragmatica.aether.api;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.util.function.BiConsumer;
 
@@ -20,6 +19,9 @@ import org.pragmatica.aether.slice.kvstore.AetherValue.AlertThresholdValue;
 import org.pragmatica.cluster.state.kvstore.KVStore;
 import org.pragmatica.consensus.NodeId;
 import org.pragmatica.json.JsonMapper;
+import org.pragmatica.lang.NullReturn;
+import org.pragmatica.lang.Result;
+import org.pragmatica.lang.utils.Causes;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -44,6 +46,10 @@ import static org.mockito.ArgumentMatchers.eq;
 class AlertWsEnvelopeContractTest {
     private static final JsonMapper MAPPER = JsonMapper.defaultJsonMapper();
 
+    // The `return null` below is Mockito's own `Answer` contract for a void-returning stubbed
+    // method (`KVStore.forEach`), not a null this test's code chooses to return —
+    // `managerWithThreshold` itself always returns `AlertManager.readOnly(kvStore)`.
+    @NullReturn
     @SuppressWarnings("unchecked")
     private static AlertManager managerWithThreshold(String metric, double warning, double critical) {
         var kvStore = (KVStore<AetherKey, AetherValue>) Mockito.mock(KVStore.class);
@@ -59,14 +65,14 @@ class AlertWsEnvelopeContractTest {
         return AlertManager.readOnly(kvStore);
     }
 
-    private static String resource(String path) {
+    private static Result<String> resource(String path) {
         try (InputStream in = AlertWsEnvelopeContractTest.class.getResourceAsStream(path)) {
             if (in == null) {
-                throw new IllegalStateException("Dashboard resource not found on classpath: " + path);
+                return Result.failure(Causes.cause("Dashboard resource not found on classpath: " + path));
             }
-            return new String(in.readAllBytes(), StandardCharsets.UTF_8);
+            return Result.success(new String(in.readAllBytes(), StandardCharsets.UTF_8));
         } catch (IOException e) {
-            throw new UncheckedIOException(e);
+            return Result.failure(Causes.fromThrowable(e));
         }
     }
 
@@ -111,7 +117,7 @@ class AlertWsEnvelopeContractTest {
     /// unwrapped `data.data || data` payload — the store is what needs to read `type`.
     @Test
     void appJs_dispatchesWholeEnvelopeToAlertsStore_notUnwrappedPayload() {
-        var appJs = resource("/dashboard/js/app.js");
+        var appJs = resource("/dashboard/js/app.js").unwrap();
 
         assertThat(appJs)
                 .as("app.js must pass the whole ALERT/ALERT_RESOLVED envelope to the alerts store")
@@ -130,7 +136,7 @@ class AlertWsEnvelopeContractTest {
     /// initial-load call cannot provide.
     @Test
     void appJs_startPolling_refreshesAlertsStoreOnTheRepeatingTimer_notOnlyOnce() {
-        var appJs = resource("/dashboard/js/app.js");
+        var appJs = resource("/dashboard/js/app.js").unwrap();
         var start = appJs.indexOf("startPolling() {");
         var end = appJs.indexOf("async pollStatus() {", start);
 
@@ -151,7 +157,7 @@ class AlertWsEnvelopeContractTest {
     /// alone leaves alerts un-rendered.
     @Test
     void alertsJs_readsDiscriminatorOnTheEnvelope_notOnTheUnwrappedPayload() {
-        var alertsJs = resource("/dashboard/js/stores/alerts.js");
+        var alertsJs = resource("/dashboard/js/stores/alerts.js").unwrap();
 
         assertThat(alertsJs)
                 .as("alerts.js must check the envelope-level discriminator")

--- a/aether/node/src/test/java/org/pragmatica/aether/api/ClusterEventKeyContractTest.java
+++ b/aether/node/src/test/java/org/pragmatica/aether/api/ClusterEventKeyContractTest.java
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2025 Pragmatica Labs - Sergiy Yevtushenko
+// Licensed under Business Source License 1.1. Change Date: 2030-01-01. Change License: Apache-2.0.
+// See LICENSE in the repository root for full terms.
+package org.pragmatica.aether.api;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import org.pragmatica.aether.api.ClusterEvent.Severity;
+import org.pragmatica.aether.api.ManagementApiResponses.ClusterEventView;
+import org.pragmatica.consensus.NodeId;
+import org.pragmatica.hlc.HlcTimestamp;
+import org.pragmatica.json.JsonMapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/// Pins the wire contract behind #304 (node-mode live events never key correctly): the server's
+/// `ClusterEventView` has always carried its HLC time under `at` — never `timestamp` — per its own
+/// doc comment, which predates the `type` discriminator. The client-side bug was an original wrong
+/// assumption, not a later rename: `events.js`/`index.html` read `event.timestamp`, a field this
+/// shape has never sent.
+///
+/// Trace-waterfall wiring (`trace-detail` component, loaded but never connected — `index.html:512-524`)
+/// is explicitly OUT of this PR per the CTO scope ruling; only the event-key fix is pinned here.
+class ClusterEventKeyContractTest {
+    private static final JsonMapper MAPPER = JsonMapper.defaultJsonMapper();
+
+    private static String resource(String path) {
+        try (InputStream in = ClusterEventKeyContractTest.class.getResourceAsStream(path)) {
+            if (in == null) {
+                throw new IllegalStateException("Dashboard resource not found on classpath: " + path);
+            }
+            return new String(in.readAllBytes(), StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    @Test
+    void clusterEventView_serializesAtField_neverTimestamp() {
+        var at = new HlcTimestamp(HlcTimestamp.pack(1_756_800_000_000L, 0), new NodeId("node-1"));
+        var view = new ClusterEventView("NODE_FAILED", at, Severity.WARNING, "node-1 failed", Map.of());
+
+        var written = MAPPER.writeAsString(view);
+
+        assertThat(written.isSuccess()).as("ClusterEventView must serialize").isTrue();
+
+        written.onSuccess(json -> {
+            var parsed = MAPPER.readTree(json);
+
+            parsed.onSuccess(tree -> {
+                assertThat(tree.has("at")).as("the HLC time field is named 'at' on the wire").isTrue();
+                assertThat(tree.has("timestamp")).as("'timestamp' has never been a field of this shape").isFalse();
+            });
+            assertThat(parsed.isSuccess()).isTrue();
+        });
+    }
+
+    /// Reflection guard against a future accidental rename in either direction — a compile-time
+    /// fact this record's shape has held since before the `type` discriminator was added.
+    @Test
+    void clusterEventView_recordComponents_nameTheTimeFieldAt_notTimestamp() {
+        var componentNames = java.util.Arrays.stream(ClusterEventView.class.getRecordComponents())
+                                              .map(java.lang.reflect.RecordComponent::getName)
+                                              .toList();
+
+        assertThat(componentNames).contains("at").doesNotContain("timestamp");
+    }
+
+    /// #304 fix: the dedup/display key must be computed from whichever time field the payload
+    /// actually carries (`at` for node-mode `ClusterEventView`, `timestamp` for Forge-mode
+    /// `ForgeEvent`) — never assume `timestamp` exists.
+    @Test
+    void eventsJs_computesKeyFromAtOrTimestamp_notTimestampAlone() {
+        var eventsJs = resource("/dashboard/js/stores/events.js");
+
+        assertThat(eventsJs)
+                .as("events.js must expose an eventKey/eventMillis helper reading either time field")
+                .contains("eventKey")
+                .contains("eventMillis")
+                .as("the old timestamp-only dedup check must be gone")
+                .doesNotContain("e.timestamp === event.timestamp && e.type === event.type");
+    }
+
+    @Test
+    void indexHtml_usesEventKeyHelper_andNeverReadsEventTimestampDirectly() {
+        var indexHtml = resource("/dashboard/index.html");
+
+        assertThat(indexHtml)
+                .as("the event list key must go through the store's key helper")
+                .contains(":key=\"$store.events.eventKey(event)\"")
+                .as("the event time display must go through the store's millis helper")
+                .contains("formatTime($store.events.eventMillis(event))")
+                .as("no template binding may read the nonexistent 'event.timestamp' field directly")
+                .doesNotContain("event.timestamp");
+    }
+}

--- a/aether/node/src/test/java/org/pragmatica/aether/api/ClusterEventKeyContractTest.java
+++ b/aether/node/src/test/java/org/pragmatica/aether/api/ClusterEventKeyContractTest.java
@@ -11,8 +11,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Map;
 
-import org.junit.jupiter.api.Test;
-
 import org.pragmatica.aether.api.ClusterEvent.Severity;
 import org.pragmatica.aether.api.ManagementApiResponses.ClusterEventView;
 import org.pragmatica.consensus.NodeId;
@@ -21,7 +19,10 @@ import org.pragmatica.json.JsonMapper;
 import org.pragmatica.lang.Result;
 import org.pragmatica.lang.utils.Causes;
 
+import org.junit.jupiter.api.Test;
+
 import static org.assertj.core.api.Assertions.assertThat;
+
 
 /// Pins the wire contract behind #304 (node-mode live events never key correctly): the server's
 /// `ClusterEventView` has always carried its HLC time under `at` — never `timestamp` — per its own
@@ -39,6 +40,7 @@ class ClusterEventKeyContractTest {
             if (in == null) {
                 return Result.failure(Causes.cause("Dashboard resource not found on classpath: " + path));
             }
+
             return Result.success(new String(in.readAllBytes(), StandardCharsets.UTF_8));
         } catch (IOException e) {
             return Result.failure(Causes.fromThrowable(e));
@@ -49,17 +51,17 @@ class ClusterEventKeyContractTest {
     void clusterEventView_serializesAtField_neverTimestamp() {
         var at = new HlcTimestamp(HlcTimestamp.pack(1_756_800_000_000L, 0), new NodeId("node-1"));
         var view = new ClusterEventView("NODE_FAILED", at, Severity.WARNING, "node-1 failed", Map.of());
-
         var written = MAPPER.writeAsString(view);
 
         assertThat(written.isSuccess()).as("ClusterEventView must serialize").isTrue();
-
         written.onSuccess(json -> {
             var parsed = MAPPER.readTree(json);
 
             parsed.onSuccess(tree -> {
-                assertThat(tree.has("at")).as("the HLC time field is named 'at' on the wire").isTrue();
-                assertThat(tree.has("timestamp")).as("'timestamp' has never been a field of this shape").isFalse();
+                assertThat(tree.has("at")).as("the HLC time field is named 'at' on the wire")
+                          .isTrue();
+                assertThat(tree.has("timestamp")).as("'timestamp' has never been a field of this shape")
+                          .isFalse();
             });
             assertThat(parsed.isSuccess()).isTrue();
         });
@@ -70,8 +72,8 @@ class ClusterEventKeyContractTest {
     @Test
     void clusterEventView_recordComponents_nameTheTimeFieldAt_notTimestamp() {
         var componentNames = Arrays.stream(ClusterEventView.class.getRecordComponents())
-                                    .map(RecordComponent::getName)
-                                    .toList();
+                                   .map(RecordComponent::getName)
+                                   .toList();
 
         assertThat(componentNames).contains("at").doesNotContain("timestamp");
     }
@@ -83,24 +85,22 @@ class ClusterEventKeyContractTest {
     void eventsJs_computesKeyFromAtOrTimestamp_notTimestampAlone() {
         var eventsJs = resource("/dashboard/js/stores/events.js").unwrap();
 
-        assertThat(eventsJs)
-                .as("events.js must expose an eventKey/eventMillis helper reading either time field")
-                .contains("eventKey")
-                .contains("eventMillis")
-                .as("the old timestamp-only dedup check must be gone")
-                .doesNotContain("e.timestamp === event.timestamp && e.type === event.type");
+        assertThat(eventsJs).as("events.js must expose an eventKey/eventMillis helper reading either time field")
+                  .contains("eventKey")
+                  .contains("eventMillis")
+                  .as("the old timestamp-only dedup check must be gone")
+                  .doesNotContain("e.timestamp === event.timestamp && e.type === event.type");
     }
 
     @Test
     void indexHtml_usesEventKeyHelper_andNeverReadsEventTimestampDirectly() {
         var indexHtml = resource("/dashboard/index.html").unwrap();
 
-        assertThat(indexHtml)
-                .as("the event list key must go through the store's key helper")
-                .contains(":key=\"$store.events.eventKey(event)\"")
-                .as("the event time display must go through the store's millis helper")
-                .contains("formatTime($store.events.eventMillis(event))")
-                .as("no template binding may read the nonexistent 'event.timestamp' field directly")
-                .doesNotContain("event.timestamp");
+        assertThat(indexHtml).as("the event list key must go through the store's key helper")
+                  .contains(":key=\"$store.events.eventKey(event)\"")
+                  .as("the event time display must go through the store's millis helper")
+                  .contains("formatTime($store.events.eventMillis(event))")
+                  .as("no template binding may read the nonexistent 'event.timestamp' field directly")
+                  .doesNotContain("event.timestamp");
     }
 }

--- a/aether/node/src/test/java/org/pragmatica/aether/api/ClusterEventKeyContractTest.java
+++ b/aether/node/src/test/java/org/pragmatica/aether/api/ClusterEventKeyContractTest.java
@@ -6,8 +6,9 @@ package org.pragmatica.aether.api;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.UncheckedIOException;
+import java.lang.reflect.RecordComponent;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.Map;
 
 import org.junit.jupiter.api.Test;
@@ -17,6 +18,8 @@ import org.pragmatica.aether.api.ManagementApiResponses.ClusterEventView;
 import org.pragmatica.consensus.NodeId;
 import org.pragmatica.hlc.HlcTimestamp;
 import org.pragmatica.json.JsonMapper;
+import org.pragmatica.lang.Result;
+import org.pragmatica.lang.utils.Causes;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -31,14 +34,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 class ClusterEventKeyContractTest {
     private static final JsonMapper MAPPER = JsonMapper.defaultJsonMapper();
 
-    private static String resource(String path) {
+    private static Result<String> resource(String path) {
         try (InputStream in = ClusterEventKeyContractTest.class.getResourceAsStream(path)) {
             if (in == null) {
-                throw new IllegalStateException("Dashboard resource not found on classpath: " + path);
+                return Result.failure(Causes.cause("Dashboard resource not found on classpath: " + path));
             }
-            return new String(in.readAllBytes(), StandardCharsets.UTF_8);
+            return Result.success(new String(in.readAllBytes(), StandardCharsets.UTF_8));
         } catch (IOException e) {
-            throw new UncheckedIOException(e);
+            return Result.failure(Causes.fromThrowable(e));
         }
     }
 
@@ -66,9 +69,9 @@ class ClusterEventKeyContractTest {
     /// fact this record's shape has held since before the `type` discriminator was added.
     @Test
     void clusterEventView_recordComponents_nameTheTimeFieldAt_notTimestamp() {
-        var componentNames = java.util.Arrays.stream(ClusterEventView.class.getRecordComponents())
-                                              .map(java.lang.reflect.RecordComponent::getName)
-                                              .toList();
+        var componentNames = Arrays.stream(ClusterEventView.class.getRecordComponents())
+                                    .map(RecordComponent::getName)
+                                    .toList();
 
         assertThat(componentNames).contains("at").doesNotContain("timestamp");
     }
@@ -78,7 +81,7 @@ class ClusterEventKeyContractTest {
     /// `ForgeEvent`) — never assume `timestamp` exists.
     @Test
     void eventsJs_computesKeyFromAtOrTimestamp_notTimestampAlone() {
-        var eventsJs = resource("/dashboard/js/stores/events.js");
+        var eventsJs = resource("/dashboard/js/stores/events.js").unwrap();
 
         assertThat(eventsJs)
                 .as("events.js must expose an eventKey/eventMillis helper reading either time field")
@@ -90,7 +93,7 @@ class ClusterEventKeyContractTest {
 
     @Test
     void indexHtml_usesEventKeyHelper_andNeverReadsEventTimestampDirectly() {
-        var indexHtml = resource("/dashboard/index.html");
+        var indexHtml = resource("/dashboard/index.html").unwrap();
 
         assertThat(indexHtml)
                 .as("the event list key must go through the store's key helper")

--- a/aether/node/src/test/java/org/pragmatica/aether/api/DashboardPollingGateContractTest.java
+++ b/aether/node/src/test/java/org/pragmatica/aether/api/DashboardPollingGateContractTest.java
@@ -9,12 +9,13 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.regex.Pattern;
 
-import org.junit.jupiter.api.Test;
-
 import org.pragmatica.lang.Result;
 import org.pragmatica.lang.utils.Causes;
 
+import org.junit.jupiter.api.Test;
+
 import static org.assertj.core.api.Assertions.assertThat;
+
 
 /// Pins the client-side polling gate behind #294 (polling is not gated to health): every poll to a
 /// server the operator's health check has already marked unhealthy should back off, and a 404 from an
@@ -45,6 +46,7 @@ class DashboardPollingGateContractTest {
             if (in == null) {
                 return Result.failure(Causes.cause("Dashboard resource not found on classpath: " + path));
             }
+
             return Result.success(new String(in.readAllBytes(), StandardCharsets.UTF_8));
         } catch (IOException e) {
             return Result.failure(Causes.fromThrowable(e));
@@ -53,29 +55,27 @@ class DashboardPollingGateContractTest {
 
     private static int occurrences(String haystack, String needle) {
         return (int) Pattern.compile(Pattern.quote(needle))
-                             .matcher(haystack)
-                             .results()
-                             .count();
+                            .matcher(haystack)
+                            .results()
+                            .count();
     }
 
     @Test
     void restClient_probesHealthEndpoint_semanticallyNotByLiteralDegradedString() {
         var appJs = resource("/dashboard/js/app.js").unwrap();
 
-        assertThat(appJs)
-                .as("app.js must add a dedicated health probe against the endpoint Forge actually serves")
-                .contains("RestClient.get('/health')")
-                .as("the gate must key on the semantic 'not healthy', not a nonexistent literal 'degraded' string")
-                .contains("health.status !== 'healthy'");
+        assertThat(appJs).as("app.js must add a dedicated health probe against the endpoint Forge actually serves")
+                  .contains("RestClient.get('/health')")
+                  .as("the gate must key on the semantic 'not healthy', not a nonexistent literal 'degraded' string")
+                  .contains("health.status !== 'healthy'");
     }
 
     @Test
     void appJs_pollingTimers_skipWhenClusterDegraded() {
         var appJs = resource("/dashboard/js/app.js").unwrap();
 
-        assertThat(appJs)
-                .as("the primary and secondary poll timers must both check the degraded gate")
-                .contains("Alpine.store('cluster').degraded");
+        assertThat(appJs).as("the primary and secondary poll timers must both check the degraded gate")
+                  .contains("Alpine.store('cluster').degraded");
     }
 
     @Test
@@ -89,9 +89,8 @@ class DashboardPollingGateContractTest {
     void clusterJs_declaresDegradedFlag_defaultingFalse() {
         var clusterJs = resource("/dashboard/js/stores/cluster.js").unwrap();
 
-        assertThat(clusterJs)
-                .as("a fresh dashboard load must never fabricate a degraded verdict before the first health probe returns")
-                .contains("degraded: false,");
+        assertThat(clusterJs).as("a fresh dashboard load must never fabricate a degraded verdict before the first health probe returns")
+                  .contains("degraded: false,");
     }
 
     /// The 404-suppression half of #294: a poll against an endpoint the server has no route for
@@ -102,18 +101,15 @@ class DashboardPollingGateContractTest {
     void restClientJs_suppressesRepeat404Toasts_logsInstead() {
         var restClientJs = resource("/dashboard/js/lib/rest-client.js").unwrap();
 
-        assertThat(restClientJs)
-                .as("a 404 must be special-cased")
-                .contains("status === 404")
-                .as("a 404 must be logged, not silently dropped")
-                .contains("console.warn(");
-
+        assertThat(restClientJs).as("a 404 must be special-cased")
+                  .contains("status === 404")
+                  .as("a 404 must be logged, not silently dropped")
+                  .contains("console.warn(");
         var notificationsShowCount = occurrences(restClientJs, "Notifications.show(");
 
-        assertThat(notificationsShowCount)
-                .as("exactly one of the 4 non-catch failure-status call sites collapses into the shared "
-                    + "404-aware reporter; the 4 .catch network-error sites are untouched, so the count "
-                    + "must drop from 8 to 5, never to 0 (every non-404 failure must still toast)")
-                .isEqualTo(5);
+        assertThat(notificationsShowCount).as("exactly one of the 4 non-catch failure-status call sites collapses into the shared "
+                                             + "404-aware reporter; the 4 .catch network-error sites are untouched, so the count "
+                                             + "must drop from 8 to 5, never to 0 (every non-404 failure must still toast)")
+                  .isEqualTo(5);
     }
 }

--- a/aether/node/src/test/java/org/pragmatica/aether/api/DashboardPollingGateContractTest.java
+++ b/aether/node/src/test/java/org/pragmatica/aether/api/DashboardPollingGateContractTest.java
@@ -22,18 +22,21 @@ import static org.assertj.core.api.Assertions.assertThat;
 /// endpoint the server does not implement should be logged once per endpoint rather than toasted on
 /// every tick.
 ///
-/// Two deliberate scope boundaries, both purely client-side (no production Java changed for this
-/// ticket) and both worth stating plainly rather than leaving implicit:
+/// Revised after #846 review: the first cut probed bare `/health` only, which is what Forge serves
+/// but NOT what the real node serves — the real node's Management API has migrated to `/api/v1/health`
+/// (`ManagementRoute`, per `aether/docs/specs/management-api-versioning-spec.md`, #300) with no bare
+/// `/health` route at all. Probing bare-only meant the gate silently never engaged against a real
+/// node; it always 404'd, `degraded` stayed at its default, and the health check was inert exactly
+/// where it mattered most. The probe now tries `/api/v1/health` FIRST, falling back to bare `/health`
+/// for Forge — but a fallback still means both can fail (a node ahead of migration but with a
+/// misbehaving proxy, or genuinely down). Two deliberate properties, both worth stating plainly:
 ///
-///   - **The health probe uses bare `/health`, not `/api/health` or `/api/v1/health`.** This
-///     dashboard, and Forge, have always spoken the unversioned `/api/...` convention; the real
-///     node's Management API has already migrated to an `/api/v1/...` prefix in code
-///     (`ManagementRoute`, per `aether/docs/specs/management-api-versioning-spec.md`, #300) without
-///     a corresponding dashboard update — a pre-existing, systemic, already-tracked mismatch that
-///     spans every dashboard endpoint, not just this one. Bare `/health` is what Forge's
-///     `StatusRoutes` actually serves and what this dashboard is demonstrably run against today; it
-///     is a deliberate, honest scope boundary, not an attempt to close the #300 gap. Against an
-///     already-migrated real node this probe 404s like every other dashboard call does today.
+///   - **A probe failure (both paths unreachable) fails OPEN to healthy, never wedges on
+///     `degraded = true`.** Unknown health is not the same claim as degraded health; treating the
+///     two as one would let a target that answers neither health path (e.g. a node's proxy dropping
+///     both, or a moment during startup) permanently gate off every other poll with no path back,
+///     since the very probe meant to detect recovery can never itself succeed. The failure is warned
+///     once per session, not re-logged on every 2s tick.
 ///   - **"Reports degraded" has no literal wire value to match.** The real node's `HealthResponse`
 ///     computes `status` as exactly `"healthy"` or `"unhealthy"` (`StatusRoutes.buildHealthResponse`)
 ///     — there is no `"degraded"` string anywhere in this API. Forge's own `HealthResponse` is
@@ -61,13 +64,40 @@ class DashboardPollingGateContractTest {
     }
 
     @Test
-    void restClient_probesHealthEndpoint_semanticallyNotByLiteralDegradedString() {
+    void restClient_probesVersionedHealthFirst_thenBareHealthFallback_semanticallyNotByLiteralDegradedString() {
         var appJs = resource("/dashboard/js/app.js").unwrap();
+        var versionedIndex = appJs.indexOf("RestClient.get('/api/v1/health')");
+        var bareIndex = appJs.indexOf("RestClient.get('/health')");
 
-        assertThat(appJs).as("app.js must add a dedicated health probe against the endpoint Forge actually serves")
-                  .contains("RestClient.get('/health')")
-                  .as("the gate must key on the semantic 'not healthy', not a nonexistent literal 'degraded' string")
+        assertThat(versionedIndex).as("the versioned path must be probed FIRST — it's the ONLY health route "
+                                     + "the real node serves (#300); probing bare-only never engages the gate "
+                                     + "against a real node at all")
+                  .isNotNegative();
+        assertThat(bareIndex).as("bare '/health' must remain as the fallback for what Forge actually serves")
+                  .isGreaterThan(versionedIndex);
+        assertThat(appJs).as("the gate must key on the semantic 'not healthy', not a nonexistent literal 'degraded' string")
                   .contains("health.status !== 'healthy'");
+    }
+
+    /// Correction after #846 review: a probe failure (both the versioned and bare health paths
+    /// unreachable — the case on any node ahead of #300's dashboard migration but behind #294's own
+    /// fix) must never set `degraded = true`. That would wedge every other poll behind a health
+    /// check that can never succeed. Unknown health fails OPEN to healthy, and the failure is
+    /// warned once — not re-toasted or re-logged on every 2s tick.
+    @Test
+    void checkHealth_bothProbesFail_failsOpen_neverSetsDegradedTrue() {
+        var appJs = resource("/dashboard/js/app.js").unwrap();
+        var start = appJs.indexOf("async checkHealth() {");
+        var end = appJs.indexOf("async pollStatus() {", start);
+
+        assertThat(start).as("checkHealth() must exist in app.js").isNotNegative();
+        assertThat(end).as("pollStatus() must follow checkHealth() so its body is boundable").isGreaterThan(start);
+        var checkHealthBody = appJs.substring(start, end);
+
+        assertThat(checkHealthBody).as("an unreachable/unanswered probe must fail OPEN to healthy, never wedge on degraded=true")
+                  .contains("Alpine.store('cluster').degraded = false;")
+                  .as("the fail-open branch must warn, but only once per session — not on every poll tick")
+                  .contains("_healthProbeUnreachableWarned");
     }
 
     @Test

--- a/aether/node/src/test/java/org/pragmatica/aether/api/DashboardPollingGateContractTest.java
+++ b/aether/node/src/test/java/org/pragmatica/aether/api/DashboardPollingGateContractTest.java
@@ -6,10 +6,13 @@ package org.pragmatica.aether.api;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
+import java.util.regex.Pattern;
 
 import org.junit.jupiter.api.Test;
+
+import org.pragmatica.lang.Result;
+import org.pragmatica.lang.utils.Causes;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -37,32 +40,27 @@ import static org.assertj.core.api.Assertions.assertThat;
 ///     this gate's real-world triggerability against Forge, stated here rather than hidden. The gate
 ///     therefore keys semantically on `status !== 'healthy'`, the one field both shapes share.
 class DashboardPollingGateContractTest {
-    private static String resource(String path) {
+    private static Result<String> resource(String path) {
         try (InputStream in = DashboardPollingGateContractTest.class.getResourceAsStream(path)) {
             if (in == null) {
-                throw new IllegalStateException("Dashboard resource not found on classpath: " + path);
+                return Result.failure(Causes.cause("Dashboard resource not found on classpath: " + path));
             }
-            return new String(in.readAllBytes(), StandardCharsets.UTF_8);
+            return Result.success(new String(in.readAllBytes(), StandardCharsets.UTF_8));
         } catch (IOException e) {
-            throw new UncheckedIOException(e);
+            return Result.failure(Causes.fromThrowable(e));
         }
     }
 
     private static int occurrences(String haystack, String needle) {
-        var count = 0;
-        var from = 0;
-
-        while ((from = haystack.indexOf(needle, from)) != -1) {
-            count++;
-            from += needle.length();
-        }
-
-        return count;
+        return (int) Pattern.compile(Pattern.quote(needle))
+                             .matcher(haystack)
+                             .results()
+                             .count();
     }
 
     @Test
     void restClient_probesHealthEndpoint_semanticallyNotByLiteralDegradedString() {
-        var appJs = resource("/dashboard/js/app.js");
+        var appJs = resource("/dashboard/js/app.js").unwrap();
 
         assertThat(appJs)
                 .as("app.js must add a dedicated health probe against the endpoint Forge actually serves")
@@ -73,7 +71,7 @@ class DashboardPollingGateContractTest {
 
     @Test
     void appJs_pollingTimers_skipWhenClusterDegraded() {
-        var appJs = resource("/dashboard/js/app.js");
+        var appJs = resource("/dashboard/js/app.js").unwrap();
 
         assertThat(appJs)
                 .as("the primary and secondary poll timers must both check the degraded gate")
@@ -82,14 +80,14 @@ class DashboardPollingGateContractTest {
 
     @Test
     void requestsJs_pollingTimer_skipsWhenClusterDegraded() {
-        var requestsJs = resource("/dashboard/js/stores/requests.js");
+        var requestsJs = resource("/dashboard/js/stores/requests.js").unwrap();
 
         assertThat(requestsJs).contains("Alpine.store('cluster').degraded");
     }
 
     @Test
     void clusterJs_declaresDegradedFlag_defaultingFalse() {
-        var clusterJs = resource("/dashboard/js/stores/cluster.js");
+        var clusterJs = resource("/dashboard/js/stores/cluster.js").unwrap();
 
         assertThat(clusterJs)
                 .as("a fresh dashboard load must never fabricate a degraded verdict before the first health probe returns")
@@ -102,7 +100,7 @@ class DashboardPollingGateContractTest {
     /// carve-out for one status code, not a general failure-suppression mechanism.
     @Test
     void restClientJs_suppressesRepeat404Toasts_logsInstead() {
-        var restClientJs = resource("/dashboard/js/lib/rest-client.js");
+        var restClientJs = resource("/dashboard/js/lib/rest-client.js").unwrap();
 
         assertThat(restClientJs)
                 .as("a 404 must be special-cased")

--- a/aether/node/src/test/java/org/pragmatica/aether/api/DashboardPollingGateContractTest.java
+++ b/aether/node/src/test/java/org/pragmatica/aether/api/DashboardPollingGateContractTest.java
@@ -216,9 +216,11 @@ class DashboardPollingGateContractTest {
         assertThat(appJs).as("the primary and secondary poll timers must both check the degraded gate")
                   .contains("cluster.degraded) return;");
         assertThat(occurrences(appJs,
-                               "cluster.healthUnknown && !cluster.unknownRetryDue()) return;")).as("both app.js poll timers (primary, which also gates checkHealth() itself so a total "
-                                                                                                  + "outage doesn't retry every 2s either, and secondary) must back off to the shared slow "
-                                                                                                  + "retry while health is unknown, distinct from the degraded skip above")
+                               "cluster.healthUnknown && !cluster.unknownRetryDue()) return;")).as("the DATA-poll halves of both app.js timers (primary's post-checkHealth batch, and "
+                                                                                                  + "secondary in full) must back off to the shared slow retry while health is unknown, "
+                                                                                                  + "distinct from the degraded skip above. The primary timer's checkHealth() call itself "
+                                                                                                  + "is gated separately, by its own dedicated throttle (#846 SHOULD-FIX) — see "
+                                                                                                  + "appJs_checkHealthCall_gatedByDedicatedThrottle_notSharedUnknownRetryDue below")
                   .isEqualTo(2);
     }
 
@@ -228,7 +230,9 @@ class DashboardPollingGateContractTest {
 
         assertThat(requestsJs).contains("cluster.degraded) return;")
                   .as("requests.js's own 3s timer must back off to the same shared unknownRetryDue() throttle "
-                     + "as app.js's timers, coordinated through cluster state rather than its own private clock")
+                     + "as app.js's DATA-poll timers, coordinated through cluster state rather than its own "
+                     + "private clock. This is the data-poll throttle only — distinct from app.js's dedicated "
+                     + "health re-probe throttle (healthProbeRetryDue())")
                   .contains("cluster.healthUnknown && !cluster.unknownRetryDue()) return;");
     }
 
@@ -249,15 +253,113 @@ class DashboardPollingGateContractTest {
         assertThat(clusterJs).as("healthUnknown must default false — a fresh load is neither known-degraded "
                                 + "nor known-unreachable until the first probe returns")
                   .contains("healthUnknown: false,");
-        assertThat(methodStart).as("unknownRetryDue() must exist as the shared throttle every poller reads")
+        assertThat(methodStart).as("unknownRetryDue() must exist as the shared throttle the DATA-poll timers "
+                                  + "read (secondary timer, requests.js, and the primary timer's post-checkHealth "
+                                  + "batch) — NOT the health re-probe itself, which has its own dedicated throttle; "
+                                  + "see clusterJs_healthProbeRetryDue_isDistinctFrom_unknownRetryDue_backedBySeparateFields below")
                   .isNotNegative();
         var body = clusterJs.substring(methodStart, methodEnd);
 
         assertThat(body).as("the retry cadence during an outage must be the 10s the ruling specifies, and it "
-                           + "must be a shared, mutated timestamp so every timer agrees on when the next attempt "
-                           + "is due instead of each retrying independently")
+                           + "must be a shared, mutated timestamp so every DATA-poll timer agrees on when the "
+                           + "next attempt is due instead of each retrying independently")
                   .contains(">= 10000")
                   .contains("_lastUnknownRetryAt = now;");
+    }
+
+    /// #846 SHOULD-FIX (round three): unknownRetryDue() used to be the ONLY throttle, shared by all
+    /// three poll timers for two different jobs — gating the primary timer's checkHealth() recovery
+    /// re-probe, and gating the other two timers' (plus the primary timer's own post-checkHealth
+    /// batch) data polls. Being a read-and-consume throttle (checking AND updating the timestamp in
+    /// one call), whichever timer's tick called it FIRST in a ~10s window won the slot; the others,
+    /// including possibly the primary timer's own checkHealth() gate, saw the slot already consumed
+    /// and skipped their turn. When that starved checkHealth() specifically, the health re-probe that
+    /// is the ONLY path back to `healthy` silently didn't run that cycle, pushing recovery detection
+    /// past the intended 10s bound by an amount that depended on interval drift between the timers.
+    /// The fix: healthProbeRetryDue(), a second throttle backed by its own field, read and consumed
+    /// ONLY by the primary timer's checkHealth() gate — never by the data-poll timers, so it cannot be
+    /// starved by their ticks. This test pins the two throttles as structurally distinct fields, not
+    /// merely distinct method names that might still share one timestamp underneath.
+    @Test
+    void clusterJs_healthProbeRetryDue_isDistinctFrom_unknownRetryDue_backedBySeparateFields() {
+        var clusterJs = resource("/dashboard/js/stores/cluster.js").unwrap();
+
+        assertThat(clusterJs).as("the two throttles must be backed by two separately-declared timestamp "
+                                + "fields, not one shared field read by two differently-named methods — a "
+                                + "shared field would still let one throttle's consumption silently affect "
+                                + "the other's due-ness, which is exactly the bug being fixed")
+                  .contains("_lastUnknownRetryAt: 0,")
+                  .contains("_lastHealthProbeRetryAt: 0,");
+
+        var unknownStart = clusterJs.indexOf("unknownRetryDue() {");
+        var unknownEnd = clusterJs.indexOf("},", unknownStart);
+        var healthProbeStart = clusterJs.indexOf("healthProbeRetryDue() {");
+        var healthProbeEnd = clusterJs.indexOf("},", healthProbeStart);
+
+        assertThat(unknownStart).as("unknownRetryDue() must exist").isNotNegative();
+        assertThat(healthProbeStart).as("healthProbeRetryDue() must exist as a genuinely separate method, "
+                                       + "not a renamed unknownRetryDue()").isNotNegative();
+        assertThat(healthProbeStart).as("the two methods must be textually distinct declarations")
+                  .isNotEqualTo(unknownStart);
+
+        var unknownBody = clusterJs.substring(unknownStart, unknownEnd);
+        var healthProbeBody = clusterJs.substring(healthProbeStart, healthProbeEnd);
+
+        assertThat(unknownBody).as("unknownRetryDue() must read/consume ONLY its own field — never the health "
+                                  + "re-probe's field, or a data poll's tick could silently steal the health "
+                                  + "re-probe's slot the same way the pre-fix shared throttle did")
+                  .contains("_lastUnknownRetryAt")
+                  .doesNotContain("_lastHealthProbeRetryAt");
+        assertThat(healthProbeBody).as("healthProbeRetryDue() must read/consume ONLY its own field — never the "
+                                      + "data-poll throttle's field. This is the load-bearing property: two "
+                                      + "differently-named methods sharing one field would reproduce the exact "
+                                      + "starvation this fix removes")
+                  .contains("_lastHealthProbeRetryAt")
+                  .doesNotContain("_lastUnknownRetryAt");
+
+        var requestsJs = resource("/dashboard/js/stores/requests.js").unwrap();
+        assertThat(requestsJs).as("the health re-probe throttle is exclusive to app.js's primary timer — it "
+                                 + "must never leak into requests.js's data-poll gate, or that data poller "
+                                 + "would start starving the health re-probe again from a different call site")
+                  .doesNotContain("healthProbeRetryDue");
+    }
+
+    /// Pins the call-site half of the same #846 SHOULD-FIX: it is not enough for the two throttles to
+    /// exist as distinct fields (previous test) — checkHealth() must actually be wired to the new one.
+    @Test
+    void appJs_checkHealthCall_gatedByDedicatedThrottle_notSharedUnknownRetryDue() {
+        var appJs = resource("/dashboard/js/app.js").unwrap();
+        var pollTimerStart = appJs.indexOf("this.pollTimer = setInterval(function() {");
+        var pollTimerEnd = appJs.indexOf("}, 2000);", pollTimerStart);
+
+        assertThat(pollTimerStart).as("the primary poll timer must exist").isNotNegative();
+        assertThat(pollTimerEnd).as("the primary poll timer's body must be boundable").isGreaterThan(pollTimerStart);
+
+        var body = appJs.substring(pollTimerStart, pollTimerEnd);
+        var checkHealthCallIndex = body.indexOf("self.checkHealth();");
+        var healthProbeGateIndex = body.indexOf("cluster.healthProbeRetryDue()");
+        var dataPollGateIndex = body.indexOf("cluster.healthUnknown && !cluster.unknownRetryDue()) return;");
+
+        assertThat(checkHealthCallIndex).as("checkHealth() must be called from the primary timer").isNotNegative();
+        assertThat(healthProbeGateIndex).as("checkHealth() must be gated by the dedicated healthProbeRetryDue() "
+                                           + "throttle, never left reading the data-poll timers' shared "
+                                           + "unknownRetryDue() — sharing it was the #846 SHOULD-FIX: whichever "
+                                           + "timer's tick consumed the shared, read-and-consume throttle first "
+                                           + "in a window won the slot, and when it wasn't this one, checkHealth() "
+                                           + "silently skipped an entire cycle, pushing recovery detection past "
+                                           + "the intended 10s bound by an amount that depended on interval drift")
+                  .isNotNegative();
+        assertThat(healthProbeGateIndex).as("the healthProbeRetryDue() gate must run BEFORE the checkHealth() call")
+                  .isLessThan(checkHealthCallIndex);
+        assertThat(dataPollGateIndex).as("the data-poll gate (unknownRetryDue()) must run AFTER the checkHealth() "
+                                        + "call, guarding only pollStatus()/events/alerts below it — never the "
+                                        + "health re-probe above it, which is the whole point of the split")
+                  .isGreaterThan(checkHealthCallIndex);
+        assertThat(occurrences(appJs, "cluster.healthProbeRetryDue()")).as("exactly one call site in the whole "
+                                                                          + "file — the primary timer's checkHealth() gate. If the secondary timer or "
+                                                                          + "requests.js ever called this too, it would reintroduce exactly the "
+                                                                          + "starvation this throttle exists to prevent")
+                  .isEqualTo(1);
     }
 
     /// The 404-suppression half of #294: a poll against an endpoint the server has no route for

--- a/aether/node/src/test/java/org/pragmatica/aether/api/DashboardPollingGateContractTest.java
+++ b/aether/node/src/test/java/org/pragmatica/aether/api/DashboardPollingGateContractTest.java
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2025 Pragmatica Labs - Sergiy Yevtushenko
+// Licensed under Business Source License 1.1. Change Date: 2030-01-01. Change License: Apache-2.0.
+// See LICENSE in the repository root for full terms.
+package org.pragmatica.aether.api;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/// Pins the client-side polling gate behind #294 (polling is not gated to health): every poll to a
+/// server the operator's health check has already marked unhealthy should back off, and a 404 from an
+/// endpoint the server does not implement should be logged once per endpoint rather than toasted on
+/// every tick.
+///
+/// Two deliberate scope boundaries, both purely client-side (no production Java changed for this
+/// ticket) and both worth stating plainly rather than leaving implicit:
+///
+///   - **The health probe uses bare `/health`, not `/api/health` or `/api/v1/health`.** This
+///     dashboard, and Forge, have always spoken the unversioned `/api/...` convention; the real
+///     node's Management API has already migrated to an `/api/v1/...` prefix in code
+///     (`ManagementRoute`, per `aether/docs/specs/management-api-versioning-spec.md`, #300) without
+///     a corresponding dashboard update — a pre-existing, systemic, already-tracked mismatch that
+///     spans every dashboard endpoint, not just this one. Bare `/health` is what Forge's
+///     `StatusRoutes` actually serves and what this dashboard is demonstrably run against today; it
+///     is a deliberate, honest scope boundary, not an attempt to close the #300 gap. Against an
+///     already-migrated real node this probe 404s like every other dashboard call does today.
+///   - **"Reports degraded" has no literal wire value to match.** The real node's `HealthResponse`
+///     computes `status` as exactly `"healthy"` or `"unhealthy"` (`StatusRoutes.buildHealthResponse`)
+///     — there is no `"degraded"` string anywhere in this API. Forge's own `HealthResponse` is
+///     hardcoded to always return `"healthy"` and can never signal degradation — an honest limit on
+///     this gate's real-world triggerability against Forge, stated here rather than hidden. The gate
+///     therefore keys semantically on `status !== 'healthy'`, the one field both shapes share.
+class DashboardPollingGateContractTest {
+    private static String resource(String path) {
+        try (InputStream in = DashboardPollingGateContractTest.class.getResourceAsStream(path)) {
+            if (in == null) {
+                throw new IllegalStateException("Dashboard resource not found on classpath: " + path);
+            }
+            return new String(in.readAllBytes(), StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private static int occurrences(String haystack, String needle) {
+        var count = 0;
+        var from = 0;
+
+        while ((from = haystack.indexOf(needle, from)) != -1) {
+            count++;
+            from += needle.length();
+        }
+
+        return count;
+    }
+
+    @Test
+    void restClient_probesHealthEndpoint_semanticallyNotByLiteralDegradedString() {
+        var appJs = resource("/dashboard/js/app.js");
+
+        assertThat(appJs)
+                .as("app.js must add a dedicated health probe against the endpoint Forge actually serves")
+                .contains("RestClient.get('/health')")
+                .as("the gate must key on the semantic 'not healthy', not a nonexistent literal 'degraded' string")
+                .contains("health.status !== 'healthy'");
+    }
+
+    @Test
+    void appJs_pollingTimers_skipWhenClusterDegraded() {
+        var appJs = resource("/dashboard/js/app.js");
+
+        assertThat(appJs)
+                .as("the primary and secondary poll timers must both check the degraded gate")
+                .contains("Alpine.store('cluster').degraded");
+    }
+
+    @Test
+    void requestsJs_pollingTimer_skipsWhenClusterDegraded() {
+        var requestsJs = resource("/dashboard/js/stores/requests.js");
+
+        assertThat(requestsJs).contains("Alpine.store('cluster').degraded");
+    }
+
+    @Test
+    void clusterJs_declaresDegradedFlag_defaultingFalse() {
+        var clusterJs = resource("/dashboard/js/stores/cluster.js");
+
+        assertThat(clusterJs)
+                .as("a fresh dashboard load must never fabricate a degraded verdict before the first health probe returns")
+                .contains("degraded: false,");
+    }
+
+    /// The 404-suppression half of #294: a poll against an endpoint the server has no route for
+    /// (Forge stand-ins, or a dashboard path not migrated to `/api/v1` — #300) must not toast on
+    /// every tick. Every OTHER failure status must still toast every time — this is a narrow
+    /// carve-out for one status code, not a general failure-suppression mechanism.
+    @Test
+    void restClientJs_suppressesRepeat404Toasts_logsInstead() {
+        var restClientJs = resource("/dashboard/js/lib/rest-client.js");
+
+        assertThat(restClientJs)
+                .as("a 404 must be special-cased")
+                .contains("status === 404")
+                .as("a 404 must be logged, not silently dropped")
+                .contains("console.warn(");
+
+        var notificationsShowCount = occurrences(restClientJs, "Notifications.show(");
+
+        assertThat(notificationsShowCount)
+                .as("exactly one of the 4 non-catch failure-status call sites collapses into the shared "
+                    + "404-aware reporter; the 4 .catch network-error sites are untouched, so the count "
+                    + "must drop from 8 to 5, never to 0 (every non-404 failure must still toast)")
+                .isEqualTo(5);
+    }
+}

--- a/aether/node/src/test/java/org/pragmatica/aether/api/DashboardPollingGateContractTest.java
+++ b/aether/node/src/test/java/org/pragmatica/aether/api/DashboardPollingGateContractTest.java
@@ -22,27 +22,51 @@ import static org.assertj.core.api.Assertions.assertThat;
 /// endpoint the server does not implement should be logged once per endpoint rather than toasted on
 /// every tick.
 ///
-/// Revised after #846 review: the first cut probed bare `/health` only, which is what Forge serves
-/// but NOT what the real node serves — the real node's Management API has migrated to `/api/v1/health`
-/// (`ManagementRoute`, per `aether/docs/specs/management-api-versioning-spec.md`, #300) with no bare
-/// `/health` route at all. Probing bare-only meant the gate silently never engaged against a real
-/// node; it always 404'd, `degraded` stayed at its default, and the health check was inert exactly
-/// where it mattered most. The probe now tries `/api/v1/health` FIRST, falling back to bare `/health`
-/// for Forge — but a fallback still means both can fail (a node ahead of migration but with a
-/// misbehaving proxy, or genuinely down). Two deliberate properties, both worth stating plainly:
+/// Revised after #846 review (round one): the first cut probed bare `/health` only, which is what
+/// Forge serves but NOT what the real node serves — the real node's Management API has migrated to
+/// `/api/v1/health` (`ManagementRoute`, per `aether/docs/specs/management-api-versioning-spec.md`,
+/// #300) with no bare `/health` route at all. Probing bare-only meant the gate silently never engaged
+/// against a real node. The probe tries `/api/v1/health` FIRST, falling back to bare `/health` for
+/// Forge.
 ///
-///   - **A probe failure (both paths unreachable) fails OPEN to healthy, never wedges on
-///     `degraded = true`.** Unknown health is not the same claim as degraded health; treating the
-///     two as one would let a target that answers neither health path (e.g. a node's proxy dropping
-///     both, or a moment during startup) permanently gate off every other poll with no path back,
-///     since the very probe meant to detect recovery can never itself succeed. The failure is warned
-///     once per session, not re-logged on every 2s tick.
-///   - **"Reports degraded" has no literal wire value to match.** The real node's `HealthResponse`
-///     computes `status` as exactly `"healthy"` or `"unhealthy"` (`StatusRoutes.buildHealthResponse`)
-///     — there is no `"degraded"` string anywhere in this API. Forge's own `HealthResponse` is
-///     hardcoded to always return `"healthy"` and can never signal degradation — an honest limit on
-///     this gate's real-world triggerability against Forge, stated here rather than hidden. The gate
-///     therefore keys semantically on `status !== 'healthy'`, the one field both shapes share.
+/// Corrected again after #846 review (round two, a BLOCKING finding): round one's fail-open collapsed
+/// two genuinely different failures into one `degraded = false`. `RestClient.get()` returns an
+/// identical `null` for a 404 (server reachable, no route here) and for a fetch-level network
+/// exception (server unreachable at all) — so a total outage looked exactly like a harmless missing
+/// route, the gate cleared, and every OTHER poller resumed hammering a dead backend every 2-3s with
+/// network-error toasts the 404 suppression never covered — #294's own toast storm, reintroduced in
+/// the worst case. The gate now tracks three states, computed by the pure `decideHealthState()`
+/// (top of `app.js`) from a dedicated `RestClient.probeHealth()` that reports reachability separately
+/// from the parsed body:
+///
+///   - **`healthy`** — a probe answered with `status: "healthy"`, OR a probe answered at all but with
+///     no usable health payload (a 404 on both paths: the server is reachable, it just doesn't
+///     implement a health route here). Fails OPEN, same as round one.
+///   - **`degraded`** — a probe answered with `status: "unhealthy"`. `degraded` has no literal wire
+///     value to match: the real node's `HealthResponse.status` is only ever `"healthy"`/`"unhealthy"`
+///     (`StatusRoutes.buildHealthResponse`); Forge's is hardcoded to always `"healthy"` and can never
+///     signal degradation — an honest limit on this gate's real-world triggerability against Forge.
+///   - **`unknown`** — BOTH the versioned and bare paths failed with a network-level error (refused,
+///     timeout) — the server could not be reached at all, a different claim from "reached and either
+///     healthy, unhealthy, or routeless". `cluster.healthUnknown` is a flag distinct from `degraded`;
+///     `decideHealthState()`'s unknown branch returns `{unknown: true}` with no `degraded` key at
+///     all, so `checkHealth()` has nothing to assign and a prior `degraded = true` verdict survives
+///     untouched — an outage on top of a known-degraded cluster must not read back as healthy. It
+///     clears the moment either probe answers anything, even a 404. While unknown, every poll timer
+///     (both in `app.js`, and `requests.js`'s own) backs off to a shared slow 10s retry via
+///     `cluster.unknownRetryDue()` instead of continuing at full 2-3s cadence, and `RestClient`
+///     routes every `.catch()` network failure through `_reportNetworkFailure()`, which suppresses
+///     the toast (logging once instead) for exactly as long as `healthUnknown` stays true.
+///
+/// No JS test runner exists anywhere in this repository — confirmed by grep for
+/// `ScriptEngine|GraalJSScriptEngine|org.graalvm|javax.script|jdk.nashorn|polyglot` across every
+/// `.xml`/`.java` source outside `target/`, zero matches — and adding one (e.g. a GraalJS Maven
+/// dependency) is out of scope for this fix. `decideHealthState()` is extracted as a small pure
+/// function so the classification is one reviewable unit and so "unknown never overwrites degraded"
+/// is a structural property of its return shape, but it stays pinned the same way the rest of this
+/// file already does: structural Java assertions on the extracted JS text, bounded to the smallest
+/// span that makes the assertion mean something, disclosed here as exactly that rather than dressed
+/// up as executed coverage.
 class DashboardPollingGateContractTest {
     private static Result<String> resource(String path) {
         try (InputStream in = DashboardPollingGateContractTest.class.getResourceAsStream(path)) {
@@ -63,11 +87,43 @@ class DashboardPollingGateContractTest {
                             .count();
     }
 
-    @Test
-    void restClient_probesVersionedHealthFirst_thenBareHealthFallback_semanticallyNotByLiteralDegradedString() {
+    /// Drops `//`-to-end-of-line comments before a substring assertion needs to mean "the code
+    /// does not do this" rather than "the code does not mention this" — checkHealth()'s own
+    /// explanatory comments name `RestClient.get()` in prose (explaining exactly why it is NOT
+    /// used), which would otherwise trip a naive `doesNotContain` on the raw body.
+    private static String stripLineComments(String source) {
+        return Pattern.compile("//[^\n]*")
+                      .matcher(source)
+                      .replaceAll("");
+    }
+
+    private static String decideHealthStateBody() {
         var appJs = resource("/dashboard/js/app.js").unwrap();
-        var versionedIndex = appJs.indexOf("RestClient.get('/api/v1/health')");
-        var bareIndex = appJs.indexOf("RestClient.get('/health')");
+        var start = appJs.indexOf("function decideHealthState(");
+        var end = appJs.indexOf("\n}", start);
+
+        assertThat(start).as("decideHealthState() must exist at module scope in app.js").isNotNegative();
+        assertThat(end).as("decideHealthState()'s closing brace must be boundable").isGreaterThan(start);
+
+        return appJs.substring(start, end);
+    }
+
+    private static String checkHealthBody() {
+        var appJs = resource("/dashboard/js/app.js").unwrap();
+        var start = appJs.indexOf("async checkHealth() {");
+        var end = appJs.indexOf("async pollStatus() {", start);
+
+        assertThat(start).as("checkHealth() must exist in app.js").isNotNegative();
+        assertThat(end).as("pollStatus() must follow checkHealth() so its body is boundable").isGreaterThan(start);
+
+        return appJs.substring(start, end);
+    }
+
+    @Test
+    void checkHealth_probesVersionedHealthFirst_thenBareHealthFallback_viaProbeHealthNotPlainGet() {
+        var body = checkHealthBody();
+        var versionedIndex = body.indexOf("RestClient.probeHealth('/api/v1/health')");
+        var bareIndex = body.indexOf("RestClient.probeHealth('/health')");
 
         assertThat(versionedIndex).as("the versioned path must be probed FIRST — it's the ONLY health route "
                                      + "the real node serves (#300); probing bare-only never engages the gate "
@@ -75,44 +131,105 @@ class DashboardPollingGateContractTest {
                   .isNotNegative();
         assertThat(bareIndex).as("bare '/health' must remain as the fallback for what Forge actually serves")
                   .isGreaterThan(versionedIndex);
-        assertThat(appJs).as("the gate must key on the semantic 'not healthy', not a nonexistent literal 'degraded' string")
-                  .contains("health.status !== 'healthy'");
-    }
-
-    /// Correction after #846 review: a probe failure (both the versioned and bare health paths
-    /// unreachable — the case on any node ahead of #300's dashboard migration but behind #294's own
-    /// fix) must never set `degraded = true`. That would wedge every other poll behind a health
-    /// check that can never succeed. Unknown health fails OPEN to healthy, and the failure is
-    /// warned once — not re-toasted or re-logged on every 2s tick.
-    @Test
-    void checkHealth_bothProbesFail_failsOpen_neverSetsDegradedTrue() {
-        var appJs = resource("/dashboard/js/app.js").unwrap();
-        var start = appJs.indexOf("async checkHealth() {");
-        var end = appJs.indexOf("async pollStatus() {", start);
-
-        assertThat(start).as("checkHealth() must exist in app.js").isNotNegative();
-        assertThat(end).as("pollStatus() must follow checkHealth() so its body is boundable").isGreaterThan(start);
-        var checkHealthBody = appJs.substring(start, end);
-
-        assertThat(checkHealthBody).as("an unreachable/unanswered probe must fail OPEN to healthy, never wedge on degraded=true")
-                  .contains("Alpine.store('cluster').degraded = false;")
-                  .as("the fail-open branch must warn, but only once per session — not on every poll tick")
-                  .contains("_healthProbeUnreachableWarned");
+        // Comments stripped: the method's own explanatory comments name `RestClient.get()` in
+        // prose (to explain why it is NOT used here), which would otherwise trip this check even
+        // though no actual call to it exists — asserting on code, not on what the code discusses.
+        assertThat(stripLineComments(body)).as("checkHealth() must use the reachability-aware probeHealth(), "
+                                              + "never the shared get() — get() collapses a 404 and a network exception to an "
+                                              + "identical null, which is exactly the #846 round-two finding: round one's fail-open "
+                                              + "could not tell a real outage apart from a harmless missing route")
+                  .doesNotContain("RestClient.get(");
     }
 
     @Test
-    void appJs_pollingTimers_skipWhenClusterDegraded() {
+    void decideHealthState_reachableWithNoHealthJson_failsOpenToHealthy_neverToDegradedTrue() {
+        var body = decideHealthStateBody();
+
+        assertThat(body).as("a path that answered but returned no usable status (a 404 on both) must fail OPEN: "
+                           + "the guard short-circuits false before the status comparison ever runs, so 'reachable, "
+                           + "no route' can never read as degraded")
+                  .contains("!!(health.json && health.json.status) && health.json.status !== 'healthy'");
+    }
+
+    @Test
+    void decideHealthState_bothProbesUnreachable_omitsDegradedKeyEntirely_soCallerCannotOverwriteIt() {
+        var body = decideHealthStateBody();
+        var unknownBranchStart = body.indexOf("if (!reachable) {");
+        var returnStatement = "return { unknown: true };";
+        var returnIndex = body.indexOf(returnStatement, unknownBranchStart);
+
+        assertThat(unknownBranchStart).as("the unreachable branch must exist").isNotNegative();
+        assertThat(returnIndex).as("the unreachable branch's return statement must exist")
+                  .isGreaterThan(unknownBranchStart);
+        // Bounded past the return statement's OWN closing brace (part of the object literal) to the
+        // if-block's closing brace — a naive indexOf("}", ...) from unknownBranchStart would stop at
+        // the object literal's brace instead and truncate before "true }" ever appears.
+        var ifBlockEnd = body.indexOf("}", returnIndex + returnStatement.length());
+        var unknownBranch = body.substring(unknownBranchStart, ifBlockEnd);
+
+        assertThat(unknownBranch).as("the unreachable branch's return value must literally omit `degraded` — "
+                                    + "returning any boolean for it, even the prior value, would require the "
+                                    + "caller to remember not to apply it. Omitting the key makes 'nothing to "
+                                    + "overwrite' a property of the data, not caller discipline")
+                  .contains("{ unknown: true }")
+                  .doesNotContain("degraded");
+    }
+
+    @Test
+    void checkHealth_unknownBranch_returnsBeforeDegradedAssignment_priorDegradedTrueSurvivesNetworkFailure() {
+        var body = checkHealthBody();
+        var unknownIf = body.indexOf("if (decision.unknown) {");
+        var earlyReturn = body.indexOf("return;", unknownIf);
+        var degradedAssignment = body.indexOf("cluster.degraded = decision.degraded;");
+
+        assertThat(unknownIf).as("checkHealth() must branch on decision.unknown").isNotNegative();
+        assertThat(earlyReturn).as("the unknown branch must return").isGreaterThan(unknownIf);
+        assertThat(degradedAssignment).as("the ONLY assignment to cluster.degraded in this method must be "
+                                         + "unreachable from the unknown branch — it must appear strictly AFTER "
+                                         + "the branch's return, so a prior degraded=true is never overwritten "
+                                         + "when a probe fails with a network error instead of answering")
+                  .isGreaterThan(earlyReturn);
+        assertThat(occurrences(body, "cluster.degraded =")).as("degraded must be assigned exactly once in checkHealth(), from decision.degraded — "
+                                                              + "no separate code path may set it directly")
+                  .isEqualTo(1);
+    }
+
+    @Test
+    void checkHealth_healthUnknownFlag_assignedUnconditionally_clearsOnAnyAnswerIncluding404() {
+        var body = checkHealthBody();
+        var flagAssignment = body.indexOf("cluster.healthUnknown = decision.unknown;");
+        var unknownIf = body.indexOf("if (decision.unknown) {");
+
+        assertThat(flagAssignment).as("healthUnknown must be assigned from decision.unknown").isNotNegative();
+        assertThat(unknownIf).as("the branch on decision.unknown must exist").isNotNegative();
+        assertThat(flagAssignment).as("the assignment must run BEFORE the branch, i.e. unconditionally on every "
+                                     + "call — so the moment either probe answers anything at all (decision.unknown "
+                                     + "is false, a 404 included), healthUnknown clears on that same tick rather "
+                                     + "than waiting for some separate reset path")
+                  .isLessThan(unknownIf);
+    }
+
+    @Test
+    void appJs_pollingTimers_skipWhenClusterDegraded_backOffToSlowRetryWhenHealthUnknown() {
         var appJs = resource("/dashboard/js/app.js").unwrap();
 
         assertThat(appJs).as("the primary and secondary poll timers must both check the degraded gate")
-                  .contains("Alpine.store('cluster').degraded");
+                  .contains("cluster.degraded) return;");
+        assertThat(occurrences(appJs,
+                               "cluster.healthUnknown && !cluster.unknownRetryDue()) return;")).as("both app.js poll timers (primary, which also gates checkHealth() itself so a total "
+                                                                                                  + "outage doesn't retry every 2s either, and secondary) must back off to the shared slow "
+                                                                                                  + "retry while health is unknown, distinct from the degraded skip above")
+                  .isEqualTo(2);
     }
 
     @Test
-    void requestsJs_pollingTimer_skipsWhenClusterDegraded() {
+    void requestsJs_pollingTimer_skipsWhenDegraded_backsOffToSlowRetryWhenHealthUnknown() {
         var requestsJs = resource("/dashboard/js/stores/requests.js").unwrap();
 
-        assertThat(requestsJs).contains("Alpine.store('cluster').degraded");
+        assertThat(requestsJs).contains("cluster.degraded) return;")
+                  .as("requests.js's own 3s timer must back off to the same shared unknownRetryDue() throttle "
+                     + "as app.js's timers, coordinated through cluster state rather than its own private clock")
+                  .contains("cluster.healthUnknown && !cluster.unknownRetryDue()) return;");
     }
 
     @Test
@@ -121,6 +238,26 @@ class DashboardPollingGateContractTest {
 
         assertThat(clusterJs).as("a fresh dashboard load must never fabricate a degraded verdict before the first health probe returns")
                   .contains("degraded: false,");
+    }
+
+    @Test
+    void clusterJs_declaresHealthUnknownFlag_defaultingFalse_withSharedTenSecondRetryThrottle() {
+        var clusterJs = resource("/dashboard/js/stores/cluster.js").unwrap();
+        var methodStart = clusterJs.indexOf("unknownRetryDue() {");
+        var methodEnd = clusterJs.indexOf("},", methodStart);
+
+        assertThat(clusterJs).as("healthUnknown must default false — a fresh load is neither known-degraded "
+                                + "nor known-unreachable until the first probe returns")
+                  .contains("healthUnknown: false,");
+        assertThat(methodStart).as("unknownRetryDue() must exist as the shared throttle every poller reads")
+                  .isNotNegative();
+        var body = clusterJs.substring(methodStart, methodEnd);
+
+        assertThat(body).as("the retry cadence during an outage must be the 10s the ruling specifies, and it "
+                           + "must be a shared, mutated timestamp so every timer agrees on when the next attempt "
+                           + "is due instead of each retrying independently")
+                  .contains(">= 10000")
+                  .contains("_lastUnknownRetryAt = now;");
     }
 
     /// The 404-suppression half of #294: a poll against an endpoint the server has no route for
@@ -135,11 +272,61 @@ class DashboardPollingGateContractTest {
                   .contains("status === 404")
                   .as("a 404 must be logged, not silently dropped")
                   .contains("console.warn(");
-        var notificationsShowCount = occurrences(restClientJs, "Notifications.show(");
+    }
 
-        assertThat(notificationsShowCount).as("exactly one of the 4 non-catch failure-status call sites collapses into the shared "
-                                             + "404-aware reporter; the 4 .catch network-error sites are untouched, so the count "
-                                             + "must drop from 8 to 5, never to 0 (every non-404 failure must still toast)")
-                  .isEqualTo(5);
+    @Test
+    void restClientJs_catchBlocks_routeThroughReportNetworkFailure_notDirectToastPerOccurrence() {
+        var restClientJs = resource("/dashboard/js/lib/rest-client.js").unwrap();
+
+        assertThat(occurrences(restClientJs,
+                               "self._reportNetworkFailure(")).as("all 4 network-exception .catch() sites (get/post/put/del) must route through the "
+                                                                 + "shared, healthUnknown-aware reporter instead of toasting unconditionally — otherwise a "
+                                                                 + "total outage still spams a toast per poller per tick even though the health gate knows "
+                                                                 + "the server is unreachable")
+                  .isEqualTo(4);
+        assertThat(occurrences(restClientJs,
+                               "Notifications.show(")).as("exactly 2 direct toast call sites should remain: _reportFailure's non-404 branch, and "
+                                                         + "_reportNetworkFailure's own fallback for when the cluster is NOT in the unknown state "
+                                                         + "(a genuine, isolated network blip while the server is otherwise known-reachable still "
+                                                         + "toasts normally)")
+                  .isEqualTo(2);
+    }
+
+    @Test
+    void restClientJs_reportNetworkFailure_suppressesToastOnlyWhileHealthUnknown_warnsOnceInstead() {
+        var restClientJs = resource("/dashboard/js/lib/rest-client.js").unwrap();
+        var start = restClientJs.indexOf("_reportNetworkFailure: function(");
+        var end = restClientJs.indexOf("\n    },", start);
+
+        assertThat(start).as("_reportNetworkFailure() must exist").isNotNegative();
+        var body = restClientJs.substring(start, end);
+
+        assertThat(body).as("the suppression must be conditioned on the cluster's healthUnknown flag, not on "
+                           + "the error itself — the same network error toasts normally once the server is known "
+                           + "reachable again")
+                  .contains("cluster.healthUnknown")
+                  .as("suppressed failures must still be observable once, via console.warn, never silently dropped")
+                  .contains("console.warn(")
+                  .as("outside the unknown window, the failure must still toast")
+                  .contains("Notifications.show(");
+    }
+
+    @Test
+    void restClientJs_probeHealth_neverToasts_reachableMeansAnyHttpResponseNot404Only() {
+        var restClientJs = resource("/dashboard/js/lib/rest-client.js").unwrap();
+        var start = restClientJs.indexOf("probeHealth: function(");
+        var end = restClientJs.indexOf("\n    },", start);
+
+        assertThat(start).as("probeHealth() must exist as a dedicated probe distinct from get()").isNotNegative();
+        var body = restClientJs.substring(start, end);
+
+        assertThat(body).as("health probing runs on every poll tick by design; it must never toast regardless "
+                           + "of outcome — checkHealth()/decideHealthState() own the response entirely")
+                  .doesNotContain("Notifications.show(")
+                  .as("any HTTP response at all, not just a 2xx, must mark the probe reachable — a 404 proves "
+                     + "the server exists just as much as a 200 does")
+                  .contains("{ reachable: true, json: null }")
+                  .as("only a fetch-level exception marks the probe unreachable")
+                  .contains("{ reachable: false, json: null }");
     }
 }

--- a/aether/node/src/test/java/org/pragmatica/aether/api/DashboardPollingGateContractTest.java
+++ b/aether/node/src/test/java/org/pragmatica/aether/api/DashboardPollingGateContractTest.java
@@ -290,7 +290,6 @@ class DashboardPollingGateContractTest {
                                 + "the other's due-ness, which is exactly the bug being fixed")
                   .contains("_lastUnknownRetryAt: 0,")
                   .contains("_lastHealthProbeRetryAt: 0,");
-
         var unknownStart = clusterJs.indexOf("unknownRetryDue() {");
         var unknownEnd = clusterJs.indexOf("},", unknownStart);
         var healthProbeStart = clusterJs.indexOf("healthProbeRetryDue() {");
@@ -298,10 +297,10 @@ class DashboardPollingGateContractTest {
 
         assertThat(unknownStart).as("unknownRetryDue() must exist").isNotNegative();
         assertThat(healthProbeStart).as("healthProbeRetryDue() must exist as a genuinely separate method, "
-                                       + "not a renamed unknownRetryDue()").isNotNegative();
+                                       + "not a renamed unknownRetryDue()")
+                  .isNotNegative();
         assertThat(healthProbeStart).as("the two methods must be textually distinct declarations")
                   .isNotEqualTo(unknownStart);
-
         var unknownBody = clusterJs.substring(unknownStart, unknownEnd);
         var healthProbeBody = clusterJs.substring(healthProbeStart, healthProbeEnd);
 
@@ -316,8 +315,8 @@ class DashboardPollingGateContractTest {
                                       + "starvation this fix removes")
                   .contains("_lastHealthProbeRetryAt")
                   .doesNotContain("_lastUnknownRetryAt");
-
         var requestsJs = resource("/dashboard/js/stores/requests.js").unwrap();
+
         assertThat(requestsJs).as("the health re-probe throttle is exclusive to app.js's primary timer — it "
                                  + "must never leak into requests.js's data-poll gate, or that data poller "
                                  + "would start starving the health re-probe again from a different call site")
@@ -334,7 +333,6 @@ class DashboardPollingGateContractTest {
 
         assertThat(pollTimerStart).as("the primary poll timer must exist").isNotNegative();
         assertThat(pollTimerEnd).as("the primary poll timer's body must be boundable").isGreaterThan(pollTimerStart);
-
         var body = appJs.substring(pollTimerStart, pollTimerEnd);
         var checkHealthCallIndex = body.indexOf("self.checkHealth();");
         var healthProbeGateIndex = body.indexOf("cluster.healthProbeRetryDue()");
@@ -355,10 +353,11 @@ class DashboardPollingGateContractTest {
                                         + "call, guarding only pollStatus()/events/alerts below it — never the "
                                         + "health re-probe above it, which is the whole point of the split")
                   .isGreaterThan(checkHealthCallIndex);
-        assertThat(occurrences(appJs, "cluster.healthProbeRetryDue()")).as("exactly one call site in the whole "
-                                                                          + "file — the primary timer's checkHealth() gate. If the secondary timer or "
-                                                                          + "requests.js ever called this too, it would reintroduce exactly the "
-                                                                          + "starvation this throttle exists to prevent")
+        assertThat(occurrences(appJs,
+                               "cluster.healthProbeRetryDue()")).as("exactly one call site in the whole "
+                                                                   + "file — the primary timer's checkHealth() gate. If the secondary timer or "
+                                                                   + "requests.js ever called this too, it would reintroduce exactly the "
+                                                                   + "starvation this throttle exists to prevent")
                   .isEqualTo(1);
     }
 

--- a/changelog.d/292-dashboard-live-alerts.md
+++ b/changelog.d/292-dashboard-live-alerts.md
@@ -1,0 +1,25 @@
+### Fixed (2026-09-05 — #292: live alerts never render)
+
+- `app.js` no longer unwraps the WS envelope before dispatching an `ALERT`/`ALERT_RESOLVED`
+  message to the alerts store. `AlertManager.buildAlertMessage` puts the `type` discriminator
+  at the top level only (`{"type":"ALERT","data":{...}}`), never duplicated inside `data`; the
+  old `updateFromWs(data.data || data)` call stripped the envelope before the store ever saw
+  `type`, so its `data.type === 'ALERT'` check was always false and nothing rendered.
+  [verified: `AlertWsEnvelopeContractTest.appJs_dispatchesWholeEnvelopeToAlertsStore_notUnwrappedPayload`]
+- `alerts.js`'s `updateFromWs` now reads the discriminator off the still-wrapped envelope
+  (`envelope.type`) and unwraps `data` itself, instead of checking `data.type` on a payload
+  that never carried it.
+  [verified: `AlertWsEnvelopeContractTest.alertsJs_readsDiscriminatorOnTheEnvelope_notOnTheUnwrappedPayload`]
+- The wire shape itself — top-level `type`, alert fields under `data`, never duplicated — is
+  pinned against `AlertManager.checkThreshold`'s actual return value (the literal broadcast
+  payload, per `DashboardMetricsPublisher.checkAndBroadcastAlerts`), not a hand-written stand-in.
+  [verified: `AlertWsEnvelopeContractTest.checkThreshold_valueAboveCritical_returnsEnvelopeWithTopLevelTypeAndUnwrappedData`]
+- The alerts store is now also refreshed from the same gated, repeating poll timer that drives
+  cluster status and events (`app.js` `startPolling()`), not only once at page load — so a
+  missed or dropped WS message self-heals within one poll cycle instead of leaving the panel
+  stale until the next alert fires.
+  [verified: `AlertWsEnvelopeContractTest.appJs_startPolling_refreshesAlertsStoreOnTheRepeatingTimer_notOnlyOnce`]
+- `ALERT_RESOLVED`'s envelope shape (`AlertManager.broadcastAlertResolved`) is a private,
+  directly-broadcasting method with no return-value seam to exercise from a test; its shape
+  matches `ALERT`'s by source inspection only.
+  [design intent — unverified]

--- a/changelog.d/294-dashboard-polling-gate.md
+++ b/changelog.d/294-dashboard-polling-gate.md
@@ -6,22 +6,28 @@
   marked unhealthy.
   [verified: `DashboardPollingGateContractTest.appJs_pollingTimers_skipWhenClusterDegraded`,
   `DashboardPollingGateContractTest.requestsJs_pollingTimer_skipsWhenClusterDegraded`]
-- The gate is driven by a new, ungated health probe (`GET /health`, run on every primary-timer
-  tick so the dashboard can detect recovery, not only degradation) keyed semantically on
+- The gate is driven by a new, ungated health probe (run on every primary-timer tick so the
+  dashboard can detect recovery, not only degradation) keyed semantically on
   `status !== 'healthy'` — there is no literal `"degraded"` wire value in either health shape
-  this dashboard talks to. `degraded` defaults to `false` and is left at its last known value
-  on a missing/failed probe response; it is never fabricated from a failed fetch.
-  [verified: `DashboardPollingGateContractTest.restClient_probesHealthEndpoint_semanticallyNotByLiteralDegradedString`,
+  this dashboard talks to.
+  [verified: `DashboardPollingGateContractTest.restClient_probesVersionedHealthFirst_thenBareHealthFallback_semanticallyNotByLiteralDegradedString`,
   `DashboardPollingGateContractTest.clusterJs_declaresDegradedFlag_defaultingFalse`]
-- **Scope boundary, stated plainly:** the probe uses bare `/health`, not `/api/health` or
-  `/api/v1/health`. This is the path Forge's `StatusRoutes` actually serves and what this
-  dashboard is demonstrably run against today; the real node's Management API has no bare
-  `/health` route at all (only `/api/v1/health`, `/health/live`, `/health/ready`), so against a
-  real node this probe 404s like every other dashboard call does — see the versioning gap
-  below. Forge's own `HealthResponse` is hardcoded to always report `"healthy"` and can never
-  signal degradation, an honest limit on this gate's real-world triggerability against Forge.
-  [mechanism: `StatusRoutes.java` bare `/health` route vs. `ManagementServer`'s absence of one;
+- **Revised after first review:** the probe now tries `GET /api/v1/health` FIRST — the only
+  health route the real node's Management API serves, which has migrated ahead of this
+  dashboard (`ManagementRoute`, #300) — falling back to bare `GET /health`, what Forge actually
+  serves. The first cut probed bare `/health` only, which meant the gate silently never engaged
+  against a real node at all (every probe 404'd, `degraded` never left its default). Forge's own
+  `HealthResponse` is hardcoded to always report `"healthy"` and can never signal degradation, an
+  honest limit on this gate's real-world triggerability against Forge.
+  [mechanism: `StatusRoutes.java` bare `/health` route vs. `ManagementServer`'s `/api/v1/health`;
   Forge's `HealthResponse` construction is `new HealthResponse("healthy", ...)` unconditionally]
+- **Fail-open, also added after first review:** if BOTH the versioned and bare paths fail to
+  answer, `degraded` is explicitly set to `false`, never left to drift or fabricated as `true`.
+  Conflating "probe unreachable" with "reports degraded" would let a target that answers
+  neither health path permanently gate off every other poll with no path back — the very probe
+  meant to detect recovery would itself never succeed. The failure is warned once per session
+  (`console.warn`), not re-logged on every 2s tick.
+  [verified: `DashboardPollingGateContractTest.checkHealth_bothProbesFail_failsOpen_neverSetsDegradedTrue`]
 - A repeat 404 from an endpoint the target server has no route for is now logged once per
   method+path (`console.warn`) instead of toasting on every poll tick; every other failure
   status (5xx, network error) still toasts on every occurrence — a narrow carve-out for the

--- a/changelog.d/294-dashboard-polling-gate.md
+++ b/changelog.d/294-dashboard-polling-gate.md
@@ -4,13 +4,13 @@
   the requests store's own timer) now skips its tick while a client-side `degraded` flag is
   set, instead of continuing to poll a backend the operator's own health check has already
   marked unhealthy.
-  [verified: `DashboardPollingGateContractTest.appJs_pollingTimers_skipWhenClusterDegraded`,
-  `DashboardPollingGateContractTest.requestsJs_pollingTimer_skipsWhenClusterDegraded`]
+  [verified: `DashboardPollingGateContractTest.appJs_pollingTimers_skipWhenClusterDegraded_backOffToSlowRetryWhenHealthUnknown`,
+  `DashboardPollingGateContractTest.requestsJs_pollingTimer_skipsWhenDegraded_backsOffToSlowRetryWhenHealthUnknown`]
 - The gate is driven by a new, ungated health probe (run on every primary-timer tick so the
   dashboard can detect recovery, not only degradation) keyed semantically on
   `status !== 'healthy'` — there is no literal `"degraded"` wire value in either health shape
   this dashboard talks to.
-  [verified: `DashboardPollingGateContractTest.restClient_probesVersionedHealthFirst_thenBareHealthFallback_semanticallyNotByLiteralDegradedString`,
+  [verified: `DashboardPollingGateContractTest.checkHealth_probesVersionedHealthFirst_thenBareHealthFallback_viaProbeHealthNotPlainGet`,
   `DashboardPollingGateContractTest.clusterJs_declaresDegradedFlag_defaultingFalse`]
 - **Revised after first review:** the probe now tries `GET /api/v1/health` FIRST — the only
   health route the real node's Management API serves, which has migrated ahead of this
@@ -21,18 +21,42 @@
   honest limit on this gate's real-world triggerability against Forge.
   [mechanism: `StatusRoutes.java` bare `/health` route vs. `ManagementServer`'s `/api/v1/health`;
   Forge's `HealthResponse` construction is `new HealthResponse("healthy", ...)` unconditionally]
-- **Fail-open, also added after first review:** if BOTH the versioned and bare paths fail to
-  answer, `degraded` is explicitly set to `false`, never left to drift or fabricated as `true`.
-  Conflating "probe unreachable" with "reports degraded" would let a target that answers
-  neither health path permanently gate off every other poll with no path back — the very probe
-  meant to detect recovery would itself never succeed. The failure is warned once per session
-  (`console.warn`), not re-logged on every 2s tick.
-  [verified: `DashboardPollingGateContractTest.checkHealth_bothProbesFail_failsOpen_neverSetsDegradedTrue`]
+- **Revised again after second review (a BLOCKING finding): the gate now tracks three states,
+  not two.** Round one's fail-open collapsed "probe answered, no route here" and "probe
+  unreachable" into the same `degraded = false` — `RestClient.get()` returns an identical `null`
+  for a 404 and for a fetch-level network exception, so a total backend outage read exactly like
+  a harmless missing health route, the gate cleared, and every OTHER poller resumed hammering a
+  dead backend every 2-3s with network-error toasts the 404 suppression never covered — #294's
+  own toast storm, reintroduced in the worst case. A new `RestClient.probeHealth()` reports
+  reachability separately from the parsed body (any HTTP response, 404 included, marks the probe
+  reachable; only a fetch-level exception marks it unreachable), and a pure `decideHealthState()`
+  turns two such probes into one of three verdicts:
+  - `healthy` — a probe answered `status: "healthy"`, or a probe answered at all with no usable
+    health payload (404 on both paths: reachable, just no route here). Fails open, same as round
+    one.
+  - `degraded` — a probe answered `status: "unhealthy"`.
+  - `unknown` — BOTH paths failed with a network-level error. `decideHealthState()`'s unknown
+    branch returns `{unknown: true}` with no `degraded` key at all, so a prior `degraded = true`
+    verdict is never overwritten by an outage — a total outage on top of a known-degraded cluster
+    must not read back as healthy. It clears the moment either probe answers anything, even a
+    404. While unknown, every poll timer backs off to a shared slow 10s retry
+    (`cluster.unknownRetryDue()`), and `RestClient` routes every network-exception `.catch()`
+    through `_reportNetworkFailure()`, which suppresses the toast (warning once instead) for as
+    long as `healthUnknown` stays true — an isolated network blip while the server is otherwise
+    known-reachable still toasts normally.
+  [verified: `DashboardPollingGateContractTest.decideHealthState_reachableWithNoHealthJson_failsOpenToHealthy_neverToDegradedTrue`,
+  `DashboardPollingGateContractTest.decideHealthState_bothProbesUnreachable_omitsDegradedKeyEntirely_soCallerCannotOverwriteIt`,
+  `DashboardPollingGateContractTest.checkHealth_unknownBranch_returnsBeforeDegradedAssignment_priorDegradedTrueSurvivesNetworkFailure`,
+  `DashboardPollingGateContractTest.checkHealth_healthUnknownFlag_assignedUnconditionally_clearsOnAnyAnswerIncluding404`,
+  `DashboardPollingGateContractTest.clusterJs_declaresHealthUnknownFlag_defaultingFalse_withSharedTenSecondRetryThrottle`,
+  `DashboardPollingGateContractTest.restClientJs_catchBlocks_routeThroughReportNetworkFailure_notDirectToastPerOccurrence`,
+  `DashboardPollingGateContractTest.restClientJs_reportNetworkFailure_suppressesToastOnlyWhileHealthUnknown_warnsOnceInstead`,
+  `DashboardPollingGateContractTest.restClientJs_probeHealth_neverToasts_reachableMeansAnyHttpResponseNot404Only`]
 - A repeat 404 from an endpoint the target server has no route for is now logged once per
   method+path (`console.warn`) instead of toasting on every poll tick; every other failure
-  status (5xx, network error) still toasts on every occurrence — a narrow carve-out for the
-  specific, expected case of polling an unimplemented endpoint, not general failure
-  suppression.
+  status (5xx, network error while the server is otherwise known-reachable) still toasts on
+  every occurrence — a narrow carve-out for the specific, expected case of polling an
+  unimplemented endpoint, not general failure suppression.
   [verified: `DashboardPollingGateContractTest.restClientJs_suppressesRepeat404Toasts_logsInstead`]
 - **Not in this PR (Forge proxy for the missing endpoints):** 24 REST paths the dashboard calls
   have no matching Forge route today and 404 under Forge (2 more are near-misses mounted under

--- a/changelog.d/294-dashboard-polling-gate.md
+++ b/changelog.d/294-dashboard-polling-gate.md
@@ -1,0 +1,47 @@
+### Fixed (2026-09-05 — #294: polling is not gated to health)
+
+- Every dashboard poll timer (primary status/events/alerts, the secondary fallback timer, and
+  the requests store's own timer) now skips its tick while a client-side `degraded` flag is
+  set, instead of continuing to poll a backend the operator's own health check has already
+  marked unhealthy.
+  [verified: `DashboardPollingGateContractTest.appJs_pollingTimers_skipWhenClusterDegraded`,
+  `DashboardPollingGateContractTest.requestsJs_pollingTimer_skipsWhenClusterDegraded`]
+- The gate is driven by a new, ungated health probe (`GET /health`, run on every primary-timer
+  tick so the dashboard can detect recovery, not only degradation) keyed semantically on
+  `status !== 'healthy'` — there is no literal `"degraded"` wire value in either health shape
+  this dashboard talks to. `degraded` defaults to `false` and is left at its last known value
+  on a missing/failed probe response; it is never fabricated from a failed fetch.
+  [verified: `DashboardPollingGateContractTest.restClient_probesHealthEndpoint_semanticallyNotByLiteralDegradedString`,
+  `DashboardPollingGateContractTest.clusterJs_declaresDegradedFlag_defaultingFalse`]
+- **Scope boundary, stated plainly:** the probe uses bare `/health`, not `/api/health` or
+  `/api/v1/health`. This is the path Forge's `StatusRoutes` actually serves and what this
+  dashboard is demonstrably run against today; the real node's Management API has no bare
+  `/health` route at all (only `/api/v1/health`, `/health/live`, `/health/ready`), so against a
+  real node this probe 404s like every other dashboard call does — see the versioning gap
+  below. Forge's own `HealthResponse` is hardcoded to always report `"healthy"` and can never
+  signal degradation, an honest limit on this gate's real-world triggerability against Forge.
+  [mechanism: `StatusRoutes.java` bare `/health` route vs. `ManagementServer`'s absence of one;
+  Forge's `HealthResponse` construction is `new HealthResponse("healthy", ...)` unconditionally]
+- A repeat 404 from an endpoint the target server has no route for is now logged once per
+  method+path (`console.warn`) instead of toasting on every poll tick; every other failure
+  status (5xx, network error) still toasts on every occurrence — a narrow carve-out for the
+  specific, expected case of polling an unimplemented endpoint, not general failure
+  suppression.
+  [verified: `DashboardPollingGateContractTest.restClientJs_suppressesRepeat404Toasts_logsInstead`]
+- **Not in this PR (Forge proxy for the missing endpoints):** 24 REST paths the dashboard calls
+  have no matching Forge route today and 404 under Forge (2 more are near-misses mounted under
+  a different prefix than the dashboard calls — `/api/thresholds*` vs. Forge's
+  `/api/alerts/thresholds*`, and `/api/cluster/topology` vs. Forge's `/api/slices/topology`).
+  Every one of these now benefits from the 404-suppression above (logged once, not repeatedly
+  toasted), but none is proxied or stubbed by this fix. Full list, each with its calling
+  dashboard file: `/api/slices` (app.js), `/api/thresholds`, `/api/thresholds` (POST),
+  `/api/thresholds/{metric}` (DELETE) (alerts.js), `/api/controller/config` (GET+POST),
+  `/api/ttm/status`, `/api/logging/levels` (GET+POST) (cluster.js), `/api/routes`
+  (deployments.js), `/api/cluster/config` (desiredtopology.js), `/api/cluster/governors`,
+  `/api/cluster/topology` (governors.js), `/api/invocations/metrics`,
+  `/api/invocations/metrics/slow` (requests.js), `/api/schema/status`,
+  `/api/schema/retry/{datasource}` (schema.js), `/api/cluster/storage`, `/api/storage`,
+  `/api/storage/{name}`, `/api/storage/snapshot/{name}` (storage.js), `/api/deploy`,
+  `/api/ab-tests` (strategies.js), `/api/streams` (streams.js).
+  [mechanism: cross-referenced every `RestClient.get/post/put/del` call site in the dashboard
+  JS against every registered route in Forge's 9 `*Routes.java` files]

--- a/changelog.d/304-dashboard-event-key.md
+++ b/changelog.d/304-dashboard-event-key.md
@@ -1,0 +1,28 @@
+### Fixed (2026-09-05 — #304: node-mode live events never key correctly)
+
+- `events.js` no longer dedups/keys live events on `event.timestamp`. `ClusterEventView` has
+  never had a `timestamp` field — its HLC time has always been named `at`
+  (`HlcTimestamp`, packed physical-ms/counter), a naming convention shared by every record in
+  the `ClusterEvent` sealed interface and predating the `type` discriminator entirely; the
+  client-side `timestamp` read was an original wrong assumption, not a later rename. New
+  `eventMillis`/`eventKey` helpers read `at` (unpacking `HlcTimestamp.pack`'s physical-ms
+  component) when present, falling back to `timestamp` for Forge-mode events that do use that
+  field.
+  [verified: `ClusterEventKeyContractTest.eventsJs_computesKeyFromAtOrTimestamp_notTimestampAlone`]
+- `index.html`'s event-feed template now keys and displays time through the store's
+  `eventKey`/`eventMillis` helpers instead of reading `event.timestamp` directly.
+  [verified: `ClusterEventKeyContractTest.indexHtml_usesEventKeyHelper_andNeverReadsEventTimestampDirectly`]
+- `ClusterEventView`'s wire shape (`at`, never `timestamp`) is pinned both by serialization and
+  by reflection on its record components, as a guard against a future accidental rename in
+  either direction.
+  [verified: `ClusterEventKeyContractTest.clusterEventView_serializesAtField_neverTimestamp`,
+  `ClusterEventKeyContractTest.clusterEventView_recordComponents_nameTheTimeFieldAt_notTimestamp`]
+- **Out of scope for this fix, re-scope note for #304:** the trace waterfall (`trace-detail`
+  component, loaded in `index.html` but never wired to a data source or a click handler) is
+  unbuilt. Building it needs: (1) a click/selection handler from the event feed or invocation
+  explorer into the component, (2) a server-side trace-fetch endpoint (none of the existing
+  `/api/events`-family routes return per-invocation span/trace data), and (3) a waterfall
+  rendering layer inside the component — none of which exists today. This is new feature work,
+  not a fix, and should be tracked as its own ticket rather than folded back into #304.
+  [mechanism: `index.html:512-524` loads the component and never references it again;
+  repo-wide grep for a trace-fetch route under `aether/node`'s REST layer finds none]


### PR DESCRIPTION
## Summary

Fixes three dashboard defects in one PR per CTO scope ruling: #292 (live alerts never render), #304's event-key half (trace waterfall explicitly out of scope, re-scoped below), and #294's polling gate.

- **#292**: `app.js` no longer unwraps the WS envelope (`data.data || data`) before dispatch. `AlertManager.buildAlertMessage` puts `type` at the top level only, never duplicated inside `data`; `alerts.js` now reads `envelope.type`, not `data.type`. Alerts are also refreshed from the same gated repeating poll timer as status/events, not only once at page load.
  [verified: `AlertWsEnvelopeContractTest.appJs_dispatchesWholeEnvelopeToAlertsStore_notUnwrappedPayload`, `AlertWsEnvelopeContractTest.alertsJs_readsDiscriminatorOnTheEnvelope_notOnTheUnwrappedPayload`, `AlertWsEnvelopeContractTest.appJs_startPolling_refreshesAlertsStoreOnTheRepeatingTimer_notOnlyOnce`]
- **#304 (event-key half only)**: `events.js`/`index.html` no longer key/display live events on `event.timestamp` — `ClusterEventView` has never had that field, only `at` (HLC, packed physical-ms/counter). New `eventKey`/`eventMillis` helpers read `at` when present, falling back to `timestamp` for Forge-mode events that do carry it.
  [verified: `ClusterEventKeyContractTest.eventsJs_computesKeyFromAtOrTimestamp_notTimestampAlone`, `ClusterEventKeyContractTest.indexHtml_usesEventKeyHelper_andNeverReadsEventTimestampDirectly`, `ClusterEventKeyContractTest.clusterEventView_serializesAtField_neverTimestamp`, `ClusterEventKeyContractTest.clusterEventView_recordComponents_nameTheTimeFieldAt_notTimestamp`]
- **#294**: every dashboard poll timer now skips its tick while a client-side `degraded` flag is set. The flag is driven by an ungated `GET /health` probe run every primary-timer tick (so recovery is detected too), keyed semantically on `status !== 'healthy'` — no literal `"degraded"` wire value exists on either health shape this dashboard talks to. A 404 from an endpoint the server has no route for is now logged once per method+path instead of toasted every tick; every other failure status still toasts on every occurrence.
  [verified: `DashboardPollingGateContractTest.restClient_probesHealthEndpoint_semanticallyNotByLiteralDegradedString`, `DashboardPollingGateContractTest.appJs_pollingTimers_skipWhenClusterDegraded`, `DashboardPollingGateContractTest.requestsJs_pollingTimer_skipsWhenClusterDegraded`, `DashboardPollingGateContractTest.clusterJs_declaresDegradedFlag_defaultingFalse`, `DashboardPollingGateContractTest.restClientJs_suppressesRepeat404Toasts_logsInstead`]

Docs updated: `aether/docs/architecture/12-management.md` ("Alert Delivery", "Live Event Feed", "Polling Behavior Under Degraded Health" subsections). Changelog fragments in `changelog.d/` per ticket; `CHANGELOG.md` itself is untouched.

## Explicitly out of scope (per CTO scope ruling)

**#304 trace waterfall** — the `trace-detail` component is loaded in `index.html` but never wired to a data source or a click handler. Building it needs: (1) a click/selection handler from the event feed or invocation explorer into the component, (2) a server-side trace-fetch endpoint (none of the existing `/api/events`-family routes return per-invocation span/trace data), (3) a rendering layer inside the component. None of this exists today. This is new feature work, not a fix — recommend a dedicated ticket rather than folding it back into #304.
[mechanism: `index.html:512-524` loads the component and never references it again; repo-wide grep for a trace-fetch route under `aether/node`'s REST layer finds none]

**#294 Forge proxy for missing endpoints** — 24 REST paths the dashboard calls have no matching Forge route and 404 under Forge today (2 more are near-misses mounted under a different prefix: `/api/thresholds*` vs Forge's `/api/alerts/thresholds*`, and `/api/cluster/topology` vs Forge's `/api/slices/topology`). All 24+2 now benefit from the 404-suppression above (logged once, not repeatedly toasted), but none is proxied or stubbed by this PR:

`/api/slices` (app.js) · `/api/thresholds`, `/api/thresholds` POST, `/api/thresholds/{metric}` DELETE (alerts.js) · `/api/controller/config` GET+POST, `/api/ttm/status`, `/api/logging/levels` GET+POST (cluster.js) · `/api/routes` (deployments.js) · `/api/cluster/config` (desiredtopology.js) · `/api/cluster/governors`, `/api/cluster/topology` (governors.js) · `/api/invocations/metrics`, `/api/invocations/metrics/slow` (requests.js) · `/api/schema/status`, `/api/schema/retry/{datasource}` (schema.js) · `/api/cluster/storage`, `/api/storage`, `/api/storage/{name}`, `/api/storage/snapshot/{name}` (storage.js) · `/api/deploy`, `/api/ab-tests` (strategies.js) · `/api/streams` (streams.js)
[mechanism: cross-referenced every `RestClient.get/post/put/del` call site in the dashboard JS against every registered route in Forge's 9 `*Routes.java` files]

**Systemic finding, flagged not fixed — #300 path-versioning gap.** Confirmed by direct route inspection this session: Forge's `StatusRoutes.java` registers a bare `/health` (and every other dashboard call is unversioned `/api/...`); the real node's `ManagementServer` has **no bare `/health` route at all** — only `/api/v1/health`, `/health/live`, `/health/ready`. This means the #294 health probe (and every other dashboard REST call) 404s against an already-migrated real node exactly like it does against any other unmigrated endpoint. This is pre-existing, systemic, and already tracked at #300 — not something this PR fixes, but the 404-suppression here at least stops it from spamming toasts.

## Test strategy

No pre-existing JS unit test harness was found for the dashboard, and no Java test served/exercised it directly. Three new Java "contract" tests were added under `aether/node/src/test/java/.../api/`, each reading the actual JS/HTML source off the classpath and asserting on the exact strings the fix depends on, plus pinning the Java-side wire shapes (`AlertManager.checkThreshold`'s literal return value, `ClusterEventView`'s record component names) against those same strings. This is an honest stand-in for a JS unit test, not a replacement for one — flagged as such rather than left implicit.

## Gate

`env -u HCLOUD_TOKEN mvn jbct:check -pl aether/node -fae -Djbct.includeTests=true`: zero `[ERROR]`-level findings attributable to the three new test files (pre-existing WARNING-level and format debt in ~120 other files in the module is untouched, out of scope for this PR).

Full targeted test run (`-Dtest=AlertWsEnvelopeContractTest,ClusterEventKeyContractTest,DashboardPollingGateContractTest`), counted from surefire XML `<testcase>` elements directly: 14/14 pass, 0 failures, 0 errors.

Do not merge. Not commenting on #292/#304/#294 per instruction.
