### PR TITLE
fix: gate DHT writes on admission latch, resolve gate on refusal (#874, #875)

### DIFF
--- a/aether/aether-storage/src/main/java/org/pragmatica/aether/storage/DhtStorageTier.java
+++ b/aether/aether-storage/src/main/java/org/pragmatica/aether/storage/DhtStorageTier.java
@@ -128,7 +128,7 @@ public final class DhtStorageTier implements StorageTier {
     @Override
     public Promise<Unit> delete(BlockId id) {
         return admission().flatMap(_ -> dhtClient.remove(buildKey(id))
-                                                  .mapToUnit());
+                                                 .mapToUnit());
     }
 
     @Override

--- a/aether/aether-storage/src/main/java/org/pragmatica/aether/storage/DhtStorageTier.java
+++ b/aether/aether-storage/src/main/java/org/pragmatica/aether/storage/DhtStorageTier.java
@@ -51,13 +51,22 @@ public final class DhtStorageTier implements StorageTier {
     }
 
     /// #858: the post-formation DHT-marker check (`StorageFactory.verifyDhtMarker`) resolves
-    /// `readGate` only after it has verified/written this namespace's encryption marker -- so a read
-    /// issued before that point (impossible for `artifacts`/`streams`, only reachable via deployed
-    /// slices which themselves need post-formation leader election, but enforced here rather than
-    /// merely documented) waits instead of racing a marker check that hasn't run yet. `put`/`delete`/
-    /// `exists` are ungated -- the ruling scopes the guard to reads. `instanceName` is the operator-
-    /// facing identity used in [StorageError.TierNotAdmitted]'s cause text -- distinct from
-    /// `keyPrefix`, which is the DHT key namespace.
+    /// `readGate` only after it has verified/written this namespace's encryption marker -- so an
+    /// operation issued before that point (impossible for `artifacts`/`streams`, only reachable via
+    /// deployed slices which themselves need post-formation leader election, but enforced here rather
+    /// than merely documented) waits instead of racing a marker check that hasn't run yet.
+    ///
+    /// #874: `get`, `put`, `delete` AND `exists` are all gated on the same `readGate` -- an earlier
+    /// ruling scoped the guard to `get` alone, reasoning only a read could observe a not-yet-verified
+    /// namespace. That missed two things. First, `AetherNode.start()` brings `managementServer`/
+    /// `appHttpServer` up BEFORE `verifyDhtMarkers()` runs, so an ungated `put` reachable over HTTP
+    /// (e.g. a Maven `deploy`) could persist a PLAINTEXT block into a namespace whose marker, once
+    /// actually checked, says it is already encrypted -- and because the DHT is a cluster-wide shared
+    /// store (`#isShared`), that block replicates to peers and survives this node's subsequent
+    /// `EncryptedTierRequiresKeyring` abort. Second, `exists` IS a read -- a DHT round trip on
+    /// `buildKey(id)`, never a local, gate-free check. `instanceName` is the operator-facing identity
+    /// used in [StorageError.TierNotAdmitted]'s cause text -- distinct from `keyPrefix`, which is the
+    /// DHT key namespace.
     public static DhtStorageTier dhtStorageTier(DHTClient dhtClient,
                                                 String keyPrefix,
                                                 String instanceName,
@@ -81,13 +90,14 @@ public final class DhtStorageTier implements StorageTier {
         return admission().flatMap(_ -> dhtClient.get(buildKey(id)));
     }
 
-    /// #858 C1: a read arriving while `readGate` is still pending waits at most `admissionTimeout`
-    /// then fails with [StorageError.TierNotAdmitted] -- never an unbounded wait. A read arriving
-    /// after `readGate` was already resolved -- success (admitted) or failure (the step REFUSED this
-    /// tier, e.g. `EncryptionError.EncryptedTierRequiresKeyring`) -- returns/fails immediately,
-    /// carrying the real cause on refusal, never waiting the bound. The `isResolved()` fast path
-    /// covers the common case (ungated tiers via `Promise.UNIT`, or any read once admission has
-    /// settled) without paying for `.map()`/`.timeout()`.
+    /// #858 C1/#874: an operation (`get`/`put`/`delete`/`exists`) arriving while `readGate` is still
+    /// pending waits at most `admissionTimeout` then fails with [StorageError.TierNotAdmitted] --
+    /// never an unbounded wait. An operation arriving after `readGate` was already resolved --
+    /// success (admitted) or failure (the step REFUSED this tier, e.g.
+    /// `EncryptionError.EncryptedTierRequiresKeyring`) -- returns/fails immediately, carrying the real
+    /// cause on refusal, never waiting the bound. The `isResolved()` fast path covers the common case
+    /// (ungated tiers via `Promise.UNIT`, or any call once admission has settled) without paying for
+    /// `.map()`/`.timeout()`.
     ///
     /// `.timeout()` is applied to a `.map()`-derived, single-use promise -- never to `readGate`
     /// itself. `readGate` is shared and resolved from a separate call path
@@ -112,18 +122,18 @@ public final class DhtStorageTier implements StorageTier {
 
     @Override
     public Promise<Unit> put(BlockId id, byte[] content) {
-        return dhtClient.put(buildKey(id), content);
+        return admission().flatMap(_ -> dhtClient.put(buildKey(id), content));
     }
 
     @Override
     public Promise<Unit> delete(BlockId id) {
-        return dhtClient.remove(buildKey(id))
-                        .mapToUnit();
+        return admission().flatMap(_ -> dhtClient.remove(buildKey(id))
+                                                  .mapToUnit());
     }
 
     @Override
     public Promise<Boolean> exists(BlockId id) {
-        return dhtClient.exists(buildKey(id));
+        return admission().flatMap(_ -> dhtClient.exists(buildKey(id)));
     }
 
     @Override

--- a/aether/aether-storage/src/test/java/org/pragmatica/aether/storage/DhtStorageTierTest.java
+++ b/aether/aether-storage/src/test/java/org/pragmatica/aether/storage/DhtStorageTierTest.java
@@ -134,11 +134,14 @@ class DhtStorageTierTest {
         }
     }
 
-    /// #858 C1: `DhtStorageTier.get` is gated on a per-instance `readGate` that
-    /// `StorageFactory.verifyDhtMarker` resolves post-formation. These pin the ruling's two required
-    /// states: a read arriving while the gate is still PENDING waits at most a bound then fails with
-    /// a named cause; a read arriving after the gate was already REFUSED fails immediately with the
-    /// refusal cause, never waiting the bound.
+    /// #858 C1/#874: `get`, `put`, `delete` and `exists` are all gated on a per-instance `readGate`
+    /// that `StorageFactory.verifyDhtMarker` resolves post-formation. These pin the ruling's two
+    /// required states: an operation arriving while the gate is still PENDING waits at most a bound
+    /// then fails with a named cause; an operation arriving after the gate was already REFUSED fails
+    /// immediately with the refusal cause, never waiting the bound. The `put` variants additionally
+    /// pin #874's hazard directly: a gated write must never reach the DHT ahead of admission, whether
+    /// it eventually times out or is refused outright -- proving no plaintext can land in a namespace
+    /// the marker check has not (or will not) admit.
     @Nested
     class Admission {
         /// Far below the 30s production default (`DhtStorageTier.DEFAULT_ADMISSION_TIMEOUT`) so the
@@ -183,6 +186,86 @@ class DhtStorageTierTest {
 
             assertThat(elapsedMillis).as("a refusal must fail immediately, never wait out the admission bound")
                                      .isLessThan(SHORT_ADMISSION_TIMEOUT.millis());
+        }
+
+        /// #874: pins the exact hazard the ticket describes -- an ungated `put` reachable over HTTP
+        /// (e.g. `managementServer`/`appHttpServer` coming up before `verifyDhtMarkers()` resolves)
+        /// could persist a PLAINTEXT block into a namespace the marker check had not yet cleared.
+        /// Asserts against the RAW `dhtClient`, bypassing the tier entirely, so this cannot pass by
+        /// accident if some other path re-reads through the same gated tier.
+        @Test
+        void put_whileGatePending_neverReachesDht_evenAfterTimingOut() {
+            var readGate = Promise.<Unit> promise();
+            var gatedTier = DhtStorageTier.dhtStorageTier(dhtClient, KEY_PREFIX, "content", readGate, SHORT_ADMISSION_TIMEOUT);
+            var blockId = blockIdOf(SAMPLE_CONTENT);
+
+            gatedTier.put(blockId, SAMPLE_CONTENT)
+                     .await()
+                     .onSuccess(_ -> fail("a write against a gate that never resolves must not succeed"))
+                     .onFailure(cause -> assertThat(cause).isInstanceOf(StorageError.TierNotAdmitted.class));
+
+            dhtClient.exists(rawKey(blockId))
+                     .await()
+                     .onFailure(_ -> fail("raw exists should succeed"))
+                     .onSuccess(found -> assertThat(found).as("#874: a write blocked on a pending gate must "
+                                                              + "never reach the DHT, not even after it times out")
+                                                           .isFalse());
+        }
+
+        /// #874/#875: a write racing a REFUSED gate must fail with the refusal cause immediately
+        /// (mirrors `get_afterGateRefused_...`) AND must never persist -- the two failure modes the
+        /// ticket names (waiting the full bound, and persisting plaintext) are pinned together here.
+        @Test
+        void put_afterGateRefused_failsImmediately_withoutPersisting() {
+            var readGate = Promise.<Unit> promise();
+            var refusal = new EncryptionError.EncryptedTierRequiresKeyring("content", "key-1");
+            readGate.resolve(Result.failure(refusal));
+
+            var gatedTier = DhtStorageTier.dhtStorageTier(dhtClient, KEY_PREFIX, "content", readGate, SHORT_ADMISSION_TIMEOUT);
+            var blockId = blockIdOf(SAMPLE_CONTENT);
+            var started = System.nanoTime();
+
+            gatedTier.put(blockId, SAMPLE_CONTENT)
+                     .await()
+                     .onSuccess(_ -> fail("a write against a refused tier must not succeed"))
+                     .onFailure(cause -> assertThat(cause).isSameAs(refusal));
+
+            var elapsedMillis = (System.nanoTime() - started) / 1_000_000;
+            assertThat(elapsedMillis).as("a refusal must fail immediately, never wait out the admission bound")
+                                     .isLessThan(SHORT_ADMISSION_TIMEOUT.millis());
+
+            dhtClient.exists(rawKey(blockId))
+                     .await()
+                     .onFailure(_ -> fail("raw exists should succeed"))
+                     .onSuccess(found -> assertThat(found).as("#874: a write refused by the marker check must "
+                                                              + "never persist plaintext into the namespace")
+                                                           .isFalse());
+        }
+
+        @Test
+        void exists_whileGatePending_timesOutWithTierNotAdmitted() {
+            var readGate = Promise.<Unit> promise();
+            var gatedTier = DhtStorageTier.dhtStorageTier(dhtClient, KEY_PREFIX, "content", readGate, SHORT_ADMISSION_TIMEOUT);
+
+            gatedTier.exists(blockIdOf(SAMPLE_CONTENT))
+                     .await()
+                     .onSuccess(_ -> fail("#874: exists is a read too -- it must gate on the same latch as get"))
+                     .onFailure(cause -> assertThat(cause).isInstanceOf(StorageError.TierNotAdmitted.class));
+        }
+
+        @Test
+        void delete_whileGatePending_timesOutWithTierNotAdmitted() {
+            var readGate = Promise.<Unit> promise();
+            var gatedTier = DhtStorageTier.dhtStorageTier(dhtClient, KEY_PREFIX, "content", readGate, SHORT_ADMISSION_TIMEOUT);
+
+            gatedTier.delete(blockIdOf(SAMPLE_CONTENT))
+                     .await()
+                     .onSuccess(_ -> fail("#874: delete must gate on the same latch as get/put"))
+                     .onFailure(cause -> assertThat(cause).isInstanceOf(StorageError.TierNotAdmitted.class));
+        }
+
+        private static byte[] rawKey(BlockId id) {
+            return (KEY_PREFIX + "/" + id.hexString()).getBytes(StandardCharsets.UTF_8);
         }
     }
 

--- a/aether/docs/reference/configuration.md
+++ b/aether/docs/reference/configuration.md
@@ -289,12 +289,16 @@ framed `AEC1...` bytes as if they were plaintext content on every read. Recovery
 to a fresh, unmarked directory or DHT namespace (`#831`). This marker/refusal pair covers the
 per-instance disk/DHT path above; the built-in `streams` segment tiers' DHT namespace
 (`stream-segments`) has neither yet — only its disk side does — and is tracked separately as `#849`.
-**Timing differs by tier (`#858`):** the local-disk marker is checked synchronously during storage
-construction, before the node object exists — a disk read needs no cluster. The DHT marker cannot be:
-its `DHTClient` can only route once cluster formation resolves, so that check runs from `start()`,
-after formation resolves and before the node reports ready; a DHT tier serves no reads until its own
-check completes (gated internally, not observable as a separate config knob). A boot that fails this
-later DHT check stops the node the same way any other `start()` failure does: exit code `1`, the
+**Timing differs by tier (`#858`/`#874`):** the local-disk marker is checked synchronously during
+storage construction, before the node object exists — a disk read needs no cluster. The DHT marker
+cannot be: its `DHTClient` can only route once cluster formation resolves, so that check runs from
+`start()`, after formation resolves. It does **not** run before the node's HTTP surfaces come up —
+`managementServer`/`appHttpServer` start earlier in the same `start()` chain and can already accept
+traffic, including the Maven protocol handler's writes, while this check is in flight. What actually
+blocks during that window is every DHT-tier operation on the pending namespace — `get`, `put`,
+`delete` and `exists` all gate on the same internal check (not observable as a separate config knob),
+so a write cannot land ahead of the check and persist plaintext into a namespace the check later finds
+already encrypted. A boot that fails this later DHT check stops the node the same way any other `start()` failure does: exit code `1`, the
 generic "fatal startup failure" path (`Main#exitWithError`) — see
 [`node-operations.md`](node-operations.md#exit-codes) for the full table.
 

--- a/aether/node/src/main/java/org/pragmatica/aether/api/routes/MavenProtocolRoutes.java
+++ b/aether/node/src/main/java/org/pragmatica/aether/api/routes/MavenProtocolRoutes.java
@@ -24,6 +24,7 @@ import org.pragmatica.lang.Option;
 import org.pragmatica.lang.Promise;
 import org.pragmatica.lang.io.CoreError;
 import org.pragmatica.lang.io.TimeSpan;
+import org.pragmatica.storage.StorageError;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -51,6 +52,14 @@ public final class MavenProtocolRoutes implements RouteHandler {
     /// (timeout tests, dev-mode tests). SECURE by default: the #520 relaxation must be opted into
     /// explicitly, never inherited by a caller that simply did not know about it.
     private static final BooleanSupplier SECURITY_ENABLED = () -> true;
+    /// #874/#875: `StorageError.TierNotAdmitted` means a request reached a DHT-backed tier before
+    /// its post-formation marker check ([org.pragmatica.aether.node.StorageFactory#verifyDhtMarker])
+    /// resolved the admission gate -- transient by construction, not a server defect, and the check
+    /// itself resolves in well under a second on a live cluster. `1` is a deliberately small,
+    /// unmeasured retry hint [design intent — unverified]: it need only beat `mvn deploy`'s own
+    /// "do not retry a 500" default so a CI deploy racing a node restart backs off and succeeds on
+    /// its own retry instead of failing hard.
+    private static final int TIER_NOT_ADMITTED_RETRY_AFTER_SECONDS = 1;
 
     /// Security-relevant bypass notices (#520). Both name the artifact, the posture that admitted it,
     /// and what an operator must change — a WARN nobody can read past without understanding it.
@@ -265,6 +274,13 @@ public final class MavenProtocolRoutes implements RouteHandler {
     private void sendFailureResponse(ResponseWriter response, Cause cause) {
         if (cause instanceof CoreError.Timeout) {
             response.error(HttpStatus.GATEWAY_TIMEOUT, cause.message());
+
+            return;
+        }
+
+        if (cause instanceof StorageError.TierNotAdmitted) {
+            response.header("Retry-After", String.valueOf(TIER_NOT_ADMITTED_RETRY_AFTER_SECONDS));
+            response.error(HttpStatus.SERVICE_UNAVAILABLE, cause.message());
 
             return;
         }

--- a/aether/node/src/main/java/org/pragmatica/aether/node/StorageFactory.java
+++ b/aether/node/src/main/java/org/pragmatica/aether/node/StorageFactory.java
@@ -526,9 +526,15 @@ public final class StorageFactory {
     /// client and no keyring (#858). No keyring: refuses if the marker is present -- same
     /// `EncryptionError.EncryptedTierRequiresKeyring` cause as before, just raised later
     /// (fail-closed; `start()` aborts and the node stops). Keyring present: (re)writes the marker.
-    /// Either branch resolves `check.readGate()` on success so [DhtStorageTier#get] starts serving
-    /// reads for this namespace; on failure the gate is left unresolved, which is safe because a
-    /// failed `start()` aborts the whole node before anything could observe it.
+    ///
+    /// #875: BOTH branches resolve `check.readGate()` -- success admits [DhtStorageTier]'s gated
+    /// operations immediately; failure resolves the SAME gate WITH the refusal cause, so a caller
+    /// racing this check fails with that cause right away instead of waiting out the full
+    /// `admissionTimeout` and surfacing the wrong error (`StorageError.TierNotAdmitted`). An earlier
+    /// version left the failure branch unresolved, reasoning a failed `start()` aborts the node before
+    /// anything could observe it -- true for `start()`'s own chain, but `readGate` is a shared,
+    /// resolve-once promise with no guarantee every caller reads it only after that abort completes;
+    /// resolving it with the cause removes the race instead of relying on the abort's timing.
     static Promise<Unit> verifyDhtMarker(DHTClient client, DhtMarkerCheck check) {
         return verifyDhtMarker(client, check, DHT_MARKER_TIMEOUT);
     }
@@ -552,7 +558,9 @@ public final class StorageFactory {
                                                  ring,
                                                  timeout))
                     .onSuccess(_ -> check.readGate()
-                                         .resolve(Result.success(unit())));
+                                         .resolve(Result.success(unit())))
+                    .onFailure(cause -> check.readGate()
+                                             .resolve(Result.failure(cause)));
     }
 
     /// #858: fans [#verifyDhtMarker] across every check in `checks` -- called once, post-formation,

--- a/aether/node/src/test/java/org/pragmatica/aether/api/routes/MavenProtocolRoutesTierNotAdmittedTest.java
+++ b/aether/node/src/test/java/org/pragmatica/aether/api/routes/MavenProtocolRoutesTierNotAdmittedTest.java
@@ -1,0 +1,162 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2025 Pragmatica Labs - Sergiy Yevtushenko
+// Licensed under Business Source License 1.1. Change Date: 2030-01-01. Change License: Apache-2.0.
+// See LICENSE in the repository root for full terms.
+
+package org.pragmatica.aether.api.routes;
+
+import org.junit.jupiter.api.Test;
+import org.pragmatica.aether.management.route.ManagementRoute;
+import org.pragmatica.aether.node.ManageableNode;
+import org.pragmatica.aether.resource.artifact.MavenProtocolHandler;
+import org.pragmatica.aether.resource.artifact.MavenProtocolHandler.MavenResponse;
+import org.pragmatica.http.ContentType;
+import org.pragmatica.http.Headers;
+import org.pragmatica.http.HttpMethod;
+import org.pragmatica.http.HttpStatus;
+import org.pragmatica.http.QueryParams;
+import org.pragmatica.http.HttpRequest;
+import org.pragmatica.http.server.ResponseWriter;
+import org.pragmatica.lang.Option;
+import org.pragmatica.lang.Promise;
+import org.pragmatica.lang.io.TimeSpan;
+import org.pragmatica.storage.StorageError;
+
+import java.lang.reflect.Proxy;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.pragmatica.lang.io.TimeSpan.timeSpan;
+
+/// #874/#875 round-1 fix: `StorageError.TierNotAdmitted` reaching the maven-protocol surface is
+/// transient by construction (a request raced a DHT tier's post-formation admission check), NOT a
+/// server defect -- so it must answer 503 Service Unavailable with a `Retry-After` hint, telling
+/// `mvn deploy` to retry, rather than 500 Internal Server Error, which tells it the opposite. Uses
+/// the GET path (mirrors `MavenProtocolRoutesTimeoutTest`) because `get` was already gated on
+/// `admission()` before #874 -- no auth setup needed to reach `sendFailureResponse`.
+class MavenProtocolRoutesTierNotAdmittedTest {
+    private static final TimeSpan SHORT_TIMEOUT = timeSpan(150).millis();
+    private static final String GET_PATH = ManagementRoute.ARTIFACT_GET.prefix() + "/org/example/app/1.0.0/app-1.0.0.jar";
+
+    @Test
+    void handle_getWhoseHandlerFailsWithTierNotAdmitted_writes503WithRetryAfter() {
+        var cause = new StorageError.TierNotAdmitted("content", 30_000L);
+        var routes = MavenProtocolRoutes.mavenProtocolRoutes(() -> nodeWith(failingHandler(cause)), SHORT_TIMEOUT);
+        var response = new CapturingResponseWriter();
+
+        var handled = routes.handle(getRequest(), response);
+
+        assertThat(handled).isTrue();
+        assertThat(response.awaitStatus()).as("a gated-write/read race is transient, not a server bug")
+                                          .isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
+        assertThat(response.header("Retry-After")).as("must tell the caller to retry, not just that it failed")
+                                                   .isEqualTo("1");
+    }
+
+    @Test
+    void handle_getWhoseHandlerFailsWithSomeOtherCause_stillWrites500() {
+        var cause = new StorageError.WriteError("disk full");
+        var routes = MavenProtocolRoutes.mavenProtocolRoutes(() -> nodeWith(failingHandler(cause)), SHORT_TIMEOUT);
+        var response = new CapturingResponseWriter();
+
+        routes.handle(getRequest(), response);
+
+        assertThat(response.awaitStatus()).as("TierNotAdmitted's remap must not swallow genuine server errors")
+                                          .isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+        assertThat(response.header("Retry-After")).isNull();
+    }
+
+    private static MavenProtocolHandler failingHandler(StorageError cause) {
+        return new MavenProtocolHandler() {
+            @Override
+            public Promise<MavenResponse> handleGet(String path) {
+                return Promise.failure(cause);
+            }
+
+            @Override
+            public Promise<MavenResponse> handlePut(String path, byte[] content) {
+                return Promise.failure(cause);
+            }
+        };
+    }
+
+    private static HttpRequest getRequest() {
+        return new HttpRequest() {
+            @Override
+            public String requestId() {
+                return "req_test";
+            }
+
+            @Override
+            public HttpMethod method() {
+                return HttpMethod.GET;
+            }
+
+            @Override
+            public String path() {
+                return GET_PATH;
+            }
+
+            @Override
+            public Headers headers() {
+                return Headers.empty();
+            }
+
+            @Override
+            public QueryParams queryParams() {
+                return QueryParams.empty();
+            }
+
+            @Override
+            public byte[] body() {
+                return new byte[0];
+            }
+        };
+    }
+
+    private static ManageableNode nodeWith(MavenProtocolHandler handler) {
+        return (ManageableNode) Proxy.newProxyInstance(
+            ManageableNode.class.getClassLoader(),
+            new Class[]{ManageableNode.class},
+            (_, method, _) -> {
+                if ("mavenProtocolHandler".equals(method.getName())) {
+                    return handler;
+                }
+                throw new UnsupportedOperationException("Not implemented in test proxy: " + method.getName());
+            });
+    }
+
+    private static final class CapturingResponseWriter implements ResponseWriter {
+        private final java.util.concurrent.CountDownLatch written = new java.util.concurrent.CountDownLatch(1);
+        private final Map<String, String> headers = new LinkedHashMap<>();
+        private volatile HttpStatus status;
+
+        HttpStatus awaitStatus() {
+            try {
+                written.await(5, java.util.concurrent.TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+
+            return status;
+        }
+
+        String header(String name) {
+            return headers.get(name);
+        }
+
+        @Override
+        public void write(HttpStatus status, byte[] body, ContentType contentType) {
+            this.status = status;
+            written.countDown();
+        }
+
+        @Override
+        public ResponseWriter header(String name, String value) {
+            headers.put(name, value);
+
+            return this;
+        }
+    }
+}

--- a/aether/node/src/test/java/org/pragmatica/aether/node/StorageFactoryEncryptionTest.java
+++ b/aether/node/src/test/java/org/pragmatica/aether/node/StorageFactoryEncryptionTest.java
@@ -569,18 +569,23 @@ class StorageFactoryEncryptionTest {
                                               + "must fail closed"))
                           .onFailure(cause -> assertThat(cause).isInstanceOf(EncryptionError.EncryptedTierRequiresKeyring.class));
 
-            // #875: the gate itself, not merely the returned Promise, must carry the refusal. If
-            // `verifyDhtMarker`'s failure branch ever dropped `check.readGate().resolve(...)`, this
-            // `.await()` would hang until DhtStorageTier's own admission bound (30s in production)
-            // rather than complete here.
+            // #875: the gate itself, not merely the returned Promise, must carry the refusal. `readGate`
+            // is independent of `DhtStorageTier`'s `admissionTimeout` -- that bound applies only to the
+            // `.map()`-derived promise inside `DhtStorageTier#admission`, never to `readGate` itself -- so
+            // if `verifyDhtMarker`'s failure branch ever dropped `check.readGate().resolve(...)`, an
+            // unbounded `.await()` here would hang forever, not for 30s. Bounded so that regressing
+            // :560-563 turns this test RED with a fast assertion failure instead of wedging the build:
+            // `await(SHORT_MARKER_TIMEOUT)` yields `CoreError.Timeout`, which fails the `isInstanceOf`
+            // check below in milliseconds.
             c.readGate()
-             .await()
+             .await(SHORT_MARKER_TIMEOUT)
              .onSuccess(_ -> fail("#875: a refused marker check must resolve readGate to FAILURE with the "
                                   + "refusal cause, not success -- a caller racing this check must fail "
                                   + "immediately, not be admitted"))
              .onFailure(cause -> assertThat(cause).as("#875: readGate must carry the SAME refusal cause the "
                                                        + "returned Promise failed with, not a generic or "
-                                                       + "unresolved state")
+                                                       + "unresolved state (or, if this is a "
+                                                       + "CoreError.Timeout, readGate was never resolved at all)")
                                                    .isInstanceOf(EncryptionError.EncryptedTierRequiresKeyring.class));
         });
     }

--- a/aether/node/src/test/java/org/pragmatica/aether/node/StorageFactoryEncryptionTest.java
+++ b/aether/node/src/test/java/org/pragmatica/aether/node/StorageFactoryEncryptionTest.java
@@ -123,6 +123,20 @@ class StorageFactoryEncryptionTest {
                     .unwrap();
     }
 
+    /// #874: `put` is now gated on the same `readGate` as `get` (previously ungated) -- a raw
+    /// `writeThrough` against a DHT-backed instance must first resolve the marker check the way
+    /// `AetherNode.start()` does post-formation, or `admission()` blocks it for the full 30s
+    /// `admissionTimeout` and fails with `StorageError.TierNotAdmitted`. Mirrors the
+    /// `dhtMarkerCheck()`/`verifyDhtMarker` sequence the read-side tests below already use
+    /// (`verifyDhtMarker_fails_...`, `createAll_stillRefusesLegacyPlaintextBlock_...`). A no-op for
+    /// instances with no DHT tier (`dhtMarkerCheck()` empty).
+    private static void admitDhtMarker(StorageFactory.StorageSetup setup, DHTClient dhtClient) {
+        setup.dhtMarkerCheck()
+             .onPresent(check -> StorageFactory.verifyDhtMarker(dhtClient, check)
+                                                .await()
+                                                .onFailure(cause -> fail("verifying the DHT marker failed: " + cause.message())));
+    }
+
     private static void assertCiphertextAtRest(byte[] stored, String where) {
         assertThat(stored).as("%s must hold ciphertext, not the plaintext block", where)
                           .isNotEqualTo(PLAINTEXT);
@@ -195,6 +209,8 @@ class StorageFactoryEncryptionTest {
 
         assertThat(setups).containsKey(ARTIFACTS);
 
+        admitDhtMarker(setups.get(ARTIFACTS), dhtClient);
+
         var blockId = writeThrough(setups.get(ARTIFACTS));
         var stored = dhtClient.rawValue("artifacts-blocks", blockId);
 
@@ -215,6 +231,8 @@ class StorageFactoryEncryptionTest {
         var setups = createAllOrFail(Map.of(), Option.some(dhtClient), Option.none());
 
         assertThat(setups).containsKey(ARTIFACTS);
+
+        admitDhtMarker(setups.get(ARTIFACTS), dhtClient);
 
         var blockId = writeThrough(setups.get(ARTIFACTS));
         var stored = dhtClient.rawValue("artifacts-blocks", blockId);
@@ -424,6 +442,8 @@ class StorageFactoryEncryptionTest {
 
         assertThat(setups).containsKey(INSTANCE);
 
+        admitDhtMarker(setups.get(INSTANCE), dhtClient);
+
         var blockId = writeThrough(setups.get(INSTANCE));
         var stored = dhtClient.rawValue(INSTANCE + "-blocks", blockId);
 
@@ -444,6 +464,8 @@ class StorageFactoryEncryptionTest {
                                      Option.some(singleKeyRing("key-1")));
 
         assertThat(setups).containsKey(INSTANCE);
+
+        admitDhtMarker(setups.get(INSTANCE), dhtClient);
 
         var blockId = writeThrough(setups.get(INSTANCE));
         var stored = dhtClient.rawValue(INSTANCE + "-blocks", blockId);

--- a/aether/node/src/test/java/org/pragmatica/aether/node/StorageFactoryEncryptionTest.java
+++ b/aether/node/src/test/java/org/pragmatica/aether/node/StorageFactoryEncryptionTest.java
@@ -501,6 +501,68 @@ class StorageFactoryEncryptionTest {
                                            .onFailure(cause -> assertThat(cause).isInstanceOf(EncryptionError.EncryptedTierRequiresKeyring.class)));
     }
 
+    /// #875: the test above proves `verifyDhtMarker`'s RETURNED `Promise` fails with the refusal
+    /// cause -- it says nothing about `check.readGate()` itself, the shared promise
+    /// [org.pragmatica.aether.storage.DhtStorageTier] actually blocks on. `DhtStorageTierTest`'s
+    /// admission-race coverage constructs and resolves `readGate` BY HAND
+    /// (`readGate.resolve(Result.failure(refusal))`), so it pins `DhtStorageTier`'s reaction to an
+    /// already-resolved gate but cannot prove `verifyDhtMarker` is what resolves it in production --
+    /// that pins its own fixture, not the production path. This test drives the real
+    /// no-keyring-refusal branch end to end (same setup as the test above) and reads `readGate()`
+    /// directly afterward; nothing here calls `.resolve(...)`. Before #875, the failure branch of
+    /// `verifyDhtMarker` left `readGate` unresolved, so a caller racing this check (a read/write
+    /// arriving mid-formation) would wait out the full `admissionTimeout` and see
+    /// `StorageError.TierNotAdmitted` instead of the real cause asserted here.
+    @Test
+    void verifyDhtMarker_resolvesReadGate_withRefusalCause_onProductionFailurePath() throws IOException {
+        var brokenDiskPath = tempDir.resolve("vault-disk-unavailable-gate");
+
+        Files.writeString(brokenDiskPath, "a plain file here forces LocalDiskTier construction to fail");
+
+        var dhtClient = new InMemoryDHTClient();
+        var seeded = createAllOrFail(Map.of(INSTANCE, storageConfigAt(brokenDiskPath, true)),
+                                     Option.some(dhtClient),
+                                     Option.some(singleKeyRing("key-1")));
+
+        seeded.get(INSTANCE)
+              .dhtMarkerCheck()
+              .onPresent(check -> StorageFactory.verifyDhtMarker(dhtClient, check)
+                                                 .await()
+                                                 .onFailure(cause -> fail("writing the DHT marker on first boot failed: " + cause.message())));
+
+        var reboot = createAllOrFail(Map.of(INSTANCE, storageConfigAt(brokenDiskPath, false)),
+                                     Option.some(dhtClient),
+                                     Option.none());
+
+        var check = reboot.get(INSTANCE).dhtMarkerCheck();
+
+        assertThat(check.isPresent()).as("an instance with a DHT tier must always carry a marker check for "
+                                         + "AetherNode.start() to verify post-formation")
+                                     .isTrue();
+
+        check.onPresent(c -> {
+            StorageFactory.verifyDhtMarker(dhtClient, c)
+                          .await()
+                          .onSuccess(_ -> fail("booting a previously-encrypted DHT namespace with no keyring "
+                                              + "must fail closed"))
+                          .onFailure(cause -> assertThat(cause).isInstanceOf(EncryptionError.EncryptedTierRequiresKeyring.class));
+
+            // #875: the gate itself, not merely the returned Promise, must carry the refusal. If
+            // `verifyDhtMarker`'s failure branch ever dropped `check.readGate().resolve(...)`, this
+            // `.await()` would hang until DhtStorageTier's own admission bound (30s in production)
+            // rather than complete here.
+            c.readGate()
+             .await()
+             .onSuccess(_ -> fail("#875: a refused marker check must resolve readGate to FAILURE with the "
+                                  + "refusal cause, not success -- a caller racing this check must fail "
+                                  + "immediately, not be admitted"))
+             .onFailure(cause -> assertThat(cause).as("#875: readGate must carry the SAME refusal cause the "
+                                                       + "returned Promise failed with, not a generic or "
+                                                       + "unresolved state")
+                                                   .isInstanceOf(EncryptionError.EncryptedTierRequiresKeyring.class));
+        });
+    }
+
     /// #858 C2: two distinct causes must never be conflated. Marker get/put timing out after
     /// formation (this test: the DHT client itself never answers) means `start()` never learned
     /// whether a marker exists at all -- fails on `EncryptionError.DhtMarkerCheckTimedOut`. That is

--- a/changelog.d/874-875-dht-write-admission-gate.md
+++ b/changelog.d/874-875-dht-write-admission-gate.md
@@ -1,0 +1,42 @@
+### Fixed (2026-09-05 — #874: DHT writes could reach the tier before admission; #875: a refused admission check never resolved the gate)
+- **A write reaching a DHT-backed storage instance during the marker-check window could persist
+  plaintext into a namespace the check later finds already encrypted.** #858's admission latch
+  (`DhtStorageTier.readGate`, resolved post-formation by `StorageFactory.verifyDhtMarker`) gated `get`
+  only, reasoning only a read could observe a not-yet-verified namespace. That missed two things:
+  `AetherNode.start()` brings `managementServer`/`appHttpServer` up *before* `verifyDhtMarkers()` runs,
+  so an ungated `put` reachable over HTTP (e.g. a Maven `deploy`) could write ahead of the check; and
+  `exists` is itself a DHT round trip, not a local, gate-free check. `put`, `delete` and `exists` are
+  now gated on the same `readGate` as `get` — no operation can reach the DHT tier ahead of admission.
+  Because the DHT is a cluster-wide shared store (`DhtStorageTier#isShared`), a write that landed ahead
+  of the check would have replicated to peers and survived this node's own subsequent
+  `EncryptedTierRequiresKeyring` abort; this closes that window without changing `AetherNode`'s startup
+  ordering, since every DHT operation — not just HTTP-surface timing — is now the enforcement point.
+- **A refused admission check left the gate unresolved, so a caller racing it waited the full 30 s
+  `admissionTimeout` and saw the wrong error.** `StorageFactory.verifyDhtMarker` resolved `readGate`
+  only on success (`.onSuccess(...)`); its failure branch (no keyring, marker already present) left
+  `readGate` pending. A reader/writer arriving during that window timed out with
+  `StorageError.TierNotAdmitted` instead of the real refusal cause
+  (`EncryptionError.EncryptedTierRequiresKeyring`). The failure branch now resolves the same gate with
+  the refusal cause, so a racing caller fails immediately with the real cause instead of waiting out
+  the bound.
+- `configuration.md`'s DHT-marker-timing section corrected: it previously claimed the check runs
+  "before the node reports ready", which reads as if HTTP surfaces wait for it. They don't — what
+  blocks during that window is every DHT-tier operation on the pending namespace, not the HTTP surface.
+- [verified: `DhtStorageTierTest$Admission` (7 tests: pending-gate timeout and immediate-refusal
+  cases for `get`/`put`/`delete`/`exists`, including two that assert directly against the raw DHT
+  client that a gated write never persists, whether it times out or is refused) — 7/7;
+  `StorageFactoryEncryptionTest#verifyDhtMarker_resolvesReadGate_withRefusalCause_onProductionFailurePath`
+  (drives the real no-keyring-refusal path through `StorageFactory.verifyDhtMarker` and reads
+  `readGate()` directly, without resolving it by hand) — 1/1;
+  `aether/aether-storage` full module suite — 30/30;
+  `aether/node` full module suite — 12900/12900 across the reactor;
+  `mvn jbct:check -pl aether/aether-storage,aether/node` — 0 format issues, 0 lint errors on both
+  touched modules]
+- **What is NOT covered:** `AetherNode.start()`'s startup ordering is unchanged — `managementServer`/
+  `appHttpServer` still come up before `verifyDhtMarkers()` resolves; protection now comes from gating
+  every DHT-tier operation rather than delaying HTTP-surface startup, which was weighed and rejected
+  because it would delay unrelated, non-DHT HTTP traffic (health checks, other endpoints) for up to the
+  full 30 s bound. `Promise.allOfOrCancel` in `StorageFactory.verifyDhtMarkers` (plural) cancels
+  sibling in-flight marker checks on the first failure; the exact cancellation cause a cancelled
+  sibling's `readGate` now resolves with is a strict improvement over the pre-#875 hang but its precise
+  type is unverified here.

--- a/changelog.d/874-875-dht-write-admission-gate.md
+++ b/changelog.d/874-875-dht-write-admission-gate.md
@@ -22,16 +22,37 @@
 - `configuration.md`'s DHT-marker-timing section corrected: it previously claimed the check runs
   "before the node reports ready", which reads as if HTTP surfaces wait for it. They don't — what
   blocks during that window is every DHT-tier operation on the pending namespace, not the HTTP surface.
-- [verified: `DhtStorageTierTest$Admission` (7 tests: pending-gate timeout and immediate-refusal
-  cases for `get`/`put`/`delete`/`exists`, including two that assert directly against the raw DHT
-  client that a gated write never persists, whether it times out or is refused) — 7/7;
+- **Round 1 (review) fix — the #875 regression test could not fail, it could only wedge.**
+  `verifyDhtMarker_resolvesReadGate_withRefusalCause_onProductionFailurePath` ended in an unbounded
+  `c.readGate().await()`; a regression on `StorageFactory.verifyDhtMarker`'s failure branch
+  (dropping `check.readGate().resolve(Result.failure(cause))`) would hang the test forever instead of
+  failing it — `readGate` is independent of `DhtStorageTier`'s `admissionTimeout` (that bound applies
+  only to the `.map()`-derived promise inside `DhtStorageTier#admission`, never to `readGate` itself),
+  so the comment claiming a 30 s production bound would eventually rescue it was false. Now bounded
+  with the file's existing `SHORT_MARKER_TIMEOUT` (150 ms); the false comment is replaced with the
+  correct mechanism. Proved by mutation: reverting the two-line fix makes the test fail in ~11s
+  wall-clock with a real assertion (`CoreError.Timeout` where `EncryptionError.EncryptedTierRequiresKeyring`
+  was expected), not a hang; restoring the fix returns it to a 0.28s pass.
+- **Round 1 (review) fix — a gated write/read answered HTTP 500, not 503.**
+  `StorageError.TierNotAdmitted` is not a `CoreError.Timeout`, so `MavenProtocolRoutes.sendFailureResponse`
+  fell through to `internalError` (500) for a state that is transient by construction — telling
+  `mvn deploy` "server bug, do not retry" instead of "retry me". `TierNotAdmitted` now maps to 503
+  Service Unavailable with a `Retry-After: 1` header; every other cause is unaffected and still gets 500.
+- [verified: `DhtStorageTierTest$Admission` (six `@Test` methods: pending-gate-timeout and
+  immediate-refusal cases for `get`/`put`/`delete`/`exists`, including two that assert directly against
+  the raw DHT client that a gated write never persists, whether it times out or is refused) — 6/6, read
+  from surefire `<testcase>` counts (not the `.txt` summary, which undercounts `@Nested` classes);
   `StorageFactoryEncryptionTest#verifyDhtMarker_resolvesReadGate_withRefusalCause_onProductionFailurePath`
   (drives the real no-keyring-refusal path through `StorageFactory.verifyDhtMarker` and reads
-  `readGate()` directly, without resolving it by hand) — 1/1;
-  `aether/aether-storage` full module suite — 30/30;
-  `aether/node` full module suite — 12900/12900 across the reactor;
-  `mvn jbct:check -pl aether/aether-storage,aether/node` — 0 format issues, 0 lint errors on both
-  touched modules]
+  `readGate()` directly, without resolving it by hand; mutation-probed per above) — 1/1;
+  `MavenProtocolRoutesTierNotAdmittedTest` (503+`Retry-After` for `TierNotAdmitted`, plain 500 with no
+  `Retry-After` for every other cause) — 2/2;
+  `aether/aether-storage` MODULE suite (full, `mvn -pl aether/aether-storage test`) — 30/30;
+  `aether/node` MODULE suite (full, `mvn -pl aether/node test`, not a reactor total — no full-monorepo
+  reactor run was performed this round since only `aether/node` sources changed) — 1138/1138, 1 skipped
+  (pre-existing, unrelated to this change);
+  `mvn jbct:check -pl aether/node -fae` — 0 format issues, 0 lint errors (aether-storage source is
+  unchanged this round, not re-gated)]
 - **What is NOT covered:** `AetherNode.start()`'s startup ordering is unchanged — `managementServer`/
   `appHttpServer` still come up before `verifyDhtMarkers()` resolves; protection now comes from gating
   every DHT-tier operation rather than delaying HTTP-surface startup, which was weighed and rejected
@@ -39,4 +60,5 @@
   full 30 s bound. `Promise.allOfOrCancel` in `StorageFactory.verifyDhtMarkers` (plural) cancels
   sibling in-flight marker checks on the first failure; the exact cancellation cause a cancelled
   sibling's `readGate` now resolves with is a strict improvement over the pre-#875 hang but its precise
-  type is unverified here.
+  type is unverified here. The `Retry-After: 1` value is a deliberately small, unmeasured hint
+  [design intent — unverified], not a measured recovery-time bound.


### PR DESCRIPTION
## Summary

Two related fixes to the #858 post-formation DHT-marker admission mechanism:

**#874 — DHT admission latch gated reads only; a write during the marker-check window could persist plaintext into an encrypted namespace.** `AetherNode.start()` brings `managementServer`/`appHttpServer` up *before* `verifyDhtMarkers()` runs, so an ungated `DhtStorageTier.put()` reachable over HTTP (e.g. a Maven `deploy`) could write ahead of the check into a namespace the marker later finds already encrypted. Because the DHT is a cluster-wide shared store (`isShared() == true`), that write would replicate to peers and survive this node's own subsequent `EncryptedTierRequiresKeyring` abort. `exists` was also misclassified as "not a read" in the javadoc — it's a DHT round trip on `buildKey(id)`, same as `get`.

Fix: `put`, `delete` and `exists` are now gated on the same `readGate` admission latch as `get`. This was chosen over delaying `managementServer`/`appHttpServer` startup until after `verifyDhtMarkers()` resolves, because that alternative would delay unrelated HTTP traffic (health checks, non-DHT endpoints) for up to the full 30s bound; gating per-operation is minimal, reuses the already-validated #858 mechanism, and fixes the `exists` misclassification for free. `AetherNode.start()`'s startup ordering is therefore unchanged.

**#875 part 1 — a refused admission check never resolved the gate, so a racing caller waited the full timeout and saw the wrong error.** `StorageFactory.verifyDhtMarker` resolved `readGate` only on `.onSuccess(...)`; the failure/refusal branch left it unresolved. A reader/writer racing a refused check waited out the full 30s `admissionTimeout` and got `StorageError.TierNotAdmitted` instead of the real refusal cause.

Fix: the failure branch now also resolves `readGate`, with the refusal cause.

**#875 part 2 — reconciliation, SETTLED.** The ticket asked whether `aether/node` was red at `e01e32dad` (a missed regression) or whether `AetherNodeContentStorageWarnBootTest` passes trivially there. Ran the test against that commit: **BUILD SUCCESS, both tests PASS in ~2.7s.** `aether/node` was never red there — single-node self-routing (self-quorum via `live.add(config.self())`) satisfies the marker read almost immediately, while multi-node quorum with no peers connected burns the full bound (the 15/16 original Forge failures). This boot-timing test structurally cannot reach the multi-node ~30s hang #858 originally fixed, so it has no discriminating power over that specific bug as a single-node fixture — not a missed regression.

Also corrected `configuration.md`'s stale claim that the DHT marker check runs "before the node reports ready" — HTTP surfaces come up first; protection now comes from gating every DHT-tier operation, not from HTTP-surface timing.

### Round 1 review fixes

- **BLOCKING, fixed** — the #875 regression test (`verifyDhtMarker_resolvesReadGate_withRefusalCause_onProductionFailurePath`) ended in an unbounded `c.readGate().await()`. A regression on `StorageFactory.verifyDhtMarker`'s failure branch would have hung the test forever instead of failing it — `readGate` is independent of `DhtStorageTier`'s `admissionTimeout`, so the comment claiming a 30s production bound would eventually rescue it was false. Now bounded with the file's existing `SHORT_MARKER_TIMEOUT` (150ms); the false comment is corrected. Proved by mutation: reverting the two-line fix makes the test fail in ~11s wall-clock with a real assertion (`CoreError.Timeout` instead of the expected `EncryptionError.EncryptedTierRequiresKeyring`), not a hang.
- **SHOULD-FIX, fixed** — a gated write/read answered HTTP 500, not 503. `StorageError.TierNotAdmitted` is not a `CoreError.Timeout`, so `MavenProtocolRoutes.sendFailureResponse` fell through to `internalError` (500) for a state that's transient by construction, telling `mvn deploy` "server bug, do not retry" instead of "retry me". Now maps to 503 Service Unavailable with `Retry-After: 1`; every other cause is unaffected and still gets 500. New test: `MavenProtocolRoutesTierNotAdmittedTest` (2 tests).
- **Evidence-count correction** — `DhtStorageTierTest$Admission` has 6 `@Test` methods, not 7 (verified from surefire `<testcase>` counts, not the `.txt` summary which undercounts `@Nested` classes). The earlier "aether/node full reactor 12900/12900" conflated a module suite with a reactor total; corrected below to report each module's own count, produced by its own standalone `mvn -pl <module> test` run.

## Test plan
- [x] `DhtStorageTierTest$Admission` — 6 tests (pending-gate timeout + immediate-refusal for get/put/delete/exists, two asserting directly against the raw DHT client that a gated write never persists) — 6/6 pass
- [x] `StorageFactoryEncryptionTest#verifyDhtMarker_resolvesReadGate_withRefusalCause_onProductionFailurePath` — drives the real no-keyring-refusal path, reads `readGate()` directly without resolving it by hand — 1/1 pass; mutation-probed (revert → fast red in ~11s, not a hang → restore → pass again)
- [x] `MavenProtocolRoutesTierNotAdmittedTest` — 503+`Retry-After` for `TierNotAdmitted`, plain 500 with no `Retry-After` for every other cause — 2/2 pass
- [x] Fixed 4 pre-existing `StorageFactoryEncryptionTest` tests that wrote to a DHT instance without first admitting the marker (a genuine consequence of gating `put` — these now call the same `verifyDhtMarker` sequence the read-side tests already used)
- [x] `aether/aether-storage` MODULE suite (full, `mvn -pl aether/aether-storage test`) — 30/30
- [x] `aether/node` MODULE suite (full, `mvn -pl aether/node test`; not a reactor total — no full-monorepo reactor run was performed since only `aether/node` sources changed this round) — 1138/1138, 1 skipped (pre-existing, unrelated)
- [x] `mvn jbct:check -pl aether/node -fae` — 0 format issues, 0 lint errors (`aether-storage` source unchanged this round, not re-gated; its own gate from the initial commit was already clean)
- [x] changelog.d fragment updated with round-1 fixes and corrected counts

Fixes #874, #875
