### PR TITLE
fix: serve deployed slice config from the materialized slice-composite (#889)

### DIFF
--- a/aether/slice-api/src/main/java/org/pragmatica/aether/slice/AbsentCompositeConfigFacade.java
+++ b/aether/slice-api/src/main/java/org/pragmatica/aether/slice/AbsentCompositeConfigFacade.java
@@ -19,11 +19,25 @@ import org.pragmatica.lang.utils.Causes;
 /// implementation of the fix falls back to [NoOpConfigFacade], whose failures say only "Config
 /// service not available" — so a slice that genuinely needed configuration surfaced as a chain of
 /// missing-KEY errors, pointing the reader at their `resources.toml` when the real fault was one
-/// level up and node-wide: the node was started without a configuration provider at all.
+/// level up: no configuration SOURCE was ever attached.
 ///
 /// That is the shape this project keeps paying for — a fallback quietly converting a refusal into a
 /// confusing failure. Here the cause names the slice, names the key that was asked for, and states
-/// which of the two things is actually missing.
+/// that a source (not a key) is missing.
+///
+/// The composite is absent in FOUR load-time conditions, and the wording is true in every one of
+/// them — the first draft named only the first and was wrong in the other three (review S1):
+///
+///   - the node runs without a configuration provider (`AetherNode.createResourceProviderFacade`);
+///   - the node has one but node.toml secret resolution failed at boot (same method, second arm);
+///   - the slice's `META-INF/resources.toml` failed to parse (`SliceStore#parseToFlatMap`);
+///   - one of that file's `${secrets:...}` placeholders failed to resolve
+///     (`SliceStore#resolveIntrinsicSecrets`).
+///
+/// The last two drop the WHOLE composite, node keys included — `SliceStore` layers the slice file
+/// over the node composite in one all-or-nothing step — so a slice whose own file is broken cannot
+/// read node.toml either. This facade cannot tell the four apart (it sees only "no composite"), so
+/// it lists them and points at the load log, which names the one that fired.
 ///
 /// KNOWN LIMIT, stated rather than hidden: the `get*` half of [ConfigFacade] returns [Option] and so
 /// has no channel to refuse, and the generated code wraps those reads in `Result.success(...)`.
@@ -33,8 +47,11 @@ import org.pragmatica.lang.utils.Causes;
 /// the all-optional case means changing what the generator emits, which is a different blast radius.
 record AbsentCompositeConfigFacade(String sliceId) implements ConfigFacade {
     private static final Fn1<Cause, String> NO_COMPOSITE = Causes.forOneValue("No configuration composite is attached to this slice, so %s cannot be read. "
-                                                                             + "This is a missing configuration SOURCE, not a missing key: the node has no "
-                                                                             + "configuration provider, so nothing was layered for the slice to read from.");
+                                                                             + "This is a missing configuration SOURCE, not a missing key. One of two layers was never built: "
+                                                                             + "the node composite (no configuration provider configured, or node.toml secret resolution failed at boot) "
+                                                                             + "or the slice's own layer (META-INF/resources.toml failed to parse, or one of its ${secrets:...} "
+                                                                             + "placeholders failed to resolve; a dropped slice layer takes the node keys with it). "
+                                                                             + "The slice load log names which.");
 
     static AbsentCompositeConfigFacade absentCompositeConfigFacade(String sliceId) {
         return new AbsentCompositeConfigFacade(sliceId);

--- a/aether/slice-api/src/main/java/org/pragmatica/aether/slice/AbsentCompositeConfigFacade.java
+++ b/aether/slice-api/src/main/java/org/pragmatica/aether/slice/AbsentCompositeConfigFacade.java
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2025 Pragmatica Labs - Sergiy Yevtushenko
+// Licensed under Business Source License 1.1. Change Date: 2030-01-01. Change License: Apache-2.0.
+// See LICENSE in the repository root for full terms.
+package org.pragmatica.aether.slice;
+
+import java.util.List;
+
+import org.pragmatica.lang.Cause;
+import org.pragmatica.lang.Functions.Fn1;
+import org.pragmatica.lang.Option;
+import org.pragmatica.lang.Result;
+import org.pragmatica.lang.utils.Causes;
+
+
+/// The refusal a slice gets when it asks for configuration and no composite was ever attached.
+///
+/// Exists so that absence fails by NAME rather than by degradation (#889 review). The obvious
+/// implementation of the fix falls back to [NoOpConfigFacade], whose failures say only "Config
+/// service not available" — so a slice that genuinely needed configuration surfaced as a chain of
+/// missing-KEY errors, pointing the reader at their `resources.toml` when the real fault was one
+/// level up and node-wide: the node was started without a configuration provider at all.
+///
+/// That is the shape this project keeps paying for — a fallback quietly converting a refusal into a
+/// confusing failure. Here the cause names the slice, names the key that was asked for, and states
+/// which of the two things is actually missing.
+///
+/// KNOWN LIMIT, stated rather than hidden: the `get*` half of [ConfigFacade] returns [Option] and so
+/// has no channel to refuse, and the generated code wraps those reads in `Result.success(...)`.
+/// A config record whose components are ALL optional will therefore still be constructed, with every
+/// value absent, against a missing composite. Any record carrying at least one required component —
+/// the overwhelmingly common case, and every example in the books — fails loudly and by name. Closing
+/// the all-optional case means changing what the generator emits, which is a different blast radius.
+record AbsentCompositeConfigFacade(String sliceId) implements ConfigFacade {
+    private static final Fn1<Cause, String> NO_COMPOSITE = Causes.forOneValue("No configuration composite is attached to this slice, so %s cannot be read. "
+                                                                             + "This is a missing configuration SOURCE, not a missing key: the node has no "
+                                                                             + "configuration provider, so nothing was layered for the slice to read from.");
+
+    static AbsentCompositeConfigFacade absentCompositeConfigFacade(String sliceId) {
+        return new AbsentCompositeConfigFacade(sliceId);
+    }
+
+    @Override
+    public Result<String> requireString(String section, String key) {
+        return refuse(section, key);
+    }
+
+    @Override
+    public Result<Integer> requireInt(String section, String key) {
+        return refuse(section, key);
+    }
+
+    @Override
+    public Result<Long> requireLong(String section, String key) {
+        return refuse(section, key);
+    }
+
+    @Override
+    public Result<Double> requireDouble(String section, String key) {
+        return refuse(section, key);
+    }
+
+    @Override
+    public Result<Boolean> requireBoolean(String section, String key) {
+        return refuse(section, key);
+    }
+
+    @Override
+    public Result<List<String>> requireStringList(String section, String key) {
+        return refuse(section, key);
+    }
+
+    @Override
+    public Option<String> getString(String section, String key) {
+        return Option.none();
+    }
+
+    @Override
+    public Option<Integer> getInt(String section, String key) {
+        return Option.none();
+    }
+
+    @Override
+    public Option<Long> getLong(String section, String key) {
+        return Option.none();
+    }
+
+    @Override
+    public Option<Double> getDouble(String section, String key) {
+        return Option.none();
+    }
+
+    @Override
+    public Option<Boolean> getBoolean(String section, String key) {
+        return Option.none();
+    }
+
+    private <T> Result<T> refuse(String section, String key) {
+        return NO_COMPOSITE.apply(describe(section, key)).result();
+    }
+
+    /// Names the slice as well as the key, because the operator reading this failure has a cluster
+    /// of slices and needs to know which one asked.
+    private String describe(String section, String key) {
+        return "key " + section + "." + key + " for slice " + sliceId;
+    }
+}

--- a/aether/slice-api/src/main/java/org/pragmatica/aether/slice/ConfigProviderFacade.java
+++ b/aether/slice-api/src/main/java/org/pragmatica/aether/slice/ConfigProviderFacade.java
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2025 Pragmatica Labs - Sergiy Yevtushenko
+// Licensed under Business Source License 1.1. Change Date: 2030-01-01. Change License: Apache-2.0.
+// See LICENSE in the repository root for full terms.
+package org.pragmatica.aether.slice;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.pragmatica.config.ConfigurationProvider;
+import org.pragmatica.lang.Cause;
+import org.pragmatica.lang.Functions.Fn1;
+import org.pragmatica.lang.Option;
+import org.pragmatica.lang.Result;
+import org.pragmatica.lang.utils.Causes;
+
+
+/// [ConfigFacade] served from a slice's effective configuration provider.
+///
+/// This is what `ctx.config()` returns for a DEPLOYED slice (#889). Before it existed every
+/// production path handed the generated factory [NoOpConfigFacade], whose `require*` methods all
+/// fail — so the `Result.all(...)` chain that `@ResourceQualifier(type = ConfigurationSection.class)`
+/// generates could never produce a record, and a slice declaring a config section could not be
+/// created at all. Nothing in the repo declared one, which is the likelier reading of that
+/// "adoption gap" than disinterest.
+///
+/// Keys are addressed as `section + "." + key`, matching the flat key space the slice-composite is
+/// built in (`SliceStore#flattenSections`) and the convention
+/// `NodeDeploymentManager.ConfigServiceConfigFacade` already used on the notification path.
+///
+/// Two deliberate divergences from that older adapter, both in the direction of working rather than
+/// failing:
+///
+///   - `requireLong`/`requireDouble` parse through [org.pragmatica.config.ConfigSource]'s own safe
+///     parsers, so a non-numeric value yields a named missing-key failure instead of throwing
+///     `NumberFormatException` out of the factory.
+///   - `requireStringList` is implemented rather than refused. Values are comma-joined scalars, the
+///     same encoding `ProviderBasedConfigService#splitCommaList` reads, because `TomlDocument`
+///     flattens every value through `toString()` before a provider ever sees it.
+///
+/// An absent key is a failure for every `require*` method, list included. That is the word
+/// "require" meaning what it says; a caller that wants absence to be legal declares the component
+/// as `Option<T>`, which the generator routes to the `get*` methods instead.
+record ConfigProviderFacade(ConfigurationProvider provider) implements ConfigFacade {
+    private static final Fn1<Cause, String> MISSING_KEY = Causes.forOneValue("Required config key not found: %s");
+
+    static ConfigFacade configProviderFacade(ConfigurationProvider provider) {
+        return new ConfigProviderFacade(provider);
+    }
+
+    @Override
+    public Result<String> requireString(String section, String key) {
+        return require(section, key, provider::getString);
+    }
+
+    @Override
+    public Result<Integer> requireInt(String section, String key) {
+        return require(section, key, provider::getInt);
+    }
+
+    @Override
+    public Result<Long> requireLong(String section, String key) {
+        return require(section, key, provider::getLong);
+    }
+
+    @Override
+    public Result<Double> requireDouble(String section, String key) {
+        return require(section, key, provider::getDouble);
+    }
+
+    @Override
+    public Result<Boolean> requireBoolean(String section, String key) {
+        return require(section, key, provider::getBoolean);
+    }
+
+    @Override
+    public Result<List<String>> requireStringList(String section, String key) {
+        return require(section, key, fullKey -> provider.getString(fullKey).map(ConfigProviderFacade::splitCommaList));
+    }
+
+    @Override
+    public Option<String> getString(String section, String key) {
+        return provider.getString(fullKey(section, key));
+    }
+
+    @Override
+    public Option<Integer> getInt(String section, String key) {
+        return provider.getInt(fullKey(section, key));
+    }
+
+    @Override
+    public Option<Long> getLong(String section, String key) {
+        return provider.getLong(fullKey(section, key));
+    }
+
+    @Override
+    public Option<Double> getDouble(String section, String key) {
+        return provider.getDouble(fullKey(section, key));
+    }
+
+    @Override
+    public Option<Boolean> getBoolean(String section, String key) {
+        return provider.getBoolean(fullKey(section, key));
+    }
+
+    private static <T> Result<T> require(String section, String key, Fn1<Option<T>, String> reader) {
+        var fullKey = fullKey(section, key);
+
+        return reader.apply(fullKey)
+                     .toResult(MISSING_KEY.apply(fullKey));
+    }
+
+    private static String fullKey(String section, String key) {
+        return section + "." + key;
+    }
+
+    private static List<String> splitCommaList(String raw) {
+        return Arrays.stream(raw.split(","))
+                     .map(String::trim)
+                     .filter(value -> !value.isEmpty())
+                     .toList();
+    }
+}

--- a/aether/slice-api/src/main/java/org/pragmatica/aether/slice/ConfigProviderFacade.java
+++ b/aether/slice-api/src/main/java/org/pragmatica/aether/slice/ConfigProviderFacade.java
@@ -34,15 +34,22 @@ import org.pragmatica.lang.utils.Causes;
 ///   - `requireLong`/`requireDouble` parse through [org.pragmatica.config.ConfigSource]'s own safe
 ///     parsers, so a non-numeric value yields a named missing-key failure instead of throwing
 ///     `NumberFormatException` out of the factory.
-///   - `requireStringList` is implemented rather than refused. Values are comma-joined scalars, the
-///     same encoding `ProviderBasedConfigService#splitCommaList` reads, because `TomlDocument`
-///     flattens every value through `toString()` before a provider ever sees it.
+///   - `requireStringList` is implemented rather than refused, and accepts BOTH spellings. The
+///     idiomatic one is a native TOML array, `tags = ["a", "b"]`, which reaches every provider as
+///     Java's `List.toString()` — `[a, b]` — because `TomlDocument#getSection` stringifies each
+///     value before a provider sees it (review S4: the first draft split that on commas and
+///     returned `["[a", "b]"]` with no diagnostic). The fallback is the comma-joined scalar
+///     `"a, b"` that `ProviderBasedConfigService#splitCommaList` established. A nested array is not
+///     a string list and is refused by name rather than split into bracket fragments.
 ///
 /// An absent key is a failure for every `require*` method, list included. That is the word
 /// "require" meaning what it says; a caller that wants absence to be legal declares the component
-/// as `Option<T>`, which the generator routes to the `get*` methods instead.
+/// as `Option<T>`, which the generator routes to the `get*` methods instead. A PRESENT but EMPTY
+/// list (`tags = []` or `tags = ""`) is a value and succeeds as `[]` — "require" pins presence, and
+/// emptiness is something a list is allowed to be (review N2, decided here).
 record ConfigProviderFacade(ConfigurationProvider provider) implements ConfigFacade {
     private static final Fn1<Cause, String> MISSING_KEY = Causes.forOneValue("Required config key not found: %s");
+    private static final Fn1<Cause, String> NESTED_ARRAY = Causes.forOneValue("Config key %s holds a nested array, which is not a string list");
 
     static ConfigProviderFacade configProviderFacade(ConfigurationProvider provider) {
         return new ConfigProviderFacade(provider);
@@ -75,7 +82,11 @@ record ConfigProviderFacade(ConfigurationProvider provider) implements ConfigFac
 
     @Override
     public Result<List<String>> requireStringList(String section, String key) {
-        return require(section, key, this::readStringList);
+        var fullKey = fullKey(section, key);
+
+        return provider.getString(fullKey)
+                       .toResult(MISSING_KEY.apply(fullKey))
+                       .flatMap(raw -> parseStringList(fullKey, raw));
     }
 
     @Override
@@ -114,9 +125,26 @@ record ConfigProviderFacade(ConfigurationProvider provider) implements ConfigFac
         return section + "." + key;
     }
 
-    private Option<List<String>> readStringList(String fullKey) {
-        return provider.getString(fullKey)
-                       .map(ConfigProviderFacade::splitCommaList);
+    /// Package-private so the two spellings, the mixed and empty forms, and the nested refusal
+    /// are pinned directly against the parse rather than through a provider.
+    static Result<List<String>> parseStringList(String fullKey, String raw) {
+        var trimmed = raw.trim();
+
+        if (!isNativeArray(trimmed)) {
+            return Result.success(splitCommaList(trimmed));
+        }
+
+        var body = trimmed.substring(1, trimmed.length() - 1);
+
+        if (body.contains("[") || body.contains("]")) {
+            return NESTED_ARRAY.apply(fullKey).result();
+        }
+
+        return Result.success(splitCommaList(body));
+    }
+
+    private static boolean isNativeArray(String trimmed) {
+        return trimmed.length() >= 2 && trimmed.startsWith("[") && trimmed.endsWith("]");
     }
 
     private static List<String> splitCommaList(String raw) {

--- a/aether/slice-api/src/main/java/org/pragmatica/aether/slice/ConfigProviderFacade.java
+++ b/aether/slice-api/src/main/java/org/pragmatica/aether/slice/ConfigProviderFacade.java
@@ -47,12 +47,17 @@ import org.pragmatica.lang.utils.Causes;
 /// as `Option<T>`, which the generator routes to the `get*` methods instead. A PRESENT but EMPTY
 /// list (`tags = []` or `tags = ""`) is a value and succeeds as `[]` — "require" pins presence, and
 /// emptiness is something a list is allowed to be (review N2, decided here).
-record ConfigProviderFacade(ConfigurationProvider provider) implements ConfigFacade {
+///
+/// Every refusal names the slice that asked as well as the key. A node loads many slices, and
+/// since #889 review S2 a `[slices]` dependency reads through a context of its own, so a
+/// missing-key failure raised while loading slice A may belong to its dependency B — the message
+/// has to say which.
+record ConfigProviderFacade(String sliceId, ConfigurationProvider provider) implements ConfigFacade {
     private static final Fn1<Cause, String> MISSING_KEY = Causes.forOneValue("Required config key not found: %s");
-    private static final Fn1<Cause, String> NESTED_ARRAY = Causes.forOneValue("Config key %s holds a nested array, which is not a string list");
+    private static final Fn1<Cause, String> NESTED_ARRAY = Causes.forOneValue("Config %s holds a nested array, which is not a string list");
 
-    static ConfigProviderFacade configProviderFacade(ConfigurationProvider provider) {
-        return new ConfigProviderFacade(provider);
+    static ConfigProviderFacade configProviderFacade(String sliceId, ConfigurationProvider provider) {
+        return new ConfigProviderFacade(sliceId, provider);
     }
 
     @Override
@@ -85,8 +90,8 @@ record ConfigProviderFacade(ConfigurationProvider provider) implements ConfigFac
         var fullKey = fullKey(section, key);
 
         return provider.getString(fullKey)
-                       .toResult(MISSING_KEY.apply(fullKey))
-                       .flatMap(raw -> parseStringList(fullKey, raw));
+                       .toResult(MISSING_KEY.apply(describe(fullKey)))
+                       .flatMap(raw -> parseStringList(describe(fullKey), raw));
     }
 
     @Override
@@ -114,20 +119,25 @@ record ConfigProviderFacade(ConfigurationProvider provider) implements ConfigFac
         return provider.getBoolean(fullKey(section, key));
     }
 
-    private static <T> Result<T> require(String section, String key, Fn1<Option<T>, String> reader) {
+    private <T> Result<T> require(String section, String key, Fn1<Option<T>, String> reader) {
         var fullKey = fullKey(section, key);
 
         return reader.apply(fullKey)
-                     .toResult(MISSING_KEY.apply(fullKey));
+                     .toResult(MISSING_KEY.apply(describe(fullKey)));
     }
 
     private static String fullKey(String section, String key) {
         return section + "." + key;
     }
 
+    private String describe(String fullKey) {
+        return "key " + fullKey + " for slice " + sliceId;
+    }
+
     /// Package-private so the two spellings, the mixed and empty forms, and the nested refusal
-    /// are pinned directly against the parse rather than through a provider.
-    static Result<List<String>> parseStringList(String fullKey, String raw) {
+    /// are pinned directly against the parse rather than through a provider. `subject` is the
+    /// already-described key, used only in the refusal.
+    static Result<List<String>> parseStringList(String subject, String raw) {
         var trimmed = raw.trim();
 
         if (!isNativeArray(trimmed)) {
@@ -137,7 +147,7 @@ record ConfigProviderFacade(ConfigurationProvider provider) implements ConfigFac
         var body = trimmed.substring(1, trimmed.length() - 1);
 
         if (body.contains("[") || body.contains("]")) {
-            return NESTED_ARRAY.apply(fullKey).result();
+            return NESTED_ARRAY.apply(subject).result();
         }
 
         return Result.success(splitCommaList(body));

--- a/aether/slice-api/src/main/java/org/pragmatica/aether/slice/ConfigProviderFacade.java
+++ b/aether/slice-api/src/main/java/org/pragmatica/aether/slice/ConfigProviderFacade.java
@@ -44,7 +44,7 @@ import org.pragmatica.lang.utils.Causes;
 record ConfigProviderFacade(ConfigurationProvider provider) implements ConfigFacade {
     private static final Fn1<Cause, String> MISSING_KEY = Causes.forOneValue("Required config key not found: %s");
 
-    static ConfigFacade configProviderFacade(ConfigurationProvider provider) {
+    static ConfigProviderFacade configProviderFacade(ConfigurationProvider provider) {
         return new ConfigProviderFacade(provider);
     }
 
@@ -75,7 +75,7 @@ record ConfigProviderFacade(ConfigurationProvider provider) implements ConfigFac
 
     @Override
     public Result<List<String>> requireStringList(String section, String key) {
-        return require(section, key, fullKey -> provider.getString(fullKey).map(ConfigProviderFacade::splitCommaList));
+        return require(section, key, this::readStringList);
     }
 
     @Override
@@ -112,6 +112,11 @@ record ConfigProviderFacade(ConfigurationProvider provider) implements ConfigFac
 
     private static String fullKey(String section, String key) {
         return section + "." + key;
+    }
+
+    private Option<List<String>> readStringList(String fullKey) {
+        return provider.getString(fullKey)
+                       .map(ConfigProviderFacade::splitCommaList);
     }
 
     private static List<String> splitCommaList(String raw) {

--- a/aether/slice-api/src/main/java/org/pragmatica/aether/slice/ConfigProviderFacade.java
+++ b/aether/slice-api/src/main/java/org/pragmatica/aether/slice/ConfigProviderFacade.java
@@ -54,6 +54,7 @@ import org.pragmatica.lang.utils.Causes;
 /// has to say which.
 record ConfigProviderFacade(String sliceId, ConfigurationProvider provider) implements ConfigFacade {
     private static final Fn1<Cause, String> MISSING_KEY = Causes.forOneValue("Required config key not found: %s");
+
     private static final Fn1<Cause, String> NESTED_ARRAY = Causes.forOneValue("Config %s holds a nested array, which is not a string list");
 
     static ConfigProviderFacade configProviderFacade(String sliceId, ConfigurationProvider provider) {
@@ -91,7 +92,8 @@ record ConfigProviderFacade(String sliceId, ConfigurationProvider provider) impl
 
         return provider.getString(fullKey)
                        .toResult(MISSING_KEY.apply(describe(fullKey)))
-                       .flatMap(raw -> parseStringList(describe(fullKey), raw));
+                       .flatMap(raw -> parseStringList(describe(fullKey),
+                                                       raw));
     }
 
     @Override
@@ -154,7 +156,9 @@ record ConfigProviderFacade(String sliceId, ConfigurationProvider provider) impl
     }
 
     private static boolean isNativeArray(String trimmed) {
-        return trimmed.length() >= 2 && trimmed.startsWith("[") && trimmed.endsWith("]");
+        return trimmed.length() >= 2
+               && trimmed.startsWith("[")
+               && trimmed.endsWith("]");
     }
 
     private static List<String> splitCommaList(String raw) {

--- a/aether/slice-api/src/main/java/org/pragmatica/aether/slice/SliceLoadingContext.java
+++ b/aether/slice-api/src/main/java/org/pragmatica/aether/slice/SliceLoadingContext.java
@@ -29,6 +29,8 @@ import static org.pragmatica.lang.utils.Causes.cause;
 
 
 public final class SliceLoadingContext implements SliceCreationContext {
+    private static final String UNNAMED_SLICE = "<unnamed slice>";
+
     private final SliceCreationContext delegate;
     private final BufferingInvokerFacade bufferingInvoker;
     private final AtomicBoolean materialized = new AtomicBoolean(false);
@@ -137,15 +139,38 @@ public final class SliceLoadingContext implements SliceCreationContext {
     /// `DependencyResolver#materializeThenResolve` attaches the composite strictly before the
     /// generated factory runs — synchronously, deliberately — and that factory is the first reader.
     ///
-    /// Falls back to the delegate when no composite is attached, so a context built without
-    /// per-slice config keeps exactly its previous behaviour instead of silently acquiring an empty
-    /// facade. On a real node that fallback means the node has no configuration provider at all, in
-    /// which case resource provisioning is a no-op too and nothing could be provisioned regardless.
+    /// When no composite is attached the result is a REFUSAL that names itself, not a degradation:
+    /// see [#configWithoutComposite].
     @Override
     public ConfigFacade config() {
         return sliceComposite.get()
                              .<ConfigFacade> map(ConfigProviderFacade::configProviderFacade)
-                             .or(delegate::config);
+                             .or(this::configWithoutComposite);
+    }
+
+    /// No composite attached — decide between an explicitly supplied facade and a named refusal.
+    ///
+    /// A caller that built its context through the config-carrying `SliceCreationContext` overload
+    /// supplied a real facade on purpose, and that must win; the test kit and the deployment path
+    /// both leave the delegate at [NoOpConfigFacade] instead, and identity against that constant is
+    /// what separates the two cases.
+    ///
+    /// For the no-op case this deliberately does NOT fall through to the delegate. Doing so is the
+    /// obvious implementation and it degrades silently: `NoOpConfigFacade` fails with "Config
+    /// service not available", so a slice that needed configuration surfaced as a chain of
+    /// missing-KEY errors and sent the reader to their `resources.toml` when the real fault was that
+    /// the node had no configuration provider at all. [AbsentCompositeConfigFacade] says which of
+    /// those two things is missing, and names the slice that asked.
+    ///
+    /// Slices declaring no config section are unaffected either way: they never call `config()`.
+    private ConfigFacade configWithoutComposite() {
+        var supplied = delegate.config();
+
+        if (supplied != NoOpConfigFacade.INSTANCE) {
+            return supplied;
+        }
+
+        return AbsentCompositeConfigFacade.absentCompositeConfigFacade(delegate.sliceId().or(UNNAMED_SLICE));
     }
 
     @Override

--- a/aether/slice-api/src/main/java/org/pragmatica/aether/slice/SliceLoadingContext.java
+++ b/aether/slice-api/src/main/java/org/pragmatica/aether/slice/SliceLoadingContext.java
@@ -144,7 +144,7 @@ public final class SliceLoadingContext implements SliceCreationContext {
     @Override
     public ConfigFacade config() {
         return sliceComposite.get()
-                             .map(ConfigProviderFacade::configProviderFacade)
+                             .<ConfigFacade> map(ConfigProviderFacade::configProviderFacade)
                              .or(delegate::config);
     }
 

--- a/aether/slice-api/src/main/java/org/pragmatica/aether/slice/SliceLoadingContext.java
+++ b/aether/slice-api/src/main/java/org/pragmatica/aether/slice/SliceLoadingContext.java
@@ -116,9 +116,36 @@ public final class SliceLoadingContext implements SliceCreationContext {
         return delegate.sliceId();
     }
 
+    /// The deployed slice's configuration, served from the materialized slice-composite
+    /// (`slice.toml` under the node-composite's operator KV overlay and node.toml) rather than from
+    /// the delegate's [NoOpConfigFacade] (#889).
+    ///
+    /// This is the seam the defect lived in. Every production path reaches slice creation through
+    /// the two- or three-argument `SliceCreationContext` factory, both of which pass the no-op, so
+    /// `ctx.config()` inside a deployed slice could never return a value and a slice declaring
+    /// `@ResourceQualifier(type = ConfigurationSection.class)` could not be created.
+    ///
+    /// Serving it HERE rather than threading a `ConfigFacade` in through
+    /// `DependencyResolver#resolveWithContext` is not a shortcut, it is the only placement that can
+    /// carry the right config: the slice-composite is LATE-BOUND — it cannot exist until the slice
+    /// classloader does, which is why the caller supplies a builder and not a value — so a facade
+    /// constructed at resolve time could only ever carry the node composite, silently missing the
+    /// slice's own `resources.toml` and every operator override layered onto it.
+    ///
+    /// Read through the [java.util.concurrent.atomic.AtomicReference] on each call for the same
+    /// reason: a facade captured at construction time would latch the pre-materialization absence.
+    /// `DependencyResolver#materializeThenResolve` attaches the composite strictly before the
+    /// generated factory runs — synchronously, deliberately — and that factory is the first reader.
+    ///
+    /// Falls back to the delegate when no composite is attached, so a context built without
+    /// per-slice config keeps exactly its previous behaviour instead of silently acquiring an empty
+    /// facade. On a real node that fallback means the node has no configuration provider at all, in
+    /// which case resource provisioning is a no-op too and nothing could be provisioned regardless.
     @Override
     public ConfigFacade config() {
-        return delegate.config();
+        return sliceComposite.get()
+                             .map(ConfigProviderFacade::configProviderFacade)
+                             .or(delegate::config);
     }
 
     @Override

--- a/aether/slice-api/src/main/java/org/pragmatica/aether/slice/SliceLoadingContext.java
+++ b/aether/slice-api/src/main/java/org/pragmatica/aether/slice/SliceLoadingContext.java
@@ -144,8 +144,12 @@ public final class SliceLoadingContext implements SliceCreationContext {
     @Override
     public ConfigFacade config() {
         return sliceComposite.get()
-                             .<ConfigFacade> map(ConfigProviderFacade::configProviderFacade)
+                             .<ConfigFacade> map(composite -> ConfigProviderFacade.configProviderFacade(sliceName(), composite))
                              .or(this::configWithoutComposite);
+    }
+
+    private String sliceName() {
+        return delegate.sliceId().or(UNNAMED_SLICE);
     }
 
     /// No composite attached — decide between an explicitly supplied facade and a named refusal.
@@ -171,7 +175,7 @@ public final class SliceLoadingContext implements SliceCreationContext {
             return supplied;
         }
 
-        return AbsentCompositeConfigFacade.absentCompositeConfigFacade(delegate.sliceId().or(UNNAMED_SLICE));
+        return AbsentCompositeConfigFacade.absentCompositeConfigFacade(sliceName());
     }
 
     @Override

--- a/aether/slice-api/src/main/java/org/pragmatica/aether/slice/SliceLoadingContext.java
+++ b/aether/slice-api/src/main/java/org/pragmatica/aether/slice/SliceLoadingContext.java
@@ -62,8 +62,7 @@ public final class SliceLoadingContext implements SliceCreationContext {
         this.delegate = delegate;
         this.bufferingInvoker = new BufferingInvokerFacade(delegate.invoker());
         this.nodeCodec = nodeCodec;
-        this.sliceCodec = nodeCodec.map(_ -> DeferredSliceCodec.deferredSliceCodec(delegate.sliceId()
-                                                                                           .or(UNNAMED_SLICE)));
+        this.sliceCodec = nodeCodec.map(_ -> DeferredSliceCodec.deferredSliceCodec(delegate.sliceId().or(UNNAMED_SLICE)));
     }
 
     public static SliceLoadingContext sliceLoadingContext(SliceCreationContext delegate) {
@@ -144,12 +143,14 @@ public final class SliceLoadingContext implements SliceCreationContext {
     @Override
     public ConfigFacade config() {
         return sliceComposite.get()
-                             .<ConfigFacade> map(composite -> ConfigProviderFacade.configProviderFacade(sliceName(), composite))
+                             .<ConfigFacade> map(composite -> ConfigProviderFacade.configProviderFacade(sliceName(),
+                                                                                                        composite))
                              .or(this::configWithoutComposite);
     }
 
     private String sliceName() {
-        return delegate.sliceId().or(UNNAMED_SLICE);
+        return delegate.sliceId()
+                       .or(UNNAMED_SLICE);
     }
 
     /// No composite attached — decide between an explicitly supplied facade and a named refusal.

--- a/aether/slice-api/src/main/java/org/pragmatica/aether/slice/SliceLoadingContext.java
+++ b/aether/slice-api/src/main/java/org/pragmatica/aether/slice/SliceLoadingContext.java
@@ -63,7 +63,7 @@ public final class SliceLoadingContext implements SliceCreationContext {
         this.bufferingInvoker = new BufferingInvokerFacade(delegate.invoker());
         this.nodeCodec = nodeCodec;
         this.sliceCodec = nodeCodec.map(_ -> DeferredSliceCodec.deferredSliceCodec(delegate.sliceId()
-                                                                                           .or("<unnamed slice>")));
+                                                                                           .or(UNNAMED_SLICE)));
     }
 
     public static SliceLoadingContext sliceLoadingContext(SliceCreationContext delegate) {
@@ -160,7 +160,8 @@ public final class SliceLoadingContext implements SliceCreationContext {
     /// service not available", so a slice that needed configuration surfaced as a chain of
     /// missing-KEY errors and sent the reader to their `resources.toml` when the real fault was that
     /// the node had no configuration provider at all. [AbsentCompositeConfigFacade] says which of
-    /// those two things is missing, and names the slice that asked.
+    /// two layers is missing, lists the load-time conditions that leave it missing, and names the
+    /// slice that asked.
     ///
     /// Slices declaring no config section are unaffected either way: they never call `config()`.
     private ConfigFacade configWithoutComposite() {

--- a/aether/slice-api/src/test/java/org/pragmatica/aether/slice/DeployedConfigFacadeTest.java
+++ b/aether/slice-api/src/test/java/org/pragmatica/aether/slice/DeployedConfigFacadeTest.java
@@ -1,0 +1,179 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2025 Pragmatica Labs - Sergiy Yevtushenko
+// Licensed under Business Source License 1.1. Change Date: 2030-01-01. Change License: Apache-2.0.
+// See LICENSE in the repository root for full terms.
+
+package org.pragmatica.aether.slice;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.pragmatica.config.ConfigurationProvider;
+import org.pragmatica.config.IntrinsicConfigProvider;
+import org.pragmatica.lang.Option;
+import org.pragmatica.lang.Result;
+import org.pragmatica.lang.type.TypeToken;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/// Unit-level cover for what a deployed slice's `ctx.config()` actually answers (#889).
+///
+/// The end-to-end proof lives in slice-testkit's `DeployedConfigSectionTest`, which drives a real
+/// jar through `SliceStore`. This pins the two halves that test can only observe in combination:
+/// the facade's own read semantics, and the seam in [SliceLoadingContext] that decides which facade
+/// a slice gets.
+class DeployedConfigFacadeTest {
+    private static final String SECTION = "app.endpoint";
+
+    private static ConfigurationProvider provider(Map<String, String> values) {
+        return IntrinsicConfigProvider.intrinsicConfigProvider("test", values);
+    }
+
+    private static ConfigFacade facade(Map<String, String> values) {
+        return ConfigProviderFacade.configProviderFacade(provider(values));
+    }
+
+    @Nested
+    class ReadSemantics {
+        @Test
+        void requireReadsAddressTheSectionQualifiedKey() {
+            var config = facade(Map.of(SECTION + ".host", "endpoint.internal"));
+
+            assertThat(config.requireString(SECTION, "host").unwrap()).isEqualTo("endpoint.internal");
+            assertThat(config.requireString("other", "host").isFailure()).describedAs("a key in a different section must not answer")
+                                                                         .isTrue();
+        }
+
+        @Test
+        void typedRequireReadsParseTheirValues() {
+            var config = facade(Map.of(SECTION + ".port", "8443",
+                                        SECTION + ".size", "9000000000",
+                                        SECTION + ".ratio", "0.25",
+                                        SECTION + ".secure", "true"));
+
+            assertThat(config.requireInt(SECTION, "port").unwrap()).isEqualTo(8443);
+            assertThat(config.requireLong(SECTION, "size").unwrap()).isEqualTo(9_000_000_000L);
+            assertThat(config.requireDouble(SECTION, "ratio").unwrap()).isEqualTo(0.25);
+            assertThat(config.requireBoolean(SECTION, "secure").unwrap()).isTrue();
+        }
+
+        /// A non-numeric value must come back as a named failure, not as a `NumberFormatException`
+        /// thrown out of the generated factory. The older `ConfigService` adapter reached
+        /// `Long::parseLong` directly and would throw here.
+        @Test
+        void unparseableNumberFailsRatherThanThrows() {
+            var config = facade(Map.of(SECTION + ".port", "not-a-number",
+                                        SECTION + ".size", "not-a-number"));
+
+            assertThat(config.requireInt(SECTION, "port").isFailure()).isTrue();
+            assertThat(config.requireLong(SECTION, "size").isFailure()).isTrue();
+        }
+
+        @Test
+        void missingRequiredKeyFailsAndNamesTheKey() {
+            var result = facade(Map.of()).requireString(SECTION, "host");
+
+            assertThat(result.isFailure()).isTrue();
+            result.onFailure(cause -> assertThat(cause.message()).describedAs("the operator has to be told WHICH key was missing")
+                                                                  .contains(SECTION + ".host"));
+        }
+
+        /// Comma-joined scalars, the same encoding `ProviderBasedConfigService#splitCommaList`
+        /// reads, because `TomlDocument` flattens every value through `toString()` before any
+        /// provider sees it. The legacy `ConfigService` adapter refused this method outright, so a
+        /// `List<String>` config field could not have worked even with that adapter wired in.
+        @Test
+        void stringListSplitsOnCommasTrimmingAndDroppingEmpties() {
+            var config = facade(Map.of(SECTION + ".tags", " alpha , beta ,, gamma "));
+
+            assertThat(config.requireStringList(SECTION, "tags").unwrap()).isEqualTo(List.of("alpha", "beta", "gamma"));
+        }
+
+        @Test
+        void missingStringListFailsRatherThanReturningEmpty() {
+            assertThat(facade(Map.of()).requireStringList(SECTION, "tags").isFailure()).describedAs("require means require; an optional list is declared as Option")
+                                                                                        .isTrue();
+        }
+
+        @Test
+        void optionalReadsReturnNoneWhenAbsentAndValueWhenPresent() {
+            var populated = facade(Map.of(SECTION + ".weight", "7"));
+
+            assertThat(populated.getInt(SECTION, "weight").or(-1)).isEqualTo(7);
+            assertThat(facade(Map.of()).getInt(SECTION, "weight").isPresent()).isFalse();
+            assertThat(facade(Map.of()).getString(SECTION, "host").isPresent()).isFalse();
+            assertThat(facade(Map.of()).getBoolean(SECTION, "secure").isPresent()).isFalse();
+            assertThat(facade(Map.of()).getLong(SECTION, "size").isPresent()).isFalse();
+            assertThat(facade(Map.of()).getDouble(SECTION, "ratio").isPresent()).isFalse();
+        }
+    }
+
+    /// The seam itself: which facade a loading context hands to the slice factory.
+    @Nested
+    class LoadingContextSeam {
+        @Test
+        void configFallsBackToTheNoOpUntilACompositeIsAttached() {
+            var context = SliceLoadingContext.sliceLoadingContext(noOpInvoker(), noOpResources(), "slice");
+
+            assertThat(context.config().requireString(SECTION, "host").isFailure()).describedAs("with no composite there is nothing to serve; this is the pre-fix state of every deployment")
+                                                                                    .isTrue();
+        }
+
+        @Test
+        void configServesTheCompositeOnceAttached() {
+            var context = SliceLoadingContext.sliceLoadingContext(noOpInvoker(), noOpResources(), "slice");
+
+            context.setSliceComposite(Option.some(provider(Map.of(SECTION + ".host", "endpoint.internal"))));
+
+            assertThat(context.config().requireString(SECTION, "host").unwrap()).isEqualTo("endpoint.internal");
+        }
+
+        /// The deployment path never calls `setSliceComposite` directly — it registers a builder and
+        /// `DependencyResolver` materializes it with the slice classloader, strictly before the
+        /// generated factory runs. `config()` must therefore read through the reference on each
+        /// call rather than latch a facade at construction time.
+        @Test
+        void configPicksUpACompositeMaterializedAfterTheContextWasBuilt() {
+            var context = SliceLoadingContext.sliceLoadingContext(noOpInvoker(), noOpResources(), "slice");
+
+            context.setCompositeBuilder(_ -> Option.some(provider(Map.of(SECTION + ".host", "materialized.host"))));
+
+            assertThat(context.config().requireString(SECTION, "host").isFailure()).describedAs("a registered builder must not take effect before materialization")
+                                                                                    .isTrue();
+
+            context.materializeComposite(DeployedConfigFacadeTest.class.getClassLoader());
+
+            assertThat(context.config().requireString(SECTION, "host").unwrap()).isEqualTo("materialized.host");
+        }
+    }
+
+    private static SliceInvokerFacade noOpInvoker() {
+        return new SliceInvokerFacade() {
+            @Override
+            public <R, T> Result<MethodHandle<R, T>> methodHandle(String sliceArtifact,
+                                                                  String methodName,
+                                                                  TypeToken<T> requestType,
+                                                                  TypeToken<R> responseType) {
+                return Result.success(null);
+            }
+        };
+    }
+
+    private static ResourceProviderFacade noOpResources() {
+        return new ResourceProviderFacade() {
+            @Override
+            public <T> org.pragmatica.lang.Promise<T> provide(Class<T> resourceType, String configSection) {
+                return org.pragmatica.lang.Promise.success(null);
+            }
+
+            @Override
+            public <T> org.pragmatica.lang.Promise<T> provide(Class<T> resourceType,
+                                                              String configSection,
+                                                              ProvisioningContext context) {
+                return org.pragmatica.lang.Promise.success(null);
+            }
+        };
+    }
+}

--- a/aether/slice-api/src/test/java/org/pragmatica/aether/slice/DeployedConfigFacadeTest.java
+++ b/aether/slice-api/src/test/java/org/pragmatica/aether/slice/DeployedConfigFacadeTest.java
@@ -31,8 +31,10 @@ class DeployedConfigFacadeTest {
         return IntrinsicConfigProvider.intrinsicConfigProvider("test", values);
     }
 
+    private static final String SLICE_ID = "org.example:probe:1.0.0";
+
     private static ConfigFacade facade(Map<String, String> values) {
-        return ConfigProviderFacade.configProviderFacade(provider(values));
+        return ConfigProviderFacade.configProviderFacade(SLICE_ID, provider(values));
     }
 
     @Nested
@@ -71,13 +73,20 @@ class DeployedConfigFacadeTest {
             assertThat(config.requireLong(SECTION, "size").isFailure()).isTrue();
         }
 
+        /// Names the slice as well as the key: a `[slices]` dependency reads through its own
+        /// context (review S2), so a missing-key failure raised while loading slice A may belong
+        /// to its dependency B, and the message has to say which.
         @Test
-        void missingRequiredKeyFailsAndNamesTheKey() {
+        void missingRequiredKeyFailsAndNamesTheKeyAndTheSlice() {
             var result = facade(Map.of()).requireString(SECTION, "host");
 
             assertThat(result.isFailure()).isTrue();
-            result.onFailure(cause -> assertThat(cause.message()).describedAs("the operator has to be told WHICH key was missing")
-                                                                  .contains(SECTION + ".host"));
+            result.onFailure(cause -> {
+                       assertThat(cause.message()).describedAs("the operator has to be told WHICH key was missing")
+                                                   .contains(SECTION + ".host");
+                       assertThat(cause.message()).describedAs("...and WHICH slice asked for it")
+                                                   .contains(SLICE_ID);
+                   });
         }
 
         /// The idiomatic spelling. A native TOML array `tags = ["alpha", "beta"]` reaches the
@@ -180,7 +189,7 @@ class DeployedConfigFacadeTest {
         /// overload meant it, and must not be overridden by the refusal above.
         @Test
         void anExplicitlySuppliedFacadeWinsOverTheRefusal() {
-            var supplied = ConfigProviderFacade.configProviderFacade(provider(Map.of(SECTION + ".host", "supplied.host")));
+            var supplied = ConfigProviderFacade.configProviderFacade("supplied", provider(Map.of(SECTION + ".host", "supplied.host")));
             var delegate = SliceCreationContext.sliceCreationContext(noOpInvoker(), noOpResources(), "slice", supplied);
             var context = SliceLoadingContext.sliceLoadingContext(delegate);
 

--- a/aether/slice-api/src/test/java/org/pragmatica/aether/slice/DeployedConfigFacadeTest.java
+++ b/aether/slice-api/src/test/java/org/pragmatica/aether/slice/DeployedConfigFacadeTest.java
@@ -80,15 +80,60 @@ class DeployedConfigFacadeTest {
                                                                   .contains(SECTION + ".host"));
         }
 
-        /// Comma-joined scalars, the same encoding `ProviderBasedConfigService#splitCommaList`
-        /// reads, because `TomlDocument` flattens every value through `toString()` before any
-        /// provider sees it. The legacy `ConfigService` adapter refused this method outright, so a
+        /// The idiomatic spelling. A native TOML array `tags = ["alpha", "beta"]` reaches the
+        /// provider as `[alpha, beta]` — `TomlDocument` stringifies every value through
+        /// `toString()` — and must come back as the two elements, not as `["[alpha", "beta]"]`
+        /// (review S4: that is what the first draft returned, silently).
+        @Test
+        void stringListAcceptsANativeTomlArray() {
+            var config = facade(Map.of(SECTION + ".tags", "[alpha, beta]",
+                                        SECTION + ".single", "[alpha]"));
+
+            assertThat(config.requireStringList(SECTION, "tags").unwrap()).isEqualTo(List.of("alpha", "beta"));
+            assertThat(config.requireStringList(SECTION, "single").unwrap()).isEqualTo(List.of("alpha"));
+        }
+
+        /// The fallback: comma-joined scalars, the encoding `ProviderBasedConfigService#splitCommaList`
+        /// established. The legacy `ConfigService` adapter refused this method outright, so a
         /// `List<String>` config field could not have worked even with that adapter wired in.
         @Test
         void stringListSplitsOnCommasTrimmingAndDroppingEmpties() {
             var config = facade(Map.of(SECTION + ".tags", " alpha , beta ,, gamma "));
 
             assertThat(config.requireStringList(SECTION, "tags").unwrap()).isEqualTo(List.of("alpha", "beta", "gamma"));
+        }
+
+        /// Whitespace and empty slots inside a native array are trimmed and dropped exactly as they
+        /// are in the comma-joined form: the two spellings must agree on every input they share.
+        @Test
+        void stringListTreatsBothSpellingsAlike() {
+            var config = facade(Map.of(SECTION + ".native", " [ alpha ,, beta ] ",
+                                        SECTION + ".scalar", " alpha ,, beta "));
+
+            assertThat(config.requireStringList(SECTION, "native").unwrap()).isEqualTo(config.requireStringList(SECTION, "scalar").unwrap());
+            assertThat(config.requireStringList(SECTION, "native").unwrap()).isEqualTo(List.of("alpha", "beta"));
+        }
+
+        /// Present-but-empty is a VALUE (review N2, decided): `require` pins presence, and an empty
+        /// list is something a list is allowed to be. Both spellings of empty agree.
+        @Test
+        void stringListPresentButEmptySucceedsAsEmptyList() {
+            var config = facade(Map.of(SECTION + ".native", "[]",
+                                        SECTION + ".scalar", ""));
+
+            assertThat(config.requireStringList(SECTION, "native").unwrap()).isEmpty();
+            assertThat(config.requireStringList(SECTION, "scalar").unwrap()).isEmpty();
+        }
+
+        /// A nested array cannot be a string list. Refuse by name rather than hand back bracket
+        /// fragments that look like elements.
+        @Test
+        void stringListRefusesANestedArrayByName() {
+            var result = facade(Map.of(SECTION + ".tags", "[[alpha, beta], [gamma]]")).requireStringList(SECTION, "tags");
+
+            assertThat(result.isFailure()).isTrue();
+            result.onFailure(cause -> assertThat(cause.message()).contains(SECTION + ".tags")
+                                                                  .contains("nested array"));
         }
 
         @Test

--- a/aether/slice-api/src/test/java/org/pragmatica/aether/slice/DeployedConfigFacadeTest.java
+++ b/aether/slice-api/src/test/java/org/pragmatica/aether/slice/DeployedConfigFacadeTest.java
@@ -113,12 +113,33 @@ class DeployedConfigFacadeTest {
     /// The seam itself: which facade a loading context hands to the slice factory.
     @Nested
     class LoadingContextSeam {
+        /// Absence must REFUSE by name, not degrade. Falling through to the no-op would report
+        /// "Config service not available" — a missing-key shape — and send the reader to their
+        /// resources.toml when the node in fact has no configuration provider at all.
         @Test
-        void configFallsBackToTheNoOpUntilACompositeIsAttached() {
-            var context = SliceLoadingContext.sliceLoadingContext(noOpInvoker(), noOpResources(), "slice");
+        void configRefusesByNameWhenNoCompositeIsAttached() {
+            var context = SliceLoadingContext.sliceLoadingContext(noOpInvoker(), noOpResources(), "org.example:probe:1.0.0");
+            var result = context.config().requireString(SECTION, "host");
 
-            assertThat(context.config().requireString(SECTION, "host").isFailure()).describedAs("with no composite there is nothing to serve; this is the pre-fix state of every deployment")
-                                                                                    .isTrue();
+            assertThat(result.isFailure()).isTrue();
+            result.onFailure(cause -> {
+                       assertThat(cause.message()).describedAs("the failure must name the missing SOURCE, not look like a missing key")
+                                                   .contains("No configuration composite");
+                       assertThat(cause.message()).describedAs("the operator has a cluster of slices and needs to know which one asked")
+                                                   .contains("org.example:probe:1.0.0");
+                       assertThat(cause.message()).contains(SECTION + ".host");
+                   });
+        }
+
+        /// A caller that supplied a real facade through the config-carrying `SliceCreationContext`
+        /// overload meant it, and must not be overridden by the refusal above.
+        @Test
+        void anExplicitlySuppliedFacadeWinsOverTheRefusal() {
+            var supplied = ConfigProviderFacade.configProviderFacade(provider(Map.of(SECTION + ".host", "supplied.host")));
+            var delegate = SliceCreationContext.sliceCreationContext(noOpInvoker(), noOpResources(), "slice", supplied);
+            var context = SliceLoadingContext.sliceLoadingContext(delegate);
+
+            assertThat(context.config().requireString(SECTION, "host").unwrap()).isEqualTo("supplied.host");
         }
 
         @Test

--- a/aether/slice-testkit/src/test/java/org/pragmatica/aether/testkit/deployedconfig/DeployedConfigSectionTest.java
+++ b/aether/slice-testkit/src/test/java/org/pragmatica/aether/testkit/deployedconfig/DeployedConfigSectionTest.java
@@ -84,18 +84,22 @@ class DeployedConfigSectionTest {
 
     /// The premise check, and the reason the assertion above means what it says.
     ///
-    /// With no node-composite there is no slice-composite to serve, `SliceLoadingContext#config`
-    /// falls back to the delegate's `NoOpConfigFacade`, and creation must FAIL. If this passed,
-    /// the test above would be satisfied by something other than the config path — and the
+    /// With no node-composite there is no slice-composite to serve and creation must FAIL. If this
+    /// passed, the test above would be satisfied by something other than the config path — and the
     /// pre-#889 runtime is exactly this state on every deployment.
+    ///
+    /// It also pins the failure's SHAPE: absence refuses by name rather than degrading into the
+    /// no-op's missing-key wording.
     @Test
     void deployedSlice_failsToCreate_whenNoConfigurationIsAvailable(@TempDir Path tempDir) throws Exception {
         var jar = packageSliceJar(tempDir);
         var result = storeFor(jar, Option.none()).loadSlice(artifact())
                                                  .await(TIMEOUT);
 
-        assertThat(result.isFailure()).describedAs("a config-section slice cannot be created against a facade that answers nothing")
+        assertThat(result.isFailure()).describedAs("a config-section slice cannot be created when there is no configuration to read")
                                       .isTrue();
+        result.onFailure(cause -> assertThat(cause.message()).describedAs("the refusal must name the missing SOURCE and the slice, not read as a missing key")
+                                                              .contains("No configuration composite"));
     }
 
     /// Cross-loader sanity: the slice really was defined by the deployment's own child-first loader,

--- a/aether/slice-testkit/src/test/java/org/pragmatica/aether/testkit/deployedconfig/DeployedConfigSectionTest.java
+++ b/aether/slice-testkit/src/test/java/org/pragmatica/aether/testkit/deployedconfig/DeployedConfigSectionTest.java
@@ -60,6 +60,7 @@ import static org.pragmatica.lang.io.TimeSpan.timeSpan;
 class DeployedConfigSectionTest {
     private static final TimeSpan TIMEOUT = timeSpan(10).seconds();
     private static final String ARTIFACT_COORDS = "org.example:endpoint-probe:1.0.0";
+    private static final String DEPENDENCY_COORDS = "org.example:endpoint-dependency:1.0.0";
     private static final String PACKAGE_PATH = "org/pragmatica/aether/testkit/deployedconfig";
     private static final String FACTORY_CLASS = "org.pragmatica.aether.testkit.deployedconfig.EndpointProbeFactory";
     private static final String ENVELOPE_VERSION = "1007";
@@ -132,9 +133,9 @@ class DeployedConfigSectionTest {
     /// no-op's missing-key wording.
     @Test
     void deployedSlice_failsToCreate_whenNoConfigurationIsAvailable(@TempDir Path tempDir) throws Exception {
-        var jar = packageSliceJar(tempDir);
-        var result = storeFor(jar, Option.none()).loadSlice(artifact())
-                                                 .await(TIMEOUT);
+        var jar = packageSliceJar(tempDir, ARTIFACT_COORDS, SLICE_RESOURCES_TOML, List.of());
+        var result = storeFor(SliceRegistry.sliceRegistry(), Map.of(ARTIFACT_COORDS, jar), Option.none()).loadSlice(artifact())
+                                                                                                          .await(TIMEOUT);
 
         assertThat(result.isFailure()).describedAs("a config-section slice cannot be created when there is no configuration to read")
                                       .isTrue();
@@ -155,13 +156,85 @@ class DeployedConfigSectionTest {
         assertThat(slice.getClass().getClassLoader()).isNotSameAs(getClass().getClassLoader());
     }
 
-    private Slice loadDeployedSlice(Path tempDir, Option<ConfigurationProvider> nodeComposite) throws IOException {
-        var jar = packageSliceJar(tempDir);
+    /// A `[slices]` dependency must read ITS OWN composite, not its parent's (review S2).
+    ///
+    /// Before this was fixed, `DependencyResolver` threaded the parent's single loading context
+    /// into every dependency it pulled from the repository; materialization is first-wins and the
+    /// builder was closed over the parent artifact, so the dependency's generated factory read
+    /// `parent.toml ⊕ node`. Here both slices declare the same key with different values and
+    /// nothing in the node layer overrides it: each must observe its own.
+    @Test
+    void dependencySlice_readsItsOwnConfig_notItsParents(@TempDir Path tempDir) throws Exception {
+        var registry = SliceRegistry.sliceRegistry();
+        var jars = Map.of(ARTIFACT_COORDS, packageSliceJar(tempDir, ARTIFACT_COORDS, tomlWithHost("parent.internal"), List.of(DEPENDENCY_COORDS)),
+                          DEPENDENCY_COORDS, packageSliceJar(tempDir, DEPENDENCY_COORDS, tomlWithHost("dependency.internal"), List.of()));
+        var parent = storeFor(registry, jars, Option.some(emptyNodeComposite())).loadSlice(artifact(ARTIFACT_COORDS))
+                                                                                  .await(TIMEOUT)
+                                                                                  .fold(cause -> fail("parent load failed: " + cause.message()),
+                                                                                        SliceStore.LoadedSlice::slice);
+        var dependency = registry.lookup(artifact(DEPENDENCY_COORDS));
 
-        return storeFor(jar, nodeComposite).loadSlice(artifact())
-                                           .await(TIMEOUT)
-                                           .fold(cause -> fail("slice load failed: " + cause.message()),
-                                                 SliceStore.LoadedSlice::slice);
+        assertThat(dependency.isPresent()).describedAs("the dependency must have been registered by the parent's load")
+                                          .isTrue();
+        assertThat(describe(dependency.unwrap())).describedAs("the dependency must observe ITS OWN resources.toml, not the parent's")
+                                        .isEqualTo("probe=dependency.internal|8080|true|alpha+beta|3");
+        assertThat(describe(parent)).describedAs("the parent keeps its own")
+                                    .isEqualTo("probe=parent.internal|8080|true|alpha+beta|3");
+    }
+
+    /// The failure side of the same seam: a key the dependency needs and does not have must fail
+    /// the load NAMING THE DEPENDENCY — not succeed by reading the parent's value for it, and not
+    /// fail pointing the operator at the parent.
+    @Test
+    void dependencySlice_refusalNamesTheDependency_whenItsOwnKeyIsMissing(@TempDir Path tempDir) throws Exception {
+        var registry = SliceRegistry.sliceRegistry();
+        var jars = Map.of(ARTIFACT_COORDS, packageSliceJar(tempDir, ARTIFACT_COORDS, tomlWithHost("parent.internal"), List.of(DEPENDENCY_COORDS)),
+                          DEPENDENCY_COORDS, packageSliceJar(tempDir, DEPENDENCY_COORDS, TOML_WITHOUT_SECURE, List.of()));
+        var result = storeFor(registry, jars, Option.some(emptyNodeComposite())).loadSlice(artifact(ARTIFACT_COORDS))
+                                                                                  .await(TIMEOUT);
+
+        assertThat(result.isFailure()).describedAs("the parent declares `secure`; the dependency must not be able to read it from there")
+                                      .isTrue();
+        result.onFailure(cause -> {
+                   assertThat(cause.message()).contains(CONFIG_SECTION + ".secure");
+                   assertThat(cause.message()).describedAs("the refusal must name the slice that asked, which is the dependency")
+                                               .contains(DEPENDENCY_COORDS);
+               });
+    }
+
+    private Slice loadDeployedSlice(Path tempDir, Option<ConfigurationProvider> nodeComposite) throws IOException {
+        var jar = packageSliceJar(tempDir, ARTIFACT_COORDS, SLICE_RESOURCES_TOML, List.of());
+
+        return storeFor(SliceRegistry.sliceRegistry(), Map.of(ARTIFACT_COORDS, jar), nodeComposite).loadSlice(artifact())
+                                                                                                    .await(TIMEOUT)
+                                                                                                    .fold(cause -> fail("slice load failed: " + cause.message()),
+                                                                                                          SliceStore.LoadedSlice::slice);
+    }
+
+    /// A complete, self-contained slice layer with a distinguishable host, for the two-slice
+    /// dependency tests. No secrets, so both slices resolve against the same store.
+    private static String tomlWithHost(String host) {
+        return """
+                [deployed.endpoint]
+                host = "%s"
+                port = 8080
+                secure = true
+                tags = ["alpha", "beta"]
+                weight = 3
+                """.formatted(host);
+    }
+
+    private static final String TOML_WITHOUT_SECURE = """
+            [deployed.endpoint]
+            host = "dependency.internal"
+            port = 8080
+            tags = ["alpha", "beta"]
+            """;
+
+    /// A node composite that is PRESENT (so a slice composite is built at all) but overrides
+    /// nothing, so every value a slice observes is attributable to its own layer.
+    private static ConfigurationProvider emptyNodeComposite() {
+        return IntrinsicConfigProvider.intrinsicConfigProvider("node.toml", Map.of());
     }
 
     /// Invoke the slice's own method across the classloader boundary.
@@ -196,16 +269,21 @@ class DeployedConfigSectionTest {
     }
 
     private static Artifact artifact() {
-        return Artifact.artifact(ARTIFACT_COORDS).unwrap();
+        return artifact(ARTIFACT_COORDS);
+    }
+
+    private static Artifact artifact(String coords) {
+        return Artifact.artifact(coords).unwrap();
     }
 
     /// Wire the store the way `AetherNode` does, minus the parts this slice does not use: a
-    /// repository that serves the jar, a fresh registry, the node-composite under test and the
-    /// secret resolver for the slice's own layer. The resource facade refuses everything on
+    /// repository that serves the jars by coordinate, the registry (the caller's, so a dependency
+    /// registered during a load can be looked up afterwards), the node-composite under test and
+    /// the secret resolver for the slice's own layer. The resource facade refuses everything on
     /// purpose — [EndpointProbe] declares no resources, so a working one could only mask a failure.
-    private static SliceStore storeFor(Path jar, Option<ConfigurationProvider> nodeComposite) {
-        return SliceStore.sliceStore(SliceRegistry.sliceRegistry(),
-                                     List.of(repositoryServing(jar)),
+    private static SliceStore storeFor(SliceRegistry registry, Map<String, Path> jars, Option<ConfigurationProvider> nodeComposite) {
+        return SliceStore.sliceStore(registry,
+                                     List.of(repositoryServing(jars)),
                                      new SharedLibraryClassLoader(DeployedConfigSectionTest.class.getClassLoader()),
                                      REFUSING_INVOKER,
                                      REFUSING_RESOURCES,
@@ -216,9 +294,13 @@ class DeployedConfigSectionTest {
                                      SliceLoadingContext.noResourceOverlay());
     }
 
-    private static Repository repositoryServing(Path jar) {
-        return artifact -> Location.location(artifact, toUrl(jar))
-                                   .async();
+    /// Serves exactly the jars the test packaged. An artifact nobody packaged is a failure, not a
+    /// fallback to some other jar — a dependency resolved to the wrong jar would look like a pass.
+    private static Repository repositoryServing(Map<String, Path> jars) {
+        return artifact -> Option.option(jars.get(artifact.asString()))
+                                 .toResult(Causes.cause("no jar packaged for " + artifact.asString()))
+                                 .flatMap(jar -> Location.location(artifact, toUrl(jar)))
+                                 .async();
     }
 
     private static java.net.URL toUrl(Path jar) {
@@ -228,33 +310,44 @@ class DeployedConfigSectionTest {
 
     /// Package the compiled fixture — including the processor-generated `EndpointProbeFactory` and
     /// every synthetic local-record class both it and [EndpointProbe] produce — plus the slice's
-    /// own `META-INF/resources.toml` into a slice jar shaped the way `PackageSlicesMojo` shapes a
-    /// real one.
+    /// own `META-INF/resources.toml` and, when it has `[slices]` dependencies, the dependency file
+    /// under `META-INF/dependencies/`, into a slice jar shaped the way `PackageSlicesMojo` shapes
+    /// a real one. The same classes serve every coordinate: a dependency is just another jar with
+    /// its own manifest and its own config layer, loaded in its own child-first loader.
     ///
     /// The whole package directory is swept rather than a hand-listed set of classes: the local
     /// records compile to synthetic names (`EndpointProbeFactory$1endpointProbeSlice`) that a list
     /// would silently miss, and a missing class surfaces as a confusing load failure rather than as
     /// a packaging error.
-    private static Path packageSliceJar(Path tempDir) throws IOException {
-        var jar = tempDir.resolve("endpoint-probe.jar");
+    private static Path packageSliceJar(Path tempDir, String coords, String resourcesToml, List<String> sliceDependencies) throws IOException {
+        var jar = tempDir.resolve(coords.split(":")[1] + ".jar");
 
-        try (var out = new JarOutputStream(Files.newOutputStream(jar), sliceManifest())) {
+        try (var out = new JarOutputStream(Files.newOutputStream(jar), sliceManifest(coords))) {
             for (var classFile : sliceClassFiles()) {
                 writeEntry(out, PACKAGE_PATH + "/" + classFile.getFileName(), Files.readAllBytes(classFile));
             }
 
-            writeEntry(out, "META-INF/resources.toml", SLICE_RESOURCES_TOML.getBytes(StandardCharsets.UTF_8));
+            writeEntry(out, "META-INF/resources.toml", resourcesToml.getBytes(StandardCharsets.UTF_8));
+
+            if (!sliceDependencies.isEmpty()) {
+                writeEntry(out, "META-INF/dependencies/" + FACTORY_CLASS, dependencyFile(sliceDependencies).getBytes(StandardCharsets.UTF_8));
+            }
         }
 
         return jar;
     }
 
-    private static Manifest sliceManifest() {
+    /// The `[slices]` section exactly as `PackageSlicesMojo` emits it: one coordinate per line.
+    private static String dependencyFile(List<String> sliceDependencies) {
+        return "[slices]\n" + String.join("\n", sliceDependencies) + "\n";
+    }
+
+    private static Manifest sliceManifest(String coords) {
         var manifest = new Manifest();
         var attributes = manifest.getMainAttributes();
 
         attributes.put(Attributes.Name.MANIFEST_VERSION, "1.0");
-        attributes.putValue(SliceManifest.SLICE_ARTIFACT_ATTR, ARTIFACT_COORDS);
+        attributes.putValue(SliceManifest.SLICE_ARTIFACT_ATTR, coords);
         attributes.putValue(SliceManifest.SLICE_CLASS_ATTR, FACTORY_CLASS);
         attributes.putValue(SliceManifest.ENVELOPE_VERSION_ATTR, ENVELOPE_VERSION);
 

--- a/aether/slice-testkit/src/test/java/org/pragmatica/aether/testkit/deployedconfig/DeployedConfigSectionTest.java
+++ b/aether/slice-testkit/src/test/java/org/pragmatica/aether/testkit/deployedconfig/DeployedConfigSectionTest.java
@@ -5,6 +5,7 @@
 package org.pragmatica.aether.testkit.deployedconfig;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
@@ -64,15 +65,33 @@ class DeployedConfigSectionTest {
     private static final String ENVELOPE_VERSION = "1007";
     private static final String CONFIG_SECTION = "deployed.endpoint";
 
-    /// The values the deployed slice must actually observe. Distinctive on purpose — a facade that
-    /// returned defaults, empties or zeroes could not produce this string.
-    private static final Map<String, String> DEPLOYED_CONFIG = Map.of(CONFIG_SECTION + ".host", "endpoint.internal",
-                                                                       CONFIG_SECTION + ".port", "8443",
-                                                                       CONFIG_SECTION + ".secure", "true",
-                                                                       CONFIG_SECTION + ".tags", "alpha, beta",
-                                                                       CONFIG_SECTION + ".weight", "7");
+    /// The slice's OWN configuration layer, shipped inside the jar as `META-INF/resources.toml`
+    /// the way `PackageSlicesMojo` ships it. Every key the record needs lives here, so the node
+    /// composite below is purely an override layer and each field can be attributed to exactly one
+    /// source. Distinctive values on purpose — a facade that returned defaults, empties or zeroes
+    /// could not produce the render below.
+    ///
+    ///   - `host` is a `${secrets:...}` placeholder, resolved by the store's secret resolver;
+    ///   - `port` and `weight` are shadowed by the operator override in the node composite;
+    ///   - `secure` and `tags` exist ONLY here, and `tags` is a native TOML array (review S4).
+    private static final String SLICE_RESOURCES_TOML = """
+            [deployed.endpoint]
+            host = "${secrets:endpoint/host}"
+            port = 8080
+            secure = true
+            tags = ["alpha", "beta"]
+            weight = 3
+            """;
 
-    private static final String EXPECTED_RENDER = "endpoint.internal|8443|true|alpha+beta|7";
+    private static final String RESOLVED_HOST = "vault.internal";
+
+    /// The operator's override layer: node.toml under the KV overlay, in production. Deliberately
+    /// carries only the keys it shadows, so a value that reaches the slice from here is provably an
+    /// override and a value that does not is provably the slice's own.
+    private static final Map<String, String> OPERATOR_OVERRIDES = Map.of(CONFIG_SECTION + ".port", "8443",
+                                                                          CONFIG_SECTION + ".weight", "7");
+
+    private static final String EXPECTED_RENDER = RESOLVED_HOST + "|8443|true|alpha+beta|7";
 
     @Test
     void deployedSlice_receivesParsedConfigRecord_withRealValues(@TempDir Path tempDir) throws Exception {
@@ -80,6 +99,27 @@ class DeployedConfigSectionTest {
 
         assertThat(describe(slice)).describedAs("the deployed slice must observe the configured values, not a no-op facade's failures")
                                    .isEqualTo("probe=" + EXPECTED_RENDER);
+    }
+
+    /// The same load, attributed field by field to the layer that supplied it (review S3). One
+    /// assertion per layer, so a regression in the composite's ORDER or in a single layer names
+    /// itself instead of surfacing as a mismatched render string.
+    @Test
+    void deployedSlice_observesEachLayerOfTheComposite(@TempDir Path tempDir) throws Exception {
+        var slice = loadDeployedSlice(tempDir, Option.some(nodeComposite()));
+        var fields = describe(slice).substring("probe=".length())
+                                    .split("\\|");
+
+        assertThat(fields[0]).describedAs("host: a ${secrets:...} placeholder in the slice's own resources.toml, resolved at load")
+                             .isEqualTo(RESOLVED_HOST);
+        assertThat(fields[1]).describedAs("port: declared 8080 in resources.toml, the operator override must WIN")
+                             .isEqualTo("8443");
+        assertThat(fields[2]).describedAs("secure: lives only in the slice's own resources.toml")
+                             .isEqualTo("true");
+        assertThat(fields[3]).describedAs("tags: a native TOML array in the slice's own resources.toml, read as its elements")
+                             .isEqualTo("alpha+beta");
+        assertThat(fields[4]).describedAs("weight: declared 3 in resources.toml, the operator override must win for an optional too")
+                             .isEqualTo("7");
     }
 
     /// The premise check, and the reason the assertion above means what it says.
@@ -144,7 +184,15 @@ class DeployedConfigSectionTest {
     }
 
     private static ConfigurationProvider nodeComposite() {
-        return IntrinsicConfigProvider.intrinsicConfigProvider("node.toml", DEPLOYED_CONFIG);
+        return IntrinsicConfigProvider.intrinsicConfigProvider("node.toml", OPERATOR_OVERRIDES);
+    }
+
+    /// The one secret the fixture asks for. Any other path is a failure, so a placeholder the test
+    /// did not plan for cannot resolve to something plausible by accident.
+    private static Promise<String> resolveSecret(String path) {
+        return "endpoint/host".equals(path)
+               ? Promise.success(RESOLVED_HOST)
+               : Causes.cause("no such secret in this fixture: " + path).promise();
     }
 
     private static Artifact artifact() {
@@ -152,9 +200,9 @@ class DeployedConfigSectionTest {
     }
 
     /// Wire the store the way `AetherNode` does, minus the parts this slice does not use: a
-    /// repository that serves the jar, a fresh registry, and the node-composite under test. The
-    /// resource facade refuses everything on purpose — [EndpointProbe] declares no resources, so a
-    /// working one could only mask a failure.
+    /// repository that serves the jar, a fresh registry, the node-composite under test and the
+    /// secret resolver for the slice's own layer. The resource facade refuses everything on
+    /// purpose — [EndpointProbe] declares no resources, so a working one could only mask a failure.
     private static SliceStore storeFor(Path jar, Option<ConfigurationProvider> nodeComposite) {
         return SliceStore.sliceStore(SliceRegistry.sliceRegistry(),
                                      List.of(repositoryServing(jar)),
@@ -164,7 +212,7 @@ class DeployedConfigSectionTest {
                                      SliceActionConfig.sliceActionConfig(),
                                      nodeComposite,
                                      Option.none(),
-                                     Option.none(),
+                                     Option.some(DeployedConfigSectionTest::resolveSecret),
                                      SliceLoadingContext.noResourceOverlay());
     }
 
@@ -179,8 +227,9 @@ class DeployedConfigSectionTest {
     }
 
     /// Package the compiled fixture — including the processor-generated `EndpointProbeFactory` and
-    /// every synthetic local-record class both it and [EndpointProbe] produce — into a slice jar
-    /// shaped the way `PackageSlicesMojo` shapes a real one.
+    /// every synthetic local-record class both it and [EndpointProbe] produce — plus the slice's
+    /// own `META-INF/resources.toml` into a slice jar shaped the way `PackageSlicesMojo` shapes a
+    /// real one.
     ///
     /// The whole package directory is swept rather than a hand-listed set of classes: the local
     /// records compile to synthetic names (`EndpointProbeFactory$1endpointProbeSlice`) that a list
@@ -193,6 +242,8 @@ class DeployedConfigSectionTest {
             for (var classFile : sliceClassFiles()) {
                 writeEntry(out, PACKAGE_PATH + "/" + classFile.getFileName(), Files.readAllBytes(classFile));
             }
+
+            writeEntry(out, "META-INF/resources.toml", SLICE_RESOURCES_TOML.getBytes(StandardCharsets.UTF_8));
         }
 
         return jar;

--- a/aether/slice-testkit/src/test/java/org/pragmatica/aether/testkit/deployedconfig/DeployedConfigSectionTest.java
+++ b/aether/slice-testkit/src/test/java/org/pragmatica/aether/testkit/deployedconfig/DeployedConfigSectionTest.java
@@ -1,0 +1,260 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2025 Pragmatica Labs - Sergiy Yevtushenko
+// Licensed under Business Source License 1.1. Change Date: 2030-01-01. Change License: Apache-2.0.
+// See LICENSE in the repository root for full terms.
+package org.pragmatica.aether.testkit.deployedconfig;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.jar.Attributes;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
+import java.util.jar.Manifest;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.pragmatica.aether.artifact.Artifact;
+import org.pragmatica.aether.slice.MethodHandle;
+import org.pragmatica.aether.slice.ProvisioningContext;
+import org.pragmatica.aether.slice.ResourceProviderFacade;
+import org.pragmatica.aether.slice.SharedLibraryClassLoader;
+import org.pragmatica.aether.slice.Slice;
+import org.pragmatica.aether.slice.SliceActionConfig;
+import org.pragmatica.aether.slice.SliceInvokerFacade;
+import org.pragmatica.aether.slice.SliceLoadingContext;
+import org.pragmatica.aether.slice.SliceManifest;
+import org.pragmatica.aether.slice.SliceStore;
+import org.pragmatica.aether.slice.dependency.SliceRegistry;
+import org.pragmatica.aether.slice.repository.Location;
+import org.pragmatica.aether.slice.repository.Repository;
+import org.pragmatica.config.ConfigurationProvider;
+import org.pragmatica.config.IntrinsicConfigProvider;
+import org.pragmatica.lang.Option;
+import org.pragmatica.lang.Promise;
+import org.pragmatica.lang.Result;
+import org.pragmatica.lang.Unit;
+import org.pragmatica.lang.io.TimeSpan;
+import org.pragmatica.lang.type.TypeToken;
+import org.pragmatica.lang.utils.Causes;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+import static org.pragmatica.lang.io.TimeSpan.timeSpan;
+
+/// A deployed slice declaring `@ResourceQualifier(type = ConfigurationSection.class)` must receive
+/// its parsed config record, populated from the real configuration (#889).
+///
+/// This drives [SliceStore#loadSlice] — the actual deployment entry point, the one
+/// `NodeDeploymentState` calls — against a real slice jar on disk: manifest, child-first
+/// `SliceClassLoader`, `DependencyResolver`, the deferred slice-composite builder, and the
+/// processor-generated `EndpointProbeFactory`. Nothing about the context is hand-built, which is
+/// the whole point: a test that constructs its own `SliceCreationContext` through the
+/// config-carrying overload bypasses precisely the code that was broken and would have passed
+/// against the defect.
+///
+/// No ports and no cluster. The premise is falsifiable with a jar and a config provider.
+class DeployedConfigSectionTest {
+    private static final TimeSpan TIMEOUT = timeSpan(10).seconds();
+    private static final String ARTIFACT_COORDS = "org.example:endpoint-probe:1.0.0";
+    private static final String PACKAGE_PATH = "org/pragmatica/aether/testkit/deployedconfig";
+    private static final String FACTORY_CLASS = "org.pragmatica.aether.testkit.deployedconfig.EndpointProbeFactory";
+    private static final String ENVELOPE_VERSION = "1007";
+    private static final String CONFIG_SECTION = "deployed.endpoint";
+
+    /// The values the deployed slice must actually observe. Distinctive on purpose — a facade that
+    /// returned defaults, empties or zeroes could not produce this string.
+    private static final Map<String, String> DEPLOYED_CONFIG = Map.of(CONFIG_SECTION + ".host", "endpoint.internal",
+                                                                       CONFIG_SECTION + ".port", "8443",
+                                                                       CONFIG_SECTION + ".secure", "true",
+                                                                       CONFIG_SECTION + ".tags", "alpha, beta",
+                                                                       CONFIG_SECTION + ".weight", "7");
+
+    private static final String EXPECTED_RENDER = "endpoint.internal|8443|true|alpha+beta|7";
+
+    @Test
+    void deployedSlice_receivesParsedConfigRecord_withRealValues(@TempDir Path tempDir) throws Exception {
+        var slice = loadDeployedSlice(tempDir, Option.some(nodeComposite()));
+
+        assertThat(describe(slice)).describedAs("the deployed slice must observe the configured values, not a no-op facade's failures")
+                                   .isEqualTo("probe=" + EXPECTED_RENDER);
+    }
+
+    /// The premise check, and the reason the assertion above means what it says.
+    ///
+    /// With no node-composite there is no slice-composite to serve, `SliceLoadingContext#config`
+    /// falls back to the delegate's `NoOpConfigFacade`, and creation must FAIL. If this passed,
+    /// the test above would be satisfied by something other than the config path — and the
+    /// pre-#889 runtime is exactly this state on every deployment.
+    @Test
+    void deployedSlice_failsToCreate_whenNoConfigurationIsAvailable(@TempDir Path tempDir) throws Exception {
+        var jar = packageSliceJar(tempDir);
+        var result = storeFor(jar, Option.none()).loadSlice(artifact())
+                                                 .await(TIMEOUT);
+
+        assertThat(result.isFailure()).describedAs("a config-section slice cannot be created against a facade that answers nothing")
+                                      .isTrue();
+    }
+
+    /// Cross-loader sanity: the slice really was defined by the deployment's own child-first loader,
+    /// so the value asserted above travelled the same path a deployed slice's would. Without this,
+    /// a regression that quietly loaded the test's own classes would look identical.
+    @Test
+    void deployedSlice_isDefinedBySliceClassLoader_notTheTestClasspath(@TempDir Path tempDir) throws Exception {
+        var slice = loadDeployedSlice(tempDir, Option.some(nodeComposite()));
+        var probeInterface = probeInterfaceOf(slice);
+
+        assertThat(probeInterface).describedAs("the deployed slice must use the slice loader's own copy of the interface")
+                                  .isNotSameAs(EndpointProbe.class);
+        assertThat(slice.getClass().getClassLoader()).isNotSameAs(getClass().getClassLoader());
+    }
+
+    private Slice loadDeployedSlice(Path tempDir, Option<ConfigurationProvider> nodeComposite) throws IOException {
+        var jar = packageSliceJar(tempDir);
+
+        return storeFor(jar, nodeComposite).loadSlice(artifact())
+                                           .await(TIMEOUT)
+                                           .fold(cause -> fail("slice load failed: " + cause.message()),
+                                                 SliceStore.LoadedSlice::slice);
+    }
+
+    /// Invoke the slice's own method across the classloader boundary.
+    ///
+    /// The `Method` is taken from the SLICE LOADER's copy of the public interface rather than from
+    /// the implementing record, which is a local class and therefore not publicly accessible. The
+    /// return travels as a `String`, a JDK type both loaders share.
+    private static String describe(Slice slice) throws Exception {
+        var method = probeInterfaceOf(slice).getMethod("describe", String.class);
+        var promise = (Promise<?>) method.invoke(slice, "probe");
+
+        return promise.await(TIMEOUT)
+                      .fold(cause -> fail("describe failed: " + cause.message()), String::valueOf);
+    }
+
+    private static Class<?> probeInterfaceOf(Slice slice) throws ClassNotFoundException {
+        return slice.getClass()
+                    .getClassLoader()
+                    .loadClass(EndpointProbe.class.getName());
+    }
+
+    private static ConfigurationProvider nodeComposite() {
+        return IntrinsicConfigProvider.intrinsicConfigProvider("node.toml", DEPLOYED_CONFIG);
+    }
+
+    private static Artifact artifact() {
+        return Artifact.artifact(ARTIFACT_COORDS).unwrap();
+    }
+
+    /// Wire the store the way `AetherNode` does, minus the parts this slice does not use: a
+    /// repository that serves the jar, a fresh registry, and the node-composite under test. The
+    /// resource facade refuses everything on purpose — [EndpointProbe] declares no resources, so a
+    /// working one could only mask a failure.
+    private static SliceStore storeFor(Path jar, Option<ConfigurationProvider> nodeComposite) {
+        return SliceStore.sliceStore(SliceRegistry.sliceRegistry(),
+                                     List.of(repositoryServing(jar)),
+                                     new SharedLibraryClassLoader(DeployedConfigSectionTest.class.getClassLoader()),
+                                     REFUSING_INVOKER,
+                                     REFUSING_RESOURCES,
+                                     SliceActionConfig.sliceActionConfig(),
+                                     nodeComposite,
+                                     Option.none(),
+                                     Option.none(),
+                                     SliceLoadingContext.noResourceOverlay());
+    }
+
+    private static Repository repositoryServing(Path jar) {
+        return artifact -> Location.location(artifact, toUrl(jar))
+                                   .async();
+    }
+
+    private static java.net.URL toUrl(Path jar) {
+        return Result.lift(Causes::fromThrowable, () -> jar.toUri().toURL())
+                     .expect("temp jar path must be a valid URL");
+    }
+
+    /// Package the compiled fixture — including the processor-generated `EndpointProbeFactory` and
+    /// every synthetic local-record class both it and [EndpointProbe] produce — into a slice jar
+    /// shaped the way `PackageSlicesMojo` shapes a real one.
+    ///
+    /// The whole package directory is swept rather than a hand-listed set of classes: the local
+    /// records compile to synthetic names (`EndpointProbeFactory$1endpointProbeSlice`) that a list
+    /// would silently miss, and a missing class surfaces as a confusing load failure rather than as
+    /// a packaging error.
+    private static Path packageSliceJar(Path tempDir) throws IOException {
+        var jar = tempDir.resolve("endpoint-probe.jar");
+
+        try (var out = new JarOutputStream(Files.newOutputStream(jar), sliceManifest())) {
+            for (var classFile : sliceClassFiles()) {
+                writeEntry(out, PACKAGE_PATH + "/" + classFile.getFileName(), Files.readAllBytes(classFile));
+            }
+        }
+
+        return jar;
+    }
+
+    private static Manifest sliceManifest() {
+        var manifest = new Manifest();
+        var attributes = manifest.getMainAttributes();
+
+        attributes.put(Attributes.Name.MANIFEST_VERSION, "1.0");
+        attributes.putValue(SliceManifest.SLICE_ARTIFACT_ATTR, ARTIFACT_COORDS);
+        attributes.putValue(SliceManifest.SLICE_CLASS_ATTR, FACTORY_CLASS);
+        attributes.putValue(SliceManifest.ENVELOPE_VERSION_ATTR, ENVELOPE_VERSION);
+
+        return manifest;
+    }
+
+    /// Every compiled class of the fixture package EXCEPT this test's own — the test never runs
+    /// inside the slice loader, and shipping it would only add a class nobody loads.
+    private static List<Path> sliceClassFiles() throws IOException {
+        try (var files = Files.list(packageDirectory())) {
+            return files.filter(path -> path.getFileName().toString().endsWith(".class"))
+                        .filter(path -> !path.getFileName().toString().startsWith(DeployedConfigSectionTest.class.getSimpleName()))
+                        .sorted()
+                        .toList();
+        }
+    }
+
+    private static Path packageDirectory() {
+        var url = DeployedConfigSectionTest.class.getClassLoader()
+                                                  .getResource(PACKAGE_PATH);
+
+        return Result.lift(Causes::fromThrowable, () -> Path.of(url.toURI()))
+                     .expect("fixture package must be on the test classpath as a directory");
+    }
+
+    private static void writeEntry(JarOutputStream out, String name, byte[] content) throws IOException {
+        out.putNextEntry(new JarEntry(name));
+        out.write(content);
+        out.closeEntry();
+    }
+
+    private static final SliceInvokerFacade REFUSING_INVOKER = new SliceInvokerFacade() {
+        @Override
+        public <R, T> Result<MethodHandle<R, T>> methodHandle(String artifact,
+                                                              String method,
+                                                              TypeToken<T> requestType,
+                                                              TypeToken<R> responseType) {
+            return Causes.cause("Slice invocation not configured for this fixture").result();
+        }
+    };
+
+    private static final ResourceProviderFacade REFUSING_RESOURCES = new ResourceProviderFacade() {
+        @Override
+        public <T> Promise<T> provide(Class<T> resourceType, String configSection) {
+            return Causes.cause("EndpointProbe must declare no resources").promise();
+        }
+
+        @Override
+        public <T> Promise<T> provide(Class<T> resourceType, String configSection, ProvisioningContext context) {
+            return Causes.cause("EndpointProbe must declare no resources").promise();
+        }
+
+        @Override
+        public Promise<Unit> releaseAll(String sliceId) {
+            return Promise.unitPromise();
+        }
+    };
+}

--- a/aether/slice-testkit/src/test/java/org/pragmatica/aether/testkit/deployedconfig/EndpointConfig.java
+++ b/aether/slice-testkit/src/test/java/org/pragmatica/aether/testkit/deployedconfig/EndpointConfig.java
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2025 Pragmatica Labs - Sergiy Yevtushenko
+// Licensed under Business Source License 1.1. Change Date: 2030-01-01. Change License: Apache-2.0.
+// See LICENSE in the repository root for full terms.
+package org.pragmatica.aether.testkit.deployedconfig;
+
+import java.util.List;
+
+import org.pragmatica.lang.Option;
+import org.pragmatica.lang.Result;
+
+
+/// The config record an [EndpointSettings] parameter binds to.
+///
+/// Deliberately spans all three access shapes the generator emits, so the acceptance test covers
+/// the whole `Result.all(...)` chain rather than one method of the facade:
+///
+///   - `host`/`port`/`secure` — `require*`, the required-primitive path
+///   - `tags` — `requireStringList`, which the pre-#889 `ConfigService` adapter refused outright
+///   - `weight` — `get*` wrapped in `Result.success`, the optional path
+///
+/// [#render] exists because the slice is loaded by a child-first `SliceClassLoader`: the test's own
+/// copy of this record is a DIFFERENT class from the one the deployed slice holds, so the values
+/// have to cross the loader boundary as a `String`, which resolves to the same JDK class on both
+/// sides.
+public record EndpointConfig(String host, int port, boolean secure, List<String> tags, Option<Integer> weight) {
+    public static Result<EndpointConfig> endpointConfig(String host,
+                                                        int port,
+                                                        boolean secure,
+                                                        List<String> tags,
+                                                        Option<Integer> weight) {
+        return Result.success(new EndpointConfig(host, port, secure, tags, weight));
+    }
+
+    public String render() {
+        return host + "|" + port + "|" + secure + "|" + String.join("+", tags) + "|" + weight.map(Object::toString).or("none");
+    }
+}

--- a/aether/slice-testkit/src/test/java/org/pragmatica/aether/testkit/deployedconfig/EndpointProbe.java
+++ b/aether/slice-testkit/src/test/java/org/pragmatica/aether/testkit/deployedconfig/EndpointProbe.java
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2025 Pragmatica Labs - Sergiy Yevtushenko
+// Licensed under Business Source License 1.1. Change Date: 2030-01-01. Change License: Apache-2.0.
+// See LICENSE in the repository root for full terms.
+package org.pragmatica.aether.testkit.deployedconfig;
+
+import org.pragmatica.aether.slice.annotation.Slice;
+import org.pragmatica.lang.Promise;
+
+
+/// A slice whose ONLY dependency is a configuration section — the artifact #889 says cannot be
+/// created in a deployed cluster.
+///
+/// It has no resource dependencies on purpose. If creation fails, the config chain is the only
+/// thing that can have failed, so a red test names the defect instead of implicating provisioning.
+@Slice
+public interface EndpointProbe {
+    Promise<String> describe(String probe);
+
+    static EndpointProbe endpointProbe(@EndpointSettings EndpointConfig config) {
+        record endpointProbe(EndpointConfig config) implements EndpointProbe {
+            @Override
+            public Promise<String> describe(String probe) {
+                return Promise.success(probe + "=" + config.render());
+            }
+        }
+
+        return new endpointProbe(config);
+    }
+}

--- a/aether/slice-testkit/src/test/java/org/pragmatica/aether/testkit/deployedconfig/EndpointSettings.java
+++ b/aether/slice-testkit/src/test/java/org/pragmatica/aether/testkit/deployedconfig/EndpointSettings.java
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2025 Pragmatica Labs - Sergiy Yevtushenko
+// Licensed under Business Source License 1.1. Change Date: 2030-01-01. Change License: Apache-2.0.
+// See LICENSE in the repository root for full terms.
+package org.pragmatica.aether.testkit.deployedconfig;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.pragmatica.aether.slice.annotation.ConfigurationSection;
+import org.pragmatica.aether.slice.annotation.ResourceQualifier;
+
+
+/// The repo's first `ConfigurationSection` qualifier (#889).
+///
+/// The books teach this resource kind as first-class (`book-aether/part1-no-magic.md`,
+/// `custom-qualifiers.md`) yet nothing in the repo, the 24 examples or the ticketing demo declared
+/// one. The likelier reading of that absence, once the deployed `ctx.config()` turned out to be a
+/// facade that fails every read, is that it could not work — so this fixture exists to make the
+/// claim falsifiable rather than to fill an adoption gap.
+@ResourceQualifier(type = ConfigurationSection.class, config = "deployed.endpoint")
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.PARAMETER)
+public @interface EndpointSettings {}

--- a/aether/slice/src/main/java/org/pragmatica/aether/slice/SliceStore.java
+++ b/aether/slice/src/main/java/org/pragmatica/aether/slice/SliceStore.java
@@ -211,8 +211,7 @@ public interface SliceStore {
                                                          sharedLibraryLoader,
                                                          invokerFacade,
                                                          resourceFacade,
-                                                         Option.some(classLoader -> buildSliceCompositeFromClassLoader(artifact,
-                                                                                                                       classLoader)),
+                                                         Option.some(this::buildSliceCompositeFromClassLoader),
                                                          nodeCodec,
                                                          resourceOverlayBuilder)
                                      .map(resolved -> {

--- a/aether/slice/src/main/java/org/pragmatica/aether/slice/SliceStore.java
+++ b/aether/slice/src/main/java/org/pragmatica/aether/slice/SliceStore.java
@@ -251,8 +251,12 @@ public interface SliceStore {
         /// Emits one INFO log per intrinsic key whose value is shadowed by an existing KV
         /// override at slice-load time (operator override preceded slice deploy) — see
         /// [#logShadowedKeys].
-        private Option<ConfigurationProvider> buildSliceCompositeFromClassLoader(Artifact artifact,
-                                                                                 ClassLoader classLoader) {
+        ///
+        /// Package-private (not private) so SliceStoreTest can pin the absence branches directly:
+        /// a malformed `resources.toml` drops the WHOLE composite, node keys included, and the
+        /// refusal a slice then receives from `ctx.config()` has to be true for that branch too
+        /// (#889 review S1).
+        Option<ConfigurationProvider> buildSliceCompositeFromClassLoader(Artifact artifact, ClassLoader classLoader) {
             return nodeComposite.flatMap(composite -> loadSliceIntrinsicProviderFromClassLoader(artifact, classLoader).map(intrinsic -> assembleSliceComposite(artifact,
                                                                                                                                                                intrinsic,
                                                                                                                                                                composite)));

--- a/aether/slice/src/main/java/org/pragmatica/aether/slice/dependency/DependencyResolver.java
+++ b/aether/slice/src/main/java/org/pragmatica/aether/slice/dependency/DependencyResolver.java
@@ -27,9 +27,12 @@ import org.pragmatica.aether.slice.SliceManifest;
 import org.pragmatica.aether.slice.SliceManifest.SliceManifestInfo;
 import org.pragmatica.aether.slice.repository.Location;
 import org.pragmatica.aether.slice.repository.Repository;
+import org.pragmatica.config.ConfigurationProvider;
 import org.pragmatica.serialization.SliceCodec;
 import org.pragmatica.lang.Cause;
 import org.pragmatica.lang.Contract;
+import org.pragmatica.lang.Functions.Fn1;
+import org.pragmatica.lang.Functions.Fn2;
 import org.pragmatica.lang.Option;
 import org.pragmatica.lang.Promise;
 import org.pragmatica.lang.Result;
@@ -80,22 +83,31 @@ public interface DependencyResolver {
     /// the #773 defect for writing less code, which is the same silence the ticket is about moved
     /// one level out. A caller that wants no overlay says so with
     /// [SliceLoadingContext#noResourceOverlay].
+    ///
+    /// `compositeBuilder` takes the ARTIFACT as well as the classloader because every slice this
+    /// call loads — the one asked for and each `[slices]` dependency it pulls in — gets a
+    /// [SliceLoadingContext] of its own, built by [#loadingContextFor] (#889 review S2). One
+    /// context shared down the dependency chain meant the dependency's generated factory read
+    /// `ctx.config()` from the PARENT's composite (first-wins materialization, builder closed over
+    /// the parent artifact) and its refusals named the parent; with the codec, the parent's later
+    /// `bind` overwrote the dependency's. Per-slice contexts remove both: each composite closes
+    /// over its own artifact and each deferred codec is bound exactly once, by its own slice.
     static Promise<ResolvedSlice> resolveWithContext(Artifact artifact,
                                                      Repository repository,
                                                      SliceRegistry registry,
                                                      SharedLibraryClassLoader sharedLibraryLoader,
                                                      SliceInvokerFacade invokerFacade,
                                                      ResourceProviderFacade resourceFacade,
-                                                     Option<org.pragmatica.lang.Functions.Fn1<Option<org.pragmatica.config.ConfigurationProvider>, ClassLoader>> compositeBuilder,
+                                                     Option<Fn2<Option<ConfigurationProvider>, Artifact, ClassLoader>> compositeBuilder,
                                                      Option<SliceCodec> nodeCodec,
-                                                     org.pragmatica.lang.Functions.Fn1<Option<ResourceProviderFacade>, ClassLoader> resourceOverlayBuilder) {
-        var loadingContext = SliceLoadingContext.sliceLoadingContext(invokerFacade,
-                                                                     resourceFacade,
-                                                                     artifact.asString(),
-                                                                     nodeCodec);
-
-        compositeBuilder.onPresent(loadingContext::setCompositeBuilder);
-        loadingContext.setResourceOverlayBuilder(resourceOverlayBuilder);
+                                                     Fn1<Option<ResourceProviderFacade>, ClassLoader> resourceOverlayBuilder) {
+        Fn1<SliceLoadingContext, Artifact> contextFor = slice -> loadingContextFor(slice,
+                                                                                    invokerFacade,
+                                                                                    resourceFacade,
+                                                                                    compositeBuilder,
+                                                                                    nodeCodec,
+                                                                                    resourceOverlayBuilder);
+        var loadingContext = contextFor.apply(artifact);
 
         return registry.lookup(artifact)
                        .map(slice -> Promise.success(resolvedSlice(slice, loadingContext)))
@@ -104,7 +116,28 @@ public interface DependencyResolver {
                                                                    registry,
                                                                    sharedLibraryLoader,
                                                                    loadingContext,
+                                                                   contextFor,
                                                                    new HashSet<>()));
+    }
+
+    /// One loading context per slice, whether it is the artifact asked for or a `[slices]`
+    /// dependency reached on the way. The composite builder is closed over THIS artifact, so the
+    /// context's `config()` serves `this-slice.toml ⊕ node` and names this slice when it refuses.
+    private static SliceLoadingContext loadingContextFor(Artifact artifact,
+                                                         SliceInvokerFacade invokerFacade,
+                                                         ResourceProviderFacade resourceFacade,
+                                                         Option<Fn2<Option<ConfigurationProvider>, Artifact, ClassLoader>> compositeBuilder,
+                                                         Option<SliceCodec> nodeCodec,
+                                                         Fn1<Option<ResourceProviderFacade>, ClassLoader> resourceOverlayBuilder) {
+        var loadingContext = SliceLoadingContext.sliceLoadingContext(invokerFacade,
+                                                                     resourceFacade,
+                                                                     artifact.asString(),
+                                                                     nodeCodec);
+
+        compositeBuilder.onPresent(builder -> loadingContext.setCompositeBuilder(classLoader -> builder.apply(artifact, classLoader)));
+        loadingContext.setResourceOverlayBuilder(resourceOverlayBuilder);
+
+        return loadingContext;
     }
 
     /// Pair a freshly created slice with its loading context, binding the slice's codec on the way
@@ -156,6 +189,7 @@ public interface DependencyResolver {
                                                                             SliceRegistry registry,
                                                                             SharedLibraryClassLoader sharedLibraryLoader,
                                                                             SliceLoadingContext loadingContext,
+                                                                            Fn1<SliceLoadingContext, Artifact> contextFor,
                                                                             Set<String> resolutionPath) {
         log.info("Resolving artifact {} with shared loader and context", artifact.asString());
         var artifactKey = artifact.asString();
@@ -178,6 +212,7 @@ public interface DependencyResolver {
                                                                                    registry,
                                                                                    sharedLibraryLoader,
                                                                                    loadingContext,
+                                                                                   contextFor,
                                                                                    resolutionPath))
                          .onSuccess(_ -> {
                                         log.info("Resolved artifact {} with context",
@@ -198,6 +233,7 @@ public interface DependencyResolver {
                                                                                SliceRegistry registry,
                                                                                SharedLibraryClassLoader sharedLibraryLoader,
                                                                                SliceLoadingContext loadingContext,
+                                                                               Fn1<SliceLoadingContext, Artifact> contextFor,
                                                                                Set<String> resolutionPath) {
         return SliceManifest.read(location.url())
                             .flatMap(manifest -> SliceManifest.checkEnvelopeCompatibility(manifest.envelopeVersion()).map(_ -> manifest))
@@ -212,6 +248,7 @@ public interface DependencyResolver {
                                                                                      registry,
                                                                                      sharedLibraryLoader,
                                                                                      loadingContext,
+                                                                                     contextFor,
                                                                                      resolutionPath));
     }
 
@@ -222,6 +259,7 @@ public interface DependencyResolver {
                                                                               SliceRegistry registry,
                                                                               SharedLibraryClassLoader sharedLibraryLoader,
                                                                               SliceLoadingContext loadingContext,
+                                                                              Fn1<SliceLoadingContext, Artifact> contextFor,
                                                                               Set<String> resolutionPath) {
         if (!manifest.artifact().equals(artifact)) {
             log.error("Artifact mismatch: requested {} but JAR declares {}", artifact, manifest.artifact());
@@ -240,6 +278,7 @@ public interface DependencyResolver {
                                                                                       registry,
                                                                                       sharedLibraryLoader,
                                                                                       loadingContext,
+                                                                                      contextFor,
                                                                                       resolutionPath));
     }
 
@@ -250,6 +289,7 @@ public interface DependencyResolver {
                                                                                SliceRegistry registry,
                                                                                SharedLibraryClassLoader sharedLibraryLoader,
                                                                                SliceLoadingContext loadingContext,
+                                                                               Fn1<SliceLoadingContext, Artifact> contextFor,
                                                                                Set<String> resolutionPath) {
         return SharedDependencyLoader.processSharedDependencies(depFile.shared(),
                                                                 sharedLibraryLoader,
@@ -269,6 +309,7 @@ public interface DependencyResolver {
                                                                                                       registry,
                                                                                                       sharedLibraryLoader,
                                                                                                       loadingContext,
+                                                                                                      contextFor,
                                                                                                       resolutionPath));
     }
 
@@ -279,6 +320,7 @@ public interface DependencyResolver {
                                                                                   SliceRegistry registry,
                                                                                   SharedLibraryClassLoader sharedLibraryLoader,
                                                                                   SliceLoadingContext loadingContext,
+                                                                                  Fn1<SliceLoadingContext, Artifact> contextFor,
                                                                                   Set<String> resolutionPath) {
         return loadClass(manifest.sliceClassName(), sharedResult.sliceClassLoader()).flatMap(sliceClass -> materializeThenResolve(manifest,
                                                                                                                                   depFile,
@@ -288,6 +330,7 @@ public interface DependencyResolver {
                                                                                                                                   registry,
                                                                                                                                   sharedLibraryLoader,
                                                                                                                                   loadingContext,
+                                                                                                                                  contextFor,
                                                                                                                                   resolutionPath));
     }
 
@@ -305,6 +348,7 @@ public interface DependencyResolver {
                                                                  SliceRegistry registry,
                                                                  SharedLibraryClassLoader sharedLibraryLoader,
                                                                  SliceLoadingContext loadingContext,
+                                                                 Fn1<SliceLoadingContext, Artifact> contextFor,
                                                                  Set<String> resolutionPath) {
         loadingContext.materializeComposite(sharedResult.sliceClassLoader());
 
@@ -316,6 +360,7 @@ public interface DependencyResolver {
                                                    registry,
                                                    sharedLibraryLoader,
                                                    loadingContext,
+                                                   contextFor,
                                                    resolutionPath);
     }
 
@@ -327,6 +372,7 @@ public interface DependencyResolver {
                                                                               SliceRegistry registry,
                                                                               SharedLibraryClassLoader sharedLibraryLoader,
                                                                               SliceLoadingContext loadingContext,
+                                                                              Fn1<SliceLoadingContext, Artifact> contextFor,
                                                                               Set<String> resolutionPath) {
         log.info("Resolving {} slice dependencies for {} with context", sliceDeps.size(), artifact.asString());
         if (sliceDeps.isEmpty()) {
@@ -344,6 +390,7 @@ public interface DependencyResolver {
                                                                   registry,
                                                                   sharedLibraryLoader,
                                                                   loadingContext,
+                                                                  contextFor,
                                                                   resolutionPath,
                                                                   List.of()).onSuccess(resolved -> log.info("Resolved all {} slice dependencies for {} with context",
                                                                                                             resolved.size(),
@@ -685,6 +732,7 @@ public interface DependencyResolver {
                                                                                            SliceRegistry registry,
                                                                                            SharedLibraryClassLoader sharedLibraryLoader,
                                                                                            SliceLoadingContext loadingContext,
+                                                                                           Fn1<SliceLoadingContext, Artifact> contextFor,
                                                                                            Set<String> resolutionPath,
                                                                                            List<Slice> accumulated) {
         if (dependencies.isEmpty()) {
@@ -699,11 +747,13 @@ public interface DependencyResolver {
                                                     registry,
                                                     sharedLibraryLoader,
                                                     loadingContext,
+                                                    contextFor,
                                                     resolutionPath).flatMap(slice -> resolveArtifactDependenciesWithContextSequentially(remaining,
                                                                                                                                         repository,
                                                                                                                                         registry,
                                                                                                                                         sharedLibraryLoader,
                                                                                                                                         loadingContext,
+                                                                                                                                        contextFor,
                                                                                                                                         resolutionPath,
                                                                                                                                         appendToList(accumulated,
                                                                                                                                                      slice)));
@@ -714,6 +764,7 @@ public interface DependencyResolver {
                                                                        SliceRegistry registry,
                                                                        SharedLibraryClassLoader sharedLibraryLoader,
                                                                        SliceLoadingContext loadingContext,
+                                                                       Fn1<SliceLoadingContext, Artifact> contextFor,
                                                                        Set<String> resolutionPath) {
         var inRegistry = registry.findByArtifactKey(dependency.groupId(),
                                                     dependency.artifactId(),
@@ -732,6 +783,7 @@ public interface DependencyResolver {
                                                         registry,
                                                         sharedLibraryLoader,
                                                         loadingContext,
+                                                        contextFor,
                                                         resolutionPath);
     }
 
@@ -740,13 +792,15 @@ public interface DependencyResolver {
                                                                            SliceRegistry registry,
                                                                            SharedLibraryClassLoader sharedLibraryLoader,
                                                                            SliceLoadingContext loadingContext,
+                                                                           Fn1<SliceLoadingContext, Artifact> contextFor,
                                                                            Set<String> resolutionPath) {
         return toArtifact(dependency).async()
                          .flatMap(artifact -> resolveWithSharedLoaderAndContext(artifact,
                                                                                 repository,
                                                                                 registry,
                                                                                 sharedLibraryLoader,
-                                                                                loadingContext,
+                                                                                contextFor.apply(artifact),
+                                                                                contextFor,
                                                                                 resolutionPath))
                          .map(ResolvedSlice::slice);
     }

--- a/aether/slice/src/main/java/org/pragmatica/aether/slice/dependency/DependencyResolver.java
+++ b/aether/slice/src/main/java/org/pragmatica/aether/slice/dependency/DependencyResolver.java
@@ -102,11 +102,11 @@ public interface DependencyResolver {
                                                      Option<SliceCodec> nodeCodec,
                                                      Fn1<Option<ResourceProviderFacade>, ClassLoader> resourceOverlayBuilder) {
         Fn1<SliceLoadingContext, Artifact> contextFor = slice -> loadingContextFor(slice,
-                                                                                    invokerFacade,
-                                                                                    resourceFacade,
-                                                                                    compositeBuilder,
-                                                                                    nodeCodec,
-                                                                                    resourceOverlayBuilder);
+                                                                                   invokerFacade,
+                                                                                   resourceFacade,
+                                                                                   compositeBuilder,
+                                                                                   nodeCodec,
+                                                                                   resourceOverlayBuilder);
         var loadingContext = contextFor.apply(artifact);
 
         return registry.lookup(artifact)
@@ -134,7 +134,8 @@ public interface DependencyResolver {
                                                                      artifact.asString(),
                                                                      nodeCodec);
 
-        compositeBuilder.onPresent(builder -> loadingContext.setCompositeBuilder(classLoader -> builder.apply(artifact, classLoader)));
+        compositeBuilder.onPresent(builder -> loadingContext.setCompositeBuilder(classLoader -> builder.apply(artifact,
+                                                                                                              classLoader)));
         loadingContext.setResourceOverlayBuilder(resourceOverlayBuilder);
 
         return loadingContext;

--- a/aether/slice/src/test/java/org/pragmatica/aether/slice/SliceStoreTest.java
+++ b/aether/slice/src/test/java/org/pragmatica/aether/slice/SliceStoreTest.java
@@ -23,7 +23,10 @@ import org.pragmatica.lang.Unit;
 import org.pragmatica.lang.type.TypeToken;
 import org.pragmatica.lang.utils.Causes;
 
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -362,6 +365,100 @@ class SliceStoreTest {
 
         assertThat(composite.isEmpty()).isTrue();
     }
+
+    // === Slice-composite absence branches (#889 review S1) ===
+    //
+    // `AbsentCompositeConfigFacade` names four load-time conditions. Three of them leave the node
+    // WITH a provider, so a refusal that blamed "no configuration provider" was false there. The
+    // parse-failure branch is pinned here: the malformed slice file drops the whole composite (node
+    // keys included — the layering is all-or-nothing), and the refusal the slice receives must be
+    // true for that branch, i.e. it must name the slice's own layer as a candidate.
+
+    @Test
+    void buildSliceCompositeFromClassLoader_dropsWholeComposite_whenResourcesTomlIsMalformed() {
+        var store = storeWithNodeComposite(Map.of("deployed.endpoint.host", "node.internal"));
+
+        // Positive control: the same store and a parseable file yield a composite carrying BOTH
+        // layers. Without this, an empty result below could mean the loader stub never answered.
+        var composite = store.buildSliceCompositeFromClassLoader(artifact, resourcesTomlLoader(WELL_FORMED_TOML));
+
+        assertThat(composite.isPresent()).isTrue();
+        assertThat(composite.unwrap().getString("deployed.endpoint.port").unwrap()).isEqualTo("8080");
+        assertThat(composite.unwrap().getString("deployed.endpoint.host").unwrap()).isEqualTo("node.internal");
+
+        // The branch under test.
+        assertThat(store.buildSliceCompositeFromClassLoader(artifact, resourcesTomlLoader(MALFORMED_TOML)).isEmpty())
+                .describedAs("a malformed resources.toml drops the WHOLE composite, node keys included")
+                .isTrue();
+    }
+
+    @Test
+    void configRefusal_namesTheSliceLayer_whenResourcesTomlIsMalformed() {
+        var store = storeWithNodeComposite(Map.of("deployed.endpoint.host", "node.internal"));
+        var context = SliceLoadingContext.sliceLoadingContext(STUB_INVOKER, REFUSING_RESOURCES, artifact.asString());
+
+        context.setCompositeBuilder(loader -> store.buildSliceCompositeFromClassLoader(artifact, loader));
+        context.materializeComposite(resourcesTomlLoader(MALFORMED_TOML));
+
+        var result = context.config().requireString("deployed.endpoint", "host");
+
+        assertThat(result.isFailure()).describedAs("node.toml carries the key, but the dropped composite took it away").isTrue();
+        result.onFailure(cause -> {
+            assertThat(cause.message()).contains("No configuration composite");
+            assertThat(cause.message()).describedAs("the node HAS a provider here; the refusal must not blame it alone")
+                                       .contains("resources.toml");
+            assertThat(cause.message()).contains(artifact.asString());
+        });
+    }
+
+    private static final String WELL_FORMED_TOML = """
+            [deployed.endpoint]
+            port = 8080
+            """;
+
+    // An unterminated array is a parse error by TomlParser's own contract (TomlError.unterminatedArray).
+    private static final String MALFORMED_TOML = """
+            [deployed.endpoint]
+            host = [
+            """;
+
+    private sliceStore storeWithNodeComposite(Map<String, String> nodeValues) {
+        return (sliceStore) SliceStore.sliceStore(registry,
+                                                  List.of(),
+                                                  sharedLoader,
+                                                  STUB_INVOKER,
+                                                  REFUSING_RESOURCES,
+                                                  SliceActionConfig.sliceActionConfig(),
+                                                  Option.some(IntrinsicConfigProvider.intrinsicConfigProvider("node.toml", nodeValues)),
+                                                  Option.empty(),
+                                                  Option.empty(),
+                                                  SliceLoadingContext.noResourceOverlay());
+    }
+
+    /// A classloader whose `META-INF/resources.toml` is the given text — the only resource the
+    /// composite builder reads through the slice loader.
+    private static ClassLoader resourcesTomlLoader(String content) {
+        return new ClassLoader(SliceStoreTest.class.getClassLoader()) {
+            @Override
+            public InputStream getResourceAsStream(String name) {
+                return "META-INF/resources.toml".equals(name)
+                       ? new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8))
+                       : super.getResourceAsStream(name);
+            }
+        };
+    }
+
+    private static final ResourceProviderFacade REFUSING_RESOURCES = new ResourceProviderFacade() {
+        @Override
+        public <T> Promise<T> provide(Class<T> resourceType, String configSection) {
+            return Causes.cause("no resources in this test").promise();
+        }
+
+        @Override
+        public <T> Promise<T> provide(Class<T> resourceType, String configSection, ProvisioningContext context) {
+            return Causes.cause("no resources in this test").promise();
+        }
+    };
 
     // === Slice-intrinsic secret resolution (#269) ===
     //

--- a/changelog.d/889-deployed-config-facade.md
+++ b/changelog.d/889-deployed-config-facade.md
@@ -5,58 +5,81 @@
   [mechanism: the deployment path is `SliceStore.loadSlice` → `DependencyResolver.resolveWithContext`
   → `SliceLoadingContext.sliceLoadingContext(invoker, resources, sliceId, nodeCodec)`, which routes
   through the three-argument `SliceCreationContext` factory and passes `NoOpConfigFacade.INSTANCE`;
-  the config-carrying overloads had no production caller at all]. A working facade *was* built, at
-  `NodeDeploymentState:1261`, and wired only to `notifyInitial` — the plumbing existed and pointed at
-  the wrong place.
-- This explains a fact previously recorded as an adoption gap: `ConfigurationSection` had **zero**
-  consumers across the repo, the 24 examples and the ticketing demo. The likelier reading is that it
-  could not work, so nothing used it. The books teach it as a first-class resource type
-  (`book-aether/part1-no-magic.md`, `custom-qualifiers.md`), so they taught a pattern that did not
-  function once deployed.
+  the config-carrying overloads had no production caller; reverting `SliceLoadingContext.config()`
+  to `delegate.config()` reproduces it — every `DeployedConfigSectionTest` case fails with one
+  `Config service not available` cause per `require*` the generated factory emits]. No deployable
+  consumer of `ConfigurationSection` existed in the repo, the examples or the ticketing demo before
+  this fix's fixture [mechanism: repo-wide grep for `type = ConfigurationSection.class` finds the
+  slice-processor's own generator unit test and nothing else; the first deployable consumer is
+  `aether/slice-testkit`'s `EndpointSettings`], which reads as "it could not work" rather than
+  "nobody wanted it".
 - `SliceLoadingContext.config()` now serves the **materialized slice-composite** (`slice.toml` under
-  the node-composite's operator KV overlay and node.toml) through a new `ConfigProviderFacade`.
-  Fixed at that seam rather than by threading a `ConfigFacade` through
-  `DependencyResolver.resolveWithContext`, for two independent reasons: the slice-composite is
-  **late-bound** (it cannot exist until the slice classloader does, which is why `SliceStore` already
-  passes a *builder*), so a facade constructed at resolve time could only carry the node composite
-  and would silently miss the slice's own `resources.toml` and every operator override on it; and the
-  existing `NodeDeploymentManager.ConfigServiceConfigFacade` — the obvious thing to thread in —
-  **refuses `requireStringList` outright**, so a `List<String>` config component would have stayed
-  broken behind a fix that looked complete.
-- **Absence now refuses by name instead of degrading.** When no composite is attached, `config()`
-  does not fall through to the no-op — whose "Config service not available" reads as a missing *key*
-  and sends the operator to their `resources.toml` — but returns `AbsentCompositeConfigFacade`, whose
-  cause names the missing *source*, the key, and the slice that asked. A facade supplied explicitly
-  through the config-carrying overload still wins, distinguished by identity against
-  `NoOpConfigFacade.INSTANCE`.
-- **Verified** by the repo's first `ConfigurationSection` slice
-  (`DeployedConfigSectionTest`, `aether/slice-testkit`), driven through `SliceStore.loadSlice` against
-  a real slice jar on disk — manifest, child-first `SliceClassLoader`, `DependencyResolver`, the
-  deferred composite builder and the processor-generated `EndpointProbeFactory`. The context is not
-  hand-built, deliberately: a test constructing its own `SliceCreationContext` through the
-  config-carrying overload bypasses exactly the broken code and passes against the defect.
-  Mutation probe — reverting only the `config()` hunk against a committed base — turns two of the
-  three deployment tests red with four `Config service not available` causes, one per `require*` the
-  generated factory emits (the fifth component is optional and routed through
-  `Result.success(getInt(...))`, which cannot fail). Recompilation was confirmed by mtime, since the
-  tree's `-T1C` build swallows the compiler's "Compiling N source files" line, and the restore by
-  reading the method body back rather than by `git status`.
-- **Scope of the closure, stated precisely.** `createSliceFromClass` is also reached at
-  `DependencyResolver:583` and `:613` via the two-argument overload, bypassing this seam. Those sit in
-  a closed subgraph whose only entries are `DependencyResolver.resolve` and `resolveBridge`, and a
-  repo-wide sweep finds **zero** callers of either (positive control: the same sweep shape finds
-  `resolveWithContext` at `SliceStore.java:208`, so the null is an absence rather than a bad search).
-  So no in-repo caller can hand a deployed slice a no-op facade. Both remain `static` members of a
-  public interface in a published artifact, so an out-of-repo caller could still reach them — that
-  path also passes `noOpResourceProvider()` and so refuses *every* resource, not config specifically.
+  the node-composite's operator KV overlay and node.toml) through a new `ConfigProviderFacade`,
+  reading through the reference on each call so a composite attached after construction is seen
+  [verified: `DeployedConfigFacadeTest$LoadingContextSeam#configPicksUpACompositeMaterializedAfterTheContextWasBuilt`,
+  `#configServesTheCompositeOnceAttached`]. Fixed at that seam rather than by threading a
+  `ConfigFacade` through `DependencyResolver.resolveWithContext` [mechanism: the composite is
+  late-bound — it cannot exist until the slice classloader does, which is why `SliceStore` passes a
+  builder — so a facade built at resolve time could carry only the node composite; and the existing
+  `NodeDeploymentManager.ConfigServiceConfigFacade` refuses `requireStringList` outright, so a
+  `List<String>` component would have stayed broken behind a fix that looked complete].
+- **Absence refuses by name instead of degrading.** With no composite attached, `config()` returns
+  `AbsentCompositeConfigFacade` rather than falling through to the no-op: the cause says a
+  configuration SOURCE is missing (not a key), lists the four load-time conditions that leave it
+  missing — no node provider, node.toml secret resolution failed, the slice's `resources.toml`
+  failed to parse, or one of its `${secrets:...}` placeholders failed — and names the slice that
+  asked [verified: `DeployedConfigFacadeTest$LoadingContextSeam#configRefusesByNameWhenNoCompositeIsAttached`
+  for the wording, `SliceStoreTest#configRefusal_namesTheSliceLayer_whenResourcesTomlIsMalformed`
+  for the parse-failure branch, where the node HAS a provider and the first draft's wording was
+  false; `SliceStoreTest#buildSliceCompositeFromClassLoader_dropsWholeComposite_whenResourcesTomlIsMalformed`
+  for the fact that a dropped slice layer takes the node keys with it]. A facade supplied through
+  the config-carrying overload still wins [verified: `#anExplicitlySuppliedFacadeWinsOverTheRefusal`].
+- **Each `[slices]` dependency now loads through a loading context of its own.** One context was
+  threaded down the dependency chain, so a dependency's generated factory read `ctx.config()` from
+  the PARENT's composite (first-wins materialization, builder closed over the parent artifact) and
+  its refusals named the parent; the parent's later codec `bind` also overwrote the dependency's.
+  `DependencyResolver.resolveWithContext` now takes an artifact-keyed composite builder and builds
+  one context per slice reached [verified: `DeployedConfigSectionTest#dependencySlice_readsItsOwnConfig_notItsParents`
+  — two jars declaring the same key with different values, each observes its own;
+  `#dependencySlice_refusalNamesTheDependency_whenItsOwnKeyIsMissing` — a key the dependency lacks
+  fails the load naming the dependency instead of being read from the parent]. Every missing-key
+  refusal from `ConfigProviderFacade` names the slice as well as the key for the same reason
+  [verified: `DeployedConfigFacadeTest$ReadSemantics#missingRequiredKeyFailsAndNamesTheKeyAndTheSlice`].
+- **`requireStringList` accepts the idiomatic spelling.** A native TOML array reaches every
+  provider as Java's `List.toString()` — `[a, b]` — because `TomlDocument#getSection` stringifies
+  each value; the first draft split that on commas and returned `["[a", "b]"]` silently. Both the
+  native array and the comma-joined scalar are read, whitespace and empty slots are treated alike
+  in both, a present-but-empty list is a value (`[]`), and a nested array is refused by name
+  [verified: `DeployedConfigFacadeTest$ReadSemantics#stringListAcceptsANativeTomlArray`,
+  `#stringListSplitsOnCommasTrimmingAndDroppingEmpties`, `#stringListTreatsBothSpellingsAlike`,
+  `#stringListPresentButEmptySucceedsAsEmptyList`, `#stringListRefusesANestedArrayByName`].
+- **Verified through the real deployment path** by the repo's first `ConfigurationSection` slice,
+  driven through `SliceStore.loadSlice` against a jar on disk that carries its own
+  `META-INF/resources.toml`: manifest, child-first `SliceClassLoader`, `DependencyResolver`, the
+  deferred composite builder, the secret resolver and the processor-generated
+  `EndpointProbeFactory`. Each field of the parsed record is attributed to the layer that supplied
+  it — a `${secrets:...}` placeholder resolved from the slice's own file, an operator override
+  winning over the slice's value, a key that exists only in the slice's file, and a native TOML
+  array [verified: `DeployedConfigSectionTest#deployedSlice_receivesParsedConfigRecord_withRealValues`,
+  `#deployedSlice_observesEachLayerOfTheComposite`, `#deployedSlice_isDefinedBySliceClassLoader_notTheTestClasspath`].
+- **Scope of the closure, stated precisely.** `createSliceFromClass` is also reached through the
+  two-argument overload in `DependencyResolver.resolveSliceDependencies` and
+  `createAndRegisterSlice`, bypassing this seam. Those sit in a closed subgraph whose only entries
+  are `DependencyResolver.resolve` and `resolveBridge`, and both remain `static` members of a
+  public interface in a published artifact — an out-of-repo caller could still reach them, and
+  that path also passes `noOpResourceProvider()` and so refuses every resource, not config
+  specifically [mechanism: repo-wide grep finds zero callers of either; positive control — the
+  same sweep finds `resolveWithContext` called once, at `SliceStore.loadFromLocation`].
 - **Known limit, not closed here:** the `get*` half of `ConfigFacade` returns `Option` and has no
-  channel to refuse, and the generator wraps those reads in `Result.success(...)`. A config record
-  whose components are **all** optional is therefore still constructed, with every value absent,
-  against a missing composite. Any record carrying at least one required component — every example in
-  the books — fails loudly and by name. Closing the all-optional case means changing what the
-  generator emits.
-- **Adjacent gap found, filed as #897 rather than fixed here:** `SliceTestKit` uses the two-argument
-  overload and exposes no config registration at all (`withResource`, `withPublisher`, `withHttp`,
-  `withNotifications`, `withContainer`, but no `withConfig`), so a user can now *deploy* a
-  `ConfigurationSection` slice and still cannot *unit-test* one. Growing the public API of a published
-  artifact is a scope decision, not something to acquire inside a bug fix.
+  channel to refuse, and the generator wraps those reads in `Result.success(...)`, so a config
+  record whose components are **all** optional is still constructed, with every value absent,
+  against a missing composite [mechanism: `FactoryClassGenerator`'s component-read switch emits
+  `Result.success(ctx.config().get*(...))` for the `OPTIONAL_PRIMITIVE` and
+  `OPTIONAL_VALUE_OBJECT` arms]. Any record with at least
+  one required component fails loudly and by name. Closing this means changing what the generator
+  emits.
+- **Adjacent gap, filed as #897 rather than fixed here:** `SliceTestKit` exposes no config
+  registration at all, so a user can now *deploy* a `ConfigurationSection` slice and still cannot
+  *unit-test* one [mechanism: `SliceTestKit.build()` constructs its context through the
+  two-argument `SliceCreationContext` overload, and the builder offers `withResource`,
+  `withPublisher`, `withHttp`, `withNotifications`, `withContainer` and no `withConfig`].

--- a/changelog.d/889-deployed-config-facade.md
+++ b/changelog.d/889-deployed-config-facade.md
@@ -1,0 +1,62 @@
+### Fixed (2026-09-06 — #889: a slice declaring a configuration section could not be created in a deployed cluster)
+- **`ctx.config()` inside a deployed slice was always `NoOpConfigFacade`**, whose every `require*`
+  method fails, so the `Result.all(...)` chain generated for
+  `@ResourceQualifier(type = ConfigurationSection.class)` could never produce a record
+  [mechanism: the deployment path is `SliceStore.loadSlice` → `DependencyResolver.resolveWithContext`
+  → `SliceLoadingContext.sliceLoadingContext(invoker, resources, sliceId, nodeCodec)`, which routes
+  through the three-argument `SliceCreationContext` factory and passes `NoOpConfigFacade.INSTANCE`;
+  the config-carrying overloads had no production caller at all]. A working facade *was* built, at
+  `NodeDeploymentState:1261`, and wired only to `notifyInitial` — the plumbing existed and pointed at
+  the wrong place.
+- This explains a fact previously recorded as an adoption gap: `ConfigurationSection` had **zero**
+  consumers across the repo, the 24 examples and the ticketing demo. The likelier reading is that it
+  could not work, so nothing used it. The books teach it as a first-class resource type
+  (`book-aether/part1-no-magic.md`, `custom-qualifiers.md`), so they taught a pattern that did not
+  function once deployed.
+- `SliceLoadingContext.config()` now serves the **materialized slice-composite** (`slice.toml` under
+  the node-composite's operator KV overlay and node.toml) through a new `ConfigProviderFacade`.
+  Fixed at that seam rather than by threading a `ConfigFacade` through
+  `DependencyResolver.resolveWithContext`, for two independent reasons: the slice-composite is
+  **late-bound** (it cannot exist until the slice classloader does, which is why `SliceStore` already
+  passes a *builder*), so a facade constructed at resolve time could only carry the node composite
+  and would silently miss the slice's own `resources.toml` and every operator override on it; and the
+  existing `NodeDeploymentManager.ConfigServiceConfigFacade` — the obvious thing to thread in —
+  **refuses `requireStringList` outright**, so a `List<String>` config component would have stayed
+  broken behind a fix that looked complete.
+- **Absence now refuses by name instead of degrading.** When no composite is attached, `config()`
+  does not fall through to the no-op — whose "Config service not available" reads as a missing *key*
+  and sends the operator to their `resources.toml` — but returns `AbsentCompositeConfigFacade`, whose
+  cause names the missing *source*, the key, and the slice that asked. A facade supplied explicitly
+  through the config-carrying overload still wins, distinguished by identity against
+  `NoOpConfigFacade.INSTANCE`.
+- **Verified** by the repo's first `ConfigurationSection` slice
+  (`DeployedConfigSectionTest`, `aether/slice-testkit`), driven through `SliceStore.loadSlice` against
+  a real slice jar on disk — manifest, child-first `SliceClassLoader`, `DependencyResolver`, the
+  deferred composite builder and the processor-generated `EndpointProbeFactory`. The context is not
+  hand-built, deliberately: a test constructing its own `SliceCreationContext` through the
+  config-carrying overload bypasses exactly the broken code and passes against the defect.
+  Mutation probe — reverting only the `config()` hunk against a committed base — turns two of the
+  three deployment tests red with four `Config service not available` causes, one per `require*` the
+  generated factory emits (the fifth component is optional and routed through
+  `Result.success(getInt(...))`, which cannot fail). Recompilation was confirmed by mtime, since the
+  tree's `-T1C` build swallows the compiler's "Compiling N source files" line, and the restore by
+  reading the method body back rather than by `git status`.
+- **Scope of the closure, stated precisely.** `createSliceFromClass` is also reached at
+  `DependencyResolver:583` and `:613` via the two-argument overload, bypassing this seam. Those sit in
+  a closed subgraph whose only entries are `DependencyResolver.resolve` and `resolveBridge`, and a
+  repo-wide sweep finds **zero** callers of either (positive control: the same sweep shape finds
+  `resolveWithContext` at `SliceStore.java:208`, so the null is an absence rather than a bad search).
+  So no in-repo caller can hand a deployed slice a no-op facade. Both remain `static` members of a
+  public interface in a published artifact, so an out-of-repo caller could still reach them — that
+  path also passes `noOpResourceProvider()` and so refuses *every* resource, not config specifically.
+- **Known limit, not closed here:** the `get*` half of `ConfigFacade` returns `Option` and has no
+  channel to refuse, and the generator wraps those reads in `Result.success(...)`. A config record
+  whose components are **all** optional is therefore still constructed, with every value absent,
+  against a missing composite. Any record carrying at least one required component — every example in
+  the books — fails loudly and by name. Closing the all-optional case means changing what the
+  generator emits.
+- **Adjacent gap found, filed as #897 rather than fixed here:** `SliceTestKit` uses the two-argument
+  overload and exposes no config registration at all (`withResource`, `withPublisher`, `withHttp`,
+  `withNotifications`, `withContainer`, but no `withConfig`), so a user can now *deploy* a
+  `ConfigurationSection` slice and still cannot *unit-test* one. Growing the public API of a published
+  artifact is a scope decision, not something to acquire inside a bug fix.


### PR DESCRIPTION
Fixes #889.

## The defect

`ctx.config()` inside a deployed slice was always `NoOpConfigFacade`, whose every `require*` method fails. So the `Result.all(...)` chain that `@ResourceQualifier(type = ConfigurationSection.class)` generates could never produce a record, and **a slice declaring a config section could not be created in a deployed cluster.**

The ticket recorded that as inferred but never executed — there was no such slice anywhere in the repo to deploy. It has now been executed; see the probe below.

### Corrected overload inventory

The ticket lists three `SliceCreationContext` factory overloads. There are **four** — it also has `(invoker, resources, config)` at `SliceCreationContext.java:47`, which likewise had no production caller. The corrected set:

| overload | line | config passed |
|---|---|---|
| `(invoker, resources)` | `:24` | `NoOpConfigFacade.INSTANCE` |
| `(invoker, resources, sliceId)` | `:31` | `NoOpConfigFacade.INSTANCE` |
| `(invoker, resources, sliceId, config)` | `:40` | caller's `ConfigFacade` |
| `(invoker, resources, config)` | `:47` | caller's `ConfigFacade` |

## The fix

`SliceLoadingContext.config()` now serves the **materialized slice-composite** (`slice.toml` under the node-composite's operator KV overlay and node.toml) through a new `ConfigProviderFacade`.

Serving it there rather than threading a `ConfigFacade` through `DependencyResolver.resolveWithContext` is deliberate, and is the acceptance criterion's "or an equivalent". Two independent arguments land on the same seam:

**1. The composite is late-bound.** It cannot exist until the slice classloader does, which is why `SliceStore` already passes a *builder* rather than a value. A facade constructed at resolve time could only carry the node composite, silently missing the slice's own `resources.toml` and every operator override layered on it. The literal reading produces a facade that looks fixed and is subtly wrong.

**2. The existing adapter cannot read lists.** `NodeDeploymentManager.ConfigServiceConfigFacade` — the facade already built at `NodeDeploymentState:1261` and the obvious thing to thread onto the deployment path — **refuses `requireStringList` outright**: `"String list config not supported via legacy ConfigService adapter"`. The generator emits exactly that call for a `List<String>` component. So the literal fix would have shipped a facade that still could not read a list-valued config field, passed any test that happened not to use one, and left the pattern broken for anyone whose config has one. `ConfigProviderFacade` implements it against the same comma-joined-scalar convention `ProviderBasedConfigService.splitCommaList` reads.

`DependencyResolver.materializeThenResolve` attaches the composite synchronously, strictly before the generated factory runs — and that factory is the first reader. `config()` therefore reads through the `AtomicReference` on each call instead of latching a facade at construction.

### Absence refuses by name; it does not degrade

When no composite is attached, `config()` does **not** fall through to the no-op. That fallback is the obvious implementation and it degrades silently: `NoOpConfigFacade` fails with `"Config service not available"`, a missing-*key* shape, which sends the reader to their `resources.toml` when the real fault is node-wide — the node has no configuration provider at all.

`AbsentCompositeConfigFacade` instead says a SOURCE is missing rather than a key, lists the four load-time conditions that leave it missing, and names the slice that asked:

> No configuration composite is attached to this slice, so key `deployed.endpoint.host` for slice `org.example:endpoint-probe:1.0.0` cannot be read. This is a missing configuration SOURCE, not a missing key. One of two layers was never built: the node composite (no configuration provider configured, or node.toml secret resolution failed at boot) or the slice's own layer (META-INF/resources.toml failed to parse, or one of its ${secrets:...} placeholders failed to resolve; a dropped slice layer takes the node keys with it). The slice load log names which.

The first draft of that sentence blamed the node provider alone, which is true in one of the four branches (review S1). The facade cannot tell them apart — it sees only "no composite" — so it lists them; the parse-failure branch, where the node *has* a provider, is pinned in `SliceStoreTest`.

A facade supplied explicitly through the config-carrying overload still wins — identity against `NoOpConfigFacade.INSTANCE` separates "caller meant this" from "nobody set anything". Slices declaring no config section are unaffected either way: they never call `config()`.

**Honest residual, stated rather than hidden.** The `get*` half of `ConfigFacade` returns `Option`
and has no channel to refuse, and the generator wraps those reads in `Result.success(...)`. A config
record whose components are **all** optional is therefore still constructed, with every value absent,
against a missing composite. Any record carrying at least one required component — every example in
the books — fails loudly and by name. Closing the all-optional case means changing what the generator
emits, which is a different blast radius than this PR carries, so it is named here rather than taken.

## Does this close #889, or only narrow it?

**Closed** for every in-repo caller, top-level and dependency-loaded alike. The first round closed only top-level loads: `resolveWithContext` built ONE `SliceLoadingContext` and threaded it into every `[slices]` dependency, so a dependency's factory read `ctx.config()` from the parent's composite (review S2). Each slice reached now gets a context of its own — see "Review round 1" below. Evidence for the remaining path, with a positive control beside each absence claim.

`createSliceFromClass` is called at four sites. `:335` and `:367` pass the `loadingContext` (the fixed seam). `:583` and `:613` pass `toCreationContext(invokerFacade)` — the 2-arg overload — and bypass it. Those two sit in a closed subgraph:

```
resolve(:51) ─→ resolveWithSharedLoader(:384) ─→ loadFromLocationWithShared(:425)
  ─→ validateAndLoadWithShared(:448) ─→ processSharedAndLoadSlice(:480)
  ─→ loadSliceClassAndResolveDeps(:551) ─→ resolveSliceDependencies(:570)
       ├─→ createSliceFromClass(toCreationContext)            :583
       └─→ resolveArtifactDependenciesSequentially(:618) ─→ resolveArtifactDependency(:642)
             ─→ resolveArtifactFromRepository(:668) ─→ resolveWithSharedLoader  (recurses, stays inside)
                 └─→ createAndRegisterSlice(:605) ─→ createSliceFromClass(toCreationContext)  :613
```

`toCreationContext` is called from `:583` and `:613` and nowhere else. The only ways into that subgraph are `resolve` and `resolveBridge`.

Sweep of every in-repo reference to the type, excluding `target/` and the declaring file:

```
$ grep -rn 'DependencyResolver' --include='*.java' <repo> | grep -v '/target/' | grep -v 'dependency/DependencyResolver.java'
jbct/.../FactoryClassGenerator.java:2300   (doc comment: `DependencyResolver#resolveBridge`)
aether/slice/.../SliceStore.java:18        (import)
aether/slice/.../SliceStore.java:208       DependencyResolver.resolveWithContext(...)
aether/slice-testkit/.../DeployedConfigSectionTest.java:52   (doc comment, mine)
aether/slice-api/.../DeployedConfigFacadeTest.java:134       (doc comment, mine)
aether/slice-api/.../SliceLoadingContext.java:129, :137      (doc comments, mine)
--- total: 7
```

Exactly **one** is a call, and it is `resolveWithContext`. Zero calls to `resolve`; zero to `resolveBridge`.

**Positive control** — the same sweep shape does find calls when they exist: `grep -rn 'DependencyResolver.resolveWithContext(' ...` returns 1 hit (`SliceStore.java:208`), while `grep -rn 'DependencyResolver.resolve(' ...` returns 0. The pattern finds what is there, so the null is a real absence and not a bad search.

**Caveat kept rather than dropped:** `resolve` and `resolveBridge` are `static` members of a public interface in a published artifact, so an out-of-repo caller could reach them. That path also passes `noOpResourceProvider()`, so it cannot provision *any* resource, not just config — it is not a config-specific hole, and deleting public API is not this PR's call.

## Is "node has no composite at all" reachable? (yes — see found-not-fixed below)

**Yes, two ways** — reported, not widened into. `AetherNode.createResourceProviderFacade` has three branches:

| branch | line | `nodeComposite` | resource facade |
|---|---|---|---|
| no `configProvider` configured | `:5966` | `Option.empty()` | `noOpResourceProviderFacade()` |
| secret resolution failed | `:5990` | `Option.empty()` | `noOpResourceProviderFacade()` |
| success | `:6038` | `Option.some(nodeComposite)` | real provider |

Both empty branches also disable resource provisioning entirely, so this is a node-wide "no configuration" state rather than a config-only gap — which is precisely what the new named cause says. The second branch is worth its own look: a node that *has* a config provider whose secret resolution fails logs an error and then boots into a state where nothing can be provisioned. That is a separate defect and is not touched here.

## Evidence

**The repo's first `ConfigurationSection` slice** (`aether/slice-testkit`, test scope) is the acceptance artifact, driven through `SliceStore.loadSlice` — the real deployment entry point — against a real jar on disk: manifest, child-first `SliceClassLoader`, `DependencyResolver`, the deferred composite builder, and the processor-generated `EndpointProbeFactory`. Nothing about the context is hand-built; a test constructing its own `SliceCreationContext` through the config-carrying overload would bypass exactly the broken code and pass against the defect.

The generated factory, verbatim:

```java
Result.all(
    ctx.config().requireString("deployed.endpoint", "host"),
    ctx.config().requireInt("deployed.endpoint", "port"),
    ctx.config().requireBoolean("deployed.endpoint", "secure"),
    ctx.config().requireStringList("deployed.endpoint", "tags"),
    Result.success(ctx.config().getInt("deployed.endpoint", "weight"))
).flatMap(EndpointConfig::endpointConfig).async()
```

**Mutation probe.** Production hunk and tests were committed first; the probe reverted *only* `SliceLoadingContext.config()` back to `return delegate.config();` as a working-tree hunk against that committed base. All three deployment tests went red (the first draft of this paragraph said two; the absent-config test fails on its message assertion, as the review noted) with four `Config service not available` causes — one per `require*` call; the fifth field is optional and routed through `Result.success(getInt(...))`, which cannot fail. That is #889's predicted shape exactly. Recompilation of `slice-api` was confirmed by **mtime**, because the tree's `-T1C` build swallows the compiler's "Compiling N source files" line; the restore was verified by **reading the method body back**, not by `git status`.

## Verification

Counted from surefire **XML**, not `.txt` headers — the outer `DeployedConfigFacadeTest` XML reports `tests="0"` because its cases live in `@Nested` classes.

| module | testcases | failures | errors |
|---|---|---|---|
| `aether/slice-api` | 325 | 0 | 0 |
| `aether/slice` | 763 | 0 | 0 |
| `aether/slice-testkit` | 14 | 0 | 0 |

(Round 1 added 4, 2 and 3 tests respectively; round-0 counts were 321 / 761 / 11. All three declared before the run and matched, on a `clean test` after the probes so no probe bytecode remained in `target/`, and again on a full `-am` reactor of 38 modules.)

All three were declared as expected values *before* the run and matched exactly. `aether/slice` was expected to stay at 761 because nothing it covers was touched, and it did.

`jbct:check` on all three modules: 0 format issues, 0 lint errors.

Producer and consumers were built in one reactor call throughout (`-pl aether/slice-api,aether/slice,aether/slice-testkit -am`), so no consumer resolved a stale `slice-api`.

### On reading these results

Three things in this PR's verification were nearly counted as passes while having produced no data at all, and they share one shape worth naming.

1. **A banned module.** The first `jbct:check` run failed on a format issue in the new file; the reactor then printed *"This project has been banned from the build due to previous failures"* for `slice` and `slice-testkit`. Those two were never checked. Nothing anywhere emitted "0 modules checked" — the log simply did not mention them. Both were re-run to completion afterwards.
2. **`@Nested` surefire counts.** `TEST-…DeployedConfigFacadeTest.xml` reports `tests="0"`; its ten cases live in two separate per-nested-class XML files. A total read off the outer file, or off any `.txt` header, undercounts silently.
3. **A stale CI head.** The checks list on this PR reported against a superseded head after the branch moved. A green there is not evidence about the current head.

The general rule, which covers all three: **state the expected count before reading the output, not after.** A check that never ran and a check that passed are indistinguishable unless you know in advance how many results to expect. Here that means three `Check results:` lines, three surefire module totals, and a checks list whose head SHA matches the branch tip.

Related, in the checks list itself: **CodeRabbit's green is a SKIP, not a review** — *"Review skipped: reviews are disabled for this base branch."* It renders identically to a passing review while representing no coverage whatsoever.

## Scope held

- `notifyChange` / `dispatchNotification` / `lastParsedConfig` untouched (retired under #381). `notifyInitial` untouched, still on its own facade.
- `SpiResourceProvider` and `ResourceFactory` untouched (#268/#891).
- No new `AetherKey`/`AetherValue`, so no `SystemTags` pinning required.
- All four `SliceCreationContext` overloads left in place and unchanged.

## Found here, deliberately NOT fixed here

**#897 — the test kit cannot test what this PR makes deployable.** `SliceTestKit.build()`
(`SliceTestKit.java:97`) uses the 2-arg overload, and the kit exposes **no** config registration at
all: `withResource`, `withPublisher`, `withHttp`, `withNotifications`, `withContainer`, but no
`withConfig`. So after this PR a reader following the books can *deploy* a `ConfigurationSection`
slice and still cannot *unit-test* one — the taught story is not whole. Not fixed here because
growing the public API of a published artifact is a scope decision, not something to acquire inside
a bug fix. Note for whoever picks it up: **#607** (the kit cannot exercise the core programming model
because `NoOpSliceInvoker` fails every slice call) is a second independent gap in the same kit, and
the two may want one change rather than two — reconcile them before starting either.

**Degraded boot on failed secret resolution — recorded, not filed.** `AetherNode:5990`: a node that
*has* a configured provider but fails secret resolution logs an error and then returns a
`ResourceProviderSetup` with `Option.empty()` for the composite and `noOpResourceProviderFacade()` —
i.e. it **boots into a state where nothing can be provisioned at all**, rather than refusing to boot.
That is a degraded boot rather than a refusal, the same family as #888's validator granting access
when it cannot check. The three-branch shape is tabulated above so this is filable without
re-deriving it. Out of scope here; this PR only makes the resulting failure say what is missing.

## Review round 1 (adversarial review 2026-09-06: 0 BLOCKING, 5 SHOULD-FIX, 6 NOTE — all five fixed, three notes taken)

| item | finding | fix | commit | red-before |
|---|---|---|---|---|
| **S1** | the refusal blamed "no configuration provider", true in 1 of 4 branches | cause lists all four load-time conditions and states that a dropped slice layer takes the node keys with it; `buildSliceCompositeFromClassLoader` made package-private and pinned: malformed `resources.toml` → whole composite dropped (with a well-formed positive control), and the refusal the slice then gets names the slice layer | `06222d080` | wording test: Probe A turns `configRefusal_namesTheSliceLayer_whenResourcesTomlIsMalformed` red |
| **S2** | a `[slices]` dependency read its parent's composite and sliceId (one context threaded down the chain, first-wins materialization, builder closed over the parent artifact) | `resolveWithContext` takes an artifact-keyed builder (`Fn2<…, Artifact, ClassLoader>`) and builds one `SliceLoadingContext` per slice reached; `SliceStore` passes `this::buildSliceCompositeFromClassLoader`; `ConfigProviderFacade` refusals now name the slice as well as the key | `1cd1cefa5` | resolver + store hunks reverted to `45777fd8c`: `dependencySlice_readsItsOwnConfig_notItsParents` red (dependency observed `parent.internal`), `dependencySlice_refusalNamesTheDependency_whenItsOwnKeyIsMissing` red (load succeeded by reading the parent's key); 2 of 6 red, restored |
| **S3** | deployment fixture packaged class files only; the claimed grid (slice layer, override, secret) was untested | fixture jar now carries `META-INF/resources.toml`: `host` is a `${secrets:…}` placeholder resolved by the store's resolver, `port`/`weight` are overridden by the node layer, `secure`/`tags` exist only in the slice file, `tags` is a native TOML array; `deployedSlice_observesEachLayerOfTheComposite` asserts each field against its layer | `45777fd8c` | covered by Probe A (6 of 6 deployment tests red) and Probe S4 (3 of 6 red on the `tags` field) |
| **S4** | `requireStringList` mangled a native TOML array into `["[a", "b]"]` | native array accepted as the idiomatic form, comma-joined scalar kept as fallback, both spellings agree on whitespace and empty slots, nested array refused by name | `19c9e6cc6` | `parseStringList` reverted to comma-split: 4 red in `DeployedConfigFacadeTest$ReadSemantics`, 3 red on the deployed path (`"[alpha+beta]"`), restored |
| **S5** | changelog fragment had 1 evidence tag across 8 bullets | every bullet carries `[verified: Class#method]` or `[mechanism: …]`; the two claims the code contradicted are corrected | `84542cbc5` | n/a (prose); each `[verified:]` name exists in the tree |
| chore | `jbct:format` | whitespace only, three files | `5c85998bc` | — |

**Notes taken:** N1 (`UNNAMED_SLICE` constant used at the codec label, in `06222d080`); N2 decided — a present-but-empty list is a value and succeeds as `[]`, documented on `ConfigProviderFacade` and pinned by `stringListPresentButEmptySucceedsAsEmptyList`. **Notes left as stated:** N3 (`sliceStoreWithoutResourceProvisioning` public static, test-only), N4 (no-arg config record constructs against nothing), N5 (no cross-slice sharing remains after S2), N6 (degraded boot on failed node secret resolution — still unfiled, recorded above).

**S2 took the full fix, not the refuse-by-name fallback.** The codec binding did NOT need to move: with one `DeferredSliceCodec` per context, each is bound exactly once by its own slice in `resolvedSlice`, so the "parent's later `bind` overwrites the dependency's" hazard disappears as a consequence rather than needing a reorder.

**API note, stated rather than hidden:** the 9-argument `resolveWithContext` is a `static` member of a public interface and its `compositeBuilder` parameter type changed from `Fn1<…, ClassLoader>` to `Fn2<…, Artifact, ClassLoader>`. Its only in-repo caller is `SliceStore.loadFromLocation`. Keeping a bug-preserving overload for out-of-repo callers would have been a silent fallback of the kind this PR is about, so it was not kept.

**Probe A, re-run at `84542cbc5`** (revert only the `config()` body to `return delegate.config();`): 10 red — 3 in `DeployedConfigFacadeTest$LoadingContextSeam`, 1 in `SliceStoreTest`, **6 of 6** in `DeployedConfigSectionTest`, every deployment failure carrying four `Config service not available` causes. Recompilation confirmed by class mtime; restore by reading the method body back; `clean test` afterwards.

**Gate:** `jbct:check -am` on the three modules — three `Check results` lines, 0 format issues and 0 lint errors in each (warnings pre-existing). Probes that fail `slice-api` tests run with `-Dmaven.test.failure.ignore=true`, because `-fae` alone lets the reactor skip `slice-testkit` after an upstream test failure and an empty report directory then reads as nothing-to-report.
