### PR TITLE
test: bound the auto-heal pin await in StreamOwnerFailoverPinnedTest (#685)

### DIFF
--- a/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/StreamOwnerFailoverPinnedTest.java
+++ b/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/StreamOwnerFailoverPinnedTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
 
 import org.pragmatica.aether.ember.EmberCluster;
+import org.pragmatica.lang.io.TimeSpan;
 
 /// #491 — membership-PINNED variant of the RF=2 stream owner-kill failover proof (shared flow in
 /// [AbstractStreamOwnerFailover]). Identical to [StreamOwnerFailoverTest] except it pins membership two
@@ -66,7 +67,7 @@ class StreamOwnerFailoverPinnedTest extends AbstractStreamOwnerFailover {
         cluster.allNodes()
                .forEach(node -> node.clusterTopologyManager()
                                     .onPresent(ctm -> ctm.setAutoHealEnabled(false, PIN_REASON)
-                                                         .await()
+                                                         .await(TimeSpan.timeSpan(30).seconds())
                                                          .onFailure(cause -> {
                                                              throw new AssertionError("auto-heal pin failed: " + cause.message());
                                                          })));

--- a/changelog.d/685-bounded-autoheal-pin-await.md
+++ b/changelog.d/685-bounded-autoheal-pin-await.md
@@ -1,0 +1,4 @@
+### Fixed (2026-09-06 — #685: the membership-pin await in `StreamOwnerFailoverPinnedTest` was unbounded under a comment claiming it was bounded)
+
+- **`StreamOwnerFailoverPinnedTest.pinMembership` awaited `setAutoHealEnabled(false, …)` — a consensus round-trip since #685 — with a bare `.await()`, directly under a comment reading "Await it, bounded, and fail".** A pin that never resolved would park the `forge-tests` job until the runner's own timeout instead of failing the test by name. The await is now bounded at 30 s; on expiry the existing `onFailure` arm throws with the timeout cause
+  [mechanism: `Promise.await(TimeSpan)` returns a failed `Result` on expiry, which the existing `onFailure(cause -> throw new AssertionError(...))` arm converts into a named test failure; the success path is unchanged]. This was #867's one SHOULD-FIX from its review round 1: it was edited in the stream tree but never committed, so #867 merged with the comment and without the code.


### PR DESCRIPTION
## Summary

- `StreamOwnerFailoverPinnedTest.pinMembership` awaited `setAutoHealEnabled(false, …)` with a bare `.await()` under a comment that says "Await it, bounded, and fail". Since #685 that call is a consensus round-trip, so a pin that never resolves parked the `forge-tests` job until the runner's own timeout instead of failing the test by name. The await is now bounded at 30 s (`TimeSpan.timeSpan(30).seconds()`); on expiry the existing `onFailure` arm throws with the timeout cause.
- This was #867's one SHOULD-FIX from its review round 1. The session-9 handover recorded it as fixed directly by the CTO; the edit was made in the stream tree but never committed, so #867 merged with the comment and without the code. This PR restores it.

## Verification

- Test-only, two lines plus an import. `Promise.await(TimeSpan)` exists (`core/src/main/java/org/pragmatica/lang/Promise.java:687`) and returns a failed `Result` on expiry, which the existing `onFailure` arm converts into an `AssertionError`.
- Not run locally; the `forge-tests` CI job executes this test. Success-path behaviour is unchanged.

Refs #685, #867.
