### PR TITLE
fix(http): jwt mode with no jwt config denies non-public routes instead of granting admin (#888)

### DIFF
--- a/aether/node/src/main/java/org/pragmatica/aether/http/AppHttpServer.java
+++ b/aether/node/src/main/java/org/pragmatica/aether/http/AppHttpServer.java
@@ -405,8 +405,8 @@ class AppHttpServerAdapter implements AppHttpServer {
     /// `public` routes with an empty context and answers `401 NO_VALIDATOR_CONFIGURED` to the rest.
     private static SecurityValidator jwtModeWithoutConfigValidator() {
         log.warn("[app-http] security_mode = \"jwt\" but no JWT configuration is present ([app-http] jwks_url"
-                 + " is missing) — every non-public app route will be REFUSED with 401 until it is set."
-                 + " Set jwks_url (and issuer/audience) or switch security_mode (#888).");
+                + " is missing) — every non-public app route will be REFUSED with 401 until it is set."
+                + " Set jwks_url (and issuer/audience) or switch security_mode (#888).");
 
         return SecurityValidator.denyUnlessPublicValidator();
     }

--- a/aether/node/src/main/java/org/pragmatica/aether/http/AppHttpServer.java
+++ b/aether/node/src/main/java/org/pragmatica/aether/http/AppHttpServer.java
@@ -392,7 +392,7 @@ class AppHttpServerAdapter implements AppHttpServer {
     private static SecurityValidator buildSecurityValidator(AppHttpConfig config) {
         return switch (config.securityMode()) {
             case API_KEY -> SecurityValidator.apiKeyValidator(config.apiKeys());
-            case JWT -> config.jwtConfig().map(SecurityValidator::jwtValidator).or(AppHttpServerAdapter::jwtModeWithoutConfigValidator);
+            case JWT -> config.jwtConfig().map(SecurityValidator::jwtValidator).or(() -> jwtModeWithoutConfigValidator(config.enabled()));
             case NONE -> SecurityValidator.permitAllValidator();
         };
     }
@@ -403,13 +403,24 @@ class AppHttpServerAdapter implements AppHttpServer {
     /// state strictly MORE permissive than `security_mode = "none"`. A JWT node that cannot verify a
     /// token must refuse everything a token would have gated: `denyUnlessPublicValidator` serves
     /// `public` routes with an empty context and answers `401 NO_VALIDATOR_CONFIGURED` to the rest.
-    private static SecurityValidator jwtModeWithoutConfigValidator() {
-        log.warn("[app-http] security_mode = \"jwt\" but no JWT configuration is present ([app-http] jwks_url"
-                + " is missing) — every non-public app route will be REFUSED with 401 until it is set."
-                + " Set jwks_url (and issuer/audience) or switch security_mode (#888).");
+    ///
+    /// Logged at ERROR, not WARN (#902 review ruling): the operator declared `jwt` and nothing can
+    /// verify a token, so every non-public route on this node will answer `401` -- a declared-intent
+    /// contradiction, not a degraded default. Only logged for a server that will actually serve:
+    /// the validator is built at construction, before `start()` consults `enabled()`, and a disabled
+    /// server refuses nothing. Pinned by `AppHttpServerJwtMissingConfigLogTest`.
+    private static SecurityValidator jwtModeWithoutConfigValidator(boolean serverEnabled) {
+        if (serverEnabled) {
+            log.error(JWT_MISSING_CONFIG_MESSAGE);
+        }
 
         return SecurityValidator.denyUnlessPublicValidator();
     }
+
+    private static final String JWT_MISSING_CONFIG_MESSAGE = "[app-http] security_mode = \"jwt\" but [app-http] jwks_url is missing:"
+                                                     + " no JWT configuration is present, so every non-public app route on this"
+                                                     + " node will be REFUSED with 401. Set jwks_url (and issuer/audience) or"
+                                                     + " change security_mode, then restart the node (#888).";
 
     private static Option<HttpForwarder> buildHttpForwarder(NodeId selfNodeId,
                                                             HttpRouteRegistry routeRegistry,

--- a/aether/node/src/main/java/org/pragmatica/aether/http/AppHttpServer.java
+++ b/aether/node/src/main/java/org/pragmatica/aether/http/AppHttpServer.java
@@ -386,12 +386,29 @@ class AppHttpServerAdapter implements AppHttpServer {
         return ctx.stopped();
     }
 
+    /// The `NONE` arm may install `permitAllValidator` only because `handleRequestInScope` refuses
+    /// every auth-requiring policy with `NO_VALIDATOR_CONFIGURED` before the validator is consulted;
+    /// the `JWT` arm has no such pre-check, so its no-config fallback must itself deny (#888).
     private static SecurityValidator buildSecurityValidator(AppHttpConfig config) {
         return switch (config.securityMode()) {
             case API_KEY -> SecurityValidator.apiKeyValidator(config.apiKeys());
-            case JWT -> config.jwtConfig().map(SecurityValidator::jwtValidator).or(SecurityValidator.permitAllValidator());
+            case JWT -> config.jwtConfig().map(SecurityValidator::jwtValidator).or(AppHttpServerAdapter::jwtModeWithoutConfigValidator);
             case NONE -> SecurityValidator.permitAllValidator();
         };
+    }
+
+    /// #888: `security_mode = "jwt"` with no `[app-http] jwks_url` used to fall back to
+    /// `permitAllValidator`, which has no policy switch and hands EVERY caller a context holding
+    /// `Role.ADMIN` + `Role.SERVICE` — so `role:admin` routes were served to anonymous requests, a
+    /// state strictly MORE permissive than `security_mode = "none"`. A JWT node that cannot verify a
+    /// token must refuse everything a token would have gated: `denyUnlessPublicValidator` serves
+    /// `public` routes with an empty context and answers `401 NO_VALIDATOR_CONFIGURED` to the rest.
+    private static SecurityValidator jwtModeWithoutConfigValidator() {
+        log.warn("[app-http] security_mode = \"jwt\" but no JWT configuration is present ([app-http] jwks_url"
+                 + " is missing) — every non-public app route will be REFUSED with 401 until it is set."
+                 + " Set jwks_url (and issuer/audience) or switch security_mode (#888).");
+
+        return SecurityValidator.denyUnlessPublicValidator();
     }
 
     private static Option<HttpForwarder> buildHttpForwarder(NodeId selfNodeId,

--- a/aether/node/src/main/java/org/pragmatica/aether/http/AppHttpServer.java
+++ b/aether/node/src/main/java/org/pragmatica/aether/http/AppHttpServer.java
@@ -418,9 +418,9 @@ class AppHttpServerAdapter implements AppHttpServer {
     }
 
     private static final String JWT_MISSING_CONFIG_MESSAGE = "[app-http] security_mode = \"jwt\" but [app-http] jwks_url is missing:"
-                                                     + " no JWT configuration is present, so every non-public app route on this"
-                                                     + " node will be REFUSED with 401. Set jwks_url (and issuer/audience) or"
-                                                     + " change security_mode, then restart the node (#888).";
+                                                           + " no JWT configuration is present, so every non-public app route on this"
+                                                           + " node will be REFUSED with 401. Set jwks_url (and issuer/audience) or"
+                                                           + " change security_mode, then restart the node (#888).";
 
     private static Option<HttpForwarder> buildHttpForwarder(NodeId selfNodeId,
                                                             HttpRouteRegistry routeRegistry,

--- a/aether/node/src/test/java/org/pragmatica/aether/http/AppHttpServerJwtMissingConfigLogTest.java
+++ b/aether/node/src/test/java/org/pragmatica/aether/http/AppHttpServerJwtMissingConfigLogTest.java
@@ -1,0 +1,183 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2025 Pragmatica Labs - Sergiy Yevtushenko
+// Licensed under Business Source License 1.1. Change Date: 2030-01-01. Change License: Apache-2.0.
+// See LICENSE in the repository root for full terms.
+package org.pragmatica.aether.http;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.Filter;
+import org.apache.logging.log4j.core.Layout;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.apache.logging.log4j.core.config.Configuration;
+import org.apache.logging.log4j.core.config.LoggerConfig;
+import org.apache.logging.log4j.core.config.Property;
+import org.apache.logging.log4j.core.layout.PatternLayout;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.pragmatica.aether.config.AppHttpConfig;
+import org.pragmatica.aether.config.HttpProtocol;
+import org.pragmatica.aether.config.JwtConfig;
+import org.pragmatica.aether.config.SecurityMode;
+import org.pragmatica.aether.config.TimeoutsConfig.ForwardingTimeouts;
+import org.pragmatica.consensus.NodeId;
+import org.pragmatica.lang.Option;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/// #888 / #902 review ruling: a node with `security_mode = "jwt"` and no `[app-http] jwks_url` is
+/// MISCONFIGURED, not degraded — it will answer `401` on every non-public route — and the operator
+/// must see that at the top of the log. This pins the level (ERROR, ruled over WARN), the missing
+/// key, and the consequence, through the real constructor path (`AppHttpServer.appHttpServer`), where
+/// `buildSecurityValidator` runs. The server is never started: the validator is built at
+/// construction, so no port is bound.
+///
+/// The appender captures EVERY level on `AppHttpServerAdapter`'s own logger, so a demotion to WARN
+/// fails the level assertion by name rather than by silent absence. Message fragments are literal
+/// here, not read back from production, so a reworded message that drops the key or the consequence
+/// is a change to this file.
+///
+/// Controls: with `jwks_url` set nothing is logged (the fallback is never built — `Option.or` is
+/// lazy), and with the server disabled nothing is logged either: a server that never starts refuses
+/// nothing, so the ERROR would be about a consequence that cannot occur (#902 review, section 4).
+class AppHttpServerJwtMissingConfigLogTest {
+    private static final String LOGGER_NAME = AppHttpServerAdapter.class.getName();
+    private static final NodeId SELF_NODE = NodeId.nodeId("test-node-jwt-log").unwrap();
+    private static final String UNREACHABLE_JWKS = "http://127.0.0.1:1/.well-known/jwks.json";
+    private static final int PORT = 19095;
+
+    private CapturingAppender appender;
+    private LoggerConfig loggerConfig;
+    private Level originalLevel;
+
+    @BeforeEach
+    void setUp() {
+        appender = CapturingAppender.create("AppHttpServerJwtMissingConfigCapture");
+        appender.start();
+        var ctx = (LoggerContext) LogManager.getContext(false);
+        loggerConfig = getOrCreateLoggerConfig(ctx.getConfiguration());
+        originalLevel = loggerConfig.getLevel();
+        loggerConfig.addAppender(appender, Level.ALL, null);
+        loggerConfig.setLevel(Level.ALL);
+        ctx.updateLoggers();
+    }
+
+    @AfterEach
+    void tearDown() {
+        var ctx = (LoggerContext) LogManager.getContext(false);
+        loggerConfig.removeAppender(appender.getName());
+        loggerConfig.setLevel(originalLevel);
+        ctx.updateLoggers();
+        appender.stop();
+    }
+
+    @Test
+    void jwtModeWithoutJwksUrl_logsErrorNamingTheKeyAndTheConsequence_atConstruction() {
+        construct(appHttp(true, SecurityMode.JWT, Option.empty()));
+
+        var events = appender.eventsMentioning("jwks_url");
+
+        assertThat(events).as("exactly one startup message about the missing jwks_url").hasSize(1);
+
+        var event = events.getFirst();
+
+        assertThat(event.level()).as("ruled ERROR, not WARN: the node is misconfigured, not degraded").isEqualTo(Level.ERROR);
+        assertThat(event.message()).contains("security_mode = \"jwt\"")
+                                   .contains("[app-http] jwks_url is missing")
+                                   .contains("every non-public app route")
+                                   .contains("REFUSED with 401")
+                                   .contains("restart")
+                                   .contains("#888");
+    }
+
+    @Test
+    void jwtModeWithJwksUrl_logsNothingAboutMissingConfig() {
+        construct(appHttp(true, SecurityMode.JWT, Option.some(JwtConfig.jwtConfig(UNREACHABLE_JWKS).unwrap())));
+
+        assertThat(appender.eventsMentioning("jwks_url")).as("with jwks_url set the fallback is never built").isEmpty();
+    }
+
+    @Test
+    void jwtModeWithoutJwksUrl_onDisabledServer_logsNothing() {
+        construct(appHttp(false, SecurityMode.JWT, Option.empty()));
+
+        assertThat(appender.eventsMentioning("jwks_url")).as("a server that never starts refuses nothing").isEmpty();
+    }
+
+    @Test
+    void apiKeyAndNoneModes_logNothingAboutJwt() {
+        construct(appHttp(true, SecurityMode.API_KEY, Option.empty()));
+        construct(appHttp(true, SecurityMode.NONE, Option.empty()));
+
+        assertThat(appender.eventsMentioning("jwks_url")).isEmpty();
+    }
+
+    private static void construct(AppHttpConfig config) {
+        AppHttpServer.appHttpServer(config,
+                                    ForwardingTimeouts.forwardingTimeouts(),
+                                    SELF_NODE,
+                                    HttpRouteRegistry.httpRouteRegistry(),
+                                    Option.none(),
+                                    Option.none(),
+                                    Option.none(),
+                                    Option.none(),
+                                    Option.none(),
+                                    Option.none(),
+                                    Option.none(),
+                                    Option.none(),
+                                    Option.none());
+    }
+
+    private static AppHttpConfig appHttp(boolean enabled, SecurityMode mode, Option<JwtConfig> jwtConfig) {
+        return AppHttpConfig.appHttpConfig(enabled,
+                                           PORT,
+                                           Map.of(),
+                                           AppHttpConfig.DEFAULT_MAX_REQUEST_SIZE,
+                                           mode,
+                                           jwtConfig,
+                                           HttpProtocol.H1)
+                            .unwrap();
+    }
+
+    private static LoggerConfig getOrCreateLoggerConfig(Configuration configuration) {
+        var existing = configuration.getLoggerConfig(LOGGER_NAME);
+        if (LOGGER_NAME.equals(existing.getName())) {
+            return existing;
+        }
+        var fresh = new LoggerConfig(LOGGER_NAME, Level.ALL, false);
+        configuration.addLogger(LOGGER_NAME, fresh);
+        return fresh;
+    }
+
+    record Captured(Level level, String message) {}
+
+    /// In-memory log4j2 appender capturing every event with its level, so a level change is
+    /// observable rather than filtered away.
+    private static final class CapturingAppender extends AbstractAppender {
+        private final List<Captured> events = new CopyOnWriteArrayList<>();
+
+        private CapturingAppender(String name, Layout<?> layout) {
+            super(name, (Filter) null, layout, true, Property.EMPTY_ARRAY);
+        }
+
+        static CapturingAppender create(String name) {
+            return new CapturingAppender(name, PatternLayout.createDefaultLayout());
+        }
+
+        @Override
+        public void append(LogEvent event) {
+            events.add(new Captured(event.getLevel(), event.getMessage().getFormattedMessage()));
+        }
+
+        List<Captured> eventsMentioning(String fragment) {
+            return events.stream().filter(captured -> captured.message().contains(fragment)).toList();
+        }
+    }
+}

--- a/aether/node/src/test/java/org/pragmatica/aether/http/AppHttpServerSecurityGridTest.java
+++ b/aether/node/src/test/java/org/pragmatica/aether/http/AppHttpServerSecurityGridTest.java
@@ -49,10 +49,18 @@ import static org.pragmatica.lang.Unit.unit;
 /// #888 — the FULL `security_mode` x effective-policy grid, through a live `AppHttpServer` with a
 /// real `HttpClient`, one anonymous `GET` per cell.
 ///
-/// Four server configurations (`none`, `api-key`, `jwt` WITHOUT `jwks_url`, `jwt` WITH it) times six
-/// effective policies (`public`, `authenticated`, `role:admin`, `unspecified`, `api_key`,
-/// `bearer_token`). The expected status per cell is written down as a literal table, not derived from
-/// the code under test, so a change to any cell is a change to this file.
+/// Five server configurations (`none`, `api-key` WITH keys, `api-key` WITHOUT keys, `jwt` WITHOUT
+/// `jwks_url`, `jwt` WITH it) times six effective policies (`public`, `authenticated`, `role:admin`,
+/// `unspecified`, `api_key`, `bearer_token`). The expected status per cell is written down as a
+/// literal table, not derived from the code under test, so a change to any cell is a change to this
+/// file. These five are every behaviourally distinct configuration: `buildSecurityValidator` reads
+/// `jwtConfig` only under `JWT` and `apiKeys` only under `API_KEY`, and the request path reads the
+/// mode alone, so the raw 3 x 2 x 2 product collapses to these five (#902 review, section 2).
+///
+/// `api-key` WITHOUT keys is the shipped default (`ConfigLoader` defaults `security_mode` to
+/// `api-key`; `[app-http.api-keys]` may be empty), the configuration symmetric to #888 on the
+/// api-key side. It is fail-closed by construction -- `ApiKeySecurityValidator` answers
+/// `MISSING_API_KEY` to a header-less request whatever the key map holds -- and that row pins it.
 ///
 /// The #888 cells are `jwt`-without-config x every non-`public` policy. Before the fix that
 /// configuration installed `permitAllValidator`, whose context carries `Role.ADMIN`, so all five
@@ -76,10 +84,12 @@ class AppHttpServerSecurityGridTest {
     private HttpClient httpClient;
 
     /// The server-side configuration axis. `JWT_WITHOUT_CONFIG` is `security_mode = "jwt"` with no
-    /// `[app-http] jwks_url` — the #888 configuration.
+    /// `[app-http] jwks_url` — the #888 configuration. `API_KEY_WITHOUT_KEYS` is `security_mode =
+    /// "api-key"` with an empty `[app-http.api-keys]` — the shipped default.
     enum Setup {
         NONE,
         API_KEY,
+        API_KEY_WITHOUT_KEYS,
         JWT_WITHOUT_CONFIG,
         JWT_WITH_CONFIG;
 
@@ -87,6 +97,7 @@ class AppHttpServerSecurityGridTest {
             return switch (this) {
                 case NONE -> appHttp(SecurityMode.NONE, Option.empty());
                 case API_KEY -> AppHttpConfig.appHttpConfig(PORT, Set.of(VALID_API_KEY));
+                case API_KEY_WITHOUT_KEYS -> appHttp(SecurityMode.API_KEY, Option.empty());
                 case JWT_WITHOUT_CONFIG -> appHttp(SecurityMode.JWT, Option.empty());
                 case JWT_WITH_CONFIG -> appHttp(SecurityMode.JWT, Option.some(JwtConfig.jwtConfig(UNREACHABLE_JWKS).unwrap()));
             };
@@ -129,9 +140,11 @@ class AppHttpServerSecurityGridTest {
 
     /// The pinned grid, anonymous caller. Read: `none` refuses every auth-requiring policy before any
     /// validator runs (`NO_VALIDATOR_CONFIGURED`) and resolves `unspecified` to its global `public`
-    /// policy; `api-key` and both `jwt` columns resolve `unspecified` to their credential type and
-    /// refuse every non-`public` policy for want of a credential (or, for the mismatched credential
-    /// type, with `UNENFORCEABLE_POLICY`). No configuration serves anything but `public` anonymously.
+    /// policy; both `api-key` rows and both `jwt` rows resolve `unspecified` to their credential type
+    /// and refuse every non-`public` policy for want of a credential (or, for the mismatched
+    /// credential type, with `UNENFORCEABLE_POLICY`). `api-key` with no keys refuses identically to
+    /// `api-key` with keys: the header is checked before the key map is consulted. No configuration
+    /// serves anything but `public` anonymously.
     static final List<Cell> GRID = List.of(new Cell(Setup.NONE, Policy.PUBLIC, 200),
                                            new Cell(Setup.NONE, Policy.AUTHENTICATED, 401),
                                            new Cell(Setup.NONE, Policy.ROLE_ADMIN, 401),
@@ -144,6 +157,12 @@ class AppHttpServerSecurityGridTest {
                                            new Cell(Setup.API_KEY, Policy.UNSPECIFIED, 401),
                                            new Cell(Setup.API_KEY, Policy.API_KEY, 401),
                                            new Cell(Setup.API_KEY, Policy.BEARER_TOKEN, 401),
+                                           new Cell(Setup.API_KEY_WITHOUT_KEYS, Policy.PUBLIC, 200),
+                                           new Cell(Setup.API_KEY_WITHOUT_KEYS, Policy.AUTHENTICATED, 401),
+                                           new Cell(Setup.API_KEY_WITHOUT_KEYS, Policy.ROLE_ADMIN, 401),
+                                           new Cell(Setup.API_KEY_WITHOUT_KEYS, Policy.UNSPECIFIED, 401),
+                                           new Cell(Setup.API_KEY_WITHOUT_KEYS, Policy.API_KEY, 401),
+                                           new Cell(Setup.API_KEY_WITHOUT_KEYS, Policy.BEARER_TOKEN, 401),
                                            new Cell(Setup.JWT_WITHOUT_CONFIG, Policy.PUBLIC, 200),
                                            new Cell(Setup.JWT_WITHOUT_CONFIG, Policy.AUTHENTICATED, 401),
                                            new Cell(Setup.JWT_WITHOUT_CONFIG, Policy.ROLE_ADMIN, 401),

--- a/aether/node/src/test/java/org/pragmatica/aether/http/AppHttpServerSecurityGridTest.java
+++ b/aether/node/src/test/java/org/pragmatica/aether/http/AppHttpServerSecurityGridTest.java
@@ -1,0 +1,400 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2025 Pragmatica Labs - Sergiy Yevtushenko
+// Licensed under Business Source License 1.1. Change Date: 2030-01-01. Change License: Apache-2.0.
+// See LICENSE in the repository root for full terms.
+
+package org.pragmatica.aether.http;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestFactory;
+import org.pragmatica.aether.artifact.Artifact;
+import org.pragmatica.aether.config.AppHttpConfig;
+import org.pragmatica.aether.config.HttpProtocol;
+import org.pragmatica.aether.config.JwtConfig;
+import org.pragmatica.aether.config.SecurityMode;
+import org.pragmatica.aether.config.TimeoutsConfig.ForwardingTimeouts;
+import org.pragmatica.aether.http.HttpRoutePublisher.LocalRouteInfo;
+import org.pragmatica.aether.http.adapter.RouteDecorator;
+import org.pragmatica.aether.http.adapter.SliceRouter;
+import org.pragmatica.aether.http.handler.HttpRequestContext;
+import org.pragmatica.aether.http.handler.HttpRequestHandler;
+import org.pragmatica.aether.http.handler.HttpResponseData;
+import org.pragmatica.aether.http.handler.security.SecurityPolicy;
+import org.pragmatica.aether.slice.ObservabilityCellRegistrar;
+import org.pragmatica.aether.slice.SliceInvokerFacade;
+import org.pragmatica.aether.slice.blueprint.SecurityOverrides;
+import org.pragmatica.aether.slice.kvstore.AetherKey.HttpNodeRouteKey;
+import org.pragmatica.consensus.NodeId;
+import org.pragmatica.http.routing.SliceVersionRegistry;
+import org.pragmatica.http.routing.VersioningMetricsSink;
+import org.pragmatica.lang.Option;
+import org.pragmatica.lang.Promise;
+import org.pragmatica.lang.Unit;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.pragmatica.lang.Unit.unit;
+
+/// #888 — the FULL `security_mode` x effective-policy grid, through a live `AppHttpServer` with a
+/// real `HttpClient`, one anonymous `GET` per cell.
+///
+/// Four server configurations (`none`, `api-key`, `jwt` WITHOUT `jwks_url`, `jwt` WITH it) times six
+/// effective policies (`public`, `authenticated`, `role:admin`, `unspecified`, `api_key`,
+/// `bearer_token`). The expected status per cell is written down as a literal table, not derived from
+/// the code under test, so a change to any cell is a change to this file.
+///
+/// The #888 cells are `jwt`-without-config x every non-`public` policy. Before the fix that
+/// configuration installed `permitAllValidator`, whose context carries `Role.ADMIN`, so all five
+/// answered `200` to an anonymous caller — `role:admin` included. Reverting the production hunk in
+/// `AppHttpServerAdapter#buildSecurityValidator` turns exactly those five cells red.
+///
+/// The `public` column doubles as the harness's positive control: every configuration must actually
+/// SERVE a request, so a refused cell cannot be mistaken for a server that never came up.
+///
+/// JWKS fetching is lazy (`JwksKeyStore` fetches on first token lookup), so the jwt-with-config
+/// column never touches the network: an anonymous request fails at `MISSING_BEARER_TOKEN`.
+class AppHttpServerSecurityGridTest {
+    private static final NodeId SELF_NODE = NodeId.nodeId("test-node-sec-grid").unwrap();
+    private static final Artifact TEST_ARTIFACT = Artifact.artifact("com.example:grid:1.0.0").unwrap();
+    private static final String VALID_API_KEY = "sec-grid-test-key-13579";
+    private static final String UNREACHABLE_JWKS = "http://127.0.0.1:1/.well-known/jwks.json";
+    private static final int PORT = 19094;
+    private static final String SERVED = "served-locally";
+
+    private AppHttpServer server;
+    private HttpClient httpClient;
+
+    /// The server-side configuration axis. `JWT_WITHOUT_CONFIG` is `security_mode = "jwt"` with no
+    /// `[app-http] jwks_url` — the #888 configuration.
+    enum Setup {
+        NONE,
+        API_KEY,
+        JWT_WITHOUT_CONFIG,
+        JWT_WITH_CONFIG;
+
+        AppHttpConfig config() {
+            return switch (this) {
+                case NONE -> appHttp(SecurityMode.NONE, Option.empty());
+                case API_KEY -> AppHttpConfig.appHttpConfig(PORT, Set.of(VALID_API_KEY));
+                case JWT_WITHOUT_CONFIG -> appHttp(SecurityMode.JWT, Option.empty());
+                case JWT_WITH_CONFIG -> appHttp(SecurityMode.JWT, Option.some(JwtConfig.jwtConfig(UNREACHABLE_JWKS).unwrap()));
+            };
+        }
+
+        private static AppHttpConfig appHttp(SecurityMode mode, Option<JwtConfig> jwtConfig) {
+            return AppHttpConfig.appHttpConfig(true,
+                                               PORT,
+                                               Map.of(),
+                                               AppHttpConfig.DEFAULT_MAX_REQUEST_SIZE,
+                                               mode,
+                                               jwtConfig,
+                                               HttpProtocol.H1)
+                                .unwrap();
+        }
+    }
+
+    /// The route-side policy axis: every value `RouteSecurityLevel` can declare plus the two only an
+    /// operator override can produce.
+    enum Policy {
+        PUBLIC(SecurityPolicy.publicRoute()),
+        AUTHENTICATED(SecurityPolicy.authenticated()),
+        ROLE_ADMIN(SecurityPolicy.roleRequired("admin")),
+        UNSPECIFIED(SecurityPolicy.unspecified()),
+        API_KEY(SecurityPolicy.apiKeyRequired()),
+        BEARER_TOKEN(SecurityPolicy.bearerTokenRequired());
+
+        final SecurityPolicy policy;
+
+        Policy(SecurityPolicy policy) {
+            this.policy = policy;
+        }
+    }
+
+    record Cell(Setup setup, Policy policy, int expectedStatus) {
+        String name() {
+            return setup + " x " + policy + " -> " + expectedStatus;
+        }
+    }
+
+    /// The pinned grid, anonymous caller. Read: `none` refuses every auth-requiring policy before any
+    /// validator runs (`NO_VALIDATOR_CONFIGURED`) and resolves `unspecified` to its global `public`
+    /// policy; `api-key` and both `jwt` columns resolve `unspecified` to their credential type and
+    /// refuse every non-`public` policy for want of a credential (or, for the mismatched credential
+    /// type, with `UNENFORCEABLE_POLICY`). No configuration serves anything but `public` anonymously.
+    static final List<Cell> GRID = List.of(new Cell(Setup.NONE, Policy.PUBLIC, 200),
+                                           new Cell(Setup.NONE, Policy.AUTHENTICATED, 401),
+                                           new Cell(Setup.NONE, Policy.ROLE_ADMIN, 401),
+                                           new Cell(Setup.NONE, Policy.UNSPECIFIED, 200),
+                                           new Cell(Setup.NONE, Policy.API_KEY, 401),
+                                           new Cell(Setup.NONE, Policy.BEARER_TOKEN, 401),
+                                           new Cell(Setup.API_KEY, Policy.PUBLIC, 200),
+                                           new Cell(Setup.API_KEY, Policy.AUTHENTICATED, 401),
+                                           new Cell(Setup.API_KEY, Policy.ROLE_ADMIN, 401),
+                                           new Cell(Setup.API_KEY, Policy.UNSPECIFIED, 401),
+                                           new Cell(Setup.API_KEY, Policy.API_KEY, 401),
+                                           new Cell(Setup.API_KEY, Policy.BEARER_TOKEN, 401),
+                                           new Cell(Setup.JWT_WITHOUT_CONFIG, Policy.PUBLIC, 200),
+                                           new Cell(Setup.JWT_WITHOUT_CONFIG, Policy.AUTHENTICATED, 401),
+                                           new Cell(Setup.JWT_WITHOUT_CONFIG, Policy.ROLE_ADMIN, 401),
+                                           new Cell(Setup.JWT_WITHOUT_CONFIG, Policy.UNSPECIFIED, 401),
+                                           new Cell(Setup.JWT_WITHOUT_CONFIG, Policy.API_KEY, 401),
+                                           new Cell(Setup.JWT_WITHOUT_CONFIG, Policy.BEARER_TOKEN, 401),
+                                           new Cell(Setup.JWT_WITH_CONFIG, Policy.PUBLIC, 200),
+                                           new Cell(Setup.JWT_WITH_CONFIG, Policy.AUTHENTICATED, 401),
+                                           new Cell(Setup.JWT_WITH_CONFIG, Policy.ROLE_ADMIN, 401),
+                                           new Cell(Setup.JWT_WITH_CONFIG, Policy.UNSPECIFIED, 401),
+                                           new Cell(Setup.JWT_WITH_CONFIG, Policy.API_KEY, 401),
+                                           new Cell(Setup.JWT_WITH_CONFIG, Policy.BEARER_TOKEN, 401));
+
+    @AfterEach
+    void tearDown() {
+        stopServer();
+    }
+
+    @TestFactory
+    Stream<DynamicTest> anonymousRequest_perGridCell() {
+        return GRID.stream()
+                   .map(cell -> DynamicTest.dynamicTest(cell.name(), () -> assertCell(cell)));
+    }
+
+    @Test
+    void grid_coversEveryConfigurationAndEveryPolicyExactlyOnce() {
+        var expected = (long) Setup.values().length * Policy.values().length;
+        var distinct = GRID.stream()
+                           .map(cell -> cell.setup() + "/" + cell.policy())
+                           .distinct()
+                           .count();
+
+        assertThat(GRID).hasSize((int) expected);
+        assertThat(distinct).isEqualTo(expected);
+    }
+
+    /// #888 acceptance (3): boot with `security_mode = "jwt"` and no jwt config, declare `role:admin`,
+    /// and an anonymous caller must be refused. Before the fix this answered `200`: the injected
+    /// `permitAll` context holds `Role.ADMIN`, so `enforceRoleIfRequired` passed.
+    @Test
+    void jwtModeWithoutJwtConfig_refusesRoleAdminRouteToAnonymousCaller() throws Exception {
+        startServer(Setup.JWT_WITHOUT_CONFIG, SecurityPolicy.roleRequired("admin"));
+
+        var response = get("/local/thing", Option.none());
+
+        assertThat(response.statusCode()).isEqualTo(401);
+        assertThat(response.body()).doesNotContain(SERVED);
+        assertThat(response.headers().firstValue("WWW-Authenticate")).contains("Bearer realm=\"Aether\"");
+    }
+
+    /// No credential can satisfy the no-config validator either: a bearer token presented to a node
+    /// that has nothing to verify it against is refused, not waved through.
+    @Test
+    void jwtModeWithoutJwtConfig_refusesRoleAdminRoute_evenWithABearerTokenPresented() throws Exception {
+        startServer(Setup.JWT_WITHOUT_CONFIG, SecurityPolicy.roleRequired("admin"));
+
+        var response = get("/local/thing", Option.some("Bearer eyJhbGciOiJub25lIn0.e30."));
+
+        assertThat(response.statusCode()).isEqualTo(401);
+        assertThat(response.body()).doesNotContain(SERVED);
+    }
+
+    /// #888 acceptance (4): whatever a misconfigured `jwt` node does, it must not be MORE permissive
+    /// than `security_mode = "none"`. Compared live, per policy, against the same anonymous request.
+    @Test
+    void jwtModeWithoutJwtConfig_isNeverMorePermissiveThanNone() throws Exception {
+        for (var policy : Policy.values()) {
+            var underNone = statusFor(Setup.NONE, policy);
+            var underJwtWithoutConfig = statusFor(Setup.JWT_WITHOUT_CONFIG, policy);
+
+            if (underNone != 200) {
+                assertThat(underJwtWithoutConfig).as("policy %s: none refused with %d, jwt-without-config must not serve",
+                                                     policy,
+                                                     underNone)
+                                                 .isNotEqualTo(200);
+            }
+        }
+    }
+
+    /// Each cell owns its server: `@AfterEach` runs once per `@TestFactory`, not once per dynamic
+    /// test, so without the `finally` the first cell's server would stay bound on the port and answer
+    /// every later cell — a NONE-mode server hosting a `public` route serves everything.
+    private void assertCell(Cell cell) throws Exception {
+        startServer(cell.setup(), cell.policy().policy);
+
+        try {
+            var response = get("/local/thing", Option.none());
+
+            assertThat(response.statusCode()).as(cell.name()).isEqualTo(cell.expectedStatus());
+
+            if (cell.expectedStatus() == 200) {
+                assertThat(response.body()).as(cell.name()).contains(SERVED);
+            } else {
+                assertThat(response.body()).as(cell.name()).doesNotContain(SERVED);
+            }
+        } finally {
+            stopServer();
+        }
+    }
+
+    private int statusFor(Setup setup, Policy policy) throws Exception {
+        startServer(setup, policy.policy);
+
+        try {
+            return get("/local/thing", Option.none()).statusCode();
+        } finally {
+            stopServer();
+        }
+    }
+
+    private void startServer(Setup setup, SecurityPolicy routePolicy) {
+        httpClient = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(5)).build();
+
+        var publisher = StubRoutePublisher.hosting("GET", "/local/", routePolicy);
+
+        server = AppHttpServer.appHttpServer(setup.config(),
+                                             ForwardingTimeouts.forwardingTimeouts(),
+                                             SELF_NODE,
+                                             HttpRouteRegistry.httpRouteRegistry(),
+                                             Option.some(publisher),
+                                             Option.none(),
+                                             Option.none(),
+                                             Option.none(),
+                                             Option.none(),
+                                             Option.none(),
+                                             Option.none(),
+                                             Option.none(),
+                                             Option.none());
+        server.start().await().unwrap();
+    }
+
+    private void stopServer() {
+        if (server != null) {
+            server.stop().await();
+            server = null;
+        }
+    }
+
+    private HttpResponse<String> get(String path, Option<String> authorization) throws Exception {
+        var builder = HttpRequest.newBuilder().uri(URI.create("http://localhost:" + PORT + path)).GET();
+
+        authorization.onPresent(value -> builder.header("Authorization", value));
+
+        return httpClient.send(builder.build(), HttpResponse.BodyHandlers.ofString());
+    }
+
+    /// Minimal HttpRoutePublisher stub hosting exactly one local route carrying a caller-supplied
+    /// SecurityPolicy — mirrors AppHttpServerRouteSecurityPolicyTest's StubRoutePublisher.
+    private record StubRoutePublisher(String httpMethod, String pathPrefix, SecurityPolicy security, SliceRouter router)
+        implements HttpRoutePublisher {
+        static StubRoutePublisher hosting(String httpMethod, String pathPrefix, SecurityPolicy security) {
+            return new StubRoutePublisher(httpMethod, pathPrefix, security, new StubSliceRouter());
+        }
+
+        private boolean matches(String method, String path) {
+            return httpMethod.equalsIgnoreCase(method) && path.startsWith(pathPrefix);
+        }
+
+        @Override
+        public Set<HttpNodeRouteKey> allLocalRoutes() {
+            return Set.of(HttpNodeRouteKey.httpNodeRouteKey(httpMethod, pathPrefix, SELF_NODE));
+        }
+
+        @Override
+        public Option<SliceRouter> findLocalRouter(String method, String prefix) {
+            return matches(method, prefix)
+                   ? Option.some(router)
+                   : Option.none();
+        }
+
+        @Override
+        public Option<LocalRouteInfo> findLocalRoute(String method, String path) {
+            return matches(method, path)
+                   ? Option.some(new LocalRouteInfo(httpMethod, pathPrefix, TEST_ARTIFACT.asString(), "create", security))
+                   : Option.none();
+        }
+
+        @Override
+        public Promise<Unit> publishRoutes(Artifact artifact, ClassLoader classLoader, SliceInvokerFacade invokerFacade) {
+            return Promise.success(unit());
+        }
+
+        @Override
+        public Promise<Unit> publishRoutes(Artifact artifact,
+                                           ClassLoader classLoader,
+                                           Object sliceInstance,
+                                           SliceInvokerFacade invokerFacade) {
+            return Promise.success(unit());
+        }
+
+        @Override
+        public boolean hasRoutes(ClassLoader classLoader, Object sliceInstance) {
+            return true;
+        }
+
+        @Override
+        public Promise<Unit> unpublishRoutes(Artifact artifact) {
+            return Promise.success(unit());
+        }
+
+        @Override
+        public Option<HttpRequestHandler> getHandler(Artifact artifact) {
+            return Option.none();
+        }
+
+        @Override
+        public Option<SliceRouter> getSliceRouter(Artifact artifact) {
+            return Option.some(router);
+        }
+
+        @Override
+        public Unit updateSecurityOverrides(SecurityOverrides overrides) {
+            return unit();
+        }
+
+        @Override
+        public Unit setVersioningMetricsSink(VersioningMetricsSink sink) {
+            return unit();
+        }
+
+        @Override
+        public Map<Artifact, SliceVersionRegistry> versionRegistries() {
+            return Map.of();
+        }
+
+        @Override
+        public Unit setObservabilityCellRegistrar(ObservabilityCellRegistrar registrar) {
+            return unit();
+        }
+    }
+
+    /// Minimal SliceRouter stub returning a fixed 200; unversioned registry, identity observability.
+    private static final class StubSliceRouter implements SliceRouter {
+        @Override
+        public Promise<HttpResponseData> handle(HttpRequestContext request) {
+            return Promise.success(HttpResponseData.httpResponseData(200, "{\"result\":\"" + SERVED + "\"}"));
+        }
+
+        @Override
+        public SliceVersionRegistry versionRegistry() {
+            return SliceVersionRegistry.UNVERSIONED;
+        }
+
+        @Override
+        public SliceRouter withObservability(String sliceName, VersioningMetricsSink sink) {
+            return this;
+        }
+
+        @Override
+        public SliceRouter withInvocationCells(RouteDecorator decorator) {
+            return this;
+        }
+    }
+}

--- a/changelog.d/888-jwt-missing-config-denies.md
+++ b/changelog.d/888-jwt-missing-config-denies.md
@@ -1,0 +1,66 @@
+### Security (2026-09-06 — #888: `security_mode = "jwt"` with no jwt config installed `permitAllValidator`: every caller received ADMIN + SERVICE authority)
+
+- **Action required if you run `security_mode = "jwt"` and your `[app-http]` section has no `jwks_url`.**
+  Every non-`public` app route on such a node — `authenticated`, `role:*`, undeclared (`unspecified`),
+  and the credential-type policies — **used to answer `200` to any caller with no credential inspected,
+  and now answers `401`** with `WWW-Authenticate: Bearer`. Requests that worked yesterday will fail on
+  upgrade. This is not a regression: every one of those `200`s was served to an unauthenticated caller
+  holding an injected `admin` role, and the `401` is the correction. **What to do:** set `[app-http]
+  jwks_url` (plus `issuer`/`audience`) so tokens can actually be verified, or change `security_mode`
+  to the credential type you do provision. `public` routes are unaffected; `security_mode = "none"`
+  and `"api-key"` deployments are unaffected
+  [verified: `AppHttpServerSecurityGridTest#anonymousRequest_perGridCell` — the `JWT_WITHOUT_CONFIG` column].
+- **The no-config fallback of the `jwt` arm was `permitAllValidator`**, a validator with no policy
+  switch that hands every request a `SecurityContext` carrying `Role.ADMIN` + `Role.SERVICE`. So on a
+  node whose operator enabled JWT mode but omitted or mistyped the `[app-http] jwks_url` line, a
+  `role:admin` route was served to an anonymous request — `enforceRoleIfRequired` asked the injected
+  context `hasRole("admin")` and it said yes. The `SecurityMode.NONE` pre-check does not fire (the
+  mode is `JWT`), so nothing stood between the request and the grant. This was strictly MORE
+  permissive than `security_mode = "none"`, which refuses every auth-requiring route. The fallback is
+  now `denyUnlessPublicValidator`, the same validator the management plane, Ember and Forge install
+  when they have nothing to check with: `public` routes pass with an empty context, everything else
+  is refused with `NO_VALIDATOR_CONFIGURED` (`401`), and a bearer token presented anyway is refused
+  too — nothing can verify it. The node also logs a startup warning naming the missing key
+  [verified: `AppHttpServerSecurityGridTest#jwtModeWithoutJwtConfig_refusesRoleAdminRouteToAnonymousCaller`,
+  `#jwtModeWithoutJwtConfig_refusesRoleAdminRoute_evenWithABearerTokenPresented`; reverting the
+  production hunk turns both red, plus the five `JWT_WITHOUT_CONFIG x <non-public>` grid cells].
+- **The whole `security_mode` x effective-policy grid is now pinned against a live server**, one
+  anonymous `GET` per cell, expected status written as a literal table so a future two-cell change
+  cannot silently move a cell nobody touched — which is exactly how #888 was found. Before/after,
+  anonymous caller:
+
+  | configuration | `public` | `authenticated` | `role:admin` | `unspecified` | `api_key` | `bearer_token` |
+  |---|---|---|---|---|---|---|
+  | `none` | 200 | 401 | 401 | 200 | 401 | 401 |
+  | `api-key` | 200 | 401 | 401 | 401 | 401 | 401 |
+  | `jwt`, no `jwks_url` — **before** | 200 | **200** | **200** | **200** | **200** | **200** |
+  | `jwt`, no `jwks_url` — **after** | 200 | 401 | 401 | 401 | 401 | 401 |
+  | `jwt`, `jwks_url` set | 200 | 401 | 401 | 401 | 401 | 401 |
+
+  Only the `jwt`-without-config row changes. `unspecified` under `none` is `200` by design: an
+  undeclared route inherits the global policy, and `none`'s global policy is `public` (#763)
+  [verified: `AppHttpServerSecurityGridTest#anonymousRequest_perGridCell` (24 cells),
+  `#grid_coversEveryConfigurationAndEveryPolicyExactlyOnce`,
+  `#jwtModeWithoutJwtConfig_isNeverMorePermissiveThanNone` — #888 acceptance (4), compared live per policy].
+- **Config loading does not reject this configuration, so the window was the whole boot path, not a
+  corner.** `ConfigLoader` derives `jwtConfig` solely from the presence of `jwks_url`, and
+  `AppHttpConfig.appHttpConfig(...)` succeeds unconditionally, so `security_mode = "jwt"` with no
+  `jwks_url` loads, boots, and reaches the fallback on every request
+  [mechanism: `ConfigLoader.parseJwtConfig` maps `getString("app-http", "jwks_url")`; `AppHttpConfig`'s
+  factory returns `success(...)` with no cross-field check].
+- **Residual, stated plainly: the node still boots.** A JWT node with nothing to verify tokens against
+  now refuses rather than grants, but it comes up, logs one warning, and serves `401`s — a
+  misconfigured security mode is a runtime degradation, not a boot failure. Refusing at boot
+  (`ConfigLoader`/`AppHttpConfig` returning a failure naming `[app-http] jwks_url`) is the preferred
+  end state and is deferred: it needs `ConfigLoader.populateAppHttpConfig` to stop `unwrap()`-ing the
+  config result, and the in-process builders (`AppHttpConfig.withSecurityMode`, #665) bypass the
+  factory, so the deny fallback must exist regardless as the floor beneath it. Until then, grep node
+  logs for `no JWT configuration is present` after enabling JWT mode.
+- **Other `permitAllValidator` sites, audited.** `AppHttpServerAdapter`'s `NONE` arm is guarded by the
+  request-time pre-check that refuses every auth-requiring policy before the validator runs (pinned by
+  the `none` row above). `ForgeServer`'s three websocket handlers pass `authRequired = false`, the
+  documented local-dev case. The management plane already installs `denyUnlessPublicValidator` (#573).
+  No other site installs it. `KvStoreApiKeyValidator` (management plane) still has a `BearerTokenRequired
+  -> success(anonymous context)` arm of the #866 G1 family — reported to the tracker, not changed here:
+  no management route carries that policy and it grants no role, so it is a different defect
+  [mechanism: repo-wide grep for `permitAllValidator` and for unconditional `Result.success(SecurityContext`].

--- a/changelog.d/888-jwt-missing-config-denies.md
+++ b/changelog.d/888-jwt-missing-config-denies.md
@@ -9,7 +9,9 @@
   jwks_url` (plus `issuer`/`audience`) so tokens can actually be verified, or change `security_mode`
   to the credential type you do provision. `public` routes are unaffected; `security_mode = "none"`
   and `"api-key"` deployments are unaffected
-  [verified: `AppHttpServerSecurityGridTest#anonymousRequest_perGridCell` — the `JWT_WITHOUT_CONFIG` column].
+  [verified: `AppHttpServerSecurityGridTest#anonymousRequest_perGridCell` — the `NONE`, `API_KEY`,
+  `API_KEY_WITHOUT_KEYS` and `JWT_WITH_CONFIG` rows, 24 cells, all of which stay green when the
+  production hunk is reverted; only the `JWT_WITHOUT_CONFIG` row moves].
 - **The no-config fallback of the `jwt` arm was `permitAllValidator`**, a validator with no policy
   switch that hands every request a `SecurityContext` carrying `Role.ADMIN` + `Role.SERVICE`. So on a
   node whose operator enabled JWT mode but omitted or mistyped the `[app-http] jwks_url` line, a
@@ -20,10 +22,20 @@
   now `denyUnlessPublicValidator`, the same validator the management plane, Ember and Forge install
   when they have nothing to check with: `public` routes pass with an empty context, everything else
   is refused with `NO_VALIDATOR_CONFIGURED` (`401`), and a bearer token presented anyway is refused
-  too — nothing can verify it. The node also logs a startup warning naming the missing key
+  too — nothing can verify it
   [verified: `AppHttpServerSecurityGridTest#jwtModeWithoutJwtConfig_refusesRoleAdminRouteToAnonymousCaller`,
   `#jwtModeWithoutJwtConfig_refusesRoleAdminRoute_evenWithABearerTokenPresented`; reverting the
   production hunk turns both red, plus the five `JWT_WITHOUT_CONFIG x <non-public>` grid cells].
+- **The node logs the misconfiguration at ERROR, at the top of the log, naming the key and the
+  consequence.** `security_mode = "jwt"` with no `jwks_url` is a declared-intent contradiction — the
+  operator asked for token verification and nothing can perform it — not a degraded default, so it
+  is ERROR rather than the WARN the management plane uses for "nothing configured" (#573). The
+  message names `[app-http] jwks_url`, states that every non-public app route will be REFUSED with
+  `401`, and says a restart is needed after the fix. It is emitted only for a server that will
+  actually serve: a node with `enabled = false` refuses nothing and logs nothing
+  [verified: `AppHttpServerJwtMissingConfigLogTest` — level pinned as `ERROR` through an appender
+  capturing every level, so a demotion to WARN fails by name; controls for `jwks_url` set, server
+  disabled, and the other two modes].
 - **The whole `security_mode` x effective-policy grid is now pinned against a live server**, one
   anonymous `GET` per cell, expected status written as a literal table so a future two-cell change
   cannot silently move a cell nobody touched — which is exactly how #888 was found. Before/after,
@@ -32,14 +44,21 @@
   | configuration | `public` | `authenticated` | `role:admin` | `unspecified` | `api_key` | `bearer_token` |
   |---|---|---|---|---|---|---|
   | `none` | 200 | 401 | 401 | 200 | 401 | 401 |
-  | `api-key` | 200 | 401 | 401 | 401 | 401 | 401 |
+  | `api-key`, keys configured | 200 | 401 | 401 | 401 | 401 | 401 |
+  | `api-key`, no keys (shipped default) | 200 | 401 | 401 | 401 | 401 | 401 |
   | `jwt`, no `jwks_url` — **before** | 200 | **200** | **200** | **200** | **200** | **200** |
   | `jwt`, no `jwks_url` — **after** | 200 | 401 | 401 | 401 | 401 | 401 |
   | `jwt`, `jwks_url` set | 200 | 401 | 401 | 401 | 401 | 401 |
 
   Only the `jwt`-without-config row changes. `unspecified` under `none` is `200` by design: an
-  undeclared route inherits the global policy, and `none`'s global policy is `public` (#763)
-  [verified: `AppHttpServerSecurityGridTest#anonymousRequest_perGridCell` (24 cells),
+  undeclared route inherits the global policy, and `none`'s global policy is `public` (#763). The
+  five rows are every behaviourally distinct configuration: the validator reads `jwtConfig` only
+  under `jwt` and the key set only under `api-key`, and the request path reads the mode alone, so
+  the raw mode x jwt-config x api-keys product collapses to these five. `api-key` with no keys is
+  the shipped default (`ConfigLoader` defaults `security_mode` to `api-key`) and the api-key-side
+  mirror of #888; it was fail-closed by construction — the header is checked before the key map —
+  and is now pinned rather than read
+  [verified: `AppHttpServerSecurityGridTest#anonymousRequest_perGridCell` (30 cells),
   `#grid_coversEveryConfigurationAndEveryPolicyExactlyOnce`,
   `#jwtModeWithoutJwtConfig_isNeverMorePermissiveThanNone` — #888 acceptance (4), compared live per policy].
 - **Config loading does not reject this configuration, so the window was the whole boot path, not a
@@ -49,18 +68,30 @@
   [mechanism: `ConfigLoader.parseJwtConfig` maps `getString("app-http", "jwks_url")`; `AppHttpConfig`'s
   factory returns `success(...)` with no cross-field check].
 - **Residual, stated plainly: the node still boots.** A JWT node with nothing to verify tokens against
-  now refuses rather than grants, but it comes up, logs one warning, and serves `401`s — a
-  misconfigured security mode is a runtime degradation, not a boot failure. Refusing at boot
+  now refuses rather than grants, but it comes up, logs one ERROR, and serves `401`s — a
+  misconfigured security mode is a runtime refusal, not a boot failure. Refusing at boot
   (`ConfigLoader`/`AppHttpConfig` returning a failure naming `[app-http] jwks_url`) is the preferred
   end state and is deferred: it needs `ConfigLoader.populateAppHttpConfig` to stop `unwrap()`-ing the
   config result, and the in-process builders (`AppHttpConfig.withSecurityMode`, #665) bypass the
   factory, so the deny fallback must exist regardless as the floor beneath it. Until then, grep node
-  logs for `no JWT configuration is present` after enabling JWT mode.
+  logs at ERROR for `jwks_url is missing` after enabling JWT mode
+  [mechanism: `ConfigLoader.populateAppHttpConfig` calls `.unwrap()` on a factory that returns
+  `success(...)` unconditionally, so there is no failure to propagate; `AppHttpConfig.withSecurityMode`
+  constructs the record directly].
+- **Residuals from the #902 review, recorded not fixed.** (1) #888 acceptance 2 asked that "no path
+  installs `permitAllValidator` where the route's policy is the only gate" be structural; it remains
+  conventional — the static factory the javadoc forbids is one `.or(...)` away, and only the grid
+  catches a reintroduction. (2) `AppHttpServer.start()` on an already-bound port was reported by the
+  stream as returning success; the code as read maps a failed `bind()` to `BindFailed`, so this may
+  be a macOS wildcard-bind quirk — unreproduced, check on Linux before filing. (3) The management
+  plane's `KvStoreApiKeyValidator` has a dead `BearerTokenRequired -> success(anonymous)` arm and a
+  reachable no-header, no-keys `-> success(anonymous VIEWER)` arm (#866 G1 family), and the
+  `AetherNode` bootstrap warning states the inverse of that code; all pre-existing, outside this
+  diff, filed separately
+  [mechanism: review section 5 and 8 of `review-902-888-2026-09-06`; read-verified, not executed].
 - **Other `permitAllValidator` sites, audited.** `AppHttpServerAdapter`'s `NONE` arm is guarded by the
   request-time pre-check that refuses every auth-requiring policy before the validator runs (pinned by
   the `none` row above). `ForgeServer`'s three websocket handlers pass `authRequired = false`, the
   documented local-dev case. The management plane already installs `denyUnlessPublicValidator` (#573).
-  No other site installs it. `KvStoreApiKeyValidator` (management plane) still has a `BearerTokenRequired
-  -> success(anonymous context)` arm of the #866 G1 family — reported to the tracker, not changed here:
-  no management route carries that policy and it grants no role, so it is a different defect
+  No other site installs it
   [mechanism: repo-wide grep for `permitAllValidator` and for unconditional `Result.success(SecurityContext`].

--- a/changelog.d/888-jwt-missing-config-denies.md
+++ b/changelog.d/888-jwt-missing-config-denies.md
@@ -87,11 +87,11 @@
   plane's `KvStoreApiKeyValidator` has a dead `BearerTokenRequired -> success(anonymous)` arm and a
   reachable no-header, no-keys `-> success(anonymous VIEWER)` arm (#866 G1 family), and the
   `AetherNode` bootstrap warning states the inverse of that code; all pre-existing, outside this
-  diff, filed separately
+  diff, filed as #908
   [mechanism: review section 5 and 8 of `review-902-888-2026-09-06`; read-verified, not executed].
 - **Other `permitAllValidator` sites, audited.** `AppHttpServerAdapter`'s `NONE` arm is guarded by the
   request-time pre-check that refuses every auth-requiring policy before the validator runs (pinned by
-  the `none` row above). `ForgeServer`'s three websocket handlers pass `authRequired = false`, the
+  the `none` row above). `ForgeServer`'s three websocket handlers pass `securityEnabled = false`, the
   documented local-dev case. The management plane already installs `denyUnlessPublicValidator` (#573).
   No other site installs it
   [mechanism: repo-wide grep for `permitAllValidator` and for unconditional `Result.success(SecurityContext`].


### PR DESCRIPTION
Closes #888

## What

`security_mode = "jwt"` with no `[app-http] jwks_url` installed `permitAllValidator` on the app HTTP server. That validator has no policy switch and hands every request a context carrying `Role.ADMIN` + `Role.SERVICE`, so every non-`public` route — `role:admin` included — was served to anonymous callers. The `SecurityMode.NONE` pre-check does not fire (the mode is `JWT`). The fallback is now `denyUnlessPublicValidator`, matching the management plane, Ember and Forge, plus a startup ERROR naming the missing key and the consequence (level ruled in review round 1).

Config loading does not reject this configuration (`ConfigLoader.parseJwtConfig` keys solely on `jwks_url`; `AppHttpConfig.appHttpConfig` succeeds unconditionally), so the window was the whole boot path.

## Before / after — anonymous caller

| configuration | `public` | `authenticated` | `role:admin` | `unspecified` | `api_key` | `bearer_token` |
|---|---|---|---|---|---|---|
| `none` | 200 | 401 | 401 | 200 | 401 | 401 |
| `api-key`, keys configured | 200 | 401 | 401 | 401 | 401 | 401 |
| `api-key`, no keys (shipped default) | 200 | 401 | 401 | 401 | 401 | 401 |
| `jwt`, no `jwks_url` — before | 200 | **200** | **200** | **200** | **200** | **200** |
| `jwt`, no `jwks_url` — after | 200 | 401 | 401 | 401 | 401 | 401 |
| `jwt`, `jwks_url` set | 200 | 401 | 401 | 401 | 401 | 401 |

## Tests

`AppHttpServerSecurityGridTest` — live `AppHttpServer`, real `HttpClient`, one anonymous GET per cell, 24 cells pinned as a literal table, plus three named #888 tests (acceptance 3 and 4, and "a bearer token presented anyway is still refused").

Red-before probe (production hunk reverted on the committed base, tests kept): exactly 8 red — the five `JWT_WITHOUT_CONFIG x <non-public>` cells and the three named tests; the other 20 cells stayed green. Restored, re-run green: 40/40 across the grid test and its two neighbours.

`mvn jbct:check -pl aether/node` green (one whitespace fix in the new hunk, committed separately as `chore:`).

## Not done here, reported to the CTO

- Boot refusal for `jwt` without `jwks_url` (preferred end state per the ticket) — needs `ConfigLoader.populateAppHttpConfig` to stop `unwrap()`-ing and the in-process builders bypass the factory; the deny fallback remains the floor either way.
- `KvStoreApiKeyValidator` still has a `BearerTokenRequired -> success(anonymous)` arm (management plane, #866 G1 family, no role granted, no management route carries that policy). Review round 1 found the arm is unreachable and that the reachable anonymous arm is the no-header, no-keys one (`:67-70`, anonymous VIEWER). Filed separately by the CTO; not touched here.

## Review round 1 (2026-09-06, `review-902-888`: 0 BLOCKING, 2 SHOULD-FIX, 7 NOTE)

Commits on top of `c4af3a5e4`: `d049a9371` fix, `44df0bae7` test, `22f2e2a8b` docs, `ff2807314` chore (format).

**Rulings applied**

1. **Fragment evidence tags** — the "Residual" bullet now carries a `[mechanism:]` tag; every bullet audited, 8 of 8 tagged. Bullet 1's evidence now cites the four rows that stay green on revert instead of the `JWT_WITHOUT_CONFIG` column.
2. **Startup severity: ERROR, ruled.** Message names `[app-http] jwks_url`, states every non-public app route will be REFUSED with 401, and says a restart is needed (replacing "until it is set"). Emitted only when `enabled = true`: a disabled server refuses nothing (review NOTE). Pinned by the new `AppHttpServerJwtMissingConfigLogTest` — a log4j2 appender on `AppHttpServerAdapter`'s logger capturing every level, asserting `Level.ERROR` by name plus the literal key/consequence/ticket, with controls for `jwks_url` set, server disabled, and `api-key`/`none` modes. 4 tests.
3. **Uncovered grid cells.** `Setup.API_KEY_WITHOUT_KEYS` (`security_mode = "api-key"`, empty key map — the shipped default) added to `AppHttpServerSecurityGridTest` as a live-server row: `public` 200; `authenticated`, `role:admin`, `unspecified`, `api_key`, `bearer_token` all 401. Actual behaviour matched the reviewer's reading in every cell; nothing to flag as found-not-fixed. Grid is now 30 cells + 4 named = 34.
4. **NOTEs:** "fires at construction, even when disabled" and "until it is set" fixed in this PR (above). Residuals recorded in the fragment: acceptance-2 structural guard (still conventional), `start()` on a bound port (unreproduced, check on Linux), the `KvStoreApiKeyValidator` arms and the inverted `AetherNode` bootstrap warning (CTO filing).

**Evidence**

- Tests (surefire XML, `-pl aether/node -am`): grid 34, log 4, route policy 4, `SecurityModeTest$ParsingTests` 9 — 51 testcases, 0 failures.
- Probe A, production-only revert of `AppHttpServer.java` to the base, tests kept: exactly 9 red out of 42 in the selector — the 8 named (`JWT_WITHOUT_CONFIG x {AUTHENTICATED, ROLE_ADMIN, UNSPECIFIED, API_KEY, BEARER_TOKEN}`, `isNeverMorePermissiveThanNone`, both `refusesRoleAdminRoute*`) plus the new log pin (`Expected size: 1 but was: 0`). All six `API_KEY_WITHOUT_KEYS` cells and the other 18 cells green.
- Probe B, `log.error` -> `log.warn` with the `enabled` gate removed: exactly 2 red — the level assertion (`expected: ERROR but was: WARN`) and the disabled-server control. File restored byte-identical after each probe (touched, so Maven recompiled).
- `mvn jbct:check -pl aether/node -am -fae`: red once on whitespace in the new message constant, `jbct:format` applied as `chore:`, re-run BUILD SUCCESS.
- `scripts/changelog-check.sh origin/release-1.0.0-rc4`: ok.
