### PR TITLE
fix: #727 (partial) SliceInvocationTest settles undeploy before apply and fails fast on rollback; EmberCluster reports observed node state and retains the start-failure snapshot

### DIFF
--- a/aether/ember/src/main/java/org/pragmatica/aether/ember/EmberCluster.java
+++ b/aether/ember/src/main/java/org/pragmatica/aether/ember/EmberCluster.java
@@ -94,7 +94,6 @@ public final class EmberCluster {
     public static final int DEFAULT_BASE_APP_HTTP_PORT = 8070;
     private static final TimeSpan NODE_TIMEOUT = TimeSpan.timeSpan(10).seconds();
     private static final long ROLLING_RESTART_DELAY_MS = 5_000;
-
     /// #727 review B1 — the two values [#observedState] can produce, both read from the node.
     /// "active" is short for consensus-active ([AetherNode#isReady]), not a general health verdict.
     public static final String STATE_ACTIVE = "active";
@@ -603,7 +602,6 @@ public final class EmberCluster {
         var startFailures = new ConcurrentHashMap<String, String>();
 
         lastStartFailure.set(null);
-
         for (int i = 0; i < initialClusterSize; i++) {
             var nodeInfo = initialNodes.get(i);
             var nodeIdStr = nodeInfo.id().id();
@@ -621,7 +619,8 @@ public final class EmberCluster {
 
             nodes.put(nodeIdStr, node);
             startPromises.add(node.start()
-                                  .onFailure(cause -> startFailures.put(nodeIdStr, cause.message()))
+                                  .onFailure(cause -> startFailures.put(nodeIdStr,
+                                                                        cause.message()))
                                   .onFailure(firstFailure::fail)
                                   .map(_ -> NodeStartResult.nodeStartResult(nodeIdStr,
                                                                             port,
@@ -635,7 +634,9 @@ public final class EmberCluster {
 
         var outcome = Promise.<Unit> promise();
 
-        Promise.allOf(startPromises).flatMap(results -> handleStartResults(results, startFailures)).onResult(outcome::resolve);
+        Promise.allOf(startPromises)
+               .flatMap(results -> handleStartResults(results, startFailures))
+               .onResult(outcome::resolve);
         firstFailure.onFailure(cause -> abortStart(cause, startFailures).onResult(outcome::resolve));
 
         return outcome;
@@ -994,7 +995,9 @@ public final class EmberCluster {
     /// [#STATE_ACTIVE] means consensus-active, NOT "healthy in every respect" — because the next
     /// unqualified word here would be the same defect again.
     private static String observedState(AetherNode node) {
-        return node.isReady() ? STATE_ACTIVE : STATE_INACTIVE;
+        return node.isReady()
+               ? STATE_ACTIVE
+               : STATE_INACTIVE;
     }
 
     public Option<AetherNode> getNode(String nodeIdStr) {

--- a/aether/ember/src/main/java/org/pragmatica/aether/ember/EmberCluster.java
+++ b/aether/ember/src/main/java/org/pragmatica/aether/ember/EmberCluster.java
@@ -95,6 +95,11 @@ public final class EmberCluster {
     private static final TimeSpan NODE_TIMEOUT = TimeSpan.timeSpan(10).seconds();
     private static final long ROLLING_RESTART_DELAY_MS = 5_000;
 
+    /// #727 review B1 — the two values [#observedState] can produce, both read from the node.
+    /// "active" is short for consensus-active ([AetherNode#isReady]), not a general health verdict.
+    public static final String STATE_ACTIVE = "active";
+    public static final String STATE_INACTIVE = "inactive";
+
     private final Map<String, AetherNode> nodes = new ConcurrentHashMap<>();
     /// TEST SEAM (#509 probe) — nodes CREATED by [#start] with the full configured topology but whose
     /// `start()` was DEFERRED, keyed by their stable node id. Held instances keep their identity, port
@@ -196,6 +201,19 @@ public final class EmberCluster {
     /// construction time, so [#wiredCertificateProvider] and [#wiredQuicTls] can never drift from
     /// what a node was truly wired with.
     private final AtomicReference<Option<AetherNodeConfig>> lastNodeConfig = new AtomicReference<>(Option.empty());
+
+    /// #727 review B2 — the cluster state as it was when a start failed, retained past the teardown
+    /// that empties [#nodes], [#nodeInfos] and [#slotsByNodeId].
+    ///
+    /// Both start-failure paths ([#abortStart] and [#handleStartResults]) end in
+    /// `clearClusterStateOnFailure` BEFORE the failure reaches the caller, so a caller that reports
+    /// `status()` on a start failure reads an emptied registry and prints `leader=none` with no node
+    /// lines — empty on exactly the failures the report exists for. The snapshot is taken before the
+    /// stops begin and the first capture of a start attempt wins, because the two paths can both run
+    /// (whichever settles the outcome first) and the earlier observation is the one taken closest to
+    /// the failure. Reset at the head of every [#start] so a retry cannot report its predecessor's
+    /// state as its own.
+    private final AtomicReference<StartFailure> lastStartFailure = new AtomicReference<>();
 
     private static byte[] generateClusterSecret() {
         var secret = new byte[32];
@@ -579,6 +597,12 @@ public final class EmberCluster {
         nodeCounter.set(initialClusterSize);
         var startPromises = new ArrayList<Promise<NodeStartResult>>();
         var firstFailure = Promise.<Unit> promise();
+        // #727 review B2: node id -> why its start failed, accumulated as the failures land so the
+        // snapshot below can name them. Recorded BEFORE `firstFailure` fires, so the abort path that
+        // `firstFailure` triggers always sees at least the failure that triggered it.
+        var startFailures = new ConcurrentHashMap<String, String>();
+
+        lastStartFailure.set(null);
 
         for (int i = 0; i < initialClusterSize; i++) {
             var nodeInfo = initialNodes.get(i);
@@ -597,6 +621,7 @@ public final class EmberCluster {
 
             nodes.put(nodeIdStr, node);
             startPromises.add(node.start()
+                                  .onFailure(cause -> startFailures.put(nodeIdStr, cause.message()))
                                   .onFailure(firstFailure::fail)
                                   .map(_ -> NodeStartResult.nodeStartResult(nodeIdStr,
                                                                             port,
@@ -610,8 +635,8 @@ public final class EmberCluster {
 
         var outcome = Promise.<Unit> promise();
 
-        Promise.allOf(startPromises).flatMap(this::handleStartResults).onResult(outcome::resolve);
-        firstFailure.onFailure(cause -> abortStart(cause).onResult(outcome::resolve));
+        Promise.allOf(startPromises).flatMap(results -> handleStartResults(results, startFailures)).onResult(outcome::resolve);
+        firstFailure.onFailure(cause -> abortStart(cause, startFailures).onResult(outcome::resolve));
 
         return outcome;
     }
@@ -627,8 +652,11 @@ public final class EmberCluster {
     /// failsafe's 30-minute fork wall ended it — with no failing test named. Whichever path settles
     /// `outcome` first wins (`resolve` is compare-and-set); the other's stops are bounded, recovered,
     /// and idempotent on an already-stopped node.
-    private Promise<Unit> abortStart(Cause cause) {
+    private Promise<Unit> abortStart(Cause cause, Map<String, String> startFailures) {
         log.error("Cluster startup aborted on first node failure: {}", cause.message());
+        // #727 review B2: BEFORE the stops and the clear that follows them, while `nodes` and
+        // `nodeInfos` still hold the attempt. Moving this below the stops empties the snapshot.
+        captureStartFailure(startFailures);
         var stopPromises = nodes.values()
                                 .stream()
                                 .map(node -> node.stop()
@@ -640,6 +668,19 @@ public final class EmberCluster {
                       .mapToUnit()
                       .onSuccess(this::clearClusterStateOnFailure)
                       .flatMap(_ -> cause.promise());
+    }
+
+    private void captureStartFailure(Map<String, String> startFailures) {
+        lastStartFailure.compareAndSet(null, new StartFailure(status(), Map.copyOf(startFailures)));
+    }
+
+    /// #727 review B2 — what [#status] answered at the moment the most recent [#start] failed, plus
+    /// each failing node's cause, or [Option#none] when no start of this instance has failed. Read it
+    /// when `status()` is empty: a start failure clears the live registries before the caller sees the
+    /// failure, so `status()` alone cannot distinguish "the cluster has no nodes" from "the cluster
+    /// had three nodes and the abort cleared them".
+    public Option<StartFailure> lastStartFailure() {
+        return Option.option(lastStartFailure.get());
     }
 
     /// TEST SEAM (#509 probe) — start the instances [#start] created and held back, in their original
@@ -692,7 +733,7 @@ public final class EmberCluster {
         }
     }
 
-    private Promise<Unit> handleStartResults(List<Result<NodeStartResult>> results) {
+    private Promise<Unit> handleStartResults(List<Result<NodeStartResult>> results, Map<String, String> startFailures) {
         var nodeResults = results.stream().flatMap(Result::stream).toList();
         var failed = nodeResults.stream().filter(r -> !r.succeeded()).toList();
         var succeeded = nodeResults.stream().filter(NodeStartResult::succeeded).toList();
@@ -720,6 +761,9 @@ public final class EmberCluster {
         }
 
         log.error("Cluster startup failed: {} of {} nodes failed to start", failed.size(), attempted);
+        // #727 review B2: same reason as in `abortStart` — this path also clears the registries
+        // before the caller sees the failure, so the snapshot must be taken here, not after.
+        captureStartFailure(startFailures);
         var stopPromises = succeeded.stream()
                                     .map(r -> Option.option(nodes.get(r.nodeId()))
                                                     .map(node -> node.stop()
@@ -934,8 +978,23 @@ public final class EmberCluster {
         return new NodeStatus(entry.getKey(),
                               clusterPort,
                               baseMgmtPort + (clusterPort - basePort),
-                              "healthy",
+                              observedState(entry.getValue()),
                               currentLeader().map(leaderId -> leaderId.equals(entry.getKey())).or(false));
+    }
+
+    /// #727 review B1 — [NodeStatus#state] used to be the string literal `"healthy"`, passed in
+    /// unconditionally with no code path able to produce any other value. Every node in every status
+    /// answer, every `/api/nodes/status` body and every failing test's state dump therefore read
+    /// `healthy`, including a node that never formed. A diagnostic that fabricates its own evidence is
+    /// worse than one that omits the field: the reader of the next formation stall sees `leader=none`
+    /// beside three healthy nodes and looks in the wrong place.
+    ///
+    /// The value is now read from the node: [AetherNode#isReady] is `clusterNode.isActive()`, the same
+    /// consensus-active sample the readiness pong answers from. It is named for what it measures —
+    /// [#STATE_ACTIVE] means consensus-active, NOT "healthy in every respect" — because the next
+    /// unqualified word here would be the same defect again.
+    private static String observedState(AetherNode node) {
+        return node.isReady() ? STATE_ACTIVE : STATE_INACTIVE;
     }
 
     public Option<AetherNode> getNode(String nodeIdStr) {
@@ -1318,6 +1377,13 @@ public final class EmberCluster {
     }
 
     public record NodeStatus(String id, int port, int mgmtPort, String state, boolean isLeader) {}
+
+    /// #727 review B2 — a start failure's evidence, taken before the abort clears the cluster.
+    ///
+    /// @param status       what [EmberCluster#status] answered at the moment of failure
+    /// @param nodeFailures node id -> the message of the cause that failed that node's `start()`;
+    ///                     empty when the start failed without any node reporting a cause
+    public record StartFailure(ClusterStatus status, Map<String, String> nodeFailures) {}
 
     public record ClusterStatus(List<NodeStatus> nodes, String leaderId) {}
 

--- a/aether/ember/src/main/java/org/pragmatica/aether/ember/EmberCluster.java
+++ b/aether/ember/src/main/java/org/pragmatica/aether/ember/EmberCluster.java
@@ -578,6 +578,7 @@ public final class EmberCluster {
 
         nodeCounter.set(initialClusterSize);
         var startPromises = new ArrayList<Promise<NodeStartResult>>();
+        var firstFailure = Promise.<Unit> promise();
 
         for (int i = 0; i < initialClusterSize; i++) {
             var nodeInfo = initialNodes.get(i);
@@ -596,6 +597,7 @@ public final class EmberCluster {
 
             nodes.put(nodeIdStr, node);
             startPromises.add(node.start()
+                                  .onFailure(firstFailure::fail)
                                   .map(_ -> NodeStartResult.nodeStartResult(nodeIdStr,
                                                                             port,
                                                                             mgmtPort,
@@ -606,7 +608,38 @@ public final class EmberCluster {
                                                                                     Option.some(cause))));
         }
 
-        return Promise.allOf(startPromises).flatMap(this::handleStartResults);
+        var outcome = Promise.<Unit> promise();
+
+        Promise.allOf(startPromises).flatMap(this::handleStartResults).onResult(outcome::resolve);
+        firstFailure.onFailure(cause -> abortStart(cause).onResult(outcome::resolve));
+
+        return outcome;
+    }
+
+    /// #727: the first node-start failure aborts the whole start, instead of waiting for every node.
+    ///
+    /// A node whose start FAILS settles its promise at once, but a node whose start SUCCEEDS settles
+    /// only on consensus quorum (`AetherNode.start()` resolves inside `clusterNode.start()`). So once
+    /// enough peers have failed that quorum can no longer form, every survivor's start is pending
+    /// forever, `allOf` never settles, and [#start] hangs with no bound at all. Observed 2026-09-06 on
+    /// a 3-node cluster with two management ports already taken: the third node waited 500+ s for a
+    /// quorum of one, the caller's untimed `await()` then ignored JUnit's 8-minute interrupt, and only
+    /// failsafe's 30-minute fork wall ended it — with no failing test named. Whichever path settles
+    /// `outcome` first wins (`resolve` is compare-and-set); the other's stops are bounded, recovered,
+    /// and idempotent on an already-stopped node.
+    private Promise<Unit> abortStart(Cause cause) {
+        log.error("Cluster startup aborted on first node failure: {}", cause.message());
+        var stopPromises = nodes.values()
+                                .stream()
+                                .map(node -> node.stop()
+                                                 .timeout(NODE_TIMEOUT)
+                                                 .recover(_ -> Unit.unit()))
+                                .toList();
+
+        return Promise.allOf(stopPromises)
+                      .mapToUnit()
+                      .onSuccess(this::clearClusterStateOnFailure)
+                      .flatMap(_ -> cause.promise());
     }
 
     /// TEST SEAM (#509 probe) — start the instances [#start] created and held back, in their original

--- a/aether/ember/src/test/java/org/pragmatica/aether/ember/EmberClusterObservedNodeStateTest.java
+++ b/aether/ember/src/test/java/org/pragmatica/aether/ember/EmberClusterObservedNodeStateTest.java
@@ -4,9 +4,16 @@
 // See LICENSE in the repository root for full terms.
 package org.pragmatica.aether.ember;
 
+import java.io.IOException;
+import java.net.DatagramSocket;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.pragmatica.lang.Cause;
 import org.pragmatica.lang.io.TimeSpan;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -26,10 +33,21 @@ import static org.pragmatica.aether.ember.EmberCluster.emberCluster;
 /// that did NOT form reports no active node at all. Reverting `observedState` to the old literal turns
 /// that one red; replacing it with a constant `inactive` turns this one red. Neither test alone closes
 /// the defect, which is exactly why the stream's healthy-cluster-only probes could not.
+///
+/// Ports are chosen at run time rather than hardcoded. A first version fixed them at 25700+ and failed
+/// on its first run because port 25702 was held by another tenant of this shared box — a failure that
+/// says nothing about the node state this class exists to pin. `EmberClusterPartialStartFailureTest`
+/// keeps its fixed ports because it must pre-bind two of them on purpose.
 class EmberClusterObservedNodeStateTest {
-    private static final int BASE_PORT = 25700;
-    private static final int BASE_MGMT_PORT = 25740;
-    private static final int BASE_APP_HTTP_PORT = 25780;
+    private static final int CLUSTER_SIZE = 3;
+    /// `EmberCluster.start` builds a slot pool of `2 * clusterSize`, so a block must cover twice the
+    /// node count even though only [#CLUSTER_SIZE] slots are used here.
+    private static final int SLOTS = 2 * CLUSTER_SIZE;
+    private static final int MGMT_OFFSET = 40;
+    private static final int APP_HTTP_OFFSET = 80;
+    private static final int FIRST_CANDIDATE_BASE = 25700;
+    private static final int LAST_CANDIDATE_BASE = 27500;
+    private static final int CANDIDATE_STEP = 200;
     private static final TimeSpan START_BOUND = TimeSpan.timeSpan(120).seconds();
     private static final TimeSpan STOP_BOUND = TimeSpan.timeSpan(60).seconds();
 
@@ -38,29 +56,89 @@ class EmberClusterObservedNodeStateTest {
     @AfterEach
     void tearDown() {
         if (cluster != null) {
-            assertThat(cluster.stop().await(STOP_BOUND).isSuccess())
+            assertThat(cluster.stop().await(STOP_BOUND).fold(Cause::message, _ -> "stopped"))
                 .describedAs("cluster stop must complete within %s", STOP_BOUND)
-                .isTrue();
+                .isEqualTo("stopped");
         }
     }
 
     @Test
     @Timeout(240)
     void everyNodeOfAFormedCluster_reportsItsObservedStateAsActive() {
-        cluster = emberCluster(3, BASE_PORT, BASE_MGMT_PORT, BASE_APP_HTTP_PORT, "obs");
+        var basePort = freeBasePort();
 
-        assertThat(cluster.start().await(START_BOUND).isSuccess())
-            .describedAs("a three-node cluster on free ports must form within %s", START_BOUND)
-            .isTrue();
+        cluster = emberCluster(CLUSTER_SIZE,
+                               basePort,
+                               basePort + MGMT_OFFSET,
+                               basePort + APP_HTTP_OFFSET,
+                               "obs");
+
+        assertThat(cluster.start().await(START_BOUND).fold(Cause::message, _ -> "started"))
+            .describedAs("a three-node cluster on a verified-free port block at %d must form within %s",
+                         basePort,
+                         START_BOUND)
+            .isEqualTo("started");
 
         var nodes = cluster.status().nodes();
 
-        assertThat(nodes).hasSize(3);
+        assertThat(nodes).hasSize(CLUSTER_SIZE);
         assertThat(nodes).allSatisfy(node -> assertThat(node.state())
             .describedAs("node %s of a formed cluster", node.id())
             .isEqualTo(EmberCluster.STATE_ACTIVE));
         assertThat(cluster.lastStartFailure().isEmpty())
             .describedAs("a start that succeeded must leave no start-failure snapshot behind")
             .isTrue();
+    }
+
+    /// The first candidate base whose whole block — cluster ports (QUIC, so UDP as well as TCP),
+    /// management ports and app-HTTP ports — binds free right now. Not a guarantee: another tenant can
+    /// take a port between this probe and the node's own bind. It removes the standing collision with
+    /// whatever else is running on the box, which is the failure mode actually observed here, and a
+    /// residual race would surface as the named bind failure the start assertion prints.
+    private static int freeBasePort() {
+        for (int base = FIRST_CANDIDATE_BASE; base <= LAST_CANDIDATE_BASE; base += CANDIDATE_STEP) {
+            if (blockIsFree(base)) {
+                return base;
+            }
+        }
+        throw new AssertionError("no free block of " + SLOTS + " consecutive ports found between "
+                                 + FIRST_CANDIDATE_BASE + " and " + LAST_CANDIDATE_BASE
+                                 + "; this box is too busy to run a cluster test");
+    }
+
+    private static boolean blockIsFree(int base) {
+        for (int slot = 0; slot < SLOTS; slot++) {
+            if (!udpFree(base + slot)
+                || !tcpFree(base + slot)
+                || !tcpFree(base + MGMT_OFFSET + slot)
+                || !tcpFree(base + APP_HTTP_OFFSET + slot)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static boolean tcpFree(int port) {
+        try (var socket = new ServerSocket()) {
+            socket.setReuseAddress(false);
+            socket.bind(loopback(port));
+            return true;
+        } catch (IOException e) {
+            return false;
+        }
+    }
+
+    private static boolean udpFree(int port) {
+        try (var socket = new DatagramSocket(null)) {
+            socket.setReuseAddress(false);
+            socket.bind(loopback(port));
+            return true;
+        } catch (IOException e) {
+            return false;
+        }
+    }
+
+    private static InetSocketAddress loopback(int port) {
+        return new InetSocketAddress(InetAddress.getLoopbackAddress(), port);
     }
 }

--- a/aether/ember/src/test/java/org/pragmatica/aether/ember/EmberClusterObservedNodeStateTest.java
+++ b/aether/ember/src/test/java/org/pragmatica/aether/ember/EmberClusterObservedNodeStateTest.java
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2025 Pragmatica Labs - Sergiy Yevtushenko
+// Licensed under Business Source License 1.1. Change Date: 2030-01-01. Change License: Apache-2.0.
+// See LICENSE in the repository root for full terms.
+package org.pragmatica.aether.ember;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.pragmatica.lang.io.TimeSpan;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.pragmatica.aether.ember.EmberCluster.emberCluster;
+
+/// #727 review B1 — the POSITIVE control for [EmberCluster#status]'s node state.
+///
+/// `toNodeStatus` used to pass the string literal `"healthy"` into every `NodeStatus`, so every status
+/// answer, every `/api/nodes/status` body and every failing test's state dump reported three healthy
+/// nodes however broken the cluster was. It is now read from the node
+/// (`AetherNode.isReady()` — consensus-active).
+///
+/// This class is one half of the pin and cannot stand alone. It shows that a cluster that really did
+/// form reports [EmberCluster#STATE_ACTIVE], which rules out a replacement that always answers
+/// "inactive" — a fabrication in the opposite direction, and one that a broken-cluster test alone
+/// would never catch. The other half is `EmberClusterPartialStartFailureTest`, which shows a cluster
+/// that did NOT form reports no active node at all. Reverting `observedState` to the old literal turns
+/// that one red; replacing it with a constant `inactive` turns this one red. Neither test alone closes
+/// the defect, which is exactly why the stream's healthy-cluster-only probes could not.
+class EmberClusterObservedNodeStateTest {
+    private static final int BASE_PORT = 25700;
+    private static final int BASE_MGMT_PORT = 25740;
+    private static final int BASE_APP_HTTP_PORT = 25780;
+    private static final TimeSpan START_BOUND = TimeSpan.timeSpan(120).seconds();
+    private static final TimeSpan STOP_BOUND = TimeSpan.timeSpan(60).seconds();
+
+    private EmberCluster cluster;
+
+    @AfterEach
+    void tearDown() {
+        if (cluster != null) {
+            assertThat(cluster.stop().await(STOP_BOUND).isSuccess())
+                .describedAs("cluster stop must complete within %s", STOP_BOUND)
+                .isTrue();
+        }
+    }
+
+    @Test
+    @Timeout(240)
+    void everyNodeOfAFormedCluster_reportsItsObservedStateAsActive() {
+        cluster = emberCluster(3, BASE_PORT, BASE_MGMT_PORT, BASE_APP_HTTP_PORT, "obs");
+
+        assertThat(cluster.start().await(START_BOUND).isSuccess())
+            .describedAs("a three-node cluster on free ports must form within %s", START_BOUND)
+            .isTrue();
+
+        var nodes = cluster.status().nodes();
+
+        assertThat(nodes).hasSize(3);
+        assertThat(nodes).allSatisfy(node -> assertThat(node.state())
+            .describedAs("node %s of a formed cluster", node.id())
+            .isEqualTo(EmberCluster.STATE_ACTIVE));
+        assertThat(cluster.lastStartFailure().isEmpty())
+            .describedAs("a start that succeeded must leave no start-failure snapshot behind")
+            .isTrue();
+    }
+}

--- a/aether/ember/src/test/java/org/pragmatica/aether/ember/EmberClusterPartialStartFailureTest.java
+++ b/aether/ember/src/test/java/org/pragmatica/aether/ember/EmberClusterPartialStartFailureTest.java
@@ -47,9 +47,9 @@ class EmberClusterPartialStartFailureTest {
     @AfterEach
     void tearDown() {
         if (cluster != null) {
-            assertThat(cluster.stop().await(STOP_BOUND).isSuccess())
+            assertThat(cluster.stop().await(STOP_BOUND).fold(Cause::message, _ -> "stopped"))
                 .describedAs("stopping an already-aborted cluster must complete within %s", STOP_BOUND)
-                .isTrue();
+                .isEqualTo("stopped");
         }
     }
 
@@ -80,8 +80,11 @@ class EmberClusterPartialStartFailureTest {
     /// the node assertions here fail on an empty snapshot.
     ///
     /// #727 review B1 — the same snapshot is where a fabricated state does the most damage, so it is
-    /// asserted here too: not one node of a cluster that never formed may report itself active. With
-    /// the old hardcoded `"healthy"` literal all three did.
+    /// asserted here too. Two of these three nodes could not bind, and the survivor cannot reach a
+    /// quorum of one, so NONE of them is consensus-active and every one must say so. The old hardcoded
+    /// `"healthy"` literal made all three claim otherwise; restoring it turns this red, and so does
+    /// replacing `observedState` with a constant `active`. The opposite mutation — a constant
+    /// `inactive` — passes here and is caught by `EmberClusterObservedNodeStateTest` instead.
     private void assertStartFailureSnapshotSurvivedTheAbort() {
         assertThat(cluster.status().nodes())
             .describedAs("the abort clears the live registry; this is the condition the retained "
@@ -98,8 +101,9 @@ class EmberClusterPartialStartFailureTest {
             .describedAs("the snapshot must carry the nodes the failed start had created")
             .hasSize(3);
         assertThat(snapshot.status().nodes())
-            .describedAs("no node of a cluster that never formed may report itself as active")
-            .noneMatch(node -> EmberCluster.STATE_ACTIVE.equals(node.state()));
+            .allSatisfy(node -> assertThat(node.state())
+                .describedAs("node %s of a cluster that never formed", node.id())
+                .isEqualTo(EmberCluster.STATE_INACTIVE));
         assertThat(snapshot.nodeFailures())
             .describedAs("the snapshot must name the nodes whose start failed, and why")
             .isNotEmpty();

--- a/aether/ember/src/test/java/org/pragmatica/aether/ember/EmberClusterPartialStartFailureTest.java
+++ b/aether/ember/src/test/java/org/pragmatica/aether/ember/EmberClusterPartialStartFailureTest.java
@@ -39,10 +39,17 @@ class EmberClusterPartialStartFailureTest {
 
     private EmberCluster cluster;
 
+    /// #727 review S3 — the `Result` used to be discarded, so a stop that exhausted the bound passed
+    /// silently: a bounded await whose expiry names nothing is the same blind wait this ticket exists
+    /// to remove. It doubles as the pin for review N4: by the time this runs, `abortStart` has already
+    /// stopped every node, so a green assertion here is evidence that the second stop is idempotent
+    /// rather than a docstring claiming it is.
     @AfterEach
     void tearDown() {
         if (cluster != null) {
-            cluster.stop().await(STOP_BOUND);
+            assertThat(cluster.stop().await(STOP_BOUND).isSuccess())
+                .describedAs("stopping an already-aborted cluster must complete within %s", STOP_BOUND)
+                .isTrue();
         }
     }
 
@@ -55,10 +62,48 @@ class EmberClusterPartialStartFailureTest {
             var outcome = cluster.start().await(START_BOUND).fold(Cause::message, _ -> "started");
 
             assertThat(outcome).contains("Address already in use");
+            assertStartFailureSnapshotSurvivedTheAbort();
         }
         // The survivor was stopped as part of the abort: its management port is reclaimable.
         try (var reclaimed = new ServerSocket(BASE_MGMT_PORT + 2)) {
             assertThat(reclaimed.isBound()).isTrue();
         }
+    }
+
+    /// #727 review B2 — the abort clears `nodes`, `nodeInfos` and the rest BEFORE the failure reaches
+    /// the caller, so a caller that reports `status()` on a start failure reads an emptied registry:
+    /// the state dump added for this very failure was `leader=none` with zero node lines, on exactly
+    /// the failures it exists for. [EmberCluster#lastStartFailure] is captured before the stops begin.
+    ///
+    /// Red-before is a hunk revert, not a rewrite: move `captureStartFailure(startFailures)` in
+    /// `EmberCluster.abortStart` from above the stop list to below `clearClusterStateOnFailure`, and
+    /// the node assertions here fail on an empty snapshot.
+    ///
+    /// #727 review B1 — the same snapshot is where a fabricated state does the most damage, so it is
+    /// asserted here too: not one node of a cluster that never formed may report itself active. With
+    /// the old hardcoded `"healthy"` literal all three did.
+    private void assertStartFailureSnapshotSurvivedTheAbort() {
+        assertThat(cluster.status().nodes())
+            .describedAs("the abort clears the live registry; this is the condition the retained "
+                         + "snapshot exists for, and it must hold or the test proves nothing")
+            .isEmpty();
+
+        var snapshot = cluster.lastStartFailure()
+                              .or(() -> {
+                                  throw new AssertionError("no start-failure snapshot was retained; the state "
+                                                           + "dump for this failure would be empty");
+                              });
+
+        assertThat(snapshot.status().nodes())
+            .describedAs("the snapshot must carry the nodes the failed start had created")
+            .hasSize(3);
+        assertThat(snapshot.status().nodes())
+            .describedAs("no node of a cluster that never formed may report itself as active")
+            .noneMatch(node -> EmberCluster.STATE_ACTIVE.equals(node.state()));
+        assertThat(snapshot.nodeFailures())
+            .describedAs("the snapshot must name the nodes whose start failed, and why")
+            .isNotEmpty();
+        assertThat(snapshot.nodeFailures().values())
+            .allSatisfy(message -> assertThat(message).contains("Address already in use"));
     }
 }

--- a/aether/ember/src/test/java/org/pragmatica/aether/ember/EmberClusterPartialStartFailureTest.java
+++ b/aether/ember/src/test/java/org/pragmatica/aether/ember/EmberClusterPartialStartFailureTest.java
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2025 Pragmatica Labs - Sergiy Yevtushenko
+// Licensed under Business Source License 1.1. Change Date: 2030-01-01. Change License: Apache-2.0.
+// See LICENSE in the repository root for full terms.
+package org.pragmatica.aether.ember;
+
+import java.io.IOException;
+import java.net.ServerSocket;
+
+import org.pragmatica.lang.Cause;
+import org.pragmatica.lang.io.TimeSpan;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import static org.pragmatica.aether.ember.EmberCluster.emberCluster;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/// #727 — `EmberCluster.start()` must SETTLE when a partial start leaves no quorum to wait for.
+///
+/// A node whose start fails settles its promise at once; a node whose start succeeds settles only on
+/// consensus quorum. With two of three management ports already taken, the two bind failures settled
+/// and the third node's start waited for a quorum of one that could never form — so `start()` never
+/// settled, and the caller's untimed `await()` in a forge `@BeforeAll` sat past JUnit's 8-minute
+/// interrupt (`PromiseImpl.await` re-parks until resolved) until failsafe's 30-minute fork wall, with
+/// no test named in the report. Observed 2026-09-06 on a quiet box, by accident: two runs of the same
+/// forge class split one port range between them.
+///
+/// The pin is on the CAUSE, not merely on "it failed": a bounded `await` returns a `Timeout` failure
+/// too, and that is exactly the old behaviour. Reverting `EmberCluster.abortStart` turns this red
+/// with a 60-second `Timeout` cause instead of the bind failure.
+class EmberClusterPartialStartFailureTest {
+    private static final int BASE_PORT = 25600;
+    private static final int BASE_MGMT_PORT = 25640;
+    private static final int BASE_APP_HTTP_PORT = 25680;
+    private static final TimeSpan START_BOUND = TimeSpan.timeSpan(60).seconds();
+    private static final TimeSpan STOP_BOUND = TimeSpan.timeSpan(30).seconds();
+
+    private EmberCluster cluster;
+
+    @AfterEach
+    void tearDown() {
+        if (cluster != null) {
+            cluster.stop().await(STOP_BOUND);
+        }
+    }
+
+    @Test
+    @Timeout(150)
+    void start_settlesWithTheBindFailure_whenTwoOfThreeNodesCannotBindTheirManagementPort() throws IOException {
+        // Slots are assigned in node order: node 1 -> BASE_MGMT_PORT, node 2 -> +1, node 3 -> +2.
+        try (var taken1 = new ServerSocket(BASE_MGMT_PORT); var taken2 = new ServerSocket(BASE_MGMT_PORT + 1)) {
+            cluster = emberCluster(3, BASE_PORT, BASE_MGMT_PORT, BASE_APP_HTTP_PORT, "partial");
+            var outcome = cluster.start().await(START_BOUND).fold(Cause::message, _ -> "started");
+
+            assertThat(outcome).contains("Address already in use");
+        }
+        // The survivor was stopped as part of the abort: its management port is reclaimable.
+        try (var reclaimed = new ServerSocket(BASE_MGMT_PORT + 2)) {
+            assertThat(reclaimed.isBound()).isTrue();
+        }
+    }
+}

--- a/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/ClusterSnapshot.java
+++ b/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/ClusterSnapshot.java
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2025 Pragmatica Labs - Sergiy Yevtushenko
+// Licensed under Business Source License 1.1. Change Date: 2030-01-01. Change License: Apache-2.0.
+// See LICENSE in the repository root for full terms.
+package org.pragmatica.aether.forge;
+
+import java.net.URI;
+import java.net.http.HttpRequest;
+import java.time.Duration;
+import java.util.stream.Collectors;
+
+import org.pragmatica.aether.ember.EmberCluster;
+import org.pragmatica.http.HttpOperations;
+import org.pragmatica.lang.Option;
+import org.pragmatica.lang.io.TimeSpan;
+
+/// #727 — the cluster state a bounded wait prints when it expires.
+///
+/// Extracted from `SliceInvocationTest` in review round 1 so the two cases that matter can be pinned
+/// by a test instead of asserted in a comment: a cluster whose live registry has been cleared, and a
+/// node whose health endpoint cannot be reached. Every value rendered here is either something this
+/// renderer actually read or a NAMED absence. Nothing is defaulted, because the defect this exists to
+/// close (review B1) was exactly a default that read as an observation — `EmberCluster` passed the
+/// string literal `"healthy"` into every `NodeStatus`, so every dump reported three healthy nodes
+/// however broken the cluster was, and the reader of a formation stall looked in the wrong place.
+final class ClusterSnapshot {
+    /// The named absence for "there is nothing to report", used when the cluster holds no running node
+    /// AND no start of it has failed. Distinguishing this from a start failure is review B2: a failed
+    /// start clears `nodes`/`nodeInfos` before the caller sees the failure, so an un-named empty
+    /// snapshot on a start failure is indistinguishable from a cluster that was never asked to start.
+    static final String NO_STATE =
+        "  no cluster state: no node is registered and no start of this cluster has failed";
+
+    private static final TimeSpan HEALTH_BOUND = TimeSpan.timeSpan(30).seconds();
+    private static final Duration HEALTH_REQUEST_TIMEOUT = Duration.ofSeconds(5);
+
+    private ClusterSnapshot() {}
+
+    static String render(EmberCluster cluster, HttpOperations http) {
+        return render(cluster.status(), cluster.lastStartFailure(), http);
+    }
+
+    /// Split from the accessor above so the branch — live registry, retained failure, or neither —
+    /// is drivable from a test without starting and then breaking a real cluster.
+    static String render(EmberCluster.ClusterStatus live,
+                         Option<EmberCluster.StartFailure> startFailure,
+                         HttpOperations http) {
+        if (!live.nodes().isEmpty()) {
+            return renderLive(live, http);
+        }
+        return startFailure.map(ClusterSnapshot::renderCaptured)
+                           .or(NO_STATE);
+    }
+
+    private static String renderLive(EmberCluster.ClusterStatus status, HttpOperations http) {
+        return "  leader=" + status.leaderId() + "\n"
+               + status.nodes()
+                       .stream()
+                       .map(node -> liveNodeLine(node, http))
+                       .collect(Collectors.joining("\n"));
+    }
+
+    /// The captured snapshot is rendered WITHOUT probing any health endpoint: the nodes it names were
+    /// stopped by the abort that produced it, so a probe now would answer about the aftermath and read
+    /// as if it described the failure. The label says which of the two this is.
+    private static String renderCaptured(EmberCluster.StartFailure failure) {
+        var failures = failure.nodeFailures().isEmpty()
+                       ? "no node reported a cause"
+                       : failure.nodeFailures().toString();
+
+        return "  leader=" + failure.status().leaderId()
+               + " (captured when the start failed; the abort has since cleared the live cluster"
+               + " state, so no health endpoint is probed here)\n"
+               + failure.status()
+                        .nodes()
+                        .stream()
+                        .map(ClusterSnapshot::nodeLine)
+                        .collect(Collectors.joining("\n"))
+               + "\n  start failures: " + failures;
+    }
+
+    static String liveNodeLine(EmberCluster.NodeStatus node, HttpOperations http) {
+        return nodeLine(node) + " health=" + healthBody(node.mgmtPort(), http);
+    }
+
+    private static String nodeLine(EmberCluster.NodeStatus node) {
+        return "  " + node.id() + " state=" + node.state() + " leader=" + node.isLeader();
+    }
+
+    /// Bounded, unlike the `await()` this replaced (review N1): the failure path is the one that runs
+    /// when things are already wrong, and an unbounded await there re-parks past JUnit's interrupt.
+    /// The bound is far above the request's own 5s timeout, so it fires only if the promise never
+    /// settles at all — and when it does, the reason is named rather than defaulted.
+    private static String healthBody(int port, HttpOperations http) {
+        return http.sendString(healthRequest(port))
+                   .await(HEALTH_BOUND)
+                   .fold(cause -> "unavailable (" + cause.message() + ")",
+                         response -> response.statusCode() + " " + response.body());
+    }
+
+    static HttpRequest healthRequest(int port) {
+        return HttpRequest.newBuilder()
+                          .uri(URI.create("http://localhost:" + port + "/api/v1/health"))
+                          .GET()
+                          .timeout(HEALTH_REQUEST_TIMEOUT)
+                          .build();
+    }
+}

--- a/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/ClusterSnapshotTest.java
+++ b/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/ClusterSnapshotTest.java
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2025 Pragmatica Labs - Sergiy Yevtushenko
+// Licensed under Business Source License 1.1. Change Date: 2030-01-01. Change License: Apache-2.0.
+// See LICENSE in the repository root for full terms.
+package org.pragmatica.aether.forge;
+
+import java.net.http.HttpHeaders;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse.BodyHandler;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.pragmatica.aether.ember.EmberCluster;
+import org.pragmatica.http.HttpOperations;
+import org.pragmatica.http.HttpResult;
+import org.pragmatica.lang.Cause;
+import org.pragmatica.lang.Option;
+import org.pragmatica.lang.Promise;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/// #727 review B1/B2 — the state dump must report what it read, and name what it could not read.
+///
+/// The stream's own probes ran against a cluster that WAS healthy, where `EmberCluster`'s hardcoded
+/// `"healthy"` literal happened to equal the truth; they could not have caught the fabrication. These
+/// cases are the ones a healthy cluster never produces: a node reporting a state other than active, a
+/// health endpoint that cannot be answered, a cluster whose registry a failed start already cleared,
+/// and a cluster with nothing to report at all. No cluster is started here — every input is supplied
+/// directly, so each assertion is about the renderer and nothing else.
+class ClusterSnapshotTest {
+    private static final int MGMT_PORT = 6100;
+
+    @Test
+    void unreachableHealthEndpoint_isNamedUnavailable_neverHealthy() {
+        var node = new EmberCluster.NodeStatus("si-1", 6000, MGMT_PORT, EmberCluster.STATE_INACTIVE, false);
+
+        var line = ClusterSnapshot.liveNodeLine(node, failingHttp("Connection refused"));
+
+        assertThat(line).describedAs("an unanswerable health probe must be reported as such, by name")
+                        .contains("health=unavailable (Connection refused)");
+        assertThat(line).describedAs("nothing in the line may claim health that was never observed")
+                        .doesNotContain("healthy");
+        assertThat(line).describedAs("the node's own state is read from the node, not defaulted")
+                        .contains("si-1 state=inactive leader=false");
+    }
+
+    @Test
+    void reachableHealthEndpoint_reportsTheBodyItRead() {
+        var node = new EmberCluster.NodeStatus("si-2", 6001, MGMT_PORT, EmberCluster.STATE_ACTIVE, true);
+
+        var line = ClusterSnapshot.liveNodeLine(node, respondingHttp(200, "{\"quorum\":true}"));
+
+        assertThat(line).isEqualTo("  si-2 state=active leader=true health=200 {\"quorum\":true}");
+    }
+
+    /// The positive control for the assertion above: the SAME renderer, given a node that is not
+    /// active and a health endpoint answering 503, reproduces both — so "it printed active" is
+    /// evidence about the node, not about the renderer having one output.
+    @Test
+    void aNodeThatIsNotActive_isRenderedAsSuch() {
+        var node = new EmberCluster.NodeStatus("si-3", 6002, MGMT_PORT, EmberCluster.STATE_INACTIVE, false);
+
+        var line = ClusterSnapshot.liveNodeLine(node, respondingHttp(503, "{\"quorum\":false}"));
+
+        assertThat(line).isEqualTo("  si-3 state=inactive leader=false health=503 {\"quorum\":false}");
+    }
+
+    @Test
+    void aClusterWithNothingToReport_saysSo_ratherThanPrintingAnEmptyBlock() {
+        var rendered = ClusterSnapshot.render(emptyStatus(), Option.none(), failingHttp("must not be probed"));
+
+        assertThat(rendered).describedAs("no nodes and no failed start is a fact to state, not an empty block")
+                            .isEqualTo(ClusterSnapshot.NO_STATE);
+    }
+
+    /// Review B2's rendering half: when the live registry is empty because an abort cleared it, the
+    /// dump reports the retained snapshot and says that is what it is. Before this, the dump for a
+    /// start failure was `leader=none` with zero node lines — empty on exactly the failure it exists
+    /// for. That a real failed start populates the retained snapshot at all is pinned separately, by
+    /// `EmberClusterPartialStartFailureTest` in `aether/ember`.
+    @Test
+    void aClearedRegistry_rendersTheRetainedStartFailure_labelledAsCaptured() {
+        var captured = new EmberCluster.StartFailure(
+            new EmberCluster.ClusterStatus(
+                List.of(new EmberCluster.NodeStatus("si-1", 6000, 6100, EmberCluster.STATE_INACTIVE, false),
+                        new EmberCluster.NodeStatus("si-2", 6001, 6101, EmberCluster.STATE_INACTIVE, false)),
+                "none"),
+            Map.of("si-1", "Address already in use"));
+
+        var rendered = ClusterSnapshot.render(emptyStatus(), Option.some(captured), failingHttp("must not be probed"));
+
+        assertThat(rendered).contains("captured when the start failed");
+        assertThat(rendered).contains("si-1 state=inactive leader=false");
+        assertThat(rendered).contains("si-2 state=inactive leader=false");
+        assertThat(rendered).contains("start failures: {si-1=Address already in use}");
+        assertThat(rendered).describedAs("a captured snapshot must not carry a live health probe")
+                            .doesNotContain("health=");
+    }
+
+    /// The live registry wins over a retained failure: a cluster that failed one start and then
+    /// started must report what it is doing now, not what it did then.
+    @Test
+    void aLiveRegistry_isPreferredOverARetainedStartFailure() {
+        var live = new EmberCluster.ClusterStatus(
+            List.of(new EmberCluster.NodeStatus("si-1", 6000, 6100, EmberCluster.STATE_ACTIVE, true)),
+            "si-1");
+        var stale = new EmberCluster.StartFailure(new EmberCluster.ClusterStatus(List.of(), "none"),
+                                                  Map.of("si-9", "Address already in use"));
+
+        var rendered = ClusterSnapshot.render(live, Option.some(stale), respondingHttp(200, "{\"quorum\":true}"));
+
+        assertThat(rendered).isEqualTo("  leader=si-1\n  si-1 state=active leader=true health=200 {\"quorum\":true}");
+    }
+
+    private static EmberCluster.ClusterStatus emptyStatus() {
+        return new EmberCluster.ClusterStatus(List.of(), "none");
+    }
+
+    private record ProbeFailure(String message) implements Cause {}
+
+    private static HttpOperations failingHttp(String message) {
+        return new HttpOperations() {
+            @Override
+            public <T> Promise<HttpResult<T>> send(HttpRequest request, BodyHandler<T> handler) {
+                return Promise.failure(new ProbeFailure(message));
+            }
+        };
+    }
+
+    private static HttpOperations respondingHttp(int statusCode, String body) {
+        return new HttpOperations() {
+            @Override
+            @SuppressWarnings("unchecked")
+            public <T> Promise<HttpResult<T>> send(HttpRequest request, BodyHandler<T> handler) {
+                return Promise.success((HttpResult<T>) new HttpResult<>(statusCode, noHeaders(), body));
+            }
+        };
+    }
+
+    private static HttpHeaders noHeaders() {
+        return HttpHeaders.of(Map.of(), (_, _) -> true);
+    }
+}

--- a/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/SliceInvocationTest.java
+++ b/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/SliceInvocationTest.java
@@ -25,7 +25,6 @@ import java.time.Duration;
 import java.util.concurrent.Callable;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
@@ -65,6 +64,12 @@ class SliceInvocationTest {
     private static final String BLUEPRINT_ID = "forge.test:slice-invocation:1.0.0";
     private static final String ERROR_FALLBACK = "{\"error\":\"request failed\"}";
     private static final Pattern OUTCOME_TIMESTAMP = Pattern.compile("\"timestampMs\":(\\d+)");
+    /// #727 review N1: every `await()` in this class is bounded, including the ones on the failure
+    /// path — that is the path that runs when things are already wrong. `PromiseImpl.await()` re-parks
+    /// until resolved and never consults the interrupt flag, so an unbounded await here outlives
+    /// JUnit's lifecycle backstop. Far above each request's own 10s JDK timeout, so it fires only if
+    /// the promise never settles at all.
+    private static final TimeSpan HTTP_BOUND = TimeSpan.timeSpan(60).seconds();
 
     private EmberCluster cluster;
     private final HttpOperations http = jdkHttpOperations();
@@ -95,8 +100,7 @@ class SliceInvocationTest {
         // the new ACTIVATE directive cross ("state is ACTIVATE but not found in SliceStore"), the
         // leader classes that deterministic and rolls the blueprint back, and the deploy wait then
         // polls for a slice that no longer exists (reproduced 2026-09-06, 3x CPU oversubscription).
-        var leaderPort = cluster.getLeaderManagementPort().or(anyMgmtPort());
-        httpRequestDelete(leaderPort, "/api/v1/blueprints/" + BLUEPRINT_ID);
+        httpRequestDelete(leaderOrAnyMgmtPort(), "/api/v1/blueprints/" + BLUEPRINT_ID);
         awaitEchoSliceUndeployed();
     }
 
@@ -246,7 +250,7 @@ class SliceInvocationTest {
     // counts, because a stale ROLLED_BACK from an earlier test stays readable until the next apply's
     // live entry replicates to the queried node.
     private void failFastOnDeploymentFailure() {
-        var status = httpRequest("GET", anyMgmtPort(), "/api/v1/blueprints/status/" + BLUEPRINT_ID, null);
+        var status = httpRequest("GET", leaderOrAnyMgmtPort(), "/api/v1/blueprints/status/" + BLUEPRINT_ID, null);
         if (isTerminalFailure(status) && outcomeTimestampMs(status) >= applyStartedAtMs) {
             throw new AssertionError("Blueprint " + BLUEPRINT_ID + " failed after apply: " + status);
         }
@@ -259,9 +263,27 @@ class SliceInvocationTest {
         return status.contains("\"overallStatus\":\"FAILED\"") || status.contains("\"overallStatus\":\"ROLLED_BACK\"");
     }
 
+    /// #727 review N2 — this used to take the FIRST `"timestampMs"` in the body. Safe today
+    /// (`BlueprintStatusResponse` carries exactly one and `BlueprintSliceStatus` none), and it would
+    /// have broken SILENTLY the day a per-slice timestamp is added: the fail-fast would compare the
+    /// wrong number and stop firing, which reads exactly like a deployment that never failed. A second
+    /// match is now an error naming the body, and an absent one still returns 0 — which fails the
+    /// `>= applyStartedAtMs` guard, so the default stays "do not fail fast".
     private static long outcomeTimestampMs(String status) {
         var matcher = OUTCOME_TIMESTAMP.matcher(status);
-        return matcher.find() ? Long.parseLong(matcher.group(1)) : 0L;
+
+        if (!matcher.find()) {
+            return 0L;
+        }
+
+        var first = Long.parseLong(matcher.group(1));
+
+        if (matcher.find()) {
+            throw new AssertionError("Blueprint status carries more than one timestampMs, so the outcome's own "
+                                     + "timestamp is no longer identifiable — this fail-fast needs a precise "
+                                     + "reader before it can be trusted again. Body: " + status);
+        }
+        return first;
     }
 
     // The undeploy wait used to be a bare `!getSlices().contains("echo-slice")`: an error body from the
@@ -295,24 +317,19 @@ class SliceInvocationTest {
     }
 
     private String clusterSnapshot() {
-        var status = cluster.status();
-        var nodes = status.nodes().stream().map(this::nodeSnapshot).collect(Collectors.joining("\n"));
-        return "  leader=" + status.leaderId() + "\n" + nodes;
-    }
-
-    private String nodeSnapshot(EmberCluster.NodeStatus node) {
-        return "  " + node.id() + " state=" + node.state() + " leader=" + node.isLeader()
-               + " health=" + healthBody(node.mgmtPort());
-    }
-
-    private String healthBody(int port) {
-        return http.sendString(healthRequest(port))
-                   .await()
-                   .fold(cause -> "unreachable (" + cause.message() + ")",
-                         response -> response.statusCode() + " " + response.body());
+        return ClusterSnapshot.render(cluster, http);
     }
 
     // HTTP helper methods
+
+    /// The port every management call in this class goes to. #727 review S2: the deploy fail-fast used
+    /// to query [#anyMgmtPort] — always node 1, a follower — while the apply and the delete it must
+    /// observe went to the leader. The direction was safe (a lagging follower yields a MISSED fail-fast,
+    /// never a false red), but it blunted the fail-fast under exactly the load it targets, where
+    /// replication lags. One port for all three now.
+    private int leaderOrAnyMgmtPort() {
+        return cluster.getLeaderManagementPort().or(anyMgmtPort());
+    }
 
     private int anyMgmtPort() {
         return cluster.status().nodes().getFirst().mgmtPort();
@@ -355,7 +372,10 @@ class SliceInvocationTest {
             artifact = "%s"
             instances = %d
             """.formatted(BLUEPRINT_ID, artifact, instances);
-        var leaderPort = cluster.getLeaderManagementPort().or(anyMgmtPort());
+        var leaderPort = leaderOrAnyMgmtPort();
+        // #727 review N3: the test JVM's clock, compared below against the node's `ctx.nowMs()`.
+        // Sound because Forge runs every node in this JVM on this host; it is NOT a portable guard,
+        // and the comparison would need a cluster-supplied timestamp against a remote node.
         applyStartedAtMs = System.currentTimeMillis();
         return postBlueprintWithRetry(leaderPort, blueprint);
     }
@@ -387,7 +407,7 @@ class SliceInvocationTest {
                                  .timeout(Duration.ofSeconds(10))
                                  .build();
         return http.sendString(request)
-                   .await()
+                   .await(HTTP_BOUND)
                    .map(HttpResult::body)
                    .or(ERROR_FALLBACK);
     }
@@ -411,8 +431,7 @@ class SliceInvocationTest {
     }
 
     private void undeploy(String artifact) {
-        var leaderPort = cluster.getLeaderManagementPort().or(anyMgmtPort());
-        httpRequestDelete(leaderPort, "/api/v1/blueprints/" + BLUEPRINT_ID);
+        httpRequestDelete(leaderOrAnyMgmtPort(), "/api/v1/blueprints/" + BLUEPRINT_ID);
     }
 
     private String httpRequestDelete(int port, String path) {
@@ -422,7 +441,7 @@ class SliceInvocationTest {
                                  .timeout(Duration.ofSeconds(10))
                                  .build();
         return http.sendString(request)
-                   .await()
+                   .await(HTTP_BOUND)
                    .map(HttpResult::body)
                    .or(ERROR_FALLBACK);
     }
@@ -440,7 +459,7 @@ class SliceInvocationTest {
         }
 
         return http.sendString(builder.build())
-                   .await()
+                   .await(HTTP_BOUND)
                    .map(HttpResult::body)
                    .or(ERROR_FALLBACK);
     }
@@ -452,17 +471,10 @@ class SliceInvocationTest {
     }
 
     private boolean checkNodeHealth(int port) {
-        return http.sendString(healthRequest(port))
-                   .await()
+        return http.sendString(ClusterSnapshot.healthRequest(port))
+                   .await(HTTP_BOUND)
                    .map(r -> r.statusCode() == 200 && r.body().contains("\"quorum\":true"))
                    .or(false);
     }
 
-    private static HttpRequest healthRequest(int port) {
-        return HttpRequest.newBuilder()
-                          .uri(URI.create("http://localhost:" + port + "/api/v1/health"))
-                          .GET()
-                          .timeout(Duration.ofSeconds(5))
-                          .build();
-    }
 }

--- a/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/SliceInvocationTest.java
+++ b/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/SliceInvocationTest.java
@@ -14,12 +14,18 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.awaitility.core.ConditionTimeoutException;
 import org.pragmatica.http.HttpResult;
 import org.pragmatica.http.HttpOperations;
+import org.pragmatica.lang.io.TimeSpan;
 
 import java.net.URI;
 import java.net.http.HttpRequest;
 import java.time.Duration;
+import java.util.concurrent.Callable;
+import java.util.function.Predicate;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
@@ -52,47 +58,56 @@ class SliceInvocationTest {
     private static final int BASE_PORT = 6000;
     private static final int BASE_MGMT_PORT = 6100;
     private static final int BASE_APP_HTTP_PORT = 6200;
-    private static final Duration WAIT_TIMEOUT = Duration.ofSeconds(240);
+    private static final TimeSpan WAIT_BOUND = TimeSpan.timeSpan(240).seconds();
+    private static final Duration WAIT_TIMEOUT = WAIT_BOUND.duration();
     private static final Duration POLL_INTERVAL = Duration.ofMillis(500);
     private static final String TEST_ARTIFACT = TestArtifacts.ECHO_SLICE;
     private static final String BLUEPRINT_ID = "forge.test:slice-invocation:1.0.0";
     private static final String ERROR_FALLBACK = "{\"error\":\"request failed\"}";
+    private static final Pattern OUTCOME_TIMESTAMP = Pattern.compile("\"timestampMs\":(\\d+)");
 
     private EmberCluster cluster;
     private final HttpOperations http = jdkHttpOperations();
+    private long applyStartedAtMs;
 
     @BeforeAll
     void setUp() {
         cluster = emberCluster(3, BASE_PORT, BASE_MGMT_PORT, BASE_APP_HTTP_PORT, "si");
+        // Bounded, like every other wait in this class. Untimed, this await() ignores JUnit's 8-minute
+        // interrupt (PromiseImpl.await re-parks until resolved) and a start that never settles ends only
+        // at failsafe's 30-minute fork wall with no test named — observed 2026-09-06 (see #727 report).
         cluster.start()
-               .await()
+               .await(WAIT_BOUND)
                .onFailure(cause -> {
-                   throw new AssertionError("Cluster start failed: " + cause.message());
+                   throw new AssertionError("Cluster start failed: " + cause.message()
+                                            + "\nCluster state at expiry:\n" + clusterSnapshot());
                });
 
-        await().alias("cluster leader elected (3 nodes, ports " + BASE_PORT + "+)")
-               .atMost(WAIT_TIMEOUT)
-               .pollInterval(POLL_INTERVAL)
-               .until(() -> cluster.currentLeader().isPresent());
-
-        await().alias("all 3 nodes report healthy after leader election")
-               .atMost(WAIT_TIMEOUT)
-               .pollInterval(POLL_INTERVAL)
-               .until(this::allNodesHealthy);
+        awaitFormation("cluster leader elected (3 nodes, ports " + BASE_PORT + "+)",
+                       () -> cluster.currentLeader().isPresent());
+        awaitFormation("all 3 nodes report healthy after leader election", this::allNodesHealthy);
     }
 
     @BeforeEach
     void cleanUp() {
-        // Undeploy any slices left by previous tests
+        // Undeploy any slices left by previous tests — and WAIT for it. #727's 240s member is this
+        // delete racing the next test's apply of the same artifact: under load the node's unload and
+        // the new ACTIVATE directive cross ("state is ACTIVATE but not found in SliceStore"), the
+        // leader classes that deterministic and rolls the blueprint back, and the deploy wait then
+        // polls for a slice that no longer exists (reproduced 2026-09-06, 3x CPU oversubscription).
         var leaderPort = cluster.getLeaderManagementPort().or(anyMgmtPort());
         httpRequestDelete(leaderPort, "/api/v1/blueprints/" + BLUEPRINT_ID);
+        awaitEchoSliceUndeployed();
     }
 
     @AfterAll
     void tearDown() {
         if (cluster != null) {
             cluster.stop()
-                   .await();
+                   .await(WAIT_BOUND)
+                   .onFailure(cause -> {
+                       throw new AssertionError("Cluster stop did not complete: " + cause.message());
+                   });
         }
     }
 
@@ -125,18 +140,7 @@ class SliceInvocationTest {
             var deployResponse = deploy(TEST_ARTIFACT, 1);
             assertDeploymentSucceeded(deployResponse);
 
-            await().atMost(WAIT_TIMEOUT)
-                   .pollInterval(POLL_INTERVAL)
-                   .failFast(() -> {
-                       var slices = getSlices();
-                       if (slices.contains("\"error\"")) {
-                           throw new AssertionError("Slice query failed: " + slices);
-                       }
-                       if (sliceHasFailed(TEST_ARTIFACT)) {
-                           throw new AssertionError("Slice deployment failed: " + TEST_ARTIFACT);
-                       }
-                   })
-                   .until(() -> getSlices().contains("echo-slice"));
+            awaitEchoSliceDeployed();
 
             var routes = getRoutes();
             assertThat(routes).doesNotContain("\"error\"");
@@ -166,23 +170,10 @@ class SliceInvocationTest {
             var deployResponse = deploy(TEST_ARTIFACT, 1);
             assertDeploymentSucceeded(deployResponse);
 
-            await().atMost(WAIT_TIMEOUT)
-                   .pollInterval(POLL_INTERVAL)
-                   .failFast(() -> {
-                       var slices = getSlices();
-                       if (slices.contains("\"error\"")) {
-                           throw new AssertionError("Slice query failed: " + slices);
-                       }
-                       if (sliceHasFailed(TEST_ARTIFACT)) {
-                           throw new AssertionError("Slice deployment failed: " + TEST_ARTIFACT);
-                       }
-                   })
-                   .until(() -> getSlices().contains("echo-slice"));
+            awaitEchoSliceDeployed();
 
             undeploy(TEST_ARTIFACT);
-            await().atMost(WAIT_TIMEOUT)
-                   .pollInterval(POLL_INTERVAL)
-                   .until(() -> !getSlices().contains("echo-slice"));
+            awaitEchoSliceUndeployed();
 
             var response = invokeGet("/api/example");
             assertThat(response).containsAnyOf("error", "404", "not found", "Not Found");
@@ -197,18 +188,7 @@ class SliceInvocationTest {
             var deployResponse = deploy(TEST_ARTIFACT, 3);
             assertDeploymentSucceeded(deployResponse);
 
-            await().atMost(WAIT_TIMEOUT)
-                   .pollInterval(POLL_INTERVAL)
-                   .failFast(() -> {
-                       var slices = getSlices();
-                       if (slices.contains("\"error\"")) {
-                           throw new AssertionError("Slice query failed: " + slices);
-                       }
-                       if (sliceHasFailed(TEST_ARTIFACT)) {
-                           throw new AssertionError("Slice deployment failed: " + TEST_ARTIFACT);
-                       }
-                   })
-                   .until(() -> getSlices().contains("echo-slice"));
+            awaitEchoSliceDeployed();
 
             for (var node : cluster.status().nodes()) {
                 var health = getHealth(node.mgmtPort());
@@ -229,6 +209,107 @@ class SliceInvocationTest {
             assertThat(node2Response).doesNotContain("\"error\"");
             assertThat(node3Response).doesNotContain("\"error\"");
         }
+    }
+
+    // #727 wait helpers: every 240s wait in this class dies with a NAME and a STATE, never blind.
+    //
+    // The ceiling behind three CI class-level ERRORs at 240.5s is WAIT_TIMEOUT, and each occurrence
+    // reported only "Condition with Lambda expression in SliceInvocationTest was not fulfilled" — not
+    // which condition, not which node, not what it was reporting. The settling run this ticket asked
+    // for (2026-09-06, quiet 16-core box, 10 sequential runs) puts formation-to-healthy at ~7s with
+    // no run above 37s wall, so 240s is ~30x the quiet-box time: not a margin problem, and raising it
+    // would only make a stalled formation fail slower. The ceiling stays; the failure now says what
+    // it waited for and what every node answered at expiry, which is what the next occurrence needs.
+
+    private void awaitFormation(String alias, Callable<Boolean> condition) {
+        try {
+            await().alias(alias)
+                   .atMost(WAIT_TIMEOUT)
+                   .pollInterval(POLL_INTERVAL)
+                   .until(condition);
+        } catch (ConditionTimeoutException timeout) {
+            throw new AssertionError(timeout.getMessage() + "\nCluster state at expiry:\n" + clusterSnapshot(),
+                                     timeout);
+        }
+    }
+
+    private void awaitEchoSliceDeployed() {
+        awaitSlices("echo-slice present in /api/v1/slices/status after blueprint apply",
+                    slices -> slices.contains("echo-slice"),
+                    this::failFastOnDeploymentFailure);
+    }
+
+    // Under ALL_OR_NOTHING a deterministic slice failure rolls the blueprint back and removes it from
+    // the KV store, so /api/v1/slices/status shows nothing for the artifact and a poll on it has
+    // nothing left to see — that is how the 240s occurrences went blind. The terminal outcome survives
+    // the removal at the status URL (#759); only an outcome recorded AFTER this test's own apply
+    // counts, because a stale ROLLED_BACK from an earlier test stays readable until the next apply's
+    // live entry replicates to the queried node.
+    private void failFastOnDeploymentFailure() {
+        var status = httpRequest("GET", anyMgmtPort(), "/api/v1/blueprints/status/" + BLUEPRINT_ID, null);
+        if (isTerminalFailure(status) && outcomeTimestampMs(status) >= applyStartedAtMs) {
+            throw new AssertionError("Blueprint " + BLUEPRINT_ID + " failed after apply: " + status);
+        }
+        if (sliceHasFailed(TEST_ARTIFACT)) {
+            throw new AssertionError("Slice deployment failed: " + TEST_ARTIFACT);
+        }
+    }
+
+    private static boolean isTerminalFailure(String status) {
+        return status.contains("\"overallStatus\":\"FAILED\"") || status.contains("\"overallStatus\":\"ROLLED_BACK\"");
+    }
+
+    private static long outcomeTimestampMs(String status) {
+        var matcher = OUTCOME_TIMESTAMP.matcher(status);
+        return matcher.find() ? Long.parseLong(matcher.group(1)) : 0L;
+    }
+
+    // The undeploy wait used to be a bare `!getSlices().contains("echo-slice")`: an error body from the
+    // status endpoint contains no "echo-slice" either, so a failing query satisfied "undeployed". The
+    // shared fail-fast below turns that into a named failure instead of a false green.
+    private void awaitEchoSliceUndeployed() {
+        awaitSlices("echo-slice absent from /api/v1/slices/status after blueprint delete",
+                    slices -> !slices.contains("echo-slice"),
+                    () -> {});
+    }
+
+    private void awaitSlices(String alias, Predicate<String> condition, Runnable extraFailFast) {
+        try {
+            await().alias(alias)
+                   .atMost(WAIT_TIMEOUT)
+                   .pollInterval(POLL_INTERVAL)
+                   .failFast(() -> {
+                       var slices = getSlices();
+                       if (slices.contains("\"error\"")) {
+                           throw new AssertionError("Slice query failed: " + slices);
+                       }
+                       extraFailFast.run();
+                   })
+                   .until(() -> condition.test(getSlices()));
+        } catch (ConditionTimeoutException timeout) {
+            throw new AssertionError(timeout.getMessage()
+                                     + "\nLast /api/v1/slices/status: " + getSlices()
+                                     + "\nCluster state at expiry:\n" + clusterSnapshot(),
+                                     timeout);
+        }
+    }
+
+    private String clusterSnapshot() {
+        var status = cluster.status();
+        var nodes = status.nodes().stream().map(this::nodeSnapshot).collect(Collectors.joining("\n"));
+        return "  leader=" + status.leaderId() + "\n" + nodes;
+    }
+
+    private String nodeSnapshot(EmberCluster.NodeStatus node) {
+        return "  " + node.id() + " state=" + node.state() + " leader=" + node.isLeader()
+               + " health=" + healthBody(node.mgmtPort());
+    }
+
+    private String healthBody(int port) {
+        return http.sendString(healthRequest(port))
+                   .await()
+                   .fold(cause -> "unreachable (" + cause.message() + ")",
+                         response -> response.statusCode() + " " + response.body());
     }
 
     // HTTP helper methods
@@ -275,6 +356,7 @@ class SliceInvocationTest {
             instances = %d
             """.formatted(BLUEPRINT_ID, artifact, instances);
         var leaderPort = cluster.getLeaderManagementPort().or(anyMgmtPort());
+        applyStartedAtMs = System.currentTimeMillis();
         return postBlueprintWithRetry(leaderPort, blueprint);
     }
 
@@ -370,14 +452,17 @@ class SliceInvocationTest {
     }
 
     private boolean checkNodeHealth(int port) {
-        var request = HttpRequest.newBuilder()
-                                 .uri(URI.create("http://localhost:" + port + "/api/v1/health"))
-                                 .GET()
-                                 .timeout(Duration.ofSeconds(5))
-                                 .build();
-        return http.sendString(request)
+        return http.sendString(healthRequest(port))
                    .await()
                    .map(r -> r.statusCode() == 200 && r.body().contains("\"quorum\":true"))
                    .or(false);
+    }
+
+    private static HttpRequest healthRequest(int port) {
+        return HttpRequest.newBuilder()
+                          .uri(URI.create("http://localhost:" + port + "/api/v1/health"))
+                          .GET()
+                          .timeout(Duration.ofSeconds(5))
+                          .build();
     }
 }

--- a/changelog.d/727-undeploy-settling.md
+++ b/changelog.d/727-undeploy-settling.md
@@ -1,0 +1,90 @@
+### Fixed (2026-09-06 — #727: `SliceInvocationTest` died blind at a fixed 240s on CI; the settling run was never done)
+
+- **The 240s ceiling is the test's own `WAIT_TIMEOUT`
+  (`aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/SliceInvocationTest.java`),
+  and it guards five waits, not two**: leader election and all-nodes-healthy in `@BeforeAll`, the
+  echo-slice deploy wait in three tests, and the undeploy wait in
+  `invokeAfterSliceUndeploy_returnsNotFound`. #727's earlier commit named the two setup waits; the
+  three in-test waits still reported only `Condition with Lambda expression ... was not fulfilled
+  within 240 seconds`, and none of the five said what any node was doing at expiry.
+- **The settling run reproduced the signature and named its mechanism — it is not slowness.** On a
+  quiet native 16-core box (2026-09-06, no reruns) ten sequential runs of the class were
+  indistinguishable: leader elected 7.2s after cluster start every time, class 31.8s ± 0.1s. Pinned
+  to 4 CPUs like a hosted runner: 34.4–36.0s (4 runs). With those 4 CPUs three-times oversubscribed
+  by busy-loop hogs: 44.1–44.9s in four runs, and in the fifth
+  `invokeAfterSliceUndeploy_returnsNotFound` errored at **240.5s** — the ticket's exact signature,
+  and the stalled await was that test's DEPLOY wait (`SliceInvocationTest.java:180` before this
+  change), not the setup waits the earlier #727 commit named. The node logs give the chain:
+  `@BeforeEach cleanUp` deletes the previous test's blueprint without waiting; the test re-applies
+  the same artifact ~50ms later; under load the node's unload and the new ACTIVATE directive cross
+  (`Slice ... state is ACTIVATE but not found in SliceStore`); the leader classes that as
+  deterministic ("will NOT retry"), and under `ALL_OR_NOTHING` rolls the blueprint back and removes
+  it from the KV store. From then on `/api/v1/slices/status` has no echo-slice at all — the poll's
+  condition can never hold and its `sliceHasFailed` fail-fast never sees the FAILED entry, which
+  existed for 7ms against a 500ms poll. Two fixes, both in the test, and which is which:
+  (1) `cleanUp` now waits for the undeploy to settle before the next apply, so the apply no longer
+  races the unload it follows — the event-driven option, applied to the ordering that actually
+  produced the failure; (2) the deploy wait fails fast when `GET /api/v1/blueprints/status/{id}`
+  (#759) reports a `FAILED`/`ROLLED_BACK` outcome recorded after this test's own apply — the
+  diagnostic option, so a rollback is a named failure in seconds, not a blind 240s. The 240s bound
+  itself stays: it is ~30x the quiet formation time and 5x the worst emulated load, so raising it
+  would only make a rollback fail slower
+  [verified for (1): the hog5 run log and hang dump on the settling box (see the #727 report), and the
+  fixed test green through the same 4-CPU + 8-hog conditions five times out of five, against one
+  240s timeout in five before — small numbers, stated as such]
+  [design intent — unverified for (2): no deterministic post-apply failure was available to drive
+  the fail-fast — an artifact that is missing, or present but not a slice, is rejected at apply time
+  with a 500 before any rollback can occur; it rests on the #759 status contract and the hog5 log].
+- **Product defect surfaced, not fixed here: a re-apply immediately after a delete of the same
+  artifact can fail deterministically.** The node reports `state is ACTIVATE but not found in
+  SliceStore` when the ACTIVATE directive reaches it while the previous instance's unload is still
+  in flight, and the leader treats that as non-retriable and rolls the blueprint back. An operator
+  running `delete` then `apply` quickly gets the same rollback. Timing-dependent (never seen on the
+  quiet box in ten runs, once in five under 3x CPU oversubscription); needs its own ticket
+  [mechanism: `ClusterDeploymentState.handleDeterministicFailure` on `NodeDeploymentState.Active
+  .handleSliceNotFoundForActivation`; log lines at 22:16:23.894–23.990 in the hog5 run].
+- **Every wait in the class now carries a name and the cluster's state at expiry** — leader, each
+  node's formation state and its `/api/v1/health` answer (or why it was unreachable), and for slice
+  waits the last `/api/v1/slices/status` body
+  [verified: mutation probes on the same box — health condition made unsatisfiable, deploy condition
+  made unsatisfiable, each wait failed at its bound carrying the alias, the leader and all three
+  nodes' health bodies; with the conditions restored the class is green, 9 tests].
+- **The undeploy wait could pass on a failing query.** It was a bare
+  `!getSlices().contains("echo-slice")`; an error body from the status endpoint contains no
+  `echo-slice` either, so a broken query satisfied "undeployed". The shared helper fails fast on an
+  error body for the undeploy wait exactly as the deploy waits always did
+  [verified: probe injecting a failing check into the undeploy wait's fail-fast turns the test red
+  by name].
+- **Two waits in the class had no bound at all, and a bounded JUnit backstop cannot end them.**
+  `cluster.start().await()` and `cluster.stop().await()` were untimed. `PromiseImpl.await()` re-parks
+  until the promise resolves and never consults the interrupt flag, so the 8-minute lifecycle
+  backstop (#556) interrupts a thread that simply parks again: no `TimeoutException`, no thread
+  dump, no test named — only failsafe's 30-minute fork wall. Observed on the settling box when two
+  runs of this class accidentally split one port range: the survivor sat in `setUp:68` for 586s,
+  through the 480s backstop, until killed. Both awaits are now bounded by the same 240s, and a start
+  failure carries the cluster snapshot
+  [verified: probe with two management ports pre-taken fails `setUp` naming the bind, within the
+  bound].
+- **`EmberCluster.start()` hung forever on a partial start (`aether/ember`).** A node whose start
+  fails settles its promise at once; a node whose start succeeds settles only on consensus quorum.
+  With two of three nodes unable to bind, the third waited for a quorum that could never form,
+  `Promise.allOf` never settled, and `start()` had no failure path left — it is the mechanism behind
+  the 586s above, and it turns any partial bind failure in a forge class (a leaked port from a
+  previous class's wedged teardown, for example) into a silent job wall. The first node-start
+  failure now aborts the start: every node is stopped under the existing 10s per-node bound and the
+  bind failure is the returned cause
+  [verified: `aether/ember/src/test/java/org/pragmatica/aether/ember/EmberClusterPartialStartFailureTest.java`
+  — two management ports pre-bound, `start().await(60s)` returns the bind failure and the survivor's
+  port is reclaimable; against the unfixed `EmberCluster` the same test fails with a 60s `Timeout`
+  cause].
+- **The other #727 member (`ClusterProvisioningDiagnosticsProbeTest` at 497.6s) is a shutdown hang,
+  closed under #749/#750**, and on this box it passed in 23.6s inside the CI-equivalent set (16
+  classes, 44 tests, 499s wall; one failure was `ClusterFormationTest` binding port 5152, taken by
+  another tenant's container on the shared host). `EmberCluster.stop()` took 12.04s in all ten
+  `SliceInvocationTest` runs: each node's stop runs ~2s of synchronous graceful-shutdown quiet period
+  on the caller's thread before returning its promise, so the three "parallel" stops serialise. The
+  10s per-node bound never fired. Not fixed here, stated so it is not mistaken for a guarantee: that
+  bound's expiry is invisible — `Promise.allOf(...).map(_ -> unit())` discards the per-node
+  `Result`s, so a node that timed out and a node that stopped both end in "Ember cluster stopped"
+  [mechanism: `EmberCluster.stop()`; `Promise.allOf` collects `List<Result<T>>` and the `map`
+  ignores it].

--- a/changelog.d/727-undeploy-settling.md
+++ b/changelog.d/727-undeploy-settling.md
@@ -1,4 +1,13 @@
-### Fixed (2026-09-06 — #727: `SliceInvocationTest` died blind at a fixed 240s on CI; the settling run was never done)
+### Fixed (2026-09-07 — #727 (partial): `SliceInvocationTest` died blind at a fixed 240s on CI; the settling run was never done)
+
+This fixes the **reproduced member** of #727 — the 240s undeploy/re-apply race in `SliceInvocationTest` —
+and bounds that class's lifecycle awaits. It does not close the ticket. 240.5s is the value of the
+ceiling constant, not a fingerprint of a cause: any stall of that wait produces it, so five CI
+occurrences prove the same wait expired, not that the same mechanism expired it. Both failing CI logs
+also carry `HttpRoutePublisherImpl.unpublishRoutesFromCluster ... Failed to unpublish HTTP routes`
+shortly before the summary and the reproducing run carries none; that error is demonstrably benign in
+passing classes, which establishes it *can* be benign, not that it *was*. And the sibling member
+(`MultiSourceCommunitySmokeTest` at 515.4s, a different 480s backstop) is untouched. #727 stays open.
 
 - **The 240s ceiling is the test's own `WAIT_TIMEOUT`
   (`aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/SliceInvocationTest.java`),
@@ -6,7 +15,11 @@
   echo-slice deploy wait in three tests, and the undeploy wait in
   `invokeAfterSliceUndeploy_returnsNotFound`. #727's earlier commit named the two setup waits; the
   three in-test waits still reported only `Condition with Lambda expression ... was not fulfilled
-  within 240 seconds`, and none of the five said what any node was doing at expiry.
+  within 240 seconds`, and none of the five said what any node was doing at expiry
+  [verified: `WAIT_TIMEOUT` is derived from the single `WAIT_BOUND` constant and is the only `atMost`
+  in the class — `awaitFormation`, `awaitSlices` and both lifecycle awaits read it, so the five waits
+  are enumerable from the source; the three CI class-level ERRORs at 240.4-240.5s are in the #727
+  report].
 - **The settling run reproduced the signature and named its mechanism — it is not slowness.** On a
   quiet native 16-core box (2026-09-06, no reruns) ten sequential runs of the class were
   indistinguishable: leader elected 7.2s after cluster start every time, class 31.8s ± 0.1s. Pinned
@@ -40,15 +53,27 @@
   SliceStore` when the ACTIVATE directive reaches it while the previous instance's unload is still
   in flight, and the leader treats that as non-retriable and rolls the blueprint back. An operator
   running `delete` then `apply` quickly gets the same rollback. Timing-dependent: never seen on the
-  quiet box in ten runs; with the old un-awaited delete it hit 3 times in 11 runs under 3x CPU
-  oversubscription, in two orderings — failure before the new instance is counted (rollback, the
-  240s hole) or after it (the old instance counted as "fully deployed" 20ms after apply, then a
-  FAILED entry lingering ~30s until the next reconcile). Needs its own ticket
+  quiet box in ten runs; with the old un-awaited delete the race FIRED 3 times in 11 runs under 3x CPU
+  oversubscription — once as a failure and twice without one, which is the interesting part. The two
+  orderings: failure before the new instance is counted (rollback, the 240s hole, the one red) or after
+  it (the old instance counted as "fully deployed" 20ms after apply, then a FAILED entry lingering ~30s
+  until the next reconcile — both runs still passed 9/9). That the SAME race self-heals in one ordering
+  and rolls the blueprint back in the other is the sharpest available argument that the classification,
+  not the timing, is the defect: the transient branch re-drives `reconcile()`, and ordering 1 was denied
+  that only because a catch-all `Fatal` fallback made a concurrent-unload race look deterministic. Why
+  ordering 2 escapes `permanentlyFailed` is not traced here (plausibly the blueprint had already retired
+  from `inFlightBlueprints`, so the rollback loop matched nothing) — stated as unverified, and it belongs
+  to the ticket, not here. **Now filed as #916**; this change works around it and does not fix it
   [mechanism: `ClusterDeploymentState.handleDeterministicFailure` on `NodeDeploymentState.Active
-  .handleSliceNotFoundForActivation`; log lines at 22:16:23.894–23.990 in the hog5 run].
+  .handleSliceNotFoundForActivation`, whose `SLICE_NOT_FOUND_FOR_ACTIVATION` cause reaches
+  `SliceLoadingFailure.classify`'s `Fatal.UnexpectedError` fallback arm]
+  [verified for ordering 1: log lines at 22:16:23.894–23.990 in the hog5 run; for ordering 2 and for the
+  3-in-11 count, which spans both phases: the round-4 r1 and r4 run logs, which are the two greens].
 - **Every wait in the class now carries a name and the cluster's state at expiry** — leader, each
-  node's formation state and its `/api/v1/health` answer (or why it was unreachable), and for slice
-  waits the last `/api/v1/slices/status` body
+  node's observed consensus state and its `/api/v1/health` answer (or why it was unavailable), and for
+  slice waits the last `/api/v1/slices/status` body. The per-node state field was a hardcoded literal
+  when this bullet was first written; see review round 1 below for what it reports now and how that is
+  pinned
   [verified: mutation probes on the same box — health condition made unsatisfiable, deploy condition
   made unsatisfiable, each wait failed at its bound carrying the alias, the leader and all three
   nodes' health bodies; with the conditions restored the class is green, 9 tests].
@@ -91,3 +116,77 @@
   `Result`s, so a node that timed out and a node that stopped both end in "Ember cluster stopped"
   [mechanism: `EmberCluster.stop()`; `Promise.allOf` collects `List<Result<T>>` and the `map`
   ignores it].
+
+#### Review round 1 (2026-09-07)
+
+- **The state dump printed a hardcoded constant as if it were an observation, and that was the whole
+  point of the dump.** `EmberCluster.toNodeStatus` passed the string literal `"healthy"` into every
+  `NodeStatus`; no code path produced any other value. Every node in every dump, and every
+  `/api/nodes/status` body, read `state=healthy` — including a node that never formed. A reader of the
+  next formation stall would have seen `leader=none` beside three healthy nodes and looked in the wrong
+  place, which is worse than omitting the field. The value is now read from the node
+  (`AetherNode.isReady()`, the consensus-active sample the readiness pong answers from) and is named
+  for what it measures: `active` / `inactive`, never an unqualified health verdict. The test-side dump
+  reports a health endpoint it could not reach as `unavailable (<cause>)`, never as a state
+  [verified: `aether/ember/.../EmberClusterObservedNodeStateTest` — a formed three-node cluster reports
+  every node `active`; `aether/ember/.../EmberClusterPartialStartFailureTest` — a cluster where two of
+  three nodes cannot bind reports every node `inactive`; restoring the `"healthy"` literal turns both
+  red, a constant `active` turns the second red, a constant `inactive` turns the first red;
+  `aether/forge/forge-tests/.../ClusterSnapshotTest` — an unanswerable health probe renders
+  `health=unavailable (...)` and the line contains no claim of health]
+- **The cluster snapshot was empty on exactly the start failures it was added for.** Both start-failure
+  paths (`abortStart` and `handleStartResults`) run `clearClusterStateOnFailure` before the failure
+  reaches the caller, so the snapshot the caller then printed read an emptied registry: `leader=none`
+  and zero node lines. `EmberCluster.lastStartFailure()` now retains what `status()` answered at the
+  moment of failure, plus each failing node's cause, captured before the stops begin and reset at the
+  head of every `start()`. The dump labels a retained snapshot as captured rather than presenting it as
+  live, and says so by name when there is neither a live registry nor a retained failure
+  [verified: `EmberClusterPartialStartFailureTest` asserts the live registry is empty AND the retained
+  snapshot names all three nodes with their real state and the bind failures; moving
+  `captureStartFailure` below `clearClusterStateOnFailure` turns it red on an empty snapshot]
+- **The deploy fail-fast queried a follower while the apply and the delete went to the leader.** It
+  used node 1 unconditionally; under the replication lag it targets, that yields a missed fail-fast
+  rather than a false red, but it blunts the check in exactly the conditions it exists for. One port
+  helper now serves the apply, the delete and the fail-fast
+  [mechanism: `SliceInvocationTest.leaderOrAnyMgmtPort`, `getLeaderManagementPort().or(anyMgmtPort())`]
+- **A bounded await whose expiry named nothing.** `EmberClusterPartialStartFailureTest.tearDown`
+  discarded the `Result` of `cluster.stop().await(30s)`, so an exhausted bound passed silently — the
+  same blind wait this ticket exists to remove. It now asserts, and names the cause when it fails.
+  It doubles as the pin for the idempotent-stop claim: by the time it runs, `abortStart` has already
+  stopped every node, so the assertion is evidence rather than a docstring
+  [verified: same test class, green with the abort's stops preceding it]
+- **Every remaining `await()` in `SliceInvocationTest` is bounded**, including the three on the failure
+  path — the path that runs when things are already wrong. `PromiseImpl.await()` re-parks until
+  resolved and never consults the interrupt flag, so an unbounded await there outlives JUnit's
+  lifecycle backstop [mechanism: a single 60s `HTTP_BOUND`, far above each request's own 10s JDK
+  timeout, so it fires only if the promise never settles at all]
+- **An ambiguous blueprint-status body now fails loudly instead of silently.** The fail-fast's
+  timestamp reader took the first `"timestampMs"` in the body. That is correct today
+  (`BlueprintStatusResponse` carries exactly one, `BlueprintSliceStatus` none) and would have broken
+  silently the day a per-slice timestamp is added: the guard would compare the wrong number and stop
+  firing, which reads exactly like a deployment that never failed. A second match is now an error
+  naming the body; an absent one still returns 0, which fails the guard, so the default stays "do not
+  fail fast" [mechanism: `SliceInvocationTest.outcomeTimestampMs`]
+
+#### Residuals — known, not fixed here
+
+- **#916** — a transient activation race is classified as permanent: `SliceLoadingFailure.classify`'s
+  catch-all `Fatal` arm rolls the blueprint back under `ALL_OR_NOTHING`. The product half this
+  test-side change works around.
+- **#914** — `Promise.await()` ignores interruption, so a bounded JUnit backstop cannot end an untimed
+  await. Every await in the classes touched here is bounded; the underlying behaviour is unchanged.
+- **#915** — `MultiSourceCommunitySmokeTest`'s two untimed lifecycle awaits, the same pattern in
+  #727's other member.
+- **The `HttpRoutePublisherImpl` unpublish error in both failing CI logs is unexplained.** Six benign
+  occurrences inside `EmberCluster.stop()` in passing classes show it *can* be teardown noise; nothing
+  shows it *was*, in those two failures.
+- **`EmberCluster.stop()` discards its per-node `Result`s**, so a node that exhausted the 10s bound and
+  a node that stopped cleanly both end in "Ember cluster stopped". Unchanged, and the reason the stop
+  assertions added here are on the aggregate only
+  [mechanism: `Promise.allOf(...).map(_ -> unit())` drops the `List<Result<T>>`].
+- **`EmberClusterPartialStartFailureTest` keeps fixed ports** because it must pre-bind two of them on
+  purpose, so it remains exposed to another tenant of a shared box holding one of its other ports.
+  `EmberClusterObservedNodeStateTest` probes for a free block instead, after a first run failed on a
+  contended 25702.
+- **`applyStartedAtMs` compares the test JVM's clock against the node's**, which is sound only because
+  Forge runs every node in this JVM on this host. Not a portable guard.

--- a/changelog.d/727-undeploy-settling.md
+++ b/changelog.d/727-undeploy-settling.md
@@ -39,8 +39,11 @@
   artifact can fail deterministically.** The node reports `state is ACTIVATE but not found in
   SliceStore` when the ACTIVATE directive reaches it while the previous instance's unload is still
   in flight, and the leader treats that as non-retriable and rolls the blueprint back. An operator
-  running `delete` then `apply` quickly gets the same rollback. Timing-dependent (never seen on the
-  quiet box in ten runs, once in five under 3x CPU oversubscription); needs its own ticket
+  running `delete` then `apply` quickly gets the same rollback. Timing-dependent: never seen on the
+  quiet box in ten runs; with the old un-awaited delete it hit 3 times in 11 runs under 3x CPU
+  oversubscription, in two orderings — failure before the new instance is counted (rollback, the
+  240s hole) or after it (the old instance counted as "fully deployed" 20ms after apply, then a
+  FAILED entry lingering ~30s until the next reconcile). Needs its own ticket
   [mechanism: `ClusterDeploymentState.handleDeterministicFailure` on `NodeDeploymentState.Active
   .handleSliceNotFoundForActivation`; log lines at 22:16:23.894–23.990 in the hog5 run].
 - **Every wait in the class now carries a name and the cluster's state at expiry** — leader, each


### PR DESCRIPTION
## #727 (partial) — the reproduced 240 s member fixed in the test; the ticket stays open

**Scope, stated up front:** this fixes the **reproduced member** of #727 — the 240 s undeploy/re-apply race in `SliceInvocationTest` — and bounds that class's lifecycle awaits. It does **not** close the ticket. 240.5 s is the value of the ceiling constant, not a fingerprint of a cause: any stall of that wait produces it, so the five CI occurrences prove the same wait expired, not that the same mechanism expired it. Both failing CI logs also carry `HttpRoutePublisherImpl.unpublishRoutesFromCluster ... Failed to unpublish HTTP routes` shortly before the summary and the reproducing run carries none. And the sibling member (`MultiSourceCommunitySmokeTest` at 515.4 s, a different 480 s backstop) is untouched. The product half is **#916**.

**Settling run** (quiet native 16-core box, failsafe path, no reruns): 10 quiet runs of `SliceInvocationTest` at 34.6–37.0 s wall, leader at +7.2 s every run; pinned to 4 CPUs 34.4–36.0 s; 4 CPUs + 8 busy-loop hogs 44.1–44.9 s in four runs and **240.5 s in the fifth — the ticket's exact signature**. Full CI-equivalent set: 16 classes, 44 testcases, 499 s (one failure from a port taken by another tenant on the shared host).

**Mechanism (from the reproducing run's node log and hang dump):** the stalled await is the DEPLOY wait in `invokeAfterSliceUndeploy_returnsNotFound`, not the setup waits. `@BeforeEach cleanUp` deletes the previous blueprint without waiting; the test re-applies the same artifact ~50 ms later; under load the node's unload and the new ACTIVATE cross (`state is ACTIVATE but not found in SliceStore`), the leader classes it deterministic and rolls the blueprint back under `ALL_OR_NOTHING`. From then on `/api/v1/slices/status` has no echo-slice and the poll has nothing to see for 240 s. Not slowness: the bound is ~30x the quiet formation time and 5x the worst emulated load.

**Changes**
- `SliceInvocationTest`: `cleanUp` awaits the undeploy before the next apply (the event-driven option, aimed at the ordering that produced the failure); deploy waits fail fast on a `FAILED`/`ROLLED_BACK` outcome from `GET /api/v1/blueprints/status/{id}` recorded after this test's apply (diagnostic option); every 240 s wait appends the cluster state at expiry; the undeploy wait no longer accepts an error body as "undeployed"; `start()`/`stop()` awaits are bounded (untimed `Promise.await()` re-parks through JUnit's interrupt, so the 8 m backstop could never end them — observed: 586 s in `setUp:68`).
- `EmberCluster.start()`: settles on the first node-start failure instead of waiting for a quorum that cannot form (`abortStart`).

**Evidence**: fixed test 5/5 green under the reproducing 4-CPU + 8-hog conditions (48–56 s); mutation probes for each wait's message, for the undeploy fail-fast, and for the bounded start. The rollback fail-fast itself is `[design intent — unverified]`: no deterministic post-apply failure was available to drive it (missing or non-slice artifacts are rejected at apply time). Full report: `oss/internal/rc4-AO-727-report-2026-09-06.md`.

---

## Review round 1 (2026-09-07)

Adversarial review `oss/internal/review-913-727-2026-09-06.md`: 2 BLOCKING, 6 SHOULD-FIX, 7 NOTE. Every item below, in the reviewer's order.

### BLOCKING

**B1 — the state dump printed a hardcoded constant as if it were an observation.** `EmberCluster.toNodeStatus` passed the string literal `"healthy"` into every `NodeStatus`; no code path produced any other value. Every node in every dump, and every `/api/nodes/status` body, read `state=healthy` — including a node that never formed. The value is now read from the node (`AetherNode.isReady()`, the consensus-active sample the readiness pong answers from) and is named for what it measures: `active` / `inactive`, never an unqualified health verdict. The test-side dump reports a health endpoint it could not reach as `unavailable (<cause>)`, never as a state.

Pinned by two classes that catch **opposite** fabrications, because neither closes it alone — which is exactly why the original healthy-cluster-only probes could not:

| Mutation of `observedState` | `EmberClusterObservedNodeStateTest` | `EmberClusterPartialStartFailureTest` |
|---|---|---|
| `return "healthy";` (the old literal) | RED — `[node obs-3 of a formed cluster] expected: "active" but was: "healthy"` | RED — `[node partial-1 of a cluster that never formed] expected: "inactive" but was: "healthy"` |
| `return STATE_ACTIVE;` | green | RED — `expected: "inactive" but was: "active"` |
| unmutated | green | green |

The unreachable case is pinned separately by `ClusterSnapshotTest`: a health probe that cannot be answered renders `health=unavailable (Connection refused)` and the line contains no claim of health; a probe that IS answered renders the status and body it actually read.

**B2 — the cluster snapshot was empty on exactly the start failures it was added for.** Both start-failure paths (`abortStart` and `handleStartResults`) run `clearClusterStateOnFailure` before the failure reaches the caller, so the snapshot the caller then printed read an emptied registry: `leader=none` and zero node lines. `EmberCluster.lastStartFailure()` now retains what `status()` answered at the moment of failure plus each failing node's cause, captured before the stops begin, first-capture-wins, reset at the head of every `start()`. The dump labels a retained snapshot as captured rather than presenting it as live, and names the absence when there is neither a live registry nor a retained failure.

Red-before is a hunk revert: moving `captureStartFailure(startFailures)` below `clearClusterStateOnFailure` fails `EmberClusterPartialStartFailureTest` with `[the snapshot must carry the nodes the failed start had created] Expected size: 3 but was: 0 in: []` — the empty snapshot, not a different failure.

### SHOULD-FIX

- **S1 — product-defect ticket filed.** #916: a transient activation race is classified as permanent; `SliceLoadingFailure.classify`'s catch-all `Fatal` arm rolls the blueprint back under `ALL_OR_NOTHING`. Referenced in the changelog fragment as the product half this test-side change works around. Not attempted here.
- **S2 — the deploy fail-fast queried a follower, never the leader.** It used node 1 unconditionally while the apply and the delete went to the leader. Safe direction (a missed fail-fast, not a false red) but blunted under exactly the replication lag it targets. One helper, `leaderOrAnyMgmtPort()`, now serves the apply, the delete and the fail-fast.
- **S3 — a bounded await whose expiry named nothing.** `EmberClusterPartialStartFailureTest.tearDown` discarded the `Result` of `cluster.stop().await(30s)`. It now asserts and names the cause. It doubles as the pin for **N4**: by the time it runs, `abortStart` has already stopped every node, so a green assertion is evidence that the second stop is idempotent rather than a docstring claiming it.
- **S4 — fragment bullet 1 now carries an evidence tag**, naming how the five waits are enumerable from the source.
- **S5 — the product-defect bullet's tag now covers its own text.** The round-4 run ids (r1 and r4) are cited alongside the hog5 lines, each against the claim it actually supports: hog5 for ordering 1, round-4 r1/r4 for ordering 2 and for the cross-phase 3-in-11 count. "Hit 3 times in 11 runs" is corrected — the race FIRED three times, once as a failure and twice without one, both of those still passing 9/9 after the undeploy wait slowed to ~30 s. That the same race self-heals in one ordering and rolls back in the other is now stated as the sharpest argument that the classification, not the timing, is the defect. Why ordering 2 escapes `permanentlyFailed` is marked unverified and left to #916.
- **S6 — the closure claim is downgraded** to the reproduced member, in the fragment heading, this body and the title. All three of the reviewer's reasons are recorded in the fragment.

### NOTE

- **N1** — every remaining `await()` in `SliceInvocationTest` is bounded by a single 60 s `HTTP_BOUND`, including the three on the failure path. The health probe inside the snapshot renderer is bounded at 30 s. Both are far above each request's own JDK timeout, so they fire only if a promise never settles at all.
- **N2** — an ambiguous blueprint-status body now fails loudly. The reader took the first `"timestampMs"`; a second match is now an error naming the body, and an absent one still returns 0, which fails the `>= applyStartedAtMs` guard, so the default stays "do not fail fast".
- **N3** — the test-JVM-clock assumption behind `applyStartedAtMs` is named in a comment and listed as a residual; it is sound only because Forge runs every node in this JVM on this host.
- **N4** — covered by S3 above.
- **N5** — no change; the reviewer could not construct a false red and neither could I.
- **N6** — no merge-forward; confirmed by the reviewer against base tip `309a4060b`.
- **N7** — every verification run below used `-am`, so no result rests on the tree's stale `.m2-local`.

### Verification

| Run | Result |
|---|---|
| `aether/ember`, `EmberCluster*Test` | 6 testcases, 0 failures (4 + 1 + 1) |
| `aether/forge/forge-tests`, `ClusterSnapshotTest` | 6 testcases, 0 failures |
| `aether/forge/forge-tests`, `SliceInvocationTest` | 9 testcases, 0 failures, 37.4 s |
| Original #727 pin, re-proved | reverting the abort wiring fails with `"Promise is not resolved within specified timeout"` instead of `"Address already in use"` — `start()` never settles without it |
| `jbct:check -pl aether/ember,aether/forge/forge-tests` | 0 format issues, 0 lint errors (one formatting fix applied to `EmberCluster` as its own `chore:` commit) |
| `SliceInvocationTest` under load, this head | 4 runs, 9/9 green each, 59/51/49/51 s against 37.4 s quiet |

Counts are from `<testcase>` elements in the surefire/failsafe XML, not `.txt` headers.

The load run is a throwaway clone of this head on the test host, isolated maven repo, `taskset -c 0-3` with 8 busy-loop hogs — the conditions that produced the 240.5 s signature, against one 240 s timeout in five before the fix. Small numbers, stated as such. The `ember` jar under test was verified by CONTENT (it carries `EmberCluster$StartFailure`, `observedState`, `captureStartFailure` and the `active`/`inactive` strings, and no `healthy` literal), because a 35 s full install is not credible for 87 modules and a run against downloaded rc4 jars would have looked identical.

The gate's default scope is `src/main/java`; `forge-tests` has none, so its 44 test files are examined by neither this run nor CI. Under `-Djbct.includeTests=true` the module reports 211 lint errors across those 44 files, 202 of them in files this PR does not touch. The new test files are the same family as that baseline and were not reformatted, since doing so would rewrite 40 files owned by other tickets.

### Residuals

**#916** (the product defect), **#914** (`Promise.await()` ignores interruption), **#915** (`MultiSourceCommunitySmokeTest`'s two untimed awaits). Plus: the unexplained `HttpRoutePublisherImpl` unpublish error in both failing CI logs; `EmberCluster.stop()` discarding its per-node `Result`s; `EmberClusterPartialStartFailureTest`'s fixed ports (it must pre-bind two on purpose, so it stays exposed to a contended box — `EmberClusterObservedNodeStateTest` probes for a free block instead, after a first run failed on a contended 25702); and N3's clock assumption.

Related: #718, #749, #750, #759, #838, #914, #915, #916.
