### PR TITLE
docs: contributing — target branch, JBCT rules and gate coverage, review expectations, fork CI

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,18 +82,18 @@ decision about each tree, is what #813 reports. **CI does not override the defau
 therefore runs only where a pom opts back in: `aether/pom.xml` sets `jbct.skip` to `false` for the
 whole Aether tree, and most `examples/` modules set it individually.
 
-Of the modules in the root Maven reactor that contain a `src/main/java` at all — the only ones the
-gate could examine — **71 are examined and 47 are skipped.** The skipped set is `core/`, every
-module under `integrations/`, every module under `jbct/`, `testing/`, and
-`examples/pragmatica-lite`. So the gate does not examine the Core library, and does not examine a
-single integration. **A green gate is
-not coverage for those trees**, and you should not read one as evidence that code you added there
-conforms. This gap is real, known and tracked in #813 and #880.
+The population that matters is the reactor modules that contain a `src/main/java` at all, since
+those are the only ones the gate could examine. There are 118 of them, and **the gate examines 71
+and skips 47.** The skipped 47 are `core/`, every module under `integrations/`, every module under
+`jbct/`, `testing/`, and `examples/pragmatica-lite`. So the gate does not examine the Core library,
+and does not examine a single integration. **A green gate is not coverage for those trees**, and you
+should not read one as evidence that code you added there conforms. This gap is real, known and
+tracked in #813 and #880.
 
 If your change lands in a skipped module, check it by hand:
 
 ```bash
-mvn org.pragmatica-lite:jbct-maven-plugin:check -pl <module> -Djbct.skip=false
+mvn jbct:check -pl <module> -Djbct.skip=false
 ```
 
 Expect pre-existing findings in those trees — debt that has never been gated accumulates. Fix what
@@ -189,12 +189,12 @@ required from you while it waits.
 
 ### Sign-off
 
-There is no automated DCO or CLA check gating PRs in this repository today [mechanism: `.github/`
-contains only `ci.yml` and `release.yml` — no DCO/CLA bot is configured]. We nonetheless ask that
-you certify the provenance of your contribution by adding a `Signed-off-by` trailer (`git commit
--s`), per the [Developer Certificate of Origin](https://developercertificate.org/). This is a
-request, not (yet) an enforced gate — expect it to become one before GA, given the dual-license
-surface above.
+There is no automated DCO or CLA check gating PRs in this repository today [mechanism:
+`.github/workflows/` contains `changelog.yml`, `ci.yml` and `release.yml` — no DCO/CLA bot is
+configured]. We nonetheless ask that you certify the provenance of your contribution by adding a
+`Signed-off-by` trailer (`git commit -s`), per the
+[Developer Certificate of Origin](https://developercertificate.org/). This is a request, not (yet)
+an enforced gate — expect it to become one before GA, given the dual-license surface above.
 
 ## What review expects
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,7 +80,7 @@ decision about each tree, is what #813 reports. **CI does not override the defau
 `.github/workflows/ci.yml`, the "JBCT format + lint gate" step runs
 `mvn org.pragmatica-lite:jbct-maven-plugin:check -B -pl '!jbct'` — no `-Djbct.skip=false`]. The gate
 therefore runs only where a pom opts back in: `aether/pom.xml` sets `jbct.skip` to `false` for the
-whole Aether tree, and most `examples/` modules set it individually.
+whole Aether tree, and several `examples/` poms do the same for their own subtrees.
 
 The population that matters is the reactor modules that contain a `src/main/java` at all, since
 those are the only ones the gate could examine. There are 118 of them, and **the gate examines 71

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,7 +58,10 @@ goal — it fails on formatting drift but does not fix it for you [mechanism:
 `process` goal, which reformats in place. Running `build.sh` locally first means you fix
 formatting issues once, locally, instead of round-tripping through a CI failure.
 
-**What the JBCT gate does and does not cover:** it examines `src/main/java` only. Test sources are
+**What the JBCT gate does and does not cover.** Two independent limits apply, and together they mean
+a green gate is not a statement about most of this repository.
+
+*Scope inside a module that runs it.* The gate examines `src/main/java` only. Test sources are
 excluded from every JBCT goal by default (`jbct.includeTests=false`), so a **test-only** module —
 `aether/forge/forge-tests`, for instance — is not format- or lint-checked at all, and running
 `jbct:check` there is a no-op. That is deliberate policy, not an oversight (#624, #740); whether the
@@ -66,6 +69,35 @@ gate should extend to test trees is an open question, not a settled yes. The goa
 loud rather than reporting a bare success: when files exist but were excluded, they warn that the
 module was **not** examined and name the reason, so a green result is never mistaken for coverage.
 Pass `-Djbct.includeTests=true` to check a test tree by hand.
+
+*Which modules run it at all.* The root `pom.xml` defaults the `jbct.skip` property to `true`. The
+comment there gives avoiding a reactor cycle as the reason — the linter is built out of this
+repository, so it cannot run during the bootstrap of the modules it is built from [mechanism: root
+`pom.xml`, `<jbct.skip>` in `<properties>`, and its comment; `build.sh` step 2, which excludes
+`jbct` for the same reason]. That default is then **inherited by every module that does not override
+it**, which reaches far beyond the modules the cycle actually concerns — that inheritance, not a
+decision about each tree, is what #813 reports. **CI does not override the default** [mechanism:
+`.github/workflows/ci.yml`, the "JBCT format + lint gate" step runs
+`mvn org.pragmatica-lite:jbct-maven-plugin:check -B -pl '!jbct'` — no `-Djbct.skip=false`]. The gate
+therefore runs only where a pom opts back in: `aether/pom.xml` sets `jbct.skip` to `false` for the
+whole Aether tree, and most `examples/` modules set it individually.
+
+Of the modules in the root Maven reactor that contain a `src/main/java` at all — the only ones the
+gate could examine — **71 are examined and 47 are skipped.** The skipped set is `core/`, every
+module under `integrations/`, every module under `jbct/`, `testing/`, and
+`examples/pragmatica-lite`. So the gate does not examine the Core library, and does not examine a
+single integration. **A green gate is
+not coverage for those trees**, and you should not read one as evidence that code you added there
+conforms. This gap is real, known and tracked in #813 and #880.
+
+If your change lands in a skipped module, check it by hand:
+
+```bash
+mvn org.pragmatica-lite:jbct-maven-plugin:check -pl <module> -Djbct.skip=false
+```
+
+Expect pre-existing findings in those trees — debt that has never been gated accumulates. Fix what
+your own change introduces; leave the rest, and say in the PR that you did.
 
 For quick iteration on a single module: `mvn test -pl <module>`. The full matrix CI actually runs
 is in [`.github/workflows/ci.yml`](.github/workflows/ci.yml) — format+lint check, `mvn install
@@ -95,9 +127,42 @@ The smoke set is the pre-push expectation, and it is **required** for changes to
 set takes a couple of minutes, while the same defect found in CI costs a 30-minute job, a red
 branch, and the diagnosis.
 
+## What the code must look like
+
+JBCT is a coding standard, not only tooling. The linter enforces part of it mechanically — where it
+runs, see above — and review covers the rest. The rules that shape almost every diff:
+
+- **Absence is `Option<T>`, never `null`.** A lookup that legitimately finds nothing returns
+  `Option<T>`; finding nothing is a normal outcome, not an error.
+- **Failure is `Result<T>`, never an exception used for control flow.** Failures are typed `Cause`
+  values returned to the caller, not thrown past it.
+- **Asynchrony is `Promise<T>`.** Work crossing a process boundary returns a `Promise`, which
+  carries its own failure — so `Promise<Result<T>>` is a double error channel and is not used.
+- **Parse, don't validate, at the boundary.** Untrusted input is converted once, at the edge, into a
+  domain type that cannot hold an invalid value. The interior then has nothing left to re-check.
+
+A method that is synchronous, total and always present simply returns `T`. The wrappers appear only
+where absence, failure or asynchrony is real — they are not decoration.
+
+New to this? The course is free and is the fastest path:
+
+- [The JBCT course](https://pragmatica.dev/java/jbct/course/) — start here.
+- [Four return types](https://pragmatica.dev/java/jbct/course/four-return-types/) — when each of
+  `T`, `Option<T>`, `Result<T>` and `Promise<T>` applies, and which nestings are allowed.
+- [Error handling](https://pragmatica.dev/java/jbct/course/error-handling/) — `Cause`, and why
+  exceptions are not the control-flow mechanism here.
+- [*Java Backend Coding Technology*](https://leanpub.com/jbct-book) — the complete argument, if you
+  want the reasoning rather than the rules.
+
+Contributing with an AI assistant? The agent definitions under `ai-tools/` in
+[siy/coding-technology](https://github.com/siy/coding-technology) encode these rules. They are
+written for Claude Code, but their rule sections are ordinary prose and adapt to other assistants.
+
 ## Branches, commits, and pull requests
 
-- Fork the repository and branch off `main`.
+- Fork the repository and branch off the **current release branch**, not `main`. Development
+  integrates on the release branch; `main` lags it substantially and is not where changes land.
+  The README's **Current release branch** line names the one in effect.
 - This project's history uses `<type>/<issue-number>-<short-slug>` branch names (e.g.
   `fix/613-javax-parent-first`, `feat/619-nest-directive`, `docs/608-forge-debug`) — follow it
   when you have a tracking issue, but it isn't enforced.
@@ -106,11 +171,21 @@ branch, and the diagnosis.
   non-obvious "why" is welcome for external contributions (the maintainers' own internal-stream
   convention of single-line, no-body commits is specific to their release workflow and isn't
   expected of contributors).
-- Open the PR against `main`. A maintainer will review, request changes if needed, and choose the
-  merge strategy at merge time.
+- Open the PR against the same release branch you forked from — again, the README names the current
+  one. A maintainer will review, request changes if needed, and choose the merge strategy at merge
+  time.
 - Do not edit `CHANGELOG.md`. Add your entry as `changelog.d/<issue-number>-<slug>.md` in the format
   described in [`changelog.d/README.md`](changelog.d/README.md); the file is assembled at release
   prep, and a CI check refuses a direct edit. Documentation-only PRs need no fragment.
+
+### CI on a pull request from a fork
+
+Your workflow runs will not start on their own. They sit in `action_required` until a maintainer
+approves them. GitHub requires that approval for workflow runs on pull requests from forks by
+first-time contributors; it is the platform default, it applies regardless of what your change
+does, and it is **not** a judgement about your PR or a sign that something is wrong with it.
+Approval depends on maintainer availability, so a run can wait hours before it starts. Nothing is
+required from you while it waits.
 
 ### Sign-off
 
@@ -120,6 +195,21 @@ you certify the provenance of your contribution by adding a `Signed-off-by` trai
 -s`), per the [Developer Certificate of Origin](https://developercertificate.org/). This is a
 request, not (yet) an enforced gate — expect it to become one before GA, given the dual-license
 surface above.
+
+## What review expects
+
+- **A test must fail when the production change is reverted.** Revert only the production hunk, keep
+  the test, and watch it go red. A test that stays green while the code it covers is gone pins
+  nothing, however much it asserts — and this is the most common reason a PR needs a second round.
+  Rebuilding the fixture inside the test is the usual way this goes wrong.
+- **One changelog fragment per PR**, as `changelog.d/<issue-number>-<slug>.md`. Every bullet carries
+  its evidence: `[verified: <test path>]` where a live-path test pins the claim, `[mechanism: ...]`
+  where it is traced through the code. Format and the CI check are in
+  [`changelog.d/README.md`](changelog.d/README.md). Documentation-only PRs need no fragment.
+- **Scope discipline.** Only the files your change needs. Drive-by reformatting, unrelated renames
+  and opportunistic fixes make a diff hard to review and slow it down; send them separately.
+- **Expect one review round**, with specific and cited findings — a file and line, the mechanism, or
+  the test that contradicts a claim. Answering in the same terms is the fastest way through.
 
 ## Code of conduct
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A monorepo for building reliable Java backends with functional programming patterns and a unified application runtime.
 
+**Current release branch: `release-1.0.0-rc4`.** Development integrates here and pull requests target this branch, not `main`. See [CONTRIBUTING.md](CONTRIBUTING.md).
+
 ## What's Inside
 
 **[Pragmatica Core](core/README.md)** — Functional primitives for Java: `Result<T>`, `Option<T>`, `Promise<T>`. No exceptions, no nulls, composable error handling.


### PR DESCRIPTION
Corrections to `CONTRIBUTING.md` prompted by the project's first external contribution (#898), which
exposed gaps: the target branch was wrong, the gate's coverage claim was misleading, and two things
the contributor hit had no explanation in the file at all.

> **Companion PR: #918, same change against `main`.** GitHub serves `CONTRIBUTING.md` from the
> repository's default branch, so until this branch merges, contributors still read the uncorrected
> `main` copy. #918 carries the same corrections there, minus the parts that are not true on `main`
> (no `changelog.d/`, two workflows instead of three). Neither PR blocks the other; both are the
> owner's call. #918's body lists every divergence.

Documentation-only, so **no changelog fragment** — `scripts/changelog-check.sh` exempts `*.md` in
`is_exempt()`, and `changelog.d/README.md` states the same rule.

## 1. Target branch was factually wrong

The file told contributors to fork from `main` and open PRs against `main`. It is not where changes
land: `release-1.0.0-rc4` is **468 commits ahead** of `main` (`main` carries 21 the release branch
does not), and **all three open PRs target the release branch**, none targets `main`.

**Maintainer decision, marked as such:** the branch name is deliberately **not hardcoded** in
`CONTRIBUTING.md`. It points at the README instead, and this PR adds the line it points to, since
the README did not previously state a branch anywhere — only `1.0.0-rc4` version pins. The
alternative was hardcoding `release-1.0.0-rc4` in both files and updating them each cycle. This is a
judgement call, not a derivation; one place to update per cycle was the deciding factor. Branch
naming and commit-prefix guidance are unchanged.

## 2. The gate's coverage claim was true but misleading

The file said the gate examines `src/main/java` only. True, and it omitted the larger limit: **the
gate is skipped outright for most of the repository.** Root `pom.xml` defaults `jbct.skip` to `true`
(line 89), and the CI step does not override it (`ci.yml` line 33 runs
`mvn org.pragmatica-lite:jbct-maven-plugin:check -B -pl '!jbct'`, no `-Djbct.skip=false`). Only poms
that opt back in are examined — `aether/pom.xml` line 93 for the whole Aether tree, plus most
`examples/` modules individually.

**Counts, and how I got them.** I parsed every `pom.xml` reachable from the root `<modules>` graph
(143 projects), resolved each one's effective `jbct.skip` through its declared `<parent>` chain, and
intersected with whether the module actually has a `src/main/java`:

| Scope | Gate runs | Gate skipped |
|---|---|---|
| All reactor projects (143) | 82 | 61 |
| Reactor projects with `src/main/java` (118) | **71** | **47** |

The 71/47 figures are the ones in the doc, stated there against their own denominator (**118**
source-bearing reactor modules), so a bare "47 skipped" cannot be read against a different
population. A module with no sources is not something the gate could examine either way. This reconciles exactly with the 60/71 seen in a CI log: excluding only
the `jbct` aggregator (what `-pl '!jbct'` actually removes) gives **60** skipped projects, and the
11-project difference from 82 is precisely the run-enabled projects that have no sources and so
report nothing.

The skipped set is `core/`, every module under `integrations/`, every module under `jbct/`,
`testing/`, and `examples/pragmatica-lite`. Concretely: **the gate does not examine the Core library
(62 Java files) and does not examine a single integration (558 Java files).** The doc now says a
green gate is not coverage for those trees, references #813 and #880 as the tracked gap, and gives
the by-hand command.

I did **not** hardcode line numbers in the doc — they rot. They are cited here for review only.

## 3. New section: what the code must look like

The file described JBCT only as tooling and never said what the code must look like. Added a short
section: absence is `Option<T>` never `null`; failure is `Result<T>` never an exception for control
flow; asynchrony is `Promise<T>`; parse-don't-validate at the boundary. It also notes that a
synchronous, total, always-present method just returns `T`, which the four-return-types lesson makes
explicit and which a rules list phrased only as "use the wrappers" would misstate.

Links: the free course, the return-types lesson, the error-handling lesson, and the book. All four
verified HTTP 200. **No Pragmatica Core version is cited anywhere** in the new text. `ai-tools/` in
siy/coding-technology is mentioned as adaptable for AI-assisted contributors, noting it is written
for Claude Code and its rule sections are portable; `ai-tools/skills/jbct/SKILL.md` is **not**
linked.

## 4. New section: what review expects

Tests must fail when the production change is reverted, with the fixture-rebuild trap named. One
changelog fragment per PR with `[verified: …]` / `[mechanism: …]` evidence per bullet. Scope
discipline. Expect one review round with specific, cited findings.

Note: I used `[verified: <test path>]`, matching `changelog.d/README.md` verbatim, rather than a
`Test#method` form, so the two documents cannot drift.

## 5. New subsection: fork CI needs maintainer approval

#898's runs sat in `action_required` with no explanation available to the author. The doc now says
this is GitHub's default for first-time contributors from forks and is not a judgement about the PR.

I deliberately did **not** claim that later pushes queue automatically once a maintainer approves
one run: #898's second push (21:19Z, ~7h after the first) was *also* `action_required`, so the
evidence contradicts that reassurance.

## Follow-up fixes after the independent review

- **S2, wording precision (`13a4ba2f0`).** "most `examples/` modules set it individually"
  misdescribed the mechanism. Three of the opt-ins (`examples/ecommerce`, `examples/banking`,
  `examples/notification-hub`) are subtree aggregators whose submodules inherit `false`, which is the
  same inheritance the sentence implicitly contrasted them against; only four in-reactor leaves set
  it on themselves. Reworded to "several `examples/` poms do the same for their own subtrees", which
  is exact for both shapes. **No count changed.**

  One detail for the record: `examples/step-composition` sets `jbct.skip=false` and has sources, but
  is **not listed in `examples/pom.xml`**, so it is outside the reactor and outside the 71. That is
  why the in-reactor tally is four individually-set leaves rather than five poms on disk.

## Open items for the owner

- **No AI/agent-authored contribution policy** was added. Left to the owner deliberately; this PR
  does not pre-empt it.
- **Fixed in `8fce394b7`** (authorized after the first push): the sign-off section's mechanism
  bracket claimed "`.github/` contains only `ci.yml` and `release.yml`". `ls .github/workflows/`
  gives **three** — `changelog.yml`, `ci.yml`, `release.yml`. The bracket now lists all three and
  points at `.github/workflows/` rather than `.github/`, which holds only that one directory. Its
  conclusion, that no DCO/CLA bot is configured, was correct and is kept verbatim; nothing else in
  the sign-off text changed.

## The by-hand command is empirically verified

It is no longer a derivation. The #886 stream ran both halves against `integrations/storage` earlier
today (`oss/internal/rc4-AN-886-report-2026-09-06.md`, "Gate findings", items 1-2):

- `mvn jbct:check -pl integrations/storage` exits **green while printing `Skipping JBCT check`** —
  the failure mode this section warns about.
- The same command with `-Djbct.skip=false` **found real work**: three unformatted files
  (`EncryptionError`, `SingleFlightCache`, `StorageInstance`) and one pre-existing lint error,
  `RemoteTierConfig.java` `JBCT-RET-06`.

That is a positive control, not just an absence: the flag flips a silent pass into findings, so the
command demonstrably reaches code the gate otherwise never examines. It also independently confirms
the "expect pre-existing findings in those trees" sentence.

`8fce394b7` changes the doc's command from the fully-qualified
`org.pragmatica-lite:jbct-maven-plugin:check` to **`jbct:check`**, the prefix form actually run, so
the documented invocation matches the verified one exactly (same goal, same `-pl` shape, same
property). Prefix resolution works here because the root `pom.xml` declares the plugin. The
fully-qualified form still appears once, quoting `ci.yml` verbatim, which is what CI really runs.

The same report's item 2 corroborates the counts from a different instrument — rc4 CI run
`34022933385` logs `Skipping JBCT check` for 60 modules and runs it for 71.
