### PR TITLE
docs: contributing corrections on main (default-branch companion to #917)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,7 +58,10 @@ goal — it fails on formatting drift but does not fix it for you [mechanism:
 `process` goal, which reformats in place. Running `build.sh` locally first means you fix
 formatting issues once, locally, instead of round-tripping through a CI failure.
 
-**What the JBCT gate does and does not cover:** it examines `src/main/java` only. Test sources are
+**What the JBCT gate does and does not cover.** Two independent limits apply, and together they mean
+a green gate is not a statement about most of this repository.
+
+*Scope inside a module that runs it.* The gate examines `src/main/java` only. Test sources are
 excluded from every JBCT goal by default (`jbct.includeTests=false`), so a **test-only** module —
 `aether/forge/forge-tests`, for instance — is not format- or lint-checked at all, and running
 `jbct:check` there is a no-op. That is deliberate policy, not an oversight (#624, #740); whether the
@@ -66,6 +69,35 @@ gate should extend to test trees is an open question, not a settled yes. The goa
 loud rather than reporting a bare success: when files exist but were excluded, they warn that the
 module was **not** examined and name the reason, so a green result is never mistaken for coverage.
 Pass `-Djbct.includeTests=true` to check a test tree by hand.
+
+*Which modules run it at all.* The root `pom.xml` defaults the `jbct.skip` property to `true`. The
+comment there gives avoiding a reactor cycle as the reason — the linter is built out of this
+repository, so it cannot run during the bootstrap of the modules it is built from [mechanism: root
+`pom.xml`, `<jbct.skip>` in `<properties>`, and its comment; `build.sh` step 2, which excludes
+`jbct` for the same reason]. That default is then **inherited by every module that does not override
+it**, which reaches far beyond the modules the cycle actually concerns — that inheritance, not a
+decision about each tree, is what #813 reports. **CI does not override the default** [mechanism:
+`.github/workflows/ci.yml`, the "JBCT format + lint gate" step runs
+`mvn org.pragmatica-lite:jbct-maven-plugin:check -B -pl '!jbct'` — no `-Djbct.skip=false`]. The gate
+therefore runs only where a pom opts back in: `aether/pom.xml` sets `jbct.skip` to `false` for the
+whole Aether tree, and several `examples/` poms do the same for their own subtrees.
+
+The population that matters is the reactor modules that contain a `src/main/java` at all, since
+those are the only ones the gate could examine. There are 118 of them, and **the gate examines 71
+and skips 47.** The skipped 47 are `core/`, every module under `integrations/`, every module under
+`jbct/`, `testing/`, and `examples/pragmatica-lite`. So the gate does not examine the Core library,
+and does not examine a single integration. **A green gate is not coverage for those trees**, and you
+should not read one as evidence that code you added there conforms. This gap is real, known and
+tracked in #813 and #880.
+
+If your change lands in a skipped module, check it by hand:
+
+```bash
+mvn jbct:check -pl <module> -Djbct.skip=false
+```
+
+Expect pre-existing findings in those trees — debt that has never been gated accumulates. Fix what
+your own change introduces; leave the rest, and say in the PR that you did.
 
 For quick iteration on a single module: `mvn test -pl <module>`. The full matrix CI actually runs
 is in [`.github/workflows/ci.yml`](.github/workflows/ci.yml) — format+lint check, `mvn install
@@ -95,9 +127,42 @@ The smoke set is the pre-push expectation, and it is **required** for changes to
 set takes a couple of minutes, while the same defect found in CI costs a 30-minute job, a red
 branch, and the diagnosis.
 
+## What the code must look like
+
+JBCT is a coding standard, not only tooling. The linter enforces part of it mechanically — where it
+runs, see above — and review covers the rest. The rules that shape almost every diff:
+
+- **Absence is `Option<T>`, never `null`.** A lookup that legitimately finds nothing returns
+  `Option<T>`; finding nothing is a normal outcome, not an error.
+- **Failure is `Result<T>`, never an exception used for control flow.** Failures are typed `Cause`
+  values returned to the caller, not thrown past it.
+- **Asynchrony is `Promise<T>`.** Work crossing a process boundary returns a `Promise`, which
+  carries its own failure — so `Promise<Result<T>>` is a double error channel and is not used.
+- **Parse, don't validate, at the boundary.** Untrusted input is converted once, at the edge, into a
+  domain type that cannot hold an invalid value. The interior then has nothing left to re-check.
+
+A method that is synchronous, total and always present simply returns `T`. The wrappers appear only
+where absence, failure or asynchrony is real — they are not decoration.
+
+New to this? The course is free and is the fastest path:
+
+- [The JBCT course](https://pragmatica.dev/java/jbct/course/) — start here.
+- [Four return types](https://pragmatica.dev/java/jbct/course/four-return-types/) — when each of
+  `T`, `Option<T>`, `Result<T>` and `Promise<T>` applies, and which nestings are allowed.
+- [Error handling](https://pragmatica.dev/java/jbct/course/error-handling/) — `Cause`, and why
+  exceptions are not the control-flow mechanism here.
+- [*Java Backend Coding Technology*](https://leanpub.com/jbct-book) — the complete argument, if you
+  want the reasoning rather than the rules.
+
+Contributing with an AI assistant? The agent definitions under `ai-tools/` in
+[siy/coding-technology](https://github.com/siy/coding-technology) encode these rules. They are
+written for Claude Code, but their rule sections are ordinary prose and adapt to other assistants.
+
 ## Branches, commits, and pull requests
 
-- Fork the repository and branch off `main`.
+- Fork the repository and branch off the **current release branch**, not `main`. Development
+  integrates on the release branch; `main` lags it substantially and is not where changes land.
+  The README's **Current release branch** line names the one in effect.
 - This project's history uses `<type>/<issue-number>-<short-slug>` branch names (e.g.
   `fix/613-javax-parent-first`, `feat/619-nest-directive`, `docs/608-forge-debug`) — follow it
   when you have a tracking issue, but it isn't enforced.
@@ -106,17 +171,38 @@ branch, and the diagnosis.
   non-obvious "why" is welcome for external contributions (the maintainers' own internal-stream
   convention of single-line, no-body commits is specific to their release workflow and isn't
   expected of contributors).
-- Open the PR against `main`. A maintainer will review, request changes if needed, and choose the
-  merge strategy at merge time.
+- Open the PR against the same release branch you forked from — again, the README names the current
+  one. A maintainer will review, request changes if needed, and choose the merge strategy at merge
+  time.
+
+### CI on a pull request from a fork
+
+Your workflow runs will not start on their own. They sit in `action_required` until a maintainer
+approves them. GitHub requires that approval for workflow runs on pull requests from forks by
+first-time contributors; it is the platform default, it applies regardless of what your change
+does, and it is **not** a judgement about your PR or a sign that something is wrong with it.
+Approval depends on maintainer availability, so a run can wait hours before it starts. Nothing is
+required from you while it waits.
 
 ### Sign-off
 
-There is no automated DCO or CLA check gating PRs in this repository today [mechanism: `.github/`
-contains only `ci.yml` and `release.yml` — no DCO/CLA bot is configured]. We nonetheless ask that
-you certify the provenance of your contribution by adding a `Signed-off-by` trailer (`git commit
--s`), per the [Developer Certificate of Origin](https://developercertificate.org/). This is a
-request, not (yet) an enforced gate — expect it to become one before GA, given the dual-license
-surface above.
+There is no automated DCO or CLA check gating PRs in this repository today [mechanism:
+`.github/workflows/` contains `ci.yml` and `release.yml` — no DCO/CLA bot is configured]. We
+nonetheless ask that you certify the provenance of your contribution by adding a `Signed-off-by`
+trailer (`git commit -s`), per the
+[Developer Certificate of Origin](https://developercertificate.org/). This is a request, not (yet)
+an enforced gate — expect it to become one before GA, given the dual-license surface above.
+
+## What review expects
+
+- **A test must fail when the production change is reverted.** Revert only the production hunk, keep
+  the test, and watch it go red. A test that stays green while the code it covers is gone pins
+  nothing, however much it asserts — and this is the most common reason a PR needs a second round.
+  Rebuilding the fixture inside the test is the usual way this goes wrong.
+- **Scope discipline.** Only the files your change needs. Drive-by reformatting, unrelated renames
+  and opportunistic fixes make a diff hard to review and slow it down; send them separately.
+- **Expect one review round**, with specific and cited findings — a file and line, the mechanism, or
+  the test that contradicts a claim. Answering in the same terms is the fastest way through.
 
 ## Code of conduct
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A monorepo for building reliable Java backends with functional programming patterns and a unified application runtime.
 
+**Current release branch: `release-1.0.0-rc4`.** Development integrates here and pull requests target this branch, not `main`. See [CONTRIBUTING.md](CONTRIBUTING.md).
+
 ## What's Inside
 
 **[Pragmatica Core](core/README.md)** — Functional primitives for Java: `Result<T>`, `Option<T>`, `Promise<T>`. No exceptions, no nulls, composable error handling.


### PR DESCRIPTION
**Companion to #917, targeted at the default branch.** Same change, different base, and the reason is
the whole point of it.

GitHub serves `CONTRIBUTING.md` from the repository's **default branch**, which is `main`. #917
targets `release-1.0.0-rc4`. Until rc4 merges, an external contributor opening the contributing guide
still reads "branch off `main`" and "open the PR against `main`" — precisely the error #917 fixes,
sitting in the one copy contributors actually read. #898 hit that error. This PR puts the corrected
text where it is served.

Merge order does not matter and neither PR blocks the other. Both are the owner's call.

## What is in it

The same five corrections as #917, verified independently against `main` rather than copied:

1. Target branch: fork from and open PRs against the current release branch, named in the README, not
   hardcoded in `CONTRIBUTING.md`. Adds the README line it points to.
2. The JBCT gate's coverage: the gate is skipped for most modules, not merely limited to
   `src/main/java`.
3. A new section on what the code must look like, with the course and book links.
4. A new section on what review expects.
5. A note that fork CI waits for maintainer approval.

## Verified against `main`, not copied from rc4

`main` is 404 commits behind `release-1.0.0-rc4`, so every factual claim was re-checked on this
branch. I re-ran my own module counter against a `main` checkout rather than reusing the rc4 result.

**Identical on `main` and rc4** — the counts and every mechanism the text cites:

| Claim | `main` | rc4 |
|---|---|---|
| Reactor projects | 143 | 143 |
| Source-bearing modules | 118 | 118 |
| Gate examines / skips | 71 / 47 | 71 / 47 |
| Root `pom.xml` `jbct.skip` default | `true`, line 89 | `true`, line 89 |
| Plugin `<skip>` binding | line 664 | line 664 |
| `ci.yml` gate step, no `-Djbct.skip=false` | line 33 | line 33 |
| `aether/pom.xml` opt-in | `false`, line 93 | `false`, line 93 |
| Skipped trees | `core/`, `integrations/**`, `jbct/**`, `testing/`, `examples/pragmatica-lite` | same |

**Divergences, and how this PR handles each:**

- **`changelog.d/` does not exist on `main`**, and neither does `scripts/changelog-check.sh`. `main`'s
  `CONTRIBUTING.md` correctly says nothing about changelog fragments. So this PR **omits** both the
  changelog PR bullet and the changelog-fragment bullet from "What review expects". #917 keeps both,
  because on rc4 they are true. The review section here has three bullets; on #917 it has four.
- **`main` has two workflows, not three.** `.github/workflows/` here contains `ci.yml` and
  `release.yml`; rc4 also has `changelog.yml`. #917 corrects that list, since it was wrong on rc4.
  Here the two-file list is **correct and is kept**. Both PRs do change `.github/` to
  `.github/workflows/`, which is where the files actually live, so the two versions differ only in
  the list itself and will merge cleanly.
- **`main`'s README pins `1.0.0-rc3`**, rc4's pins `1.0.0-rc4`. **Left alone.** Version pins are a
  separate concern from the branch line and not this PR's scope. The added line names the current
  release branch, which is `release-1.0.0-rc4` regardless of which branch the README is served from,
  so it is true here. Worth a maintainer's attention independently.
- `integrations/` holds 555 Java files on `main` and 558 on rc4. This figure appears only in review
  discussion, never in the file, so nothing in the text depends on it.

No number, path or line number was carried over from rc4 without being re-checked here. Everything
above was verified on this branch.

## Not included, deliberately

No policy on AI-authored or agent-authored contributions, matching #917. That is the owner's to write.

## No changelog fragment

Documentation-only, and `main` has no fragment mechanism at all.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contribution guidance with current branch targeting and pull request workflow details.
  * Clarified CI approval behavior for contributions from forks.
  * Added coding standards, review expectations, and JBCT gate coverage information.
  * Updated sign-off guidance regarding DCO/CLA enforcement.
  * Updated the README to identify the current release branch and link to contribution guidelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->