### PR TITLE
fix: #915 bound and name every lifecycle await in forge-tests

### DIFF
--- a/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/AbstractMultiPartitionStream.java
+++ b/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/AbstractMultiPartitionStream.java
@@ -2,18 +2,7 @@
 // Copyright (c) 2025 Pragmatica Labs - Sergiy Yevtushenko
 // Licensed under Business Source License 1.1. Change Date: 2030-01-01. Change License: Apache-2.0.
 // See LICENSE in the repository root for full terms.
-
 package org.pragmatica.aether.forge;
-
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-import org.pragmatica.aether.ember.EmberCluster;
-import org.pragmatica.aether.stream.StreamReadRouter.ReplicaSetView;
-import org.pragmatica.config.ConfigurationProvider;
-import org.pragmatica.http.HttpOperations;
-import org.pragmatica.http.HttpResult;
-import org.pragmatica.lang.Cause;
-import org.pragmatica.lang.Option;
 
 import java.net.URI;
 import java.net.http.HttpRequest;
@@ -24,10 +13,22 @@ import java.util.concurrent.locks.LockSupport;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.awaitility.Awaitility.await;
+import org.pragmatica.aether.ember.EmberCluster;
+import org.pragmatica.aether.stream.StreamReadRouter.ReplicaSetView;
+import org.pragmatica.config.ConfigurationProvider;
+import org.pragmatica.http.HttpOperations;
+import org.pragmatica.http.HttpResult;
+import org.pragmatica.lang.Cause;
+import org.pragmatica.lang.Option;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+
 import static org.pragmatica.aether.ember.EmberCluster.emberCluster;
 import static org.pragmatica.http.JdkHttpOperations.jdkHttpOperations;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
 
 /// Shared 5-node in-JVM Forge harness for the two multi-partition stream fixtures (#429 / #430),
 /// both deploying the `test-stream-multipart` blueprint (`streams.multipart-events`, partitions=4,
@@ -51,18 +52,15 @@ abstract class AbstractMultiPartitionStream {
     static final int NODES = 5;
     static final int INSTANCES = 5;
     static final int PARTITIONS = 4;
-
     static final String STREAM_SLICE = TestArtifacts.STREAM_MULTIPART_SLICE;
     static final String STREAM_NAME = "multipart-events";
     private static final String ERROR_FALLBACK = "{\"error\":\"request failed\"}";
-
     static final Duration WAIT_TIMEOUT = Duration.ofSeconds(240);
     static final Duration POLL_INTERVAL = Duration.ofMillis(500);
     static final Duration PLACEMENT_TIMEOUT = Duration.ofSeconds(120);
     static final Duration DRAIN_TIMEOUT = Duration.ofSeconds(90);
     static final Duration FAILOVER_TIMEOUT = Duration.ofSeconds(180);
     static final long POLL_GAP_NANOS = Duration.ofMillis(20).toNanos();
-
     private static final Pattern EVENT_OBJECT = Pattern.compile("\\{[^{}]*\"offset\"[^{}]*}");
     private static final Pattern OFFSET_FIELD = Pattern.compile("\"offset\"\\s*:\\s*(\\d+)");
     private static final Pattern PAYLOAD_FIELD = Pattern.compile("\"payload\"\\s*:\\s*\"([^\"]*)\"");
@@ -76,26 +74,26 @@ abstract class AbstractMultiPartitionStream {
     record Event(long offset, long seq) {}
 
     // --- variant hooks ------------------------------------------------------
-
     abstract int basePort();
-
     abstract int baseMgmtPort();
-
     abstract int baseAppHttpPort();
-
     abstract String nodePrefix();
-
     abstract String blueprintId();
 
     // --- lifecycle ----------------------------------------------------------
-
     @BeforeAll
     void setUp() {
         var configProvider = ConfigurationProvider.builder()
                                                   .withSystemProperties("aether.")
                                                   .withEnvironment("AETHER_")
                                                   .build();
-        cluster = emberCluster(NODES, basePort(), baseMgmtPort(), baseAppHttpPort(), nodePrefix(), Option.some(configProvider));
+
+        cluster = emberCluster(NODES,
+                               basePort(),
+                               baseMgmtPort(),
+                               baseAppHttpPort(),
+                               nodePrefix(),
+                               Option.some(configProvider));
         startAndAwaitReady();
     }
 
@@ -103,22 +101,27 @@ abstract class AbstractMultiPartitionStream {
     void tearDown() {
         if (cluster != null) {
             var leaderPort = cluster.getLeaderManagementPort().or(anyMgmtPort());
+
             httpDelete(leaderPort, "/api/v1/blueprints/" + blueprintId());
-            cluster.stop().await();
+            LifecycleAwait.settled("cluster stop in tearDown()", cluster, cluster.stop());
         }
     }
 
     private void startAndAwaitReady() {
-        cluster.start().await().onFailure(AbstractMultiPartitionStream::failStart);
-
-        await().atMost(WAIT_TIMEOUT).pollInterval(POLL_INTERVAL).until(() -> cluster.currentLeader().isPresent());
+        LifecycleAwait.settled("cluster start in startAndAwaitReady()", cluster, cluster.start());
+        await().atMost(WAIT_TIMEOUT).pollInterval(POLL_INTERVAL).until(() -> cluster.currentLeader()
+                                                                                    .isPresent());
         await().atMost(WAIT_TIMEOUT).pollInterval(POLL_INTERVAL).until(this::allNodesHealthy);
         await().atMost(WAIT_TIMEOUT).pollInterval(POLL_INTERVAL).until(() -> allNodesAreMembers(NODES));
-
         deployStreamSlice();
-
-        await().atMost(WAIT_TIMEOUT).pollInterval(POLL_INTERVAL).failFast(this::failIfSliceFailed).until(this::appHttpReady);
-        await().atMost(WAIT_TIMEOUT).pollInterval(POLL_INTERVAL).failFast(this::failIfSliceFailed).until(this::publishReady);
+        await().atMost(WAIT_TIMEOUT)
+             .pollInterval(POLL_INTERVAL)
+             .failFast(this::failIfSliceFailed)
+             .until(this::appHttpReady);
+        await().atMost(WAIT_TIMEOUT)
+             .pollInterval(POLL_INTERVAL)
+             .failFast(this::failIfSliceFailed)
+             .until(this::publishReady);
     }
 
     private void deployStreamSlice() {
@@ -132,10 +135,9 @@ abstract class AbstractMultiPartitionStream {
         var leaderPort = cluster.getLeaderManagementPort().or(anyMgmtPort());
         var response = postBlueprintWithRetry(leaderPort, blueprint);
 
-        assertThat(response)
-            .describedAs("multi-partition (partitions=4, RF=2) stream-slice deployment")
-            .doesNotContain("\"error\"")
-            .contains("\"status\":\"applied\"");
+        assertThat(response).describedAs("multi-partition (partitions=4, RF=2) stream-slice deployment")
+                  .doesNotContain("\"error\"")
+                  .contains("\"status\":\"applied\"");
     }
 
     private boolean appHttpReady() {
@@ -145,9 +147,11 @@ abstract class AbstractMultiPartitionStream {
             return false;
         }
 
-        var body = httpPost(ports.getFirst(), "/api/stream-mp/read", "{\"partition\":0,\"fromOffset\":0,\"maxEvents\":1}");
+        var body = httpPost(ports.getFirst(),
+                            "/api/stream-mp/read",
+                            "{\"partition\":0,\"fromOffset\":0,\"maxEvents\":1}");
 
-        return !body.contains("\"error\"") && body.contains("events");
+        return ! body.contains("\"error\"") && body.contains("events");
     }
 
     private boolean publishReady() {
@@ -159,13 +163,15 @@ abstract class AbstractMultiPartitionStream {
 
         var response = httpPost(ports.getFirst(), "/api/stream-mp/publish", "{\"payload\":\"__warmup__\"}");
 
-        return !response.contains("\"error\"") && response.contains("published");
+        return ! response.contains("\"error\"") && response.contains("published");
     }
 
     private void failIfSliceFailed() {
         var failed = cluster.slicesStatus()
                             .stream()
-                            .anyMatch(s -> s.artifact().equals(STREAM_SLICE) && s.state().equals("FAILED"));
+                            .anyMatch(s -> s.artifact()
+                                            .equals(STREAM_SLICE) && s.state()
+                                                                      .equals("FAILED"));
 
         if (failed) {
             throw new AssertionError("multi-partition stream slice deployment FAILED: " + STREAM_SLICE);
@@ -173,7 +179,6 @@ abstract class AbstractMultiPartitionStream {
     }
 
     // --- replica-set view (in-JVM, owner-authoritative) ---------------------
-
     /// The owner-authoritative replica-set view for `(STREAM_NAME, partition)`: the registry is
     /// authoritative only on the partition's HRW owner (`servedByOwner()` true), so scan every live
     /// node's in-JVM `replicaSnapshot` and return the owner's.
@@ -190,13 +195,16 @@ abstract class AbstractMultiPartitionStream {
     }
 
     String ownerId(int partition) {
-        return ownerView(partition).flatMap(ReplicaSetView::ownerNodeId).or("");
+        return ownerView(partition).flatMap(ReplicaSetView::ownerNodeId)
+                        .or("");
     }
 
     private boolean partitionPlaced(int partition) {
-        return ownerView(partition).map(view -> view.replicas().size() >= 2
-                                                 && view.replicas().stream().anyMatch(r -> !r.hrwOwner()))
-                                   .or(false);
+        return ownerView(partition).map(view -> view.replicas()
+                                                    .size() >= 2 && view.replicas()
+                                                                        .stream()
+                                                                        .anyMatch(r -> !r.hrwOwner()))
+                        .or(false);
     }
 
     boolean allPartitionsPlaced() {
@@ -210,7 +218,6 @@ abstract class AbstractMultiPartitionStream {
     }
 
     // --- publishing + consuming --------------------------------------------
-
     /// Publish `seq` (payload = its decimal string) through `port` and return whether it was ACKED
     /// (min-sync-2 replica ack, HTTP success). An unacked publish returns false — the caller decides
     /// whether that is a failure (#429 static publish) or a tolerated in-flight loss (#430 under kill).
@@ -226,7 +233,7 @@ abstract class AbstractMultiPartitionStream {
         var body = "{\"payload\":\"" + seq + "\"}";
         var response = httpPost(port, "/api/stream-mp/publish", body, timeout);
 
-        return !response.contains("\"error\"") && response.contains("published");
+        return ! response.contains("\"error\"") && response.contains("published");
     }
 
     List<Event> readPartition(int port, int partition, long fromOffset, int maxEvents) {
@@ -269,17 +276,15 @@ abstract class AbstractMultiPartitionStream {
     /// contiguous run rather than from zero because a setup warm-up publish may occupy the partition's
     /// offset 0.
     void assertPerPartitionOrdered(List<Event> events, int partition) {
-        assertThat(events)
-            .describedAs("partition %d must be populated", partition)
-            .isNotEmpty();
-
+        assertThat(events).describedAs("partition %d must be populated", partition).isNotEmpty();
         for (int i = 1; i < events.size(); i++) {
-            assertThat(events.get(i).offset())
-                .describedAs("partition %d offset at index %d is contiguous (prev + 1) — no dup/gap", partition, i)
-                .isEqualTo(events.get(i - 1).offset() + 1);
-            assertThat(events.get(i).seq())
-                .describedAs("partition %d seq strictly increases with offset (per-partition publish order)", partition)
-                .isGreaterThan(events.get(i - 1).seq());
+            assertThat(events.get(i).offset()).describedAs("partition %d offset at index %d is contiguous (prev + 1) — no dup/gap",
+                                                           partition,
+                                                           i)
+                      .isEqualTo(events.get(i - 1).offset() + 1);
+            assertThat(events.get(i).seq()).describedAs("partition %d seq strictly increases with offset (per-partition publish order)",
+                                                        partition)
+                      .isGreaterThan(events.get(i - 1).seq());
         }
     }
 
@@ -309,7 +314,6 @@ abstract class AbstractMultiPartitionStream {
     }
 
     // --- port / node helpers ------------------------------------------------
-
     int appPort() {
         return cluster.getAvailableAppHttpPorts()
                       .stream()
@@ -324,14 +328,18 @@ abstract class AbstractMultiPartitionStream {
         return cluster.status()
                       .nodes()
                       .stream()
-                      .filter(node -> node.id().equals(nodeId))
+                      .filter(node -> node.id()
+                                          .equals(nodeId))
                       .map(node -> baseAppHttpPort() + (node.port() - basePort()))
                       .findFirst()
                       .orElseThrow(() -> new AssertionError("No app-http port for node " + nodeId));
     }
 
     private int anyMgmtPort() {
-        return cluster.status().nodes().getFirst().mgmtPort();
+        return cluster.status()
+                      .nodes()
+                      .getFirst()
+                      .mgmtPort();
     }
 
     long deadline(Duration budget) {
@@ -339,9 +347,11 @@ abstract class AbstractMultiPartitionStream {
     }
 
     // --- health / membership ------------------------------------------------
-
     private boolean allNodesHealthy() {
-        return cluster.status().nodes().stream().allMatch(node -> checkNodeHealth(node.mgmtPort()));
+        return cluster.status()
+                      .nodes()
+                      .stream()
+                      .allMatch(node -> checkNodeHealth(node.mgmtPort()));
     }
 
     private boolean checkNodeHealth(int port) {
@@ -350,9 +360,11 @@ abstract class AbstractMultiPartitionStream {
                                  .GET()
                                  .timeout(Duration.ofSeconds(5))
                                  .build();
+
         return http.sendString(request)
                    .await()
-                   .map(r -> r.statusCode() == 200 && r.body().contains("\"quorum\":true"))
+                   .map(r -> r.statusCode() == 200 && r.body()
+                                                       .contains("\"quorum\":true"))
                    .or(false);
     }
 
@@ -363,9 +375,11 @@ abstract class AbstractMultiPartitionStream {
                                  .GET()
                                  .timeout(Duration.ofSeconds(5))
                                  .build();
+
         return http.sendString(request)
                    .await()
-                   .map(r -> r.statusCode() == 200 && healthHasFullMembership(r.body(), expected))
+                   .map(r -> r.statusCode() == 200 && healthHasFullMembership(r.body(),
+                                                                              expected))
                    .or(false);
     }
 
@@ -380,13 +394,11 @@ abstract class AbstractMultiPartitionStream {
     }
 
     // --- HTTP ---------------------------------------------------------------
-
     private String postBlueprintWithRetry(int port, String body) {
         var lastResponse = ERROR_FALLBACK;
 
         for (int attempt = 1; attempt <= 3; attempt++) {
             lastResponse = httpPostToml(port, "/api/v1/blueprints", body);
-
             if (!lastResponse.contains("\"error\"")) {
                 return lastResponse;
             }
@@ -406,6 +418,7 @@ abstract class AbstractMultiPartitionStream {
                                  .POST(HttpRequest.BodyPublishers.ofString(body))
                                  .timeout(Duration.ofSeconds(10))
                                  .build();
+
         return http.sendString(request)
                    .await()
                    .map(HttpResult::body)
@@ -423,6 +436,7 @@ abstract class AbstractMultiPartitionStream {
                                  .POST(HttpRequest.BodyPublishers.ofString(body))
                                  .timeout(timeout)
                                  .build();
+
         return http.sendString(request)
                    .await()
                    .map(HttpResult::body)
@@ -435,6 +449,7 @@ abstract class AbstractMultiPartitionStream {
                                  .DELETE()
                                  .timeout(Duration.ofSeconds(10))
                                  .build();
+
         return http.sendString(request)
                    .await()
                    .map(HttpResult::body)
@@ -442,7 +457,6 @@ abstract class AbstractMultiPartitionStream {
     }
 
     // --- failure sinks ------------------------------------------------------
-
     private static void failStart(Cause cause) {
         throw new AssertionError("Cluster start failed: " + cause.message());
     }

--- a/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/AbstractMultiPartitionStream.java
+++ b/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/AbstractMultiPartitionStream.java
@@ -2,7 +2,17 @@
 // Copyright (c) 2025 Pragmatica Labs - Sergiy Yevtushenko
 // Licensed under Business Source License 1.1. Change Date: 2030-01-01. Change License: Apache-2.0.
 // See LICENSE in the repository root for full terms.
+
 package org.pragmatica.aether.forge;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.pragmatica.aether.ember.EmberCluster;
+import org.pragmatica.aether.stream.StreamReadRouter.ReplicaSetView;
+import org.pragmatica.config.ConfigurationProvider;
+import org.pragmatica.http.HttpOperations;
+import org.pragmatica.http.HttpResult;
+import org.pragmatica.lang.Option;
 
 import java.net.URI;
 import java.net.http.HttpRequest;
@@ -13,22 +23,10 @@ import java.util.concurrent.locks.LockSupport;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.pragmatica.aether.ember.EmberCluster;
-import org.pragmatica.aether.stream.StreamReadRouter.ReplicaSetView;
-import org.pragmatica.config.ConfigurationProvider;
-import org.pragmatica.http.HttpOperations;
-import org.pragmatica.http.HttpResult;
-import org.pragmatica.lang.Cause;
-import org.pragmatica.lang.Option;
-
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-
-import static org.pragmatica.aether.ember.EmberCluster.emberCluster;
-import static org.pragmatica.http.JdkHttpOperations.jdkHttpOperations;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
-
+import static org.pragmatica.aether.ember.EmberCluster.emberCluster;
+import static org.pragmatica.http.JdkHttpOperations.jdkHttpOperations;
 
 /// Shared 5-node in-JVM Forge harness for the two multi-partition stream fixtures (#429 / #430),
 /// both deploying the `test-stream-multipart` blueprint (`streams.multipart-events`, partitions=4,
@@ -52,15 +50,18 @@ abstract class AbstractMultiPartitionStream {
     static final int NODES = 5;
     static final int INSTANCES = 5;
     static final int PARTITIONS = 4;
+
     static final String STREAM_SLICE = TestArtifacts.STREAM_MULTIPART_SLICE;
     static final String STREAM_NAME = "multipart-events";
     private static final String ERROR_FALLBACK = "{\"error\":\"request failed\"}";
+
     static final Duration WAIT_TIMEOUT = Duration.ofSeconds(240);
     static final Duration POLL_INTERVAL = Duration.ofMillis(500);
     static final Duration PLACEMENT_TIMEOUT = Duration.ofSeconds(120);
     static final Duration DRAIN_TIMEOUT = Duration.ofSeconds(90);
     static final Duration FAILOVER_TIMEOUT = Duration.ofSeconds(180);
     static final long POLL_GAP_NANOS = Duration.ofMillis(20).toNanos();
+
     private static final Pattern EVENT_OBJECT = Pattern.compile("\\{[^{}]*\"offset\"[^{}]*}");
     private static final Pattern OFFSET_FIELD = Pattern.compile("\"offset\"\\s*:\\s*(\\d+)");
     private static final Pattern PAYLOAD_FIELD = Pattern.compile("\"payload\"\\s*:\\s*\"([^\"]*)\"");
@@ -74,26 +75,26 @@ abstract class AbstractMultiPartitionStream {
     record Event(long offset, long seq) {}
 
     // --- variant hooks ------------------------------------------------------
+
     abstract int basePort();
+
     abstract int baseMgmtPort();
+
     abstract int baseAppHttpPort();
+
     abstract String nodePrefix();
+
     abstract String blueprintId();
 
     // --- lifecycle ----------------------------------------------------------
+
     @BeforeAll
     void setUp() {
         var configProvider = ConfigurationProvider.builder()
                                                   .withSystemProperties("aether.")
                                                   .withEnvironment("AETHER_")
                                                   .build();
-
-        cluster = emberCluster(NODES,
-                               basePort(),
-                               baseMgmtPort(),
-                               baseAppHttpPort(),
-                               nodePrefix(),
-                               Option.some(configProvider));
+        cluster = emberCluster(NODES, basePort(), baseMgmtPort(), baseAppHttpPort(), nodePrefix(), Option.some(configProvider));
         startAndAwaitReady();
     }
 
@@ -101,27 +102,22 @@ abstract class AbstractMultiPartitionStream {
     void tearDown() {
         if (cluster != null) {
             var leaderPort = cluster.getLeaderManagementPort().or(anyMgmtPort());
-
             httpDelete(leaderPort, "/api/v1/blueprints/" + blueprintId());
-            LifecycleAwait.settled("cluster stop in tearDown()", cluster, cluster.stop());
+            LifecycleAwait.bestEffort("cluster stop in tearDown()", cluster, cluster.stop());
         }
     }
 
     private void startAndAwaitReady() {
         LifecycleAwait.settled("cluster start in startAndAwaitReady()", cluster, cluster.start());
-        await().atMost(WAIT_TIMEOUT).pollInterval(POLL_INTERVAL).until(() -> cluster.currentLeader()
-                                                                                    .isPresent());
+
+        await().atMost(WAIT_TIMEOUT).pollInterval(POLL_INTERVAL).until(() -> cluster.currentLeader().isPresent());
         await().atMost(WAIT_TIMEOUT).pollInterval(POLL_INTERVAL).until(this::allNodesHealthy);
         await().atMost(WAIT_TIMEOUT).pollInterval(POLL_INTERVAL).until(() -> allNodesAreMembers(NODES));
+
         deployStreamSlice();
-        await().atMost(WAIT_TIMEOUT)
-             .pollInterval(POLL_INTERVAL)
-             .failFast(this::failIfSliceFailed)
-             .until(this::appHttpReady);
-        await().atMost(WAIT_TIMEOUT)
-             .pollInterval(POLL_INTERVAL)
-             .failFast(this::failIfSliceFailed)
-             .until(this::publishReady);
+
+        await().atMost(WAIT_TIMEOUT).pollInterval(POLL_INTERVAL).failFast(this::failIfSliceFailed).until(this::appHttpReady);
+        await().atMost(WAIT_TIMEOUT).pollInterval(POLL_INTERVAL).failFast(this::failIfSliceFailed).until(this::publishReady);
     }
 
     private void deployStreamSlice() {
@@ -135,9 +131,10 @@ abstract class AbstractMultiPartitionStream {
         var leaderPort = cluster.getLeaderManagementPort().or(anyMgmtPort());
         var response = postBlueprintWithRetry(leaderPort, blueprint);
 
-        assertThat(response).describedAs("multi-partition (partitions=4, RF=2) stream-slice deployment")
-                  .doesNotContain("\"error\"")
-                  .contains("\"status\":\"applied\"");
+        assertThat(response)
+            .describedAs("multi-partition (partitions=4, RF=2) stream-slice deployment")
+            .doesNotContain("\"error\"")
+            .contains("\"status\":\"applied\"");
     }
 
     private boolean appHttpReady() {
@@ -147,11 +144,9 @@ abstract class AbstractMultiPartitionStream {
             return false;
         }
 
-        var body = httpPost(ports.getFirst(),
-                            "/api/stream-mp/read",
-                            "{\"partition\":0,\"fromOffset\":0,\"maxEvents\":1}");
+        var body = httpPost(ports.getFirst(), "/api/stream-mp/read", "{\"partition\":0,\"fromOffset\":0,\"maxEvents\":1}");
 
-        return ! body.contains("\"error\"") && body.contains("events");
+        return !body.contains("\"error\"") && body.contains("events");
     }
 
     private boolean publishReady() {
@@ -163,15 +158,13 @@ abstract class AbstractMultiPartitionStream {
 
         var response = httpPost(ports.getFirst(), "/api/stream-mp/publish", "{\"payload\":\"__warmup__\"}");
 
-        return ! response.contains("\"error\"") && response.contains("published");
+        return !response.contains("\"error\"") && response.contains("published");
     }
 
     private void failIfSliceFailed() {
         var failed = cluster.slicesStatus()
                             .stream()
-                            .anyMatch(s -> s.artifact()
-                                            .equals(STREAM_SLICE) && s.state()
-                                                                      .equals("FAILED"));
+                            .anyMatch(s -> s.artifact().equals(STREAM_SLICE) && s.state().equals("FAILED"));
 
         if (failed) {
             throw new AssertionError("multi-partition stream slice deployment FAILED: " + STREAM_SLICE);
@@ -179,6 +172,7 @@ abstract class AbstractMultiPartitionStream {
     }
 
     // --- replica-set view (in-JVM, owner-authoritative) ---------------------
+
     /// The owner-authoritative replica-set view for `(STREAM_NAME, partition)`: the registry is
     /// authoritative only on the partition's HRW owner (`servedByOwner()` true), so scan every live
     /// node's in-JVM `replicaSnapshot` and return the owner's.
@@ -195,16 +189,13 @@ abstract class AbstractMultiPartitionStream {
     }
 
     String ownerId(int partition) {
-        return ownerView(partition).flatMap(ReplicaSetView::ownerNodeId)
-                        .or("");
+        return ownerView(partition).flatMap(ReplicaSetView::ownerNodeId).or("");
     }
 
     private boolean partitionPlaced(int partition) {
-        return ownerView(partition).map(view -> view.replicas()
-                                                    .size() >= 2 && view.replicas()
-                                                                        .stream()
-                                                                        .anyMatch(r -> !r.hrwOwner()))
-                        .or(false);
+        return ownerView(partition).map(view -> view.replicas().size() >= 2
+                                                 && view.replicas().stream().anyMatch(r -> !r.hrwOwner()))
+                                   .or(false);
     }
 
     boolean allPartitionsPlaced() {
@@ -218,6 +209,7 @@ abstract class AbstractMultiPartitionStream {
     }
 
     // --- publishing + consuming --------------------------------------------
+
     /// Publish `seq` (payload = its decimal string) through `port` and return whether it was ACKED
     /// (min-sync-2 replica ack, HTTP success). An unacked publish returns false — the caller decides
     /// whether that is a failure (#429 static publish) or a tolerated in-flight loss (#430 under kill).
@@ -233,7 +225,7 @@ abstract class AbstractMultiPartitionStream {
         var body = "{\"payload\":\"" + seq + "\"}";
         var response = httpPost(port, "/api/stream-mp/publish", body, timeout);
 
-        return ! response.contains("\"error\"") && response.contains("published");
+        return !response.contains("\"error\"") && response.contains("published");
     }
 
     List<Event> readPartition(int port, int partition, long fromOffset, int maxEvents) {
@@ -276,15 +268,17 @@ abstract class AbstractMultiPartitionStream {
     /// contiguous run rather than from zero because a setup warm-up publish may occupy the partition's
     /// offset 0.
     void assertPerPartitionOrdered(List<Event> events, int partition) {
-        assertThat(events).describedAs("partition %d must be populated", partition).isNotEmpty();
+        assertThat(events)
+            .describedAs("partition %d must be populated", partition)
+            .isNotEmpty();
+
         for (int i = 1; i < events.size(); i++) {
-            assertThat(events.get(i).offset()).describedAs("partition %d offset at index %d is contiguous (prev + 1) — no dup/gap",
-                                                           partition,
-                                                           i)
-                      .isEqualTo(events.get(i - 1).offset() + 1);
-            assertThat(events.get(i).seq()).describedAs("partition %d seq strictly increases with offset (per-partition publish order)",
-                                                        partition)
-                      .isGreaterThan(events.get(i - 1).seq());
+            assertThat(events.get(i).offset())
+                .describedAs("partition %d offset at index %d is contiguous (prev + 1) — no dup/gap", partition, i)
+                .isEqualTo(events.get(i - 1).offset() + 1);
+            assertThat(events.get(i).seq())
+                .describedAs("partition %d seq strictly increases with offset (per-partition publish order)", partition)
+                .isGreaterThan(events.get(i - 1).seq());
         }
     }
 
@@ -314,6 +308,7 @@ abstract class AbstractMultiPartitionStream {
     }
 
     // --- port / node helpers ------------------------------------------------
+
     int appPort() {
         return cluster.getAvailableAppHttpPorts()
                       .stream()
@@ -328,18 +323,14 @@ abstract class AbstractMultiPartitionStream {
         return cluster.status()
                       .nodes()
                       .stream()
-                      .filter(node -> node.id()
-                                          .equals(nodeId))
+                      .filter(node -> node.id().equals(nodeId))
                       .map(node -> baseAppHttpPort() + (node.port() - basePort()))
                       .findFirst()
                       .orElseThrow(() -> new AssertionError("No app-http port for node " + nodeId));
     }
 
     private int anyMgmtPort() {
-        return cluster.status()
-                      .nodes()
-                      .getFirst()
-                      .mgmtPort();
+        return cluster.status().nodes().getFirst().mgmtPort();
     }
 
     long deadline(Duration budget) {
@@ -347,11 +338,9 @@ abstract class AbstractMultiPartitionStream {
     }
 
     // --- health / membership ------------------------------------------------
+
     private boolean allNodesHealthy() {
-        return cluster.status()
-                      .nodes()
-                      .stream()
-                      .allMatch(node -> checkNodeHealth(node.mgmtPort()));
+        return cluster.status().nodes().stream().allMatch(node -> checkNodeHealth(node.mgmtPort()));
     }
 
     private boolean checkNodeHealth(int port) {
@@ -360,11 +349,9 @@ abstract class AbstractMultiPartitionStream {
                                  .GET()
                                  .timeout(Duration.ofSeconds(5))
                                  .build();
-
         return http.sendString(request)
                    .await()
-                   .map(r -> r.statusCode() == 200 && r.body()
-                                                       .contains("\"quorum\":true"))
+                   .map(r -> r.statusCode() == 200 && r.body().contains("\"quorum\":true"))
                    .or(false);
     }
 
@@ -375,11 +362,9 @@ abstract class AbstractMultiPartitionStream {
                                  .GET()
                                  .timeout(Duration.ofSeconds(5))
                                  .build();
-
         return http.sendString(request)
                    .await()
-                   .map(r -> r.statusCode() == 200 && healthHasFullMembership(r.body(),
-                                                                              expected))
+                   .map(r -> r.statusCode() == 200 && healthHasFullMembership(r.body(), expected))
                    .or(false);
     }
 
@@ -394,11 +379,13 @@ abstract class AbstractMultiPartitionStream {
     }
 
     // --- HTTP ---------------------------------------------------------------
+
     private String postBlueprintWithRetry(int port, String body) {
         var lastResponse = ERROR_FALLBACK;
 
         for (int attempt = 1; attempt <= 3; attempt++) {
             lastResponse = httpPostToml(port, "/api/v1/blueprints", body);
+
             if (!lastResponse.contains("\"error\"")) {
                 return lastResponse;
             }
@@ -418,7 +405,6 @@ abstract class AbstractMultiPartitionStream {
                                  .POST(HttpRequest.BodyPublishers.ofString(body))
                                  .timeout(Duration.ofSeconds(10))
                                  .build();
-
         return http.sendString(request)
                    .await()
                    .map(HttpResult::body)
@@ -436,7 +422,6 @@ abstract class AbstractMultiPartitionStream {
                                  .POST(HttpRequest.BodyPublishers.ofString(body))
                                  .timeout(timeout)
                                  .build();
-
         return http.sendString(request)
                    .await()
                    .map(HttpResult::body)
@@ -449,7 +434,6 @@ abstract class AbstractMultiPartitionStream {
                                  .DELETE()
                                  .timeout(Duration.ofSeconds(10))
                                  .build();
-
         return http.sendString(request)
                    .await()
                    .map(HttpResult::body)
@@ -457,7 +441,5 @@ abstract class AbstractMultiPartitionStream {
     }
 
     // --- failure sinks ------------------------------------------------------
-    private static void failStart(Cause cause) {
-        throw new AssertionError("Cluster start failed: " + cause.message());
-    }
+
 }

--- a/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/AbstractStreamOwnerFailover.java
+++ b/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/AbstractStreamOwnerFailover.java
@@ -2,18 +2,7 @@
 // Copyright (c) 2025 Pragmatica Labs - Sergiy Yevtushenko
 // Licensed under Business Source License 1.1. Change Date: 2030-01-01. Change License: Apache-2.0.
 // See LICENSE in the repository root for full terms.
-
 package org.pragmatica.aether.forge;
-
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
-import org.awaitility.core.ConditionTimeoutException;
-import org.pragmatica.aether.stream.StreamReadRouter.ReplicaSetView;
-import org.pragmatica.config.ConfigurationProvider;
-import org.pragmatica.http.HttpOperations;
-import org.pragmatica.http.HttpResult;
-import org.pragmatica.lang.Option;
 
 import java.net.URI;
 import java.net.http.HttpRequest;
@@ -24,12 +13,23 @@ import java.util.concurrent.locks.LockSupport;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.awaitility.Awaitility.await;
+import org.pragmatica.aether.stream.StreamReadRouter.ReplicaSetView;
+import org.pragmatica.config.ConfigurationProvider;
+import org.pragmatica.http.HttpOperations;
+import org.pragmatica.http.HttpResult;
+import org.pragmatica.lang.Option;
+import org.pragmatica.aether.ember.EmberCluster;
+
+import org.awaitility.core.ConditionTimeoutException;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
 import static org.pragmatica.aether.ember.EmberCluster.emberCluster;
 import static org.pragmatica.http.JdkHttpOperations.jdkHttpOperations;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
 
-import org.pragmatica.aether.ember.EmberCluster;
 
 /// #457 — in-JVM Ember proof of RF=2 stream owner-kill failover: the ONLY prior coverage of the
 /// #445-arc owner-failover path was the cloud suite `02-chaos/test-stream-replica-failover.sh`, so
@@ -75,7 +75,6 @@ abstract class AbstractStreamOwnerFailover {
     private static final int N_EVENTS = 20;
     private static final int K_EVENTS = 5;
     private static final int PARTITION = 0;
-
     private static final Duration WAIT_TIMEOUT = Duration.ofSeconds(240);
     private static final Duration POLL_INTERVAL = Duration.ofMillis(500);
     private static final Duration PLACEMENT_TIMEOUT = Duration.ofSeconds(120);
@@ -83,12 +82,10 @@ abstract class AbstractStreamOwnerFailover {
     private static final Duration DRAIN_TIMEOUT = Duration.ofSeconds(90);
     private static final Duration CONVERGE_TIMEOUT = Duration.ofSeconds(120);
     private static final long POLL_GAP_NANOS = Duration.ofMillis(20).toNanos();
-
     private static final String STREAM_SLICE = TestArtifacts.STREAM_REPL_SLICE;
     private static final String STREAM_NAME = "repl-failover-events";
     private static final String BLUEPRINT_ID = "forge.test:stream-owner-failover:1.0.0";
     private static final String ERROR_FALLBACK = "{\"error\":\"request failed\"}";
-
     private static final Pattern EVENT_OBJECT = Pattern.compile("\\{[^{}]*\"offset\"[^{}]*}");
     private static final Pattern OFFSET_FIELD = Pattern.compile("\"offset\"\\s*:\\s*(\\d+)");
     private static final Pattern PAYLOAD_FIELD = Pattern.compile("\"payload\"\\s*:\\s*\"([^\"]*)\"");
@@ -100,7 +97,6 @@ abstract class AbstractStreamOwnerFailover {
     private record Event(long offset, String payload) {}
 
     // --- variant hooks ------------------------------------------------------
-
     /// Base app-port allocation for this variant's cluster. Overridden by the pinned variant so the two
     /// concrete classes never contend for the same TCP ports when the suite runs both.
     int basePort() {
@@ -140,7 +136,13 @@ abstract class AbstractStreamOwnerFailover {
                                                   .withSystemProperties("aether.")
                                                   .withEnvironment("AETHER_")
                                                   .build();
-        cluster = emberCluster(NODES, basePort(), baseMgmtPort(), baseAppHttpPort(), nodePrefix(), Option.some(configProvider));
+
+        cluster = emberCluster(NODES,
+                               basePort(),
+                               baseMgmtPort(),
+                               baseAppHttpPort(),
+                               nodePrefix(),
+                               Option.some(configProvider));
         configureCluster(cluster);
         startAndAwaitReady();
     }
@@ -149,8 +151,9 @@ abstract class AbstractStreamOwnerFailover {
     void tearDown() {
         if (cluster != null) {
             var leaderPort = cluster.getLeaderManagementPort().or(anyMgmtPort());
+
             httpDelete(leaderPort, "/api/v1/blueprints/" + BLUEPRINT_ID);
-            cluster.stop().await();
+            LifecycleAwait.settled("cluster stop in tearDown()", cluster, cluster.stop());
         }
     }
 
@@ -161,53 +164,50 @@ abstract class AbstractStreamOwnerFailover {
     void ownerKill_promotedReplicaServesCompleteHistory_andRestoresRf() {
         var port = appPort();
 
-        assertThat(head(port))
-            .describedAs("fresh RF=2 stream starts empty (offset 0)")
-            .isZero();
-
+        assertThat(head(port)).describedAs("fresh RF=2 stream starts empty (offset 0)").isZero();
         // The RF=2 config must be COMMITTED and the replica set PLACED (owner + >=1 non-owner) before the
         // first publish, else the min-sync-2 barrier has no replica to await and pre-kill markers race
         // placement. First proof RF=2 replication is in effect in-JVM.
         await().atMost(PLACEMENT_TIMEOUT).pollInterval(POLL_INTERVAL).until(this::replicaSetPlaced);
-
         var published = drainAfterPublish(port, "pre", 0, N_EVENTS, DRAIN_TIMEOUT);
-        assertContiguousBatch(published, 0L, "pre", N_EVENTS);
 
+        assertContiguousBatch(published, 0L, "pre", N_EVENTS);
         // Owner + a promotable CAUGHT_UP non-owner replica must both exist (else killing the owner cannot
         // preserve history). The min-sync-2 publishes above already proved a replica is in sync; wait for
         // its registry state to settle to CAUGHT_UP.
         await().atMost(CONVERGE_TIMEOUT)
-               .pollInterval(POLL_INTERVAL)
-               .until(() -> ownerView().map(this::hasCaughtUpNonOwner).or(false));
+             .pollInterval(POLL_INTERVAL)
+             .until(() -> ownerView().map(this::hasCaughtUpNonOwner)
+                                   .or(false));
         var owner = ownerView().flatMap(ReplicaSetView::ownerNodeId).or("");
+
         assertThat(owner).describedAs("HRW owner identified before kill").isNotBlank();
-
         // Kill the HRW owner (graceful SWIM leave -> deterministic membership shrink -> HRW re-resolves).
-        cluster.killNode(owner).await();
-
-        await().atMost(FAILOVER_TIMEOUT)
-               .pollInterval(POLL_INTERVAL)
-               .until(() -> ownerChangedAndAuthoritative(owner));
+        LifecycleAwait.nodeSettled("kill node " + owner
+                                  + " in ownerKill_promotedReplicaServesCompleteHistory_andRestoresRf()",
+                                   cluster,
+                                   cluster.killNode(owner));
+        await().atMost(FAILOVER_TIMEOUT).pollInterval(POLL_INTERVAL).until(() -> ownerChangedAndAuthoritative(owner));
         var newOwner = ownerView().flatMap(ReplicaSetView::ownerNodeId).or("");
-        assertThat(newOwner)
-            .describedAs("partition re-resolved to a NEW owner after the kill")
-            .isNotBlank().isNotEqualTo(owner);
 
+        assertThat(newOwner).describedAs("partition re-resolved to a NEW owner after the kill")
+                  .isNotBlank()
+                  .isNotEqualTo(owner);
         // THE assertion the non-destructive suites lack: the promoted owner serves the COMPLETE pre-kill
         // history (count == N, contiguous), not merely >=1.
         var recovered = drain(appPort(), 0L, N_EVENTS, deadline(FAILOVER_TIMEOUT));
-        assertContiguousBatch(recovered, 0L, "pre", N_EVENTS);
 
+        assertContiguousBatch(recovered, 0L, "pre", N_EVENTS);
         // Post-repair liveness: the new owner accepts further live batches and serves the full ordered
         // tail 0..N+K-1 contiguously (no reordering, no offset gap after the pre-kill history).
         var live = drainAfterPublish(appPort(), "post", N_EVENTS, K_EVENTS, DRAIN_TIMEOUT);
+
         assertContiguousBatch(live, N_EVENTS, "post", K_EVENTS);
         var fullTail = drain(appPort(), 0L, N_EVENTS + K_EVENTS, deadline(DRAIN_TIMEOUT));
-        assertThat(fullTail)
-            .describedAs("full ordered tail of %d+%d events present on new owner", N_EVENTS, K_EVENTS)
-            .hasSize(N_EVENTS + K_EVENTS);
-        assertInOrder(fullTail);
 
+        assertThat(fullTail).describedAs("full ordered tail of %d+%d events present on new owner", N_EVENTS, K_EVENTS)
+                  .hasSize(N_EVENTS + K_EVENTS);
+        assertInOrder(fullTail);
         // Phase 9 — RF restoration. The membership-pinned variant asserts this HARD (the #457 acceptance
         // gate, @Disabled until #499); the default variant observes it as a non-failing sensor (post-kill
         // RF-restoration can stall on #498 SWIM false-removal and #499 HRW-divergence). Phases 1–8 above
@@ -228,19 +228,18 @@ abstract class AbstractStreamOwnerFailover {
     /// for the full mechanism. On timeout this dumps every live node's replica view before rethrowing.
     private void assertRfRestorationConverges() {
         try {
-            await().atMost(CONVERGE_TIMEOUT)
-                   .pollInterval(POLL_INTERVAL)
-                   .until(this::convergedWithRfRestored);
+            await().atMost(CONVERGE_TIMEOUT).pollInterval(POLL_INTERVAL).until(this::convergedWithRfRestored);
         } catch (ConditionTimeoutException timeout) {
             // Failure-path observability: the assertion otherwise dies blind — dump EVERY live
             // node's replica snapshot so the non-converged view is diagnosable from the log.
             dumpAllReplicaViews();
+
             throw timeout;
         }
 
         ownerView().onPresent(view -> LOG.log(System.Logger.Level.INFO,
                                               "#491 RF-restoration converged: "
-                                              + "ownerCaughtUp={0} caughtUpNonOwner={1} finalView={2}",
+                                             + "ownerCaughtUp={0} caughtUpNonOwner={1} finalView={2}",
                                               ownerIsCaughtUp(view),
                                               hasCaughtUpNonOwner(view),
                                               view));
@@ -274,14 +273,15 @@ abstract class AbstractStreamOwnerFailover {
 
         var finalView = ownerView().map(ReplicaSetView::toString).or("<no owner-authoritative view>");
 
-        LOG.log(converged ? System.Logger.Level.INFO : System.Logger.Level.WARNING,
+        LOG.log(converged
+                ? System.Logger.Level.INFO
+                : System.Logger.Level.WARNING,
                 "#491 phase-9 sensor (#498 SWIM + #499 HRW-divergence): RF-restoration converged={0} finalView={1}",
                 converged,
                 finalView);
     }
 
     // --- replica-set view (in-JVM, owner-authoritative) ---------------------
-
     /// The owner-authoritative replica-set view: the registry is authoritative only on the partition's
     /// HRW owner (`servedByOwner()` true), so scan every live node's in-JVM `replicaSnapshot` and return
     /// the owner's. The HTTP `/api/v1/streams/replicas` sensor is `taskGroup(STREAMING)`-routed to a single
@@ -299,27 +299,34 @@ abstract class AbstractStreamOwnerFailover {
     }
 
     private boolean replicaSetPlaced() {
-        return ownerView().map(view -> view.replicas().size() >= 2
-                                       && view.replicas().stream().anyMatch(r -> !r.hrwOwner()))
-                          .or(false);
+        return ownerView().map(view -> view.replicas()
+                                           .size() >= 2 && view.replicas()
+                                                               .stream()
+                                                               .anyMatch(r -> !r.hrwOwner()))
+                        .or(false);
     }
 
     private boolean ownerChangedAndAuthoritative(String oldOwner) {
         return ownerView().flatMap(ReplicaSetView::ownerNodeId)
-                          .map(owner -> !owner.isBlank() && !owner.equals(oldOwner))
-                          .or(false);
+                        .map(owner -> !owner.isBlank() && !owner.equals(oldOwner))
+                        .or(false);
     }
 
     private boolean convergedWithRfRestored() {
-        return ownerView().map(view -> noCaughtUpReplicaLagsTail(view) && hasCaughtUpNonOwner(view)).or(false);
+        return ownerView().map(view -> noCaughtUpReplicaLagsTail(view) && hasCaughtUpNonOwner(view))
+                        .or(false);
     }
 
     private boolean hasCaughtUpNonOwner(ReplicaSetView view) {
-        return view.replicas().stream().anyMatch(r -> "CAUGHT_UP".equals(r.state()) && !r.hrwOwner());
+        return view.replicas()
+                   .stream()
+                   .anyMatch(r -> "CAUGHT_UP".equals(r.state()) && !r.hrwOwner());
     }
 
     private boolean ownerIsCaughtUp(ReplicaSetView view) {
-        return view.replicas().stream().anyMatch(r -> r.hrwOwner() && "CAUGHT_UP".equals(r.state()));
+        return view.replicas()
+                   .stream()
+                   .anyMatch(r -> r.hrwOwner() && "CAUGHT_UP".equals(r.state()));
     }
 
     /// True iff no CAUGHT_UP replica's confirmedOffset lags the owner's true tail (ownerHeadOffset-1) —
@@ -332,39 +339,38 @@ abstract class AbstractStreamOwnerFailover {
 
         var tail = view.ownerHeadOffset() - 1;
 
-        return view.replicas().stream()
+        return view.replicas()
+                   .stream()
                    .filter(r -> "CAUGHT_UP".equals(r.state()))
                    .allMatch(r -> r.confirmedOffset() >= tail);
     }
 
     // --- assertions ---------------------------------------------------------
-
     private void assertContiguousBatch(List<Event> events, long base, String tag, int count) {
-        assertThat(events)
-            .describedAs("consumer must receive exactly %d '%s' events (no dups, no gaps)", count, tag)
-            .hasSize(count);
-
+        assertThat(events).describedAs("consumer must receive exactly %d '%s' events (no dups, no gaps)",
+                                       count,
+                                       tag)
+                  .hasSize(count);
         for (int i = 0; i < count; i++) {
-            assertThat(events.get(i).offset())
-                .describedAs("event %d offset (contiguous from base %d)", i, base)
-                .isEqualTo(base + i);
-            assertThat(events.get(i).payload())
-                .describedAs("event %d payload (in publish order)", i)
-                .isEqualTo(tag + "-" + i);
+            assertThat(events.get(i).offset()).describedAs("event %d offset (contiguous from base %d)",
+                                                           i,
+                                                           base)
+                      .isEqualTo(base + i);
+            assertThat(events.get(i).payload()).describedAs("event %d payload (in publish order)",
+                                                            i)
+                      .isEqualTo(tag + "-" + i);
         }
     }
 
     /// Offsets 0..size-1 are contiguous on the promoted owner (log correctly sequenced, no reordering).
     private void assertInOrder(List<Event> events) {
         for (int i = 0; i < events.size(); i++) {
-            assertThat(events.get(i).offset())
-                .describedAs("offset at index %d is contiguous on the new owner", i)
-                .isEqualTo((long) i);
+            assertThat(events.get(i).offset()).describedAs("offset at index %d is contiguous on the new owner", i)
+                      .isEqualTo((long) i);
         }
     }
 
     // --- consumers ----------------------------------------------------------
-
     private List<Event> drainAfterPublish(int port, String tag, int base, int count, Duration budget) {
         publishBatch(port, tag, count);
 
@@ -411,7 +417,6 @@ abstract class AbstractStreamOwnerFailover {
     }
 
     // --- publishing ---------------------------------------------------------
-
     private void publishBatch(int port, String tag, int count) {
         for (int i = 0; i < count; i++) {
             publish(port, tag + "-" + i);
@@ -422,10 +427,10 @@ abstract class AbstractStreamOwnerFailover {
         var body = "{\"payload\":\"" + payload + "\"}";
         var response = httpPost(port, "/api/stream-repl/publish", body);
 
-        assertThat(response)
-            .describedAs("publish '%s' must succeed (min-sync-2: resolves only after a replica ack)", payload)
-            .doesNotContain("\"error\"")
-            .contains("published");
+        assertThat(response).describedAs("publish '%s' must succeed (min-sync-2: resolves only after a replica ack)",
+                                         payload)
+                  .doesNotContain("\"error\"")
+                  .contains("published");
     }
 
     private List<Event> readEvents(int port, long fromOffset, int maxEvents) {
@@ -444,7 +449,8 @@ abstract class AbstractStreamOwnerFailover {
             Matcher payload = PAYLOAD_FIELD.matcher(object);
 
             if (offset.find() && payload.find()) {
-                events.add(new Event(Long.parseLong(offset.group(1)), payload.group(1)));
+                events.add(new Event(Long.parseLong(offset.group(1)),
+                                     payload.group(1)));
             }
         }
 
@@ -452,26 +458,18 @@ abstract class AbstractStreamOwnerFailover {
     }
 
     // --- deployment + readiness --------------------------------------------
-
     private void startAndAwaitReady() {
-        cluster.start()
-               .await()
-               .onFailure(cause -> {
-                   throw new AssertionError("Cluster start failed: " + cause.message());
-               });
-
-        await().atMost(WAIT_TIMEOUT).pollInterval(POLL_INTERVAL).until(() -> cluster.currentLeader().isPresent());
+        LifecycleAwait.settled("cluster start in startAndAwaitReady()", cluster, cluster.start());
+        await().atMost(WAIT_TIMEOUT).pollInterval(POLL_INTERVAL).until(() -> cluster.currentLeader()
+                                                                                    .isPresent());
         await().atMost(WAIT_TIMEOUT).pollInterval(POLL_INTERVAL).until(this::allNodesHealthy);
         await().atMost(WAIT_TIMEOUT).pollInterval(POLL_INTERVAL).until(() -> allNodesAreMembers(NODES));
-
         pinMembership(cluster);
-
         deployStreamSlice();
-
         await().atMost(WAIT_TIMEOUT)
-               .pollInterval(POLL_INTERVAL)
-               .failFast(this::failIfSliceFailed)
-               .until(this::appHttpReady);
+             .pollInterval(POLL_INTERVAL)
+             .failFast(this::failIfSliceFailed)
+             .until(this::appHttpReady);
     }
 
     private void deployStreamSlice() {
@@ -485,10 +483,9 @@ abstract class AbstractStreamOwnerFailover {
         var leaderPort = cluster.getLeaderManagementPort().or(anyMgmtPort());
         var response = postBlueprintWithRetry(leaderPort, blueprint);
 
-        assertThat(response)
-            .describedAs("RF=2 stream-slice deployment")
-            .doesNotContain("\"error\"")
-            .contains("\"status\":\"applied\"");
+        assertThat(response).describedAs("RF=2 stream-slice deployment")
+                  .doesNotContain("\"error\"")
+                  .contains("\"status\":\"applied\"");
     }
 
     private boolean appHttpReady() {
@@ -500,13 +497,15 @@ abstract class AbstractStreamOwnerFailover {
 
         var body = httpPost(ports.getFirst(), "/api/stream-repl/read", "{\"fromOffset\":0,\"maxEvents\":1}");
 
-        return !body.contains("\"error\"") && body.contains("events");
+        return ! body.contains("\"error\"") && body.contains("events");
     }
 
     private void failIfSliceFailed() {
         var failed = cluster.slicesStatus()
                             .stream()
-                            .anyMatch(s -> s.artifact().equals(STREAM_SLICE) && s.state().equals("FAILED"));
+                            .anyMatch(s -> s.artifact()
+                                            .equals(STREAM_SLICE) && s.state()
+                                                                      .equals("FAILED"));
 
         if (failed) {
             throw new AssertionError("RF=2 stream slice deployment FAILED: " + STREAM_SLICE);
@@ -521,7 +520,10 @@ abstract class AbstractStreamOwnerFailover {
     }
 
     private int anyMgmtPort() {
-        return cluster.status().nodes().getFirst().mgmtPort();
+        return cluster.status()
+                      .nodes()
+                      .getFirst()
+                      .mgmtPort();
     }
 
     private long deadline(Duration budget) {
@@ -541,9 +543,11 @@ abstract class AbstractStreamOwnerFailover {
                                  .GET()
                                  .timeout(Duration.ofSeconds(5))
                                  .build();
+
         return http.sendString(request)
                    .await()
-                   .map(r -> r.statusCode() == 200 && r.body().contains("\"quorum\":true"))
+                   .map(r -> r.statusCode() == 200 && r.body()
+                                                       .contains("\"quorum\":true"))
                    .or(false);
     }
 
@@ -554,9 +558,11 @@ abstract class AbstractStreamOwnerFailover {
                                  .GET()
                                  .timeout(Duration.ofSeconds(5))
                                  .build();
+
         return http.sendString(request)
                    .await()
-                   .map(r -> r.statusCode() == 200 && healthHasFullMembership(r.body(), expected))
+                   .map(r -> r.statusCode() == 200 && healthHasFullMembership(r.body(),
+                                                                              expected))
                    .or(false);
     }
 
@@ -571,13 +577,11 @@ abstract class AbstractStreamOwnerFailover {
     }
 
     // --- HTTP ---------------------------------------------------------------
-
     private String postBlueprintWithRetry(int port, String body) {
         var lastResponse = ERROR_FALLBACK;
 
         for (int attempt = 1; attempt <= 3; attempt++) {
             lastResponse = httpPostToml(port, "/api/v1/blueprints", body);
-
             if (!lastResponse.contains("\"error\"")) {
                 return lastResponse;
             }
@@ -597,6 +601,7 @@ abstract class AbstractStreamOwnerFailover {
                                  .POST(HttpRequest.BodyPublishers.ofString(body))
                                  .timeout(Duration.ofSeconds(10))
                                  .build();
+
         return http.sendString(request)
                    .await()
                    .map(HttpResult::body)
@@ -610,6 +615,7 @@ abstract class AbstractStreamOwnerFailover {
                                  .POST(HttpRequest.BodyPublishers.ofString(body))
                                  .timeout(Duration.ofSeconds(15))
                                  .build();
+
         return http.sendString(request)
                    .await()
                    .map(HttpResult::body)
@@ -622,6 +628,7 @@ abstract class AbstractStreamOwnerFailover {
                                  .DELETE()
                                  .timeout(Duration.ofSeconds(10))
                                  .build();
+
         return http.sendString(request)
                    .await()
                    .map(HttpResult::body)

--- a/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/AbstractStreamOwnerFailover.java
+++ b/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/AbstractStreamOwnerFailover.java
@@ -2,7 +2,18 @@
 // Copyright (c) 2025 Pragmatica Labs - Sergiy Yevtushenko
 // Licensed under Business Source License 1.1. Change Date: 2030-01-01. Change License: Apache-2.0.
 // See LICENSE in the repository root for full terms.
+
 package org.pragmatica.aether.forge;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.awaitility.core.ConditionTimeoutException;
+import org.pragmatica.aether.stream.StreamReadRouter.ReplicaSetView;
+import org.pragmatica.config.ConfigurationProvider;
+import org.pragmatica.http.HttpOperations;
+import org.pragmatica.http.HttpResult;
+import org.pragmatica.lang.Option;
 
 import java.net.URI;
 import java.net.http.HttpRequest;
@@ -13,23 +24,12 @@ import java.util.concurrent.locks.LockSupport;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.pragmatica.aether.stream.StreamReadRouter.ReplicaSetView;
-import org.pragmatica.config.ConfigurationProvider;
-import org.pragmatica.http.HttpOperations;
-import org.pragmatica.http.HttpResult;
-import org.pragmatica.lang.Option;
-import org.pragmatica.aether.ember.EmberCluster;
-
-import org.awaitility.core.ConditionTimeoutException;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
-
-import static org.pragmatica.aether.ember.EmberCluster.emberCluster;
-import static org.pragmatica.http.JdkHttpOperations.jdkHttpOperations;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
+import static org.pragmatica.aether.ember.EmberCluster.emberCluster;
+import static org.pragmatica.http.JdkHttpOperations.jdkHttpOperations;
 
+import org.pragmatica.aether.ember.EmberCluster;
 
 /// #457 — in-JVM Ember proof of RF=2 stream owner-kill failover: the ONLY prior coverage of the
 /// #445-arc owner-failover path was the cloud suite `02-chaos/test-stream-replica-failover.sh`, so
@@ -75,6 +75,7 @@ abstract class AbstractStreamOwnerFailover {
     private static final int N_EVENTS = 20;
     private static final int K_EVENTS = 5;
     private static final int PARTITION = 0;
+
     private static final Duration WAIT_TIMEOUT = Duration.ofSeconds(240);
     private static final Duration POLL_INTERVAL = Duration.ofMillis(500);
     private static final Duration PLACEMENT_TIMEOUT = Duration.ofSeconds(120);
@@ -82,10 +83,12 @@ abstract class AbstractStreamOwnerFailover {
     private static final Duration DRAIN_TIMEOUT = Duration.ofSeconds(90);
     private static final Duration CONVERGE_TIMEOUT = Duration.ofSeconds(120);
     private static final long POLL_GAP_NANOS = Duration.ofMillis(20).toNanos();
+
     private static final String STREAM_SLICE = TestArtifacts.STREAM_REPL_SLICE;
     private static final String STREAM_NAME = "repl-failover-events";
     private static final String BLUEPRINT_ID = "forge.test:stream-owner-failover:1.0.0";
     private static final String ERROR_FALLBACK = "{\"error\":\"request failed\"}";
+
     private static final Pattern EVENT_OBJECT = Pattern.compile("\\{[^{}]*\"offset\"[^{}]*}");
     private static final Pattern OFFSET_FIELD = Pattern.compile("\"offset\"\\s*:\\s*(\\d+)");
     private static final Pattern PAYLOAD_FIELD = Pattern.compile("\"payload\"\\s*:\\s*\"([^\"]*)\"");
@@ -97,6 +100,7 @@ abstract class AbstractStreamOwnerFailover {
     private record Event(long offset, String payload) {}
 
     // --- variant hooks ------------------------------------------------------
+
     /// Base app-port allocation for this variant's cluster. Overridden by the pinned variant so the two
     /// concrete classes never contend for the same TCP ports when the suite runs both.
     int basePort() {
@@ -136,13 +140,7 @@ abstract class AbstractStreamOwnerFailover {
                                                   .withSystemProperties("aether.")
                                                   .withEnvironment("AETHER_")
                                                   .build();
-
-        cluster = emberCluster(NODES,
-                               basePort(),
-                               baseMgmtPort(),
-                               baseAppHttpPort(),
-                               nodePrefix(),
-                               Option.some(configProvider));
+        cluster = emberCluster(NODES, basePort(), baseMgmtPort(), baseAppHttpPort(), nodePrefix(), Option.some(configProvider));
         configureCluster(cluster);
         startAndAwaitReady();
     }
@@ -151,9 +149,8 @@ abstract class AbstractStreamOwnerFailover {
     void tearDown() {
         if (cluster != null) {
             var leaderPort = cluster.getLeaderManagementPort().or(anyMgmtPort());
-
             httpDelete(leaderPort, "/api/v1/blueprints/" + BLUEPRINT_ID);
-            LifecycleAwait.settled("cluster stop in tearDown()", cluster, cluster.stop());
+            LifecycleAwait.bestEffort("cluster stop in tearDown()", cluster, cluster.stop());
         }
     }
 
@@ -164,50 +161,56 @@ abstract class AbstractStreamOwnerFailover {
     void ownerKill_promotedReplicaServesCompleteHistory_andRestoresRf() {
         var port = appPort();
 
-        assertThat(head(port)).describedAs("fresh RF=2 stream starts empty (offset 0)").isZero();
+        assertThat(head(port))
+            .describedAs("fresh RF=2 stream starts empty (offset 0)")
+            .isZero();
+
         // The RF=2 config must be COMMITTED and the replica set PLACED (owner + >=1 non-owner) before the
         // first publish, else the min-sync-2 barrier has no replica to await and pre-kill markers race
         // placement. First proof RF=2 replication is in effect in-JVM.
         await().atMost(PLACEMENT_TIMEOUT).pollInterval(POLL_INTERVAL).until(this::replicaSetPlaced);
-        var published = drainAfterPublish(port, "pre", 0, N_EVENTS, DRAIN_TIMEOUT);
 
+        var published = drainAfterPublish(port, "pre", 0, N_EVENTS, DRAIN_TIMEOUT);
         assertContiguousBatch(published, 0L, "pre", N_EVENTS);
+
         // Owner + a promotable CAUGHT_UP non-owner replica must both exist (else killing the owner cannot
         // preserve history). The min-sync-2 publishes above already proved a replica is in sync; wait for
         // its registry state to settle to CAUGHT_UP.
         await().atMost(CONVERGE_TIMEOUT)
-             .pollInterval(POLL_INTERVAL)
-             .until(() -> ownerView().map(this::hasCaughtUpNonOwner)
-                                   .or(false));
+               .pollInterval(POLL_INTERVAL)
+               .until(() -> ownerView().map(this::hasCaughtUpNonOwner).or(false));
         var owner = ownerView().flatMap(ReplicaSetView::ownerNodeId).or("");
-
         assertThat(owner).describedAs("HRW owner identified before kill").isNotBlank();
+
         // Kill the HRW owner (graceful SWIM leave -> deterministic membership shrink -> HRW re-resolves).
-        LifecycleAwait.nodeSettled("kill node " + owner
+        LifecycleAwait.nodeBestEffort("kill node " + owner
                                   + " in ownerKill_promotedReplicaServesCompleteHistory_andRestoresRf()",
                                    cluster,
                                    cluster.killNode(owner));
-        await().atMost(FAILOVER_TIMEOUT).pollInterval(POLL_INTERVAL).until(() -> ownerChangedAndAuthoritative(owner));
-        var newOwner = ownerView().flatMap(ReplicaSetView::ownerNodeId).or("");
 
-        assertThat(newOwner).describedAs("partition re-resolved to a NEW owner after the kill")
-                  .isNotBlank()
-                  .isNotEqualTo(owner);
+        await().atMost(FAILOVER_TIMEOUT)
+               .pollInterval(POLL_INTERVAL)
+               .until(() -> ownerChangedAndAuthoritative(owner));
+        var newOwner = ownerView().flatMap(ReplicaSetView::ownerNodeId).or("");
+        assertThat(newOwner)
+            .describedAs("partition re-resolved to a NEW owner after the kill")
+            .isNotBlank().isNotEqualTo(owner);
+
         // THE assertion the non-destructive suites lack: the promoted owner serves the COMPLETE pre-kill
         // history (count == N, contiguous), not merely >=1.
         var recovered = drain(appPort(), 0L, N_EVENTS, deadline(FAILOVER_TIMEOUT));
-
         assertContiguousBatch(recovered, 0L, "pre", N_EVENTS);
+
         // Post-repair liveness: the new owner accepts further live batches and serves the full ordered
         // tail 0..N+K-1 contiguously (no reordering, no offset gap after the pre-kill history).
         var live = drainAfterPublish(appPort(), "post", N_EVENTS, K_EVENTS, DRAIN_TIMEOUT);
-
         assertContiguousBatch(live, N_EVENTS, "post", K_EVENTS);
         var fullTail = drain(appPort(), 0L, N_EVENTS + K_EVENTS, deadline(DRAIN_TIMEOUT));
-
-        assertThat(fullTail).describedAs("full ordered tail of %d+%d events present on new owner", N_EVENTS, K_EVENTS)
-                  .hasSize(N_EVENTS + K_EVENTS);
+        assertThat(fullTail)
+            .describedAs("full ordered tail of %d+%d events present on new owner", N_EVENTS, K_EVENTS)
+            .hasSize(N_EVENTS + K_EVENTS);
         assertInOrder(fullTail);
+
         // Phase 9 — RF restoration. The membership-pinned variant asserts this HARD (the #457 acceptance
         // gate, @Disabled until #499); the default variant observes it as a non-failing sensor (post-kill
         // RF-restoration can stall on #498 SWIM false-removal and #499 HRW-divergence). Phases 1–8 above
@@ -228,18 +231,19 @@ abstract class AbstractStreamOwnerFailover {
     /// for the full mechanism. On timeout this dumps every live node's replica view before rethrowing.
     private void assertRfRestorationConverges() {
         try {
-            await().atMost(CONVERGE_TIMEOUT).pollInterval(POLL_INTERVAL).until(this::convergedWithRfRestored);
+            await().atMost(CONVERGE_TIMEOUT)
+                   .pollInterval(POLL_INTERVAL)
+                   .until(this::convergedWithRfRestored);
         } catch (ConditionTimeoutException timeout) {
             // Failure-path observability: the assertion otherwise dies blind — dump EVERY live
             // node's replica snapshot so the non-converged view is diagnosable from the log.
             dumpAllReplicaViews();
-
             throw timeout;
         }
 
         ownerView().onPresent(view -> LOG.log(System.Logger.Level.INFO,
                                               "#491 RF-restoration converged: "
-                                             + "ownerCaughtUp={0} caughtUpNonOwner={1} finalView={2}",
+                                              + "ownerCaughtUp={0} caughtUpNonOwner={1} finalView={2}",
                                               ownerIsCaughtUp(view),
                                               hasCaughtUpNonOwner(view),
                                               view));
@@ -273,15 +277,14 @@ abstract class AbstractStreamOwnerFailover {
 
         var finalView = ownerView().map(ReplicaSetView::toString).or("<no owner-authoritative view>");
 
-        LOG.log(converged
-                ? System.Logger.Level.INFO
-                : System.Logger.Level.WARNING,
+        LOG.log(converged ? System.Logger.Level.INFO : System.Logger.Level.WARNING,
                 "#491 phase-9 sensor (#498 SWIM + #499 HRW-divergence): RF-restoration converged={0} finalView={1}",
                 converged,
                 finalView);
     }
 
     // --- replica-set view (in-JVM, owner-authoritative) ---------------------
+
     /// The owner-authoritative replica-set view: the registry is authoritative only on the partition's
     /// HRW owner (`servedByOwner()` true), so scan every live node's in-JVM `replicaSnapshot` and return
     /// the owner's. The HTTP `/api/v1/streams/replicas` sensor is `taskGroup(STREAMING)`-routed to a single
@@ -299,34 +302,27 @@ abstract class AbstractStreamOwnerFailover {
     }
 
     private boolean replicaSetPlaced() {
-        return ownerView().map(view -> view.replicas()
-                                           .size() >= 2 && view.replicas()
-                                                               .stream()
-                                                               .anyMatch(r -> !r.hrwOwner()))
-                        .or(false);
+        return ownerView().map(view -> view.replicas().size() >= 2
+                                       && view.replicas().stream().anyMatch(r -> !r.hrwOwner()))
+                          .or(false);
     }
 
     private boolean ownerChangedAndAuthoritative(String oldOwner) {
         return ownerView().flatMap(ReplicaSetView::ownerNodeId)
-                        .map(owner -> !owner.isBlank() && !owner.equals(oldOwner))
-                        .or(false);
+                          .map(owner -> !owner.isBlank() && !owner.equals(oldOwner))
+                          .or(false);
     }
 
     private boolean convergedWithRfRestored() {
-        return ownerView().map(view -> noCaughtUpReplicaLagsTail(view) && hasCaughtUpNonOwner(view))
-                        .or(false);
+        return ownerView().map(view -> noCaughtUpReplicaLagsTail(view) && hasCaughtUpNonOwner(view)).or(false);
     }
 
     private boolean hasCaughtUpNonOwner(ReplicaSetView view) {
-        return view.replicas()
-                   .stream()
-                   .anyMatch(r -> "CAUGHT_UP".equals(r.state()) && !r.hrwOwner());
+        return view.replicas().stream().anyMatch(r -> "CAUGHT_UP".equals(r.state()) && !r.hrwOwner());
     }
 
     private boolean ownerIsCaughtUp(ReplicaSetView view) {
-        return view.replicas()
-                   .stream()
-                   .anyMatch(r -> r.hrwOwner() && "CAUGHT_UP".equals(r.state()));
+        return view.replicas().stream().anyMatch(r -> r.hrwOwner() && "CAUGHT_UP".equals(r.state()));
     }
 
     /// True iff no CAUGHT_UP replica's confirmedOffset lags the owner's true tail (ownerHeadOffset-1) —
@@ -339,38 +335,39 @@ abstract class AbstractStreamOwnerFailover {
 
         var tail = view.ownerHeadOffset() - 1;
 
-        return view.replicas()
-                   .stream()
+        return view.replicas().stream()
                    .filter(r -> "CAUGHT_UP".equals(r.state()))
                    .allMatch(r -> r.confirmedOffset() >= tail);
     }
 
     // --- assertions ---------------------------------------------------------
+
     private void assertContiguousBatch(List<Event> events, long base, String tag, int count) {
-        assertThat(events).describedAs("consumer must receive exactly %d '%s' events (no dups, no gaps)",
-                                       count,
-                                       tag)
-                  .hasSize(count);
+        assertThat(events)
+            .describedAs("consumer must receive exactly %d '%s' events (no dups, no gaps)", count, tag)
+            .hasSize(count);
+
         for (int i = 0; i < count; i++) {
-            assertThat(events.get(i).offset()).describedAs("event %d offset (contiguous from base %d)",
-                                                           i,
-                                                           base)
-                      .isEqualTo(base + i);
-            assertThat(events.get(i).payload()).describedAs("event %d payload (in publish order)",
-                                                            i)
-                      .isEqualTo(tag + "-" + i);
+            assertThat(events.get(i).offset())
+                .describedAs("event %d offset (contiguous from base %d)", i, base)
+                .isEqualTo(base + i);
+            assertThat(events.get(i).payload())
+                .describedAs("event %d payload (in publish order)", i)
+                .isEqualTo(tag + "-" + i);
         }
     }
 
     /// Offsets 0..size-1 are contiguous on the promoted owner (log correctly sequenced, no reordering).
     private void assertInOrder(List<Event> events) {
         for (int i = 0; i < events.size(); i++) {
-            assertThat(events.get(i).offset()).describedAs("offset at index %d is contiguous on the new owner", i)
-                      .isEqualTo((long) i);
+            assertThat(events.get(i).offset())
+                .describedAs("offset at index %d is contiguous on the new owner", i)
+                .isEqualTo((long) i);
         }
     }
 
     // --- consumers ----------------------------------------------------------
+
     private List<Event> drainAfterPublish(int port, String tag, int base, int count, Duration budget) {
         publishBatch(port, tag, count);
 
@@ -417,6 +414,7 @@ abstract class AbstractStreamOwnerFailover {
     }
 
     // --- publishing ---------------------------------------------------------
+
     private void publishBatch(int port, String tag, int count) {
         for (int i = 0; i < count; i++) {
             publish(port, tag + "-" + i);
@@ -427,10 +425,10 @@ abstract class AbstractStreamOwnerFailover {
         var body = "{\"payload\":\"" + payload + "\"}";
         var response = httpPost(port, "/api/stream-repl/publish", body);
 
-        assertThat(response).describedAs("publish '%s' must succeed (min-sync-2: resolves only after a replica ack)",
-                                         payload)
-                  .doesNotContain("\"error\"")
-                  .contains("published");
+        assertThat(response)
+            .describedAs("publish '%s' must succeed (min-sync-2: resolves only after a replica ack)", payload)
+            .doesNotContain("\"error\"")
+            .contains("published");
     }
 
     private List<Event> readEvents(int port, long fromOffset, int maxEvents) {
@@ -449,8 +447,7 @@ abstract class AbstractStreamOwnerFailover {
             Matcher payload = PAYLOAD_FIELD.matcher(object);
 
             if (offset.find() && payload.find()) {
-                events.add(new Event(Long.parseLong(offset.group(1)),
-                                     payload.group(1)));
+                events.add(new Event(Long.parseLong(offset.group(1)), payload.group(1)));
             }
         }
 
@@ -458,18 +455,22 @@ abstract class AbstractStreamOwnerFailover {
     }
 
     // --- deployment + readiness --------------------------------------------
+
     private void startAndAwaitReady() {
         LifecycleAwait.settled("cluster start in startAndAwaitReady()", cluster, cluster.start());
-        await().atMost(WAIT_TIMEOUT).pollInterval(POLL_INTERVAL).until(() -> cluster.currentLeader()
-                                                                                    .isPresent());
+
+        await().atMost(WAIT_TIMEOUT).pollInterval(POLL_INTERVAL).until(() -> cluster.currentLeader().isPresent());
         await().atMost(WAIT_TIMEOUT).pollInterval(POLL_INTERVAL).until(this::allNodesHealthy);
         await().atMost(WAIT_TIMEOUT).pollInterval(POLL_INTERVAL).until(() -> allNodesAreMembers(NODES));
+
         pinMembership(cluster);
+
         deployStreamSlice();
+
         await().atMost(WAIT_TIMEOUT)
-             .pollInterval(POLL_INTERVAL)
-             .failFast(this::failIfSliceFailed)
-             .until(this::appHttpReady);
+               .pollInterval(POLL_INTERVAL)
+               .failFast(this::failIfSliceFailed)
+               .until(this::appHttpReady);
     }
 
     private void deployStreamSlice() {
@@ -483,9 +484,10 @@ abstract class AbstractStreamOwnerFailover {
         var leaderPort = cluster.getLeaderManagementPort().or(anyMgmtPort());
         var response = postBlueprintWithRetry(leaderPort, blueprint);
 
-        assertThat(response).describedAs("RF=2 stream-slice deployment")
-                  .doesNotContain("\"error\"")
-                  .contains("\"status\":\"applied\"");
+        assertThat(response)
+            .describedAs("RF=2 stream-slice deployment")
+            .doesNotContain("\"error\"")
+            .contains("\"status\":\"applied\"");
     }
 
     private boolean appHttpReady() {
@@ -497,15 +499,13 @@ abstract class AbstractStreamOwnerFailover {
 
         var body = httpPost(ports.getFirst(), "/api/stream-repl/read", "{\"fromOffset\":0,\"maxEvents\":1}");
 
-        return ! body.contains("\"error\"") && body.contains("events");
+        return !body.contains("\"error\"") && body.contains("events");
     }
 
     private void failIfSliceFailed() {
         var failed = cluster.slicesStatus()
                             .stream()
-                            .anyMatch(s -> s.artifact()
-                                            .equals(STREAM_SLICE) && s.state()
-                                                                      .equals("FAILED"));
+                            .anyMatch(s -> s.artifact().equals(STREAM_SLICE) && s.state().equals("FAILED"));
 
         if (failed) {
             throw new AssertionError("RF=2 stream slice deployment FAILED: " + STREAM_SLICE);
@@ -520,10 +520,7 @@ abstract class AbstractStreamOwnerFailover {
     }
 
     private int anyMgmtPort() {
-        return cluster.status()
-                      .nodes()
-                      .getFirst()
-                      .mgmtPort();
+        return cluster.status().nodes().getFirst().mgmtPort();
     }
 
     private long deadline(Duration budget) {
@@ -543,11 +540,9 @@ abstract class AbstractStreamOwnerFailover {
                                  .GET()
                                  .timeout(Duration.ofSeconds(5))
                                  .build();
-
         return http.sendString(request)
                    .await()
-                   .map(r -> r.statusCode() == 200 && r.body()
-                                                       .contains("\"quorum\":true"))
+                   .map(r -> r.statusCode() == 200 && r.body().contains("\"quorum\":true"))
                    .or(false);
     }
 
@@ -558,11 +553,9 @@ abstract class AbstractStreamOwnerFailover {
                                  .GET()
                                  .timeout(Duration.ofSeconds(5))
                                  .build();
-
         return http.sendString(request)
                    .await()
-                   .map(r -> r.statusCode() == 200 && healthHasFullMembership(r.body(),
-                                                                              expected))
+                   .map(r -> r.statusCode() == 200 && healthHasFullMembership(r.body(), expected))
                    .or(false);
     }
 
@@ -577,11 +570,13 @@ abstract class AbstractStreamOwnerFailover {
     }
 
     // --- HTTP ---------------------------------------------------------------
+
     private String postBlueprintWithRetry(int port, String body) {
         var lastResponse = ERROR_FALLBACK;
 
         for (int attempt = 1; attempt <= 3; attempt++) {
             lastResponse = httpPostToml(port, "/api/v1/blueprints", body);
+
             if (!lastResponse.contains("\"error\"")) {
                 return lastResponse;
             }
@@ -601,7 +596,6 @@ abstract class AbstractStreamOwnerFailover {
                                  .POST(HttpRequest.BodyPublishers.ofString(body))
                                  .timeout(Duration.ofSeconds(10))
                                  .build();
-
         return http.sendString(request)
                    .await()
                    .map(HttpResult::body)
@@ -615,7 +609,6 @@ abstract class AbstractStreamOwnerFailover {
                                  .POST(HttpRequest.BodyPublishers.ofString(body))
                                  .timeout(Duration.ofSeconds(15))
                                  .build();
-
         return http.sendString(request)
                    .await()
                    .map(HttpResult::body)
@@ -628,7 +621,6 @@ abstract class AbstractStreamOwnerFailover {
                                  .DELETE()
                                  .timeout(Duration.ofSeconds(10))
                                  .build();
-
         return http.sendString(request)
                    .await()
                    .map(HttpResult::body)

--- a/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/ArtifactChurnSurvival5to7to5ProbeTest.java
+++ b/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/ArtifactChurnSurvival5to7to5ProbeTest.java
@@ -2,21 +2,8 @@
 // Copyright (c) 2025 Pragmatica Labs - Sergiy Yevtushenko
 // Licensed under Business Source License 1.1. Change Date: 2030-01-01. Change License: Apache-2.0.
 // See LICENSE in the repository root for full terms.
+
 package org.pragmatica.aether.forge;
-
-import java.net.URI;
-import java.net.http.HttpRequest;
-import java.time.Duration;
-import java.util.regex.Pattern;
-
-import org.pragmatica.aether.ember.EmberCluster;
-import org.pragmatica.aether.node.AetherNode;
-import org.pragmatica.aether.slice.SliceState;
-import org.pragmatica.http.HttpOperations;
-import org.pragmatica.http.HttpResult;
-import org.pragmatica.lang.Cause;
-import org.pragmatica.lang.Option;
-import org.pragmatica.lang.TerminalOperation;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -25,14 +12,25 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.pragmatica.aether.ember.EmberCluster;
+import org.pragmatica.aether.node.AetherNode;
+import org.pragmatica.aether.slice.SliceState;
+import org.pragmatica.http.HttpOperations;
+import org.pragmatica.http.HttpResult;
+import org.pragmatica.lang.Option;
+import org.pragmatica.lang.TerminalOperation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.pragmatica.aether.ember.EmberCluster.emberCluster;
-import static org.pragmatica.http.JdkHttpOperations.jdkHttpOperations;
+import java.net.URI;
+import java.net.http.HttpRequest;
+import java.time.Duration;
+import java.util.regex.Pattern;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
-
+import static org.pragmatica.aether.ember.EmberCluster.emberCluster;
+import static org.pragmatica.http.JdkHttpOperations.jdkHttpOperations;
 
 /// #427 deliverable 4 — end-to-end evidence check: an artifact seeded before a MANAGED 5→7→5 scale
 /// cycle must survive the cycle (its DHT-resident bytecode chunks are not lost when surplus cores
@@ -76,20 +74,24 @@ import static org.awaitility.Awaitility.await;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class ArtifactChurnSurvival5to7to5ProbeTest {
     private static final Logger log = LoggerFactory.getLogger(ArtifactChurnSurvival5to7to5ProbeTest.class);
+
     private static final int INITIAL_CORES = 5;
     private static final int TARGET_CORES = 7;
     private static final int BASE_PORT = 5680;
     private static final int BASE_MGMT_PORT = 5780;
     private static final int BASE_APP_HTTP_PORT = 5880;
+
     private static final String TEST_ARTIFACT = TestArtifacts.ECHO_SLICE;
     private static final String BLUEPRINT_ID = "forge.test:artifact-churn:1.0.0";
     private static final String ERROR_FALLBACK = "{\"error\":\"request failed\"}";
+
     private static final Duration FORM_TIMEOUT = Duration.ofSeconds(240);
     private static final Duration DEPLOY_TIMEOUT = Duration.ofSeconds(60);
     private static final Duration SCALE_TIMEOUT = Duration.ofSeconds(120);
     private static final Duration SURVIVE_TIMEOUT = Duration.ofSeconds(120);
     private static final Duration POLL = Duration.ofMillis(500);
     private static final Duration LOG_EVERY = Duration.ofSeconds(5);
+
     private static final Pattern CONFIG_VERSION = Pattern.compile("\"configVersion\"\\s*:\\s*(\\d+)");
 
     private EmberCluster cluster;
@@ -100,57 +102,59 @@ class ArtifactChurnSurvival5to7to5ProbeTest {
     void setUp() {
         cluster = emberCluster(INITIAL_CORES, BASE_PORT, BASE_MGMT_PORT, BASE_APP_HTTP_PORT, "churn");
         LifecycleAwait.settled("cluster start in setUp()", cluster, cluster.start());
-        await().atMost(FORM_TIMEOUT).pollInterval(POLL).until(() -> cluster.currentLeader()
-                                                                           .isPresent());
+
+        await().atMost(FORM_TIMEOUT).pollInterval(POLL).until(() -> cluster.currentLeader().isPresent());
         await().atMost(FORM_TIMEOUT).pollInterval(POLL).until(this::allNodesHealthy);
         await().atMost(FORM_TIMEOUT).pollInterval(POLL).until(() -> countedCores() == INITIAL_CORES);
         log.info("CHURN-PROBE: {}-core cluster formed, leader={}, countedCores={}",
-                 INITIAL_CORES,
-                 cluster.currentLeader().or("none"),
-                 countedCores());
+                 INITIAL_CORES, cluster.currentLeader().or("none"), countedCores());
     }
 
     @AfterAll
     @TerminalOperation
     void tearDown() {
-        Option.option(cluster).onPresent(c -> LifecycleAwait.settled("cluster stop in tearDown()", c, c.stop()));
+        Option.option(cluster).onPresent(c -> LifecycleAwait.bestEffort("cluster stop in tearDown()", c, c.stop()));
     }
 
     @Test
     @TerminalOperation
     void seededArtifact_survivesManagedFiveToSevenToFiveChurn() {
         var deployResponse = deploy(leaderPort(), TEST_ARTIFACT);
-
         assertThat(deployResponse).doesNotContain("\"error\"");
-        await().atMost(DEPLOY_TIMEOUT).pollInterval(POLL).ignoreExceptions().until(() -> sliceIsActive(TEST_ARTIFACT));
+        await().atMost(DEPLOY_TIMEOUT).pollInterval(POLL).ignoreExceptions()
+               .until(() -> sliceIsActive(TEST_ARTIFACT));
         log.info("CHURN-PROBE: artifact seeded and ACTIVE at countedCores={}", countedCores());
+
         var upLatency = managedScale(TARGET_CORES);
+        assertThat(upLatency)
+            .as("GUARD: managed 5->7 via /api/v1/cluster/scale must physically reach %d counted cores "
+                + "within %ds (latch=-1 => no physical churn, the trigger no-ops and the departure "
+                + "push is never exercised — vacuous survival is thereby impossible).",
+                TARGET_CORES, SCALE_TIMEOUT.toSeconds())
+            .isGreaterThanOrEqualTo(0L);
 
-        assertThat(upLatency).as("GUARD: managed 5->7 via /api/v1/cluster/scale must physically reach %d counted cores "
-                                + "within %ds (latch=-1 => no physical churn, the trigger no-ops and the departure "
-                                + "push is never exercised — vacuous survival is thereby impossible).",
-                                 TARGET_CORES,
-                                 SCALE_TIMEOUT.toSeconds())
-                  .isGreaterThanOrEqualTo(0L);
         var downLatency = managedScale(INITIAL_CORES);
+        assertThat(downLatency)
+            .as("GUARD: managed 7->5 via /api/v1/cluster/scale must settle back to %d counted cores "
+                + "within %ds (latch=-1 => surplus never drained, so the departure push never ran).",
+                INITIAL_CORES, SCALE_TIMEOUT.toSeconds())
+            .isGreaterThanOrEqualTo(0L);
 
-        assertThat(downLatency).as("GUARD: managed 7->5 via /api/v1/cluster/scale must settle back to %d counted cores "
-                                  + "within %ds (latch=-1 => surplus never drained, so the departure push never ran).",
-                                   INITIAL_CORES,
-                                   SCALE_TIMEOUT.toSeconds())
-                  .isGreaterThanOrEqualTo(0L);
-        await().atMost(SURVIVE_TIMEOUT).pollInterval(POLL).ignoreExceptions().until(() -> sliceIsActive(TEST_ARTIFACT));
+        await().atMost(SURVIVE_TIMEOUT).pollInterval(POLL).ignoreExceptions()
+               .until(() -> sliceIsActive(TEST_ARTIFACT));
+
         var slices = getSlices(leaderPort());
-
-        assertThat(slices).as("LOAD-BEARING: the artifact seeded before the confirmed managed 5->7->5 churn "
-                             + "survives it and is still resolvable at HEAD (C1 departure-push fix present: "
-                             + "DHTRebalancer.pushOnDeparture wired at AetherNode.java:1852). Missing artifact => "
-                             + "its DHT chunks were lost when surplus cores drained — #427 reproducing end-to-end.")
-                  .contains(TEST_ARTIFACT)
-                  .doesNotContain("\"error\"");
+        assertThat(slices)
+            .as("LOAD-BEARING: the artifact seeded before the confirmed managed 5->7->5 churn "
+                + "survives it and is still resolvable at HEAD (C1 departure-push fix present: "
+                + "DHTRebalancer.pushOnDeparture wired at AetherNode.java:1852). Missing artifact => "
+                + "its DHT chunks were lost when surplus cores drained — #427 reproducing end-to-end.")
+            .contains(TEST_ARTIFACT)
+            .doesNotContain("\"error\"");
     }
 
     // ----- managed scale via the real ClusterConfigKey path (mirrors ScaleUpFiveToSevenProbeTest) -----
+
     /// Commits the target core count through `POST /api/v1/cluster/scale` and blocks until the
     /// in-process counted-core denominator equals it (or the budget expires). Returns the
     /// convergence latency in ms, or -1 if the target was never observed within the budget.
@@ -159,60 +163,44 @@ class ArtifactChurnSurvival5to7to5ProbeTest {
         var port = leaderPort();
         var version = readConfigVersion(port);
         var response = postScale(port, targetCores, version);
-
         log.info("CHURN-PROBE: POST /api/v1/cluster/scale {{coreCount:{}, expectedVersion:{}}} -> {}",
-                 targetCores,
-                 version,
-                 response);
-
+                 targetCores, version, response);
         return awaitCounted(targetCores, SCALE_TIMEOUT);
     }
 
     private long awaitCounted(int target, Duration budget) {
         var t0 = System.nanoTime();
-        var reached = new long[]{ - 1L};
+        var reached = new long[]{-1L};
         var lastLog = new long[]{0L};
-
         await().pollInterval(POLL)
-             .pollDelay(Duration.ZERO)
-             .timeout(budget.plusSeconds(5))
-             .until(() -> countedTick(target, t0, budget, reached, lastLog));
-
+               .pollDelay(Duration.ZERO)
+               .timeout(budget.plusSeconds(5))
+               .until(() -> countedTick(target, t0, budget, reached, lastLog));
         return reached[0];
     }
 
     private boolean countedTick(int target, long t0, Duration budget, long[] reached, long[] lastLog) {
         var elapsed = (System.nanoTime() - t0) / 1_000_000L;
-
-        if (reached[0]< 0 && countedCores() == target) {
+        if (reached[0] < 0 && countedCores() == target) {
             reached[0] = elapsed;
         }
-
         maybeLog(target, elapsed, lastLog);
-
-        return reached[0]>= 0 || elapsed >= budget.toMillis();
+        return reached[0] >= 0 || elapsed >= budget.toMillis();
     }
 
     private void maybeLog(int target, long elapsedMs, long[] lastLog) {
-        if (elapsedMs - lastLog[0]< LOG_EVERY.toMillis()) {
+        if (elapsedMs - lastLog[0] < LOG_EVERY.toMillis()) {
             return;
         }
-
         lastLog[0] = elapsedMs;
         log.info("CHURN-PROBE: t+{}ms target={} countedCores={} emberNodeCount={} leaderPresent={}",
-                 elapsedMs,
-                 target,
-                 countedCores(),
-                 cluster.nodeCount(),
-                 cluster.currentLeader().isPresent());
+                 elapsedMs, target, countedCores(), cluster.nodeCount(), cluster.currentLeader().isPresent());
     }
 
     // ----- in-process membership reads -----
+
     private int countedCores() {
-        return leaderOrAnyNode().map(node -> node.membershipFsm()
-                                                 .coreCountedMembers()
-                                                 .size())
-                              .or(0);
+        return leaderOrAnyNode().map(node -> node.membershipFsm().coreCountedMembers().size()).or(0);
     }
 
     private Option<AetherNode> leaderOrAnyNode() {
@@ -222,11 +210,11 @@ class ArtifactChurnSurvival5to7to5ProbeTest {
     }
 
     private int leaderPort() {
-        return cluster.getLeaderManagementPort()
-                      .or(cluster.status().nodes().getFirst().mgmtPort());
+        return cluster.getLeaderManagementPort().or(cluster.status().nodes().getFirst().mgmtPort());
     }
 
     // ----- HTTP helpers (scale trigger + slice deploy/resolve) -----
+
     @TerminalOperation
     private String postScale(int port, int coreCount, int expectedVersion) {
         var body = "{\"coreCount\":" + coreCount + ",\"expectedVersion\":" + expectedVersion + "}";
@@ -236,7 +224,6 @@ class ArtifactChurnSurvival5to7to5ProbeTest {
                                  .POST(HttpRequest.BodyPublishers.ofString(body))
                                  .timeout(Duration.ofSeconds(10))
                                  .build();
-
         return http.sendString(request)
                    .await()
                    .map(ArtifactChurnSurvival5to7to5ProbeTest::renderResponse)
@@ -249,7 +236,6 @@ class ArtifactChurnSurvival5to7to5ProbeTest {
 
     private int readConfigVersion(int port) {
         var matcher = CONFIG_VERSION.matcher(httpGet(port, "/api/v1/cluster/config"));
-
         return matcher.find()
                ? Integer.parseInt(matcher.group(1))
                : 0;
@@ -262,7 +248,6 @@ class ArtifactChurnSurvival5to7to5ProbeTest {
                                  .GET()
                                  .timeout(Duration.ofSeconds(5))
                                  .build();
-
         return http.sendString(request)
                    .await()
                    .map(HttpResult::body)
@@ -272,9 +257,8 @@ class ArtifactChurnSurvival5to7to5ProbeTest {
     private boolean sliceIsActive(String artifact) {
         return cluster.slicesStatus()
                       .stream()
-                      .anyMatch(status -> status.artifact()
-                                                .equals(artifact) && status.state()
-                                                                           .equals(SliceState.ACTIVE.name()));
+                      .anyMatch(status -> status.artifact().equals(artifact)
+                                          && status.state().equals(SliceState.ACTIVE.name()));
     }
 
     @TerminalOperation
@@ -286,7 +270,6 @@ class ArtifactChurnSurvival5to7to5ProbeTest {
             artifact = "%s"
             instances = 3
             """.formatted(BLUEPRINT_ID, artifact);
-
         return http.sendString(postBlueprint(port, blueprint))
                    .await()
                    .map(HttpResult::body)
@@ -309,7 +292,6 @@ class ArtifactChurnSurvival5to7to5ProbeTest {
                                  .GET()
                                  .timeout(Duration.ofSeconds(10))
                                  .build();
-
         return http.sendString(request)
                    .await()
                    .map(HttpResult::body)
@@ -317,10 +299,7 @@ class ArtifactChurnSurvival5to7to5ProbeTest {
     }
 
     private boolean allNodesHealthy() {
-        return cluster.status()
-                      .nodes()
-                      .stream()
-                      .allMatch(node -> checkNodeHealth(node.mgmtPort()));
+        return cluster.status().nodes().stream().allMatch(node -> checkNodeHealth(node.mgmtPort()));
     }
 
     @TerminalOperation
@@ -330,15 +309,10 @@ class ArtifactChurnSurvival5to7to5ProbeTest {
                                  .GET()
                                  .timeout(Duration.ofSeconds(5))
                                  .build();
-
         return http.sendString(request)
                    .await()
-                   .map(r -> r.statusCode() == 200 && r.body()
-                                                       .contains("\"quorum\":true"))
+                   .map(r -> r.statusCode() == 200 && r.body().contains("\"quorum\":true"))
                    .or(false);
     }
 
-    private static void failStart(Cause cause) {
-        throw new AssertionError("Cluster start failed: " + cause.message());
-    }
 }

--- a/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/ArtifactChurnSurvival5to7to5ProbeTest.java
+++ b/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/ArtifactChurnSurvival5to7to5ProbeTest.java
@@ -2,16 +2,13 @@
 // Copyright (c) 2025 Pragmatica Labs - Sergiy Yevtushenko
 // Licensed under Business Source License 1.1. Change Date: 2030-01-01. Change License: Apache-2.0.
 // See LICENSE in the repository root for full terms.
-
 package org.pragmatica.aether.forge;
 
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
+import java.net.URI;
+import java.net.http.HttpRequest;
+import java.time.Duration;
+import java.util.regex.Pattern;
+
 import org.pragmatica.aether.ember.EmberCluster;
 import org.pragmatica.aether.node.AetherNode;
 import org.pragmatica.aether.slice.SliceState;
@@ -20,18 +17,22 @@ import org.pragmatica.http.HttpResult;
 import org.pragmatica.lang.Cause;
 import org.pragmatica.lang.Option;
 import org.pragmatica.lang.TerminalOperation;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.net.URI;
-import java.net.http.HttpRequest;
-import java.time.Duration;
-import java.util.regex.Pattern;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.awaitility.Awaitility.await;
 import static org.pragmatica.aether.ember.EmberCluster.emberCluster;
 import static org.pragmatica.http.JdkHttpOperations.jdkHttpOperations;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
 
 /// #427 deliverable 4 — end-to-end evidence check: an artifact seeded before a MANAGED 5→7→5 scale
 /// cycle must survive the cycle (its DHT-resident bytecode chunks are not lost when surplus cores
@@ -75,24 +76,20 @@ import static org.pragmatica.http.JdkHttpOperations.jdkHttpOperations;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class ArtifactChurnSurvival5to7to5ProbeTest {
     private static final Logger log = LoggerFactory.getLogger(ArtifactChurnSurvival5to7to5ProbeTest.class);
-
     private static final int INITIAL_CORES = 5;
     private static final int TARGET_CORES = 7;
     private static final int BASE_PORT = 5680;
     private static final int BASE_MGMT_PORT = 5780;
     private static final int BASE_APP_HTTP_PORT = 5880;
-
     private static final String TEST_ARTIFACT = TestArtifacts.ECHO_SLICE;
     private static final String BLUEPRINT_ID = "forge.test:artifact-churn:1.0.0";
     private static final String ERROR_FALLBACK = "{\"error\":\"request failed\"}";
-
     private static final Duration FORM_TIMEOUT = Duration.ofSeconds(240);
     private static final Duration DEPLOY_TIMEOUT = Duration.ofSeconds(60);
     private static final Duration SCALE_TIMEOUT = Duration.ofSeconds(120);
     private static final Duration SURVIVE_TIMEOUT = Duration.ofSeconds(120);
     private static final Duration POLL = Duration.ofMillis(500);
     private static final Duration LOG_EVERY = Duration.ofSeconds(5);
-
     private static final Pattern CONFIG_VERSION = Pattern.compile("\"configVersion\"\\s*:\\s*(\\d+)");
 
     private EmberCluster cluster;
@@ -102,62 +99,58 @@ class ArtifactChurnSurvival5to7to5ProbeTest {
     @TerminalOperation
     void setUp() {
         cluster = emberCluster(INITIAL_CORES, BASE_PORT, BASE_MGMT_PORT, BASE_APP_HTTP_PORT, "churn");
-        cluster.start()
-               .await()
-               .onFailure(ArtifactChurnSurvival5to7to5ProbeTest::failStart);
-
-        await().atMost(FORM_TIMEOUT).pollInterval(POLL).until(() -> cluster.currentLeader().isPresent());
+        LifecycleAwait.settled("cluster start in setUp()", cluster, cluster.start());
+        await().atMost(FORM_TIMEOUT).pollInterval(POLL).until(() -> cluster.currentLeader()
+                                                                           .isPresent());
         await().atMost(FORM_TIMEOUT).pollInterval(POLL).until(this::allNodesHealthy);
         await().atMost(FORM_TIMEOUT).pollInterval(POLL).until(() -> countedCores() == INITIAL_CORES);
         log.info("CHURN-PROBE: {}-core cluster formed, leader={}, countedCores={}",
-                 INITIAL_CORES, cluster.currentLeader().or("none"), countedCores());
+                 INITIAL_CORES,
+                 cluster.currentLeader().or("none"),
+                 countedCores());
     }
 
     @AfterAll
     @TerminalOperation
     void tearDown() {
-        Option.option(cluster).onPresent(c -> c.stop().await());
+        Option.option(cluster).onPresent(c -> LifecycleAwait.settled("cluster stop in tearDown()", c, c.stop()));
     }
 
     @Test
     @TerminalOperation
     void seededArtifact_survivesManagedFiveToSevenToFiveChurn() {
         var deployResponse = deploy(leaderPort(), TEST_ARTIFACT);
+
         assertThat(deployResponse).doesNotContain("\"error\"");
-        await().atMost(DEPLOY_TIMEOUT).pollInterval(POLL).ignoreExceptions()
-               .until(() -> sliceIsActive(TEST_ARTIFACT));
+        await().atMost(DEPLOY_TIMEOUT).pollInterval(POLL).ignoreExceptions().until(() -> sliceIsActive(TEST_ARTIFACT));
         log.info("CHURN-PROBE: artifact seeded and ACTIVE at countedCores={}", countedCores());
-
         var upLatency = managedScale(TARGET_CORES);
-        assertThat(upLatency)
-            .as("GUARD: managed 5->7 via /api/v1/cluster/scale must physically reach %d counted cores "
-                + "within %ds (latch=-1 => no physical churn, the trigger no-ops and the departure "
-                + "push is never exercised — vacuous survival is thereby impossible).",
-                TARGET_CORES, SCALE_TIMEOUT.toSeconds())
-            .isGreaterThanOrEqualTo(0L);
 
+        assertThat(upLatency).as("GUARD: managed 5->7 via /api/v1/cluster/scale must physically reach %d counted cores "
+                                + "within %ds (latch=-1 => no physical churn, the trigger no-ops and the departure "
+                                + "push is never exercised — vacuous survival is thereby impossible).",
+                                 TARGET_CORES,
+                                 SCALE_TIMEOUT.toSeconds())
+                  .isGreaterThanOrEqualTo(0L);
         var downLatency = managedScale(INITIAL_CORES);
-        assertThat(downLatency)
-            .as("GUARD: managed 7->5 via /api/v1/cluster/scale must settle back to %d counted cores "
-                + "within %ds (latch=-1 => surplus never drained, so the departure push never ran).",
-                INITIAL_CORES, SCALE_TIMEOUT.toSeconds())
-            .isGreaterThanOrEqualTo(0L);
 
-        await().atMost(SURVIVE_TIMEOUT).pollInterval(POLL).ignoreExceptions()
-               .until(() -> sliceIsActive(TEST_ARTIFACT));
-
+        assertThat(downLatency).as("GUARD: managed 7->5 via /api/v1/cluster/scale must settle back to %d counted cores "
+                                  + "within %ds (latch=-1 => surplus never drained, so the departure push never ran).",
+                                   INITIAL_CORES,
+                                   SCALE_TIMEOUT.toSeconds())
+                  .isGreaterThanOrEqualTo(0L);
+        await().atMost(SURVIVE_TIMEOUT).pollInterval(POLL).ignoreExceptions().until(() -> sliceIsActive(TEST_ARTIFACT));
         var slices = getSlices(leaderPort());
-        assertThat(slices)
-            .as("LOAD-BEARING: the artifact seeded before the confirmed managed 5->7->5 churn "
-                + "survives it and is still resolvable at HEAD (C1 departure-push fix present: "
-                + "DHTRebalancer.pushOnDeparture wired at AetherNode.java:1852). Missing artifact => "
-                + "its DHT chunks were lost when surplus cores drained — #427 reproducing end-to-end.")
-            .contains(TEST_ARTIFACT)
-            .doesNotContain("\"error\"");
+
+        assertThat(slices).as("LOAD-BEARING: the artifact seeded before the confirmed managed 5->7->5 churn "
+                             + "survives it and is still resolvable at HEAD (C1 departure-push fix present: "
+                             + "DHTRebalancer.pushOnDeparture wired at AetherNode.java:1852). Missing artifact => "
+                             + "its DHT chunks were lost when surplus cores drained — #427 reproducing end-to-end.")
+                  .contains(TEST_ARTIFACT)
+                  .doesNotContain("\"error\"");
     }
 
     // ----- managed scale via the real ClusterConfigKey path (mirrors ScaleUpFiveToSevenProbeTest) -----
-
     /// Commits the target core count through `POST /api/v1/cluster/scale` and blocks until the
     /// in-process counted-core denominator equals it (or the budget expires). Returns the
     /// convergence latency in ms, or -1 if the target was never observed within the budget.
@@ -166,44 +159,60 @@ class ArtifactChurnSurvival5to7to5ProbeTest {
         var port = leaderPort();
         var version = readConfigVersion(port);
         var response = postScale(port, targetCores, version);
+
         log.info("CHURN-PROBE: POST /api/v1/cluster/scale {{coreCount:{}, expectedVersion:{}}} -> {}",
-                 targetCores, version, response);
+                 targetCores,
+                 version,
+                 response);
+
         return awaitCounted(targetCores, SCALE_TIMEOUT);
     }
 
     private long awaitCounted(int target, Duration budget) {
         var t0 = System.nanoTime();
-        var reached = new long[]{-1L};
+        var reached = new long[]{ - 1L};
         var lastLog = new long[]{0L};
+
         await().pollInterval(POLL)
-               .pollDelay(Duration.ZERO)
-               .timeout(budget.plusSeconds(5))
-               .until(() -> countedTick(target, t0, budget, reached, lastLog));
+             .pollDelay(Duration.ZERO)
+             .timeout(budget.plusSeconds(5))
+             .until(() -> countedTick(target, t0, budget, reached, lastLog));
+
         return reached[0];
     }
 
     private boolean countedTick(int target, long t0, Duration budget, long[] reached, long[] lastLog) {
         var elapsed = (System.nanoTime() - t0) / 1_000_000L;
-        if (reached[0] < 0 && countedCores() == target) {
+
+        if (reached[0]< 0 && countedCores() == target) {
             reached[0] = elapsed;
         }
+
         maybeLog(target, elapsed, lastLog);
-        return reached[0] >= 0 || elapsed >= budget.toMillis();
+
+        return reached[0]>= 0 || elapsed >= budget.toMillis();
     }
 
     private void maybeLog(int target, long elapsedMs, long[] lastLog) {
-        if (elapsedMs - lastLog[0] < LOG_EVERY.toMillis()) {
+        if (elapsedMs - lastLog[0]< LOG_EVERY.toMillis()) {
             return;
         }
+
         lastLog[0] = elapsedMs;
         log.info("CHURN-PROBE: t+{}ms target={} countedCores={} emberNodeCount={} leaderPresent={}",
-                 elapsedMs, target, countedCores(), cluster.nodeCount(), cluster.currentLeader().isPresent());
+                 elapsedMs,
+                 target,
+                 countedCores(),
+                 cluster.nodeCount(),
+                 cluster.currentLeader().isPresent());
     }
 
     // ----- in-process membership reads -----
-
     private int countedCores() {
-        return leaderOrAnyNode().map(node -> node.membershipFsm().coreCountedMembers().size()).or(0);
+        return leaderOrAnyNode().map(node -> node.membershipFsm()
+                                                 .coreCountedMembers()
+                                                 .size())
+                              .or(0);
     }
 
     private Option<AetherNode> leaderOrAnyNode() {
@@ -213,11 +222,11 @@ class ArtifactChurnSurvival5to7to5ProbeTest {
     }
 
     private int leaderPort() {
-        return cluster.getLeaderManagementPort().or(cluster.status().nodes().getFirst().mgmtPort());
+        return cluster.getLeaderManagementPort()
+                      .or(cluster.status().nodes().getFirst().mgmtPort());
     }
 
     // ----- HTTP helpers (scale trigger + slice deploy/resolve) -----
-
     @TerminalOperation
     private String postScale(int port, int coreCount, int expectedVersion) {
         var body = "{\"coreCount\":" + coreCount + ",\"expectedVersion\":" + expectedVersion + "}";
@@ -227,6 +236,7 @@ class ArtifactChurnSurvival5to7to5ProbeTest {
                                  .POST(HttpRequest.BodyPublishers.ofString(body))
                                  .timeout(Duration.ofSeconds(10))
                                  .build();
+
         return http.sendString(request)
                    .await()
                    .map(ArtifactChurnSurvival5to7to5ProbeTest::renderResponse)
@@ -239,6 +249,7 @@ class ArtifactChurnSurvival5to7to5ProbeTest {
 
     private int readConfigVersion(int port) {
         var matcher = CONFIG_VERSION.matcher(httpGet(port, "/api/v1/cluster/config"));
+
         return matcher.find()
                ? Integer.parseInt(matcher.group(1))
                : 0;
@@ -251,6 +262,7 @@ class ArtifactChurnSurvival5to7to5ProbeTest {
                                  .GET()
                                  .timeout(Duration.ofSeconds(5))
                                  .build();
+
         return http.sendString(request)
                    .await()
                    .map(HttpResult::body)
@@ -260,8 +272,9 @@ class ArtifactChurnSurvival5to7to5ProbeTest {
     private boolean sliceIsActive(String artifact) {
         return cluster.slicesStatus()
                       .stream()
-                      .anyMatch(status -> status.artifact().equals(artifact)
-                                          && status.state().equals(SliceState.ACTIVE.name()));
+                      .anyMatch(status -> status.artifact()
+                                                .equals(artifact) && status.state()
+                                                                           .equals(SliceState.ACTIVE.name()));
     }
 
     @TerminalOperation
@@ -273,6 +286,7 @@ class ArtifactChurnSurvival5to7to5ProbeTest {
             artifact = "%s"
             instances = 3
             """.formatted(BLUEPRINT_ID, artifact);
+
         return http.sendString(postBlueprint(port, blueprint))
                    .await()
                    .map(HttpResult::body)
@@ -295,6 +309,7 @@ class ArtifactChurnSurvival5to7to5ProbeTest {
                                  .GET()
                                  .timeout(Duration.ofSeconds(10))
                                  .build();
+
         return http.sendString(request)
                    .await()
                    .map(HttpResult::body)
@@ -302,7 +317,10 @@ class ArtifactChurnSurvival5to7to5ProbeTest {
     }
 
     private boolean allNodesHealthy() {
-        return cluster.status().nodes().stream().allMatch(node -> checkNodeHealth(node.mgmtPort()));
+        return cluster.status()
+                      .nodes()
+                      .stream()
+                      .allMatch(node -> checkNodeHealth(node.mgmtPort()));
     }
 
     @TerminalOperation
@@ -312,9 +330,11 @@ class ArtifactChurnSurvival5to7to5ProbeTest {
                                  .GET()
                                  .timeout(Duration.ofSeconds(5))
                                  .build();
+
         return http.sendString(request)
                    .await()
-                   .map(r -> r.statusCode() == 200 && r.body().contains("\"quorum\":true"))
+                   .map(r -> r.statusCode() == 200 && r.body()
+                                                       .contains("\"quorum\":true"))
                    .or(false);
     }
 

--- a/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/ClusterFormationTest.java
+++ b/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/ClusterFormationTest.java
@@ -2,28 +2,29 @@
 // Copyright (c) 2025 Pragmatica Labs - Sergiy Yevtushenko
 // Licensed under Business Source License 1.1. Change Date: 2030-01-01. Change License: Apache-2.0.
 // See LICENSE in the repository root for full terms.
-
 package org.pragmatica.aether.forge;
-
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.TestInstance;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
-import org.pragmatica.http.HttpResult;
-import org.pragmatica.http.HttpOperations;
 
 import java.net.URI;
 import java.net.http.HttpRequest;
 import java.time.Duration;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.awaitility.Awaitility.await;
+import org.pragmatica.http.HttpResult;
+import org.pragmatica.http.HttpOperations;
 import org.pragmatica.aether.ember.EmberCluster;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+
 import static org.pragmatica.aether.ember.EmberCluster.emberCluster;
 import static org.pragmatica.http.JdkHttpOperations.jdkHttpOperations;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
 
 /// Tests for cluster formation and quorum behavior using EmberCluster.
 ///
@@ -57,27 +58,16 @@ class ClusterFormationTest {
     @BeforeAll
     void setUp() {
         cluster = emberCluster(3, BASE_PORT, BASE_MGMT_PORT, BASE_APP_HTTP_PORT, "cf");
-
-        cluster.start()
-               .await()
-               .onFailure(cause -> {
-                   throw new AssertionError("Cluster start failed: " + cause.message());
-               });
-
-        await().atMost(WAIT_TIMEOUT)
-               .pollInterval(POLL_INTERVAL)
-               .until(() -> cluster.currentLeader().isPresent());
-
-        await().atMost(WAIT_TIMEOUT)
-               .pollInterval(POLL_INTERVAL)
-               .until(this::allNodesHealthy);
+        LifecycleAwait.settled("cluster start in setUp()", cluster, cluster.start());
+        await().atMost(WAIT_TIMEOUT).pollInterval(POLL_INTERVAL).until(() -> cluster.currentLeader()
+                                                                                    .isPresent());
+        await().atMost(WAIT_TIMEOUT).pollInterval(POLL_INTERVAL).until(this::allNodesHealthy);
     }
 
     @AfterAll
     void tearDown() {
         if (cluster != null) {
-            cluster.stop()
-                   .await();
+            LifecycleAwait.settled("cluster stop in tearDown()", cluster, cluster.stop());
         }
     }
 
@@ -85,14 +75,14 @@ class ClusterFormationTest {
     void threeNodeCluster_formsQuorum_andElectsLeader() {
         // All nodes should be running
         assertThat(cluster.nodeCount()).isEqualTo(3);
-
         // Health endpoint should report healthy with quorum
         var anyNodePort = cluster.status().nodes().getFirst().mgmtPort();
         var health = getHealth(anyNodePort);
-        assertThat(health).contains("\"status\"");
 
+        assertThat(health).contains("\"status\"");
         // Leader should be elected
         var leader = cluster.currentLeader();
+
         assertThat(leader.isPresent()).isTrue();
     }
 
@@ -101,6 +91,7 @@ class ClusterFormationTest {
         // Each node should report 2 connected peers via /api/v1/health endpoint
         for (var node : cluster.status().nodes()) {
             var health = getHealth(node.mgmtPort());
+
             assertThat(health).contains("\"connectedPeers\":2");
             assertThat(health).contains("\"nodeCount\":3");
         }
@@ -110,10 +101,10 @@ class ClusterFormationTest {
     void cluster_statusConsistent_acrossNodes() {
         // Collect status from all nodes
         var leaderNode = cluster.currentLeader().unwrap();
-
         // All nodes should report the same leader via /api/v1/nodes/status endpoint
         for (var node : cluster.status().nodes()) {
             var status = getStatus(node.mgmtPort());
+
             assertThat(status).contains(leaderNode);
         }
     }
@@ -122,7 +113,6 @@ class ClusterFormationTest {
     void cluster_metricsAvailable_afterFormation() {
         var anyNodePort = cluster.status().nodes().getFirst().mgmtPort();
         var metrics = getMetrics(anyNodePort);
-
         // Metrics should not contain error
         assertThat(metrics).doesNotContain("\"error\"");
     }
@@ -138,21 +128,20 @@ class ClusterFormationTest {
 
         assertThat(comprehensive).doesNotContain("\"error\"");
         assertThat(comprehensive).as("the consensus block must be on the wire")
-                                 .contains("\"consensus\"")
-                                 .contains("\"decisionsCount\"")
-                                 .contains("\"voteRound1Count\"");
-        assertThat(consensusLong(comprehensive, "decisionsCount"))
-            .as("a formed cluster has committed Rabia decisions — zero means the counter chain is disconnected")
-            .isPositive();
+                  .contains("\"consensus\"")
+                  .contains("\"decisionsCount\"")
+                  .contains("\"voteRound1Count\"");
+        assertThat(consensusLong(comprehensive, "decisionsCount")).as("a formed cluster has committed Rabia decisions — zero means the counter chain is disconnected")
+                  .isPositive();
     }
 
     private static long consensusLong(String json, String field) {
-        var matcher = java.util.regex.Pattern.compile("\"" + field + "\"\\s*:\\s*(\\d+)")
-                                             .matcher(json);
+        var matcher = java.util.regex.Pattern.compile("\"" + field + "\"\\s*:\\s*(\\d+)").matcher(json);
 
         if (!matcher.find()) {
-            throw new AssertionError("field " + field + " not found in: "
-                                     + json.substring(0, Math.min(json.length(), 400)));
+            throw new AssertionError("field " + field
+                                    + " not found in: " + json.substring(0,
+                                                                         Math.min(json.length(), 400)));
         }
 
         return Long.parseLong(matcher.group(1));
@@ -160,7 +149,9 @@ class ClusterFormationTest {
 
     private boolean allNodesHealthy() {
         var status = cluster.status();
-        return status.nodes().stream()
+
+        return status.nodes()
+                     .stream()
                      .allMatch(node -> checkNodeHealth(node.mgmtPort()));
     }
 
@@ -170,9 +161,11 @@ class ClusterFormationTest {
                                  .GET()
                                  .timeout(Duration.ofSeconds(5))
                                  .build();
+
         return http.sendString(request)
                    .await()
-                   .map(r -> r.statusCode() == 200 && r.body().contains("\"quorum\":true"))
+                   .map(r -> r.statusCode() == 200 && r.body()
+                                                       .contains("\"quorum\":true"))
                    .or(false);
     }
 
@@ -194,6 +187,7 @@ class ClusterFormationTest {
                                  .GET()
                                  .timeout(Duration.ofSeconds(5))
                                  .build();
+
         return http.sendString(request)
                    .await()
                    .map(HttpResult::body)

--- a/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/ClusterFormationTest.java
+++ b/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/ClusterFormationTest.java
@@ -2,29 +2,28 @@
 // Copyright (c) 2025 Pragmatica Labs - Sergiy Yevtushenko
 // Licensed under Business Source License 1.1. Change Date: 2030-01-01. Change License: Apache-2.0.
 // See LICENSE in the repository root for full terms.
+
 package org.pragmatica.aether.forge;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.pragmatica.http.HttpResult;
+import org.pragmatica.http.HttpOperations;
 
 import java.net.URI;
 import java.net.http.HttpRequest;
 import java.time.Duration;
 
-import org.pragmatica.http.HttpResult;
-import org.pragmatica.http.HttpOperations;
-import org.pragmatica.aether.ember.EmberCluster;
-
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
-
-import static org.pragmatica.aether.ember.EmberCluster.emberCluster;
-import static org.pragmatica.http.JdkHttpOperations.jdkHttpOperations;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
-
+import org.pragmatica.aether.ember.EmberCluster;
+import static org.pragmatica.aether.ember.EmberCluster.emberCluster;
+import static org.pragmatica.http.JdkHttpOperations.jdkHttpOperations;
 
 /// Tests for cluster formation and quorum behavior using EmberCluster.
 ///
@@ -58,16 +57,22 @@ class ClusterFormationTest {
     @BeforeAll
     void setUp() {
         cluster = emberCluster(3, BASE_PORT, BASE_MGMT_PORT, BASE_APP_HTTP_PORT, "cf");
+
         LifecycleAwait.settled("cluster start in setUp()", cluster, cluster.start());
-        await().atMost(WAIT_TIMEOUT).pollInterval(POLL_INTERVAL).until(() -> cluster.currentLeader()
-                                                                                    .isPresent());
-        await().atMost(WAIT_TIMEOUT).pollInterval(POLL_INTERVAL).until(this::allNodesHealthy);
+
+        await().atMost(WAIT_TIMEOUT)
+               .pollInterval(POLL_INTERVAL)
+               .until(() -> cluster.currentLeader().isPresent());
+
+        await().atMost(WAIT_TIMEOUT)
+               .pollInterval(POLL_INTERVAL)
+               .until(this::allNodesHealthy);
     }
 
     @AfterAll
     void tearDown() {
         if (cluster != null) {
-            LifecycleAwait.settled("cluster stop in tearDown()", cluster, cluster.stop());
+            LifecycleAwait.bestEffort("cluster stop in tearDown()", cluster, cluster.stop());
         }
     }
 
@@ -75,14 +80,14 @@ class ClusterFormationTest {
     void threeNodeCluster_formsQuorum_andElectsLeader() {
         // All nodes should be running
         assertThat(cluster.nodeCount()).isEqualTo(3);
+
         // Health endpoint should report healthy with quorum
         var anyNodePort = cluster.status().nodes().getFirst().mgmtPort();
         var health = getHealth(anyNodePort);
-
         assertThat(health).contains("\"status\"");
+
         // Leader should be elected
         var leader = cluster.currentLeader();
-
         assertThat(leader.isPresent()).isTrue();
     }
 
@@ -91,7 +96,6 @@ class ClusterFormationTest {
         // Each node should report 2 connected peers via /api/v1/health endpoint
         for (var node : cluster.status().nodes()) {
             var health = getHealth(node.mgmtPort());
-
             assertThat(health).contains("\"connectedPeers\":2");
             assertThat(health).contains("\"nodeCount\":3");
         }
@@ -101,10 +105,10 @@ class ClusterFormationTest {
     void cluster_statusConsistent_acrossNodes() {
         // Collect status from all nodes
         var leaderNode = cluster.currentLeader().unwrap();
+
         // All nodes should report the same leader via /api/v1/nodes/status endpoint
         for (var node : cluster.status().nodes()) {
             var status = getStatus(node.mgmtPort());
-
             assertThat(status).contains(leaderNode);
         }
     }
@@ -113,6 +117,7 @@ class ClusterFormationTest {
     void cluster_metricsAvailable_afterFormation() {
         var anyNodePort = cluster.status().nodes().getFirst().mgmtPort();
         var metrics = getMetrics(anyNodePort);
+
         // Metrics should not contain error
         assertThat(metrics).doesNotContain("\"error\"");
     }
@@ -128,20 +133,21 @@ class ClusterFormationTest {
 
         assertThat(comprehensive).doesNotContain("\"error\"");
         assertThat(comprehensive).as("the consensus block must be on the wire")
-                  .contains("\"consensus\"")
-                  .contains("\"decisionsCount\"")
-                  .contains("\"voteRound1Count\"");
-        assertThat(consensusLong(comprehensive, "decisionsCount")).as("a formed cluster has committed Rabia decisions — zero means the counter chain is disconnected")
-                  .isPositive();
+                                 .contains("\"consensus\"")
+                                 .contains("\"decisionsCount\"")
+                                 .contains("\"voteRound1Count\"");
+        assertThat(consensusLong(comprehensive, "decisionsCount"))
+            .as("a formed cluster has committed Rabia decisions — zero means the counter chain is disconnected")
+            .isPositive();
     }
 
     private static long consensusLong(String json, String field) {
-        var matcher = java.util.regex.Pattern.compile("\"" + field + "\"\\s*:\\s*(\\d+)").matcher(json);
+        var matcher = java.util.regex.Pattern.compile("\"" + field + "\"\\s*:\\s*(\\d+)")
+                                             .matcher(json);
 
         if (!matcher.find()) {
-            throw new AssertionError("field " + field
-                                    + " not found in: " + json.substring(0,
-                                                                         Math.min(json.length(), 400)));
+            throw new AssertionError("field " + field + " not found in: "
+                                     + json.substring(0, Math.min(json.length(), 400)));
         }
 
         return Long.parseLong(matcher.group(1));
@@ -149,9 +155,7 @@ class ClusterFormationTest {
 
     private boolean allNodesHealthy() {
         var status = cluster.status();
-
-        return status.nodes()
-                     .stream()
+        return status.nodes().stream()
                      .allMatch(node -> checkNodeHealth(node.mgmtPort()));
     }
 
@@ -161,11 +165,9 @@ class ClusterFormationTest {
                                  .GET()
                                  .timeout(Duration.ofSeconds(5))
                                  .build();
-
         return http.sendString(request)
                    .await()
-                   .map(r -> r.statusCode() == 200 && r.body()
-                                                       .contains("\"quorum\":true"))
+                   .map(r -> r.statusCode() == 200 && r.body().contains("\"quorum\":true"))
                    .or(false);
     }
 
@@ -187,7 +189,6 @@ class ClusterFormationTest {
                                  .GET()
                                  .timeout(Duration.ofSeconds(5))
                                  .build();
-
         return http.sendString(request)
                    .await()
                    .map(HttpResult::body)

--- a/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/ClusterProvisioningDiagnosticsProbeTest.java
+++ b/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/ClusterProvisioningDiagnosticsProbeTest.java
@@ -2,8 +2,19 @@
 // Copyright (c) 2025 Pragmatica Labs - Sergiy Yevtushenko
 // Licensed under Business Source License 1.1. Change Date: 2030-01-01. Change License: Apache-2.0.
 // See LICENSE in the repository root for full terms.
-
 package org.pragmatica.aether.forge;
+
+import java.net.URI;
+import java.net.http.HttpRequest;
+import java.time.Duration;
+import java.util.regex.Pattern;
+
+import org.pragmatica.aether.ember.EmberCluster;
+import org.pragmatica.http.HttpOperations;
+import org.pragmatica.http.HttpResult;
+import org.pragmatica.lang.Cause;
+import org.pragmatica.lang.Option;
+import org.pragmatica.lang.TerminalOperation;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -11,24 +22,14 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
-import org.pragmatica.aether.ember.EmberCluster;
-import org.pragmatica.http.HttpOperations;
-import org.pragmatica.http.HttpResult;
-import org.pragmatica.lang.Cause;
-import org.pragmatica.lang.Option;
-import org.pragmatica.lang.TerminalOperation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.net.URI;
-import java.net.http.HttpRequest;
-import java.time.Duration;
-import java.util.regex.Pattern;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.awaitility.Awaitility.await;
 import static org.pragmatica.aether.ember.EmberCluster.emberCluster;
 import static org.pragmatica.http.JdkHttpOperations.jdkHttpOperations;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
 
 /// #336 observability — surface-layer probe for `GET /api/v1/cluster/provisioning`. Forms a small Ember
 /// cluster, queries the provisioning-diagnostics endpoint on the leader's management port, and asserts
@@ -45,15 +46,12 @@ import static org.pragmatica.http.JdkHttpOperations.jdkHttpOperations;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class ClusterProvisioningDiagnosticsProbeTest {
     private static final Logger log = LoggerFactory.getLogger(ClusterProvisioningDiagnosticsProbeTest.class);
-
     private static final int CORES = 5;
     private static final int BASE_PORT = 5690;
     private static final int BASE_MGMT_PORT = 5790;
     private static final int BASE_APP_HTTP_PORT = 5890;
-
     private static final Duration FORM_TIMEOUT = Duration.ofSeconds(60);
     private static final Duration POLL = Duration.ofMillis(500);
-
     private static final Pattern LEADER = Pattern.compile("\"leader\"\\s*:\\s*(true|false)");
     private static final Pattern CONFIGURED = Pattern.compile("\"configuredCoreCount\"\\s*:\\s*(\\d+)");
     private static final Pattern DEFICIT = Pattern.compile("\"deficit\"\\s*:\\s*(-?\\d+)");
@@ -67,22 +65,26 @@ class ClusterProvisioningDiagnosticsProbeTest {
     @TerminalOperation
     void setUp() {
         cluster = emberCluster(CORES, BASE_PORT, BASE_MGMT_PORT, BASE_APP_HTTP_PORT, "provisioning");
-        cluster.start()
-               .await()
-               .onFailure(ClusterProvisioningDiagnosticsProbeTest::failStart);
-
+        LifecycleAwait.settled("cluster start in setUp()", cluster, cluster.start());
         await().alias("cluster leader elected")
-               .atMost(FORM_TIMEOUT).pollInterval(POLL).until(() -> cluster.currentLeader().isPresent());
+             .atMost(FORM_TIMEOUT)
+             .pollInterval(POLL)
+             .until(() -> cluster.currentLeader()
+                                 .isPresent());
         await().alias("counted cores reached " + CORES)
-               .atMost(FORM_TIMEOUT).pollInterval(POLL).until(() -> countedCores() == CORES);
+             .atMost(FORM_TIMEOUT)
+             .pollInterval(POLL)
+             .until(() -> countedCores() == CORES);
         log.info("PROVISIONING-PROBE: {}-core cluster formed, leader={}, countedCores={}",
-                 CORES, cluster.currentLeader().or("none"), countedCores());
+                 CORES,
+                 cluster.currentLeader().or("none"),
+                 countedCores());
     }
 
     @AfterAll
     @TerminalOperation
     void tearDown() {
-        Option.option(cluster).onPresent(c -> c.stop().await());
+        Option.option(cluster).onPresent(c -> LifecycleAwait.settled("cluster stop in tearDown()", c, c.stop()));
     }
 
     @Test
@@ -92,35 +94,33 @@ class ClusterProvisioningDiagnosticsProbeTest {
                                 .toResult(ProbeError.NO_LEADER)
                                 .onFailure(ClusterProvisioningDiagnosticsProbeTest::failScenario)
                                 .or(-1);
-
         var json = httpGet(leaderPort, "/api/v1/cluster/provisioning");
-        log.info("PROVISIONING-PROBE: GET /api/v1/cluster/provisioning -> {}", json);
 
-        assertThat(matchGroup(LEADER, json))
-            .as("leader endpoint must report leader=true (diagnostics are leader-only): %s", json)
-            .isEqualTo("true");
-
-        assertThat(intGroup(CONFIGURED, json))
-            .as("configuredCoreCount must match the formed cluster size %d: %s", CORES, json)
-            .isEqualTo(CORES);
-
-        assertThat(CIRCUIT_BREAKER.matcher(json).find())
-            .as("circuitBreaker object must be present in the response: %s", json)
-            .isTrue();
-
-        assertThat(intGroup(CONSECUTIVE_FAILURES, json))
-            .as("circuitBreaker.consecutiveFailures must be present and non-negative: %s", json)
-            .isGreaterThanOrEqualTo(0);
-
-        assertThat(intGroup(DEFICIT, json))
-            .as("deficit must be present and clamped non-negative: %s", json)
-            .isGreaterThanOrEqualTo(0);
+        log.info("PROVISIONING-PROBE: GET /api/v1/cluster/provisioning -> {}",
+                 json);
+        assertThat(matchGroup(LEADER, json)).as("leader endpoint must report leader=true (diagnostics are leader-only): %s",
+                                                json)
+                  .isEqualTo("true");
+        assertThat(intGroup(CONFIGURED, json)).as("configuredCoreCount must match the formed cluster size %d: %s",
+                                                  CORES,
+                                                  json)
+                  .isEqualTo(CORES);
+        assertThat(CIRCUIT_BREAKER.matcher(json).find()).as("circuitBreaker object must be present in the response: %s",
+                                                            json)
+                  .isTrue();
+        assertThat(intGroup(CONSECUTIVE_FAILURES, json)).as("circuitBreaker.consecutiveFailures must be present and non-negative: %s",
+                                                            json)
+                  .isGreaterThanOrEqualTo(0);
+        assertThat(intGroup(DEFICIT, json)).as("deficit must be present and clamped non-negative: %s", json)
+                  .isGreaterThanOrEqualTo(0);
     }
 
     private int countedCores() {
         return cluster.currentLeader()
                       .flatMap(cluster::getNode)
-                      .map(node -> node.membershipFsm().coreCountedMembers().size())
+                      .map(node -> node.membershipFsm()
+                                       .coreCountedMembers()
+                                       .size())
                       .or(0);
     }
 
@@ -164,13 +164,10 @@ class ClusterProvisioningDiagnosticsProbeTest {
 
     private enum ProbeError implements Cause {
         NO_LEADER("No leader available to receive the provisioning-diagnostics request");
-
         private final String message;
-
         ProbeError(String message) {
             this.message = message;
         }
-
         @Override
         public String message() {
             return message;

--- a/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/ClusterProvisioningDiagnosticsProbeTest.java
+++ b/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/ClusterProvisioningDiagnosticsProbeTest.java
@@ -2,19 +2,8 @@
 // Copyright (c) 2025 Pragmatica Labs - Sergiy Yevtushenko
 // Licensed under Business Source License 1.1. Change Date: 2030-01-01. Change License: Apache-2.0.
 // See LICENSE in the repository root for full terms.
+
 package org.pragmatica.aether.forge;
-
-import java.net.URI;
-import java.net.http.HttpRequest;
-import java.time.Duration;
-import java.util.regex.Pattern;
-
-import org.pragmatica.aether.ember.EmberCluster;
-import org.pragmatica.http.HttpOperations;
-import org.pragmatica.http.HttpResult;
-import org.pragmatica.lang.Cause;
-import org.pragmatica.lang.Option;
-import org.pragmatica.lang.TerminalOperation;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -22,14 +11,24 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.pragmatica.aether.ember.EmberCluster;
+import org.pragmatica.http.HttpOperations;
+import org.pragmatica.http.HttpResult;
+import org.pragmatica.lang.Cause;
+import org.pragmatica.lang.Option;
+import org.pragmatica.lang.TerminalOperation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.pragmatica.aether.ember.EmberCluster.emberCluster;
-import static org.pragmatica.http.JdkHttpOperations.jdkHttpOperations;
+import java.net.URI;
+import java.net.http.HttpRequest;
+import java.time.Duration;
+import java.util.regex.Pattern;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
-
+import static org.pragmatica.aether.ember.EmberCluster.emberCluster;
+import static org.pragmatica.http.JdkHttpOperations.jdkHttpOperations;
 
 /// #336 observability — surface-layer probe for `GET /api/v1/cluster/provisioning`. Forms a small Ember
 /// cluster, queries the provisioning-diagnostics endpoint on the leader's management port, and asserts
@@ -46,12 +45,15 @@ import static org.awaitility.Awaitility.await;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class ClusterProvisioningDiagnosticsProbeTest {
     private static final Logger log = LoggerFactory.getLogger(ClusterProvisioningDiagnosticsProbeTest.class);
+
     private static final int CORES = 5;
     private static final int BASE_PORT = 5690;
     private static final int BASE_MGMT_PORT = 5790;
     private static final int BASE_APP_HTTP_PORT = 5890;
+
     private static final Duration FORM_TIMEOUT = Duration.ofSeconds(60);
     private static final Duration POLL = Duration.ofMillis(500);
+
     private static final Pattern LEADER = Pattern.compile("\"leader\"\\s*:\\s*(true|false)");
     private static final Pattern CONFIGURED = Pattern.compile("\"configuredCoreCount\"\\s*:\\s*(\\d+)");
     private static final Pattern DEFICIT = Pattern.compile("\"deficit\"\\s*:\\s*(-?\\d+)");
@@ -66,25 +68,19 @@ class ClusterProvisioningDiagnosticsProbeTest {
     void setUp() {
         cluster = emberCluster(CORES, BASE_PORT, BASE_MGMT_PORT, BASE_APP_HTTP_PORT, "provisioning");
         LifecycleAwait.settled("cluster start in setUp()", cluster, cluster.start());
+
         await().alias("cluster leader elected")
-             .atMost(FORM_TIMEOUT)
-             .pollInterval(POLL)
-             .until(() -> cluster.currentLeader()
-                                 .isPresent());
+               .atMost(FORM_TIMEOUT).pollInterval(POLL).until(() -> cluster.currentLeader().isPresent());
         await().alias("counted cores reached " + CORES)
-             .atMost(FORM_TIMEOUT)
-             .pollInterval(POLL)
-             .until(() -> countedCores() == CORES);
+               .atMost(FORM_TIMEOUT).pollInterval(POLL).until(() -> countedCores() == CORES);
         log.info("PROVISIONING-PROBE: {}-core cluster formed, leader={}, countedCores={}",
-                 CORES,
-                 cluster.currentLeader().or("none"),
-                 countedCores());
+                 CORES, cluster.currentLeader().or("none"), countedCores());
     }
 
     @AfterAll
     @TerminalOperation
     void tearDown() {
-        Option.option(cluster).onPresent(c -> LifecycleAwait.settled("cluster stop in tearDown()", c, c.stop()));
+        Option.option(cluster).onPresent(c -> LifecycleAwait.bestEffort("cluster stop in tearDown()", c, c.stop()));
     }
 
     @Test
@@ -94,33 +90,35 @@ class ClusterProvisioningDiagnosticsProbeTest {
                                 .toResult(ProbeError.NO_LEADER)
                                 .onFailure(ClusterProvisioningDiagnosticsProbeTest::failScenario)
                                 .or(-1);
-        var json = httpGet(leaderPort, "/api/v1/cluster/provisioning");
 
-        log.info("PROVISIONING-PROBE: GET /api/v1/cluster/provisioning -> {}",
-                 json);
-        assertThat(matchGroup(LEADER, json)).as("leader endpoint must report leader=true (diagnostics are leader-only): %s",
-                                                json)
-                  .isEqualTo("true");
-        assertThat(intGroup(CONFIGURED, json)).as("configuredCoreCount must match the formed cluster size %d: %s",
-                                                  CORES,
-                                                  json)
-                  .isEqualTo(CORES);
-        assertThat(CIRCUIT_BREAKER.matcher(json).find()).as("circuitBreaker object must be present in the response: %s",
-                                                            json)
-                  .isTrue();
-        assertThat(intGroup(CONSECUTIVE_FAILURES, json)).as("circuitBreaker.consecutiveFailures must be present and non-negative: %s",
-                                                            json)
-                  .isGreaterThanOrEqualTo(0);
-        assertThat(intGroup(DEFICIT, json)).as("deficit must be present and clamped non-negative: %s", json)
-                  .isGreaterThanOrEqualTo(0);
+        var json = httpGet(leaderPort, "/api/v1/cluster/provisioning");
+        log.info("PROVISIONING-PROBE: GET /api/v1/cluster/provisioning -> {}", json);
+
+        assertThat(matchGroup(LEADER, json))
+            .as("leader endpoint must report leader=true (diagnostics are leader-only): %s", json)
+            .isEqualTo("true");
+
+        assertThat(intGroup(CONFIGURED, json))
+            .as("configuredCoreCount must match the formed cluster size %d: %s", CORES, json)
+            .isEqualTo(CORES);
+
+        assertThat(CIRCUIT_BREAKER.matcher(json).find())
+            .as("circuitBreaker object must be present in the response: %s", json)
+            .isTrue();
+
+        assertThat(intGroup(CONSECUTIVE_FAILURES, json))
+            .as("circuitBreaker.consecutiveFailures must be present and non-negative: %s", json)
+            .isGreaterThanOrEqualTo(0);
+
+        assertThat(intGroup(DEFICIT, json))
+            .as("deficit must be present and clamped non-negative: %s", json)
+            .isGreaterThanOrEqualTo(0);
     }
 
     private int countedCores() {
         return cluster.currentLeader()
                       .flatMap(cluster::getNode)
-                      .map(node -> node.membershipFsm()
-                                       .coreCountedMembers()
-                                       .size())
+                      .map(node -> node.membershipFsm().coreCountedMembers().size())
                       .or(0);
     }
 
@@ -154,9 +152,6 @@ class ClusterProvisioningDiagnosticsProbeTest {
                    .or("{}");
     }
 
-    private static void failStart(Cause cause) {
-        throw new AssertionError("Cluster start failed: " + cause.message());
-    }
 
     private static void failScenario(Cause cause) {
         throw new AssertionError("Scenario setup failed: " + cause.message());
@@ -164,10 +159,13 @@ class ClusterProvisioningDiagnosticsProbeTest {
 
     private enum ProbeError implements Cause {
         NO_LEADER("No leader available to receive the provisioning-diagnostics request");
+
         private final String message;
+
         ProbeError(String message) {
             this.message = message;
         }
+
         @Override
         public String message() {
             return message;

--- a/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/ClusterSnapshot.java
+++ b/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/ClusterSnapshot.java
@@ -7,6 +7,7 @@ package org.pragmatica.aether.forge;
 import java.net.URI;
 import java.net.http.HttpRequest;
 import java.time.Duration;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import org.pragmatica.aether.ember.EmberCluster;
@@ -45,19 +46,31 @@ final class ClusterSnapshot {
     static String render(EmberCluster.ClusterStatus live,
                          Option<EmberCluster.StartFailure> startFailure,
                          HttpOperations http) {
+        return render(live, startFailure, node -> liveNodeLine(node, http));
+    }
+
+    /// #915 — the same three branches, for a caller that holds no [HttpOperations] to probe with.
+    ///
+    /// The lifecycle awaits this serves are in `@BeforeAll`/`@AfterAll` across 36 classes, most of
+    /// which never build an http client; and a health probe on a `stop` that failed would answer
+    /// about the aftermath. What the endpoint would have told us — whether the node is
+    /// consensus-active — is already in [EmberCluster.NodeStatus#state] since #913.
+    static String render(EmberCluster.ClusterStatus live, Option<EmberCluster.StartFailure> startFailure) {
+        return render(live, startFailure, ClusterSnapshot::nodeLine);
+    }
+
+    private static String render(EmberCluster.ClusterStatus live,
+                                 Option<EmberCluster.StartFailure> startFailure,
+                                 Function<EmberCluster.NodeStatus, String> lineOf) {
         if (!live.nodes().isEmpty()) {
-            return renderLive(live, http);
+            return "  leader=" + live.leaderId() + "\n"
+                   + live.nodes()
+                         .stream()
+                         .map(lineOf)
+                         .collect(Collectors.joining("\n"));
         }
         return startFailure.map(ClusterSnapshot::renderCaptured)
                            .or(NO_STATE);
-    }
-
-    private static String renderLive(EmberCluster.ClusterStatus status, HttpOperations http) {
-        return "  leader=" + status.leaderId() + "\n"
-               + status.nodes()
-                       .stream()
-                       .map(node -> liveNodeLine(node, http))
-                       .collect(Collectors.joining("\n"));
     }
 
     /// The captured snapshot is rendered WITHOUT probing any health endpoint: the nodes it names were
@@ -83,8 +96,11 @@ final class ClusterSnapshot {
         return nodeLine(node) + " health=" + healthBody(node.mgmtPort(), http);
     }
 
+    /// #915 added the two ports. The canonical failure this dump is read for is a port that could
+    /// not be bound, and the id alone does not say which port the node was asked to take.
     private static String nodeLine(EmberCluster.NodeStatus node) {
-        return "  " + node.id() + " state=" + node.state() + " leader=" + node.isLeader();
+        return "  " + node.id() + " state=" + node.state() + " leader=" + node.isLeader()
+               + " port=" + node.port() + " mgmt=" + node.mgmtPort();
     }
 
     /// Bounded, unlike the `await()` this replaced (review N1): the failure path is the one that runs

--- a/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/ClusterSnapshotTest.java
+++ b/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/ClusterSnapshotTest.java
@@ -42,7 +42,7 @@ class ClusterSnapshotTest {
         assertThat(line).describedAs("nothing in the line may claim health that was never observed")
                         .doesNotContain("healthy");
         assertThat(line).describedAs("the node's own state is read from the node, not defaulted")
-                        .contains("si-1 state=inactive leader=false");
+                        .contains("si-1 state=inactive leader=false port=6000 mgmt=6100");
     }
 
     @Test
@@ -51,7 +51,7 @@ class ClusterSnapshotTest {
 
         var line = ClusterSnapshot.liveNodeLine(node, respondingHttp(200, "{\"quorum\":true}"));
 
-        assertThat(line).isEqualTo("  si-2 state=active leader=true health=200 {\"quorum\":true}");
+        assertThat(line).isEqualTo("  si-2 state=active leader=true port=6001 mgmt=6100 health=200 {\"quorum\":true}");
     }
 
     /// The positive control for the assertion above: the SAME renderer, given a node that is not
@@ -63,7 +63,7 @@ class ClusterSnapshotTest {
 
         var line = ClusterSnapshot.liveNodeLine(node, respondingHttp(503, "{\"quorum\":false}"));
 
-        assertThat(line).isEqualTo("  si-3 state=inactive leader=false health=503 {\"quorum\":false}");
+        assertThat(line).isEqualTo("  si-3 state=inactive leader=false port=6002 mgmt=6100 health=503 {\"quorum\":false}");
     }
 
     @Test
@@ -91,8 +91,8 @@ class ClusterSnapshotTest {
         var rendered = ClusterSnapshot.render(emptyStatus(), Option.some(captured), failingHttp("must not be probed"));
 
         assertThat(rendered).contains("captured when the start failed");
-        assertThat(rendered).contains("si-1 state=inactive leader=false");
-        assertThat(rendered).contains("si-2 state=inactive leader=false");
+        assertThat(rendered).contains("si-1 state=inactive leader=false port=6000 mgmt=6100");
+        assertThat(rendered).contains("si-2 state=inactive leader=false port=6001 mgmt=6101");
         assertThat(rendered).contains("start failures: {si-1=Address already in use}");
         assertThat(rendered).describedAs("a captured snapshot must not carry a live health probe")
                             .doesNotContain("health=");
@@ -110,7 +110,7 @@ class ClusterSnapshotTest {
 
         var rendered = ClusterSnapshot.render(live, Option.some(stale), respondingHttp(200, "{\"quorum\":true}"));
 
-        assertThat(rendered).isEqualTo("  leader=si-1\n  si-1 state=active leader=true health=200 {\"quorum\":true}");
+        assertThat(rendered).isEqualTo("  leader=si-1\n  si-1 state=active leader=true port=6000 mgmt=6100 health=200 {\"quorum\":true}");
     }
 
     private static EmberCluster.ClusterStatus emptyStatus() {

--- a/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/CommunityFormationProbeTest.java
+++ b/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/CommunityFormationProbeTest.java
@@ -2,16 +2,13 @@
 // Copyright (c) 2025 Pragmatica Labs - Sergiy Yevtushenko
 // Licensed under Business Source License 1.1. Change Date: 2030-01-01. Change License: Apache-2.0.
 // See LICENSE in the repository root for full terms.
-
 package org.pragmatica.aether.forge;
 
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
+import java.time.Duration;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
 import org.pragmatica.aether.ember.EmberCluster;
 import org.pragmatica.aether.node.AetherNode;
 import org.pragmatica.aether.slice.kvstore.AetherKey.ClusterConfigKey;
@@ -25,17 +22,21 @@ import org.pragmatica.consensus.NodeId;
 import org.pragmatica.lang.Cause;
 import org.pragmatica.lang.Option;
 import org.pragmatica.lang.TerminalOperation;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.time.Duration;
-import java.util.Set;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
-
+import static org.pragmatica.aether.ember.EmberCluster.emberCluster;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
-import static org.pragmatica.aether.ember.EmberCluster.emberCluster;
+
 
 /// Integration proof for the #241 community-formation loop — does N (≥ RF=3) worker joins to one
 /// source drive that source's committed [`CommunityKey`] to `ACTIVE`, IN-JVM, with the Ember
@@ -78,15 +79,14 @@ import static org.pragmatica.aether.ember.EmberCluster.emberCluster;
 /// were promoted to core under churn, (b) were assigned but no governor announcement landed, or
 /// (c) were announced but the FSM never flipped the state.
 @Disabled("#336: invalid as an in-JVM gate — 8 nodes on 8 cores starves SWIM probe-acks, so nodes "
-          + "genuinely reach FAULTY (LHM sawtooth = late acks, not absent), not a product bug. The "
-          + "reachability-evidence fix is validated on real infra (02-chaos kill suite). See "
-          + "aether/docs/internal/progress/336-reachability-evidence-fix-2026-06-30.md. Re-enable only "
-          + "with relaxed in-JVM SWIM timeouts for single-JVM density.")
+         + "genuinely reach FAULTY (LHM sawtooth = late acks, not absent), not a product bug. The "
+         + "reachability-evidence fix is validated on real infra (02-chaos kill suite). See "
+         + "aether/docs/internal/progress/336-reachability-evidence-fix-2026-06-30.md. Re-enable only "
+         + "with relaxed in-JVM SWIM timeouts for single-JVM density.")
 @Execution(ExecutionMode.SAME_THREAD)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class CommunityFormationProbeTest {
     private static final Logger log = LoggerFactory.getLogger(CommunityFormationProbeTest.class);
-
     /// 5 cores (quorum 3) rather than 3 (quorum 2): a single worker-add flaps SWIM, and a 3-node
     /// quorum cannot survive two suspected members, so the leader is lost and the join fails. A
     /// 5-node quorum tolerates the churn — the same size `ScaleUpFiveToSevenProbeTest` forms stably.
@@ -95,11 +95,9 @@ class CommunityFormationProbeTest {
     private static final int WORKER_COUNT = 3;
     /// Deterministic single community for the default source: `<source>-w-0`.
     private static final String COMMUNITY_ID = "default-w-0";
-
     private static final int BASE_PORT = 5960;
     private static final int BASE_MGMT_PORT = 6060;
     private static final int BASE_APP_HTTP_PORT = 6160;
-
     private static final Duration FORM_TIMEOUT = Duration.ofSeconds(60);
     private static final Duration SETTLE_TIMEOUT = Duration.ofSeconds(20);
     private static final Duration ACTIVE_TIMEOUT = Duration.ofSeconds(120);
@@ -112,20 +110,20 @@ class CommunityFormationProbeTest {
     @TerminalOperation
     void setUp() {
         cluster = emberCluster(INITIAL_CORES, BASE_PORT, BASE_MGMT_PORT, BASE_APP_HTTP_PORT, "cfm");
-        cluster.start()
-               .await()
-               .onFailure(CommunityFormationProbeTest::failStart);
-
-        await().atMost(FORM_TIMEOUT).pollInterval(POLL).until(() -> cluster.currentLeader().isPresent());
+        LifecycleAwait.settled("cluster start in setUp()", cluster, cluster.start());
+        await().atMost(FORM_TIMEOUT).pollInterval(POLL).until(() -> cluster.currentLeader()
+                                                                           .isPresent());
         await().atMost(FORM_TIMEOUT).pollInterval(POLL).until(() -> countedCores() == INITIAL_CORES);
         log.info("CFM-PROBE: {}-core cluster formed, leader={}, countedCores={}",
-                 INITIAL_CORES, cluster.currentLeader().or("none"), countedCores());
+                 INITIAL_CORES,
+                 cluster.currentLeader().or("none"),
+                 countedCores());
     }
 
     @AfterAll
     @TerminalOperation
     void tearDown() {
-        Option.option(cluster).onPresent(c -> c.stop().await());
+        Option.option(cluster).onPresent(c -> LifecycleAwait.settled("cluster stop in tearDown()", c, c.stop()));
     }
 
     @Test
@@ -134,26 +132,33 @@ class CommunityFormationProbeTest {
         awaitCoreCapCommitted();
         IntStream.rangeClosed(1, WORKER_COUNT).forEach(this::addWorkerAndSettle);
         log.info("CFM-PROBE: {} workers added; ember.nodeCount={} countedCores={} (committed cap={})",
-                 WORKER_COUNT, cluster.nodeCount(), countedCores(), committedCoreCount().or(-1));
-
+                 WORKER_COUNT,
+                 cluster.nodeCount(),
+                 countedCores(),
+                 committedCoreCount().or(-1));
         var t0 = System.nanoTime();
         var reachedActiveMs = observeUntilActive(t0);
         var finalState = communityState().map(Enum::name).or("ABSENT");
 
         log.info("CFM-PROBE RESULT: community={} reachedActiveAtMs={} (-1=NOT within {}s) finalState={}",
-                 COMMUNITY_ID, reachedActiveMs, ACTIVE_TIMEOUT.toSeconds(), finalState);
+                 COMMUNITY_ID,
+                 reachedActiveMs,
+                 ACTIVE_TIMEOUT.toSeconds(),
+                 finalState);
         dumpDiagnostics();
-
-        assertThat(reachedActiveMs)
-            .as("EXPECTED: %d workers joining the 'default' source drive committed community '%s' to "
-                + "ACTIVE within %ds (leader FSM flips FORMING→ACTIVE when governor-announced "
-                + "liveMembers ≥ RF=%d). reachedActiveAtMs=%d, finalState=%s. -1 = STALL — the loop is "
-                + "wired but did not complete IN-JVM. See the diagnostic dump above for whether the "
-                + "workers were never assigned WORKER (promoted to core under churn), were assigned "
-                + "but no governor announcement landed, or were announced but the FSM never flipped.",
-                WORKER_COUNT, COMMUNITY_ID, ACTIVE_TIMEOUT.toSeconds(), WORKER_COUNT,
-                reachedActiveMs, finalState)
-            .isGreaterThanOrEqualTo(0L);
+        assertThat(reachedActiveMs).as("EXPECTED: %d workers joining the 'default' source drive committed community '%s' to "
+                                      + "ACTIVE within %ds (leader FSM flips FORMING→ACTIVE when governor-announced "
+                                      + "liveMembers ≥ RF=%d). reachedActiveAtMs=%d, finalState=%s. -1 = STALL — the loop is "
+                                      + "wired but did not complete IN-JVM. See the diagnostic dump above for whether the "
+                                      + "workers were never assigned WORKER (promoted to core under churn), were assigned "
+                                      + "but no governor announcement landed, or were announced but the FSM never flipped.",
+                                       WORKER_COUNT,
+                                       COMMUNITY_ID,
+                                       ACTIVE_TIMEOUT.toSeconds(),
+                                       WORKER_COUNT,
+                                       reachedActiveMs,
+                                       finalState)
+                  .isGreaterThanOrEqualTo(0L);
     }
 
     /// Wait for the leader's `BootstrapModule` to commit the auto-seeded `ClusterConfig.coreCount`
@@ -161,8 +166,9 @@ class CommunityFormationProbeTest {
     /// unlimited topology `coreMax`, and joiners would be promoted to core instead of worker.
     private void awaitCoreCapCommitted() {
         await().atMost(FORM_TIMEOUT)
-               .pollInterval(POLL)
-               .until(() -> committedCoreCount().filter(count -> count == INITIAL_CORES).isPresent());
+             .pollInterval(POLL)
+             .until(() -> committedCoreCount().filter(count -> count == INITIAL_CORES)
+                                            .isPresent());
         log.info("CFM-PROBE: committed core cap = {} (joiners beyond this are assigned WORKER)",
                  committedCoreCount().or(-1));
     }
@@ -174,71 +180,86 @@ class CommunityFormationProbeTest {
     @TerminalOperation
     private void addWorkerAndSettle(int index) {
         var expectedNodeCount = INITIAL_CORES + index;
-        cluster.addNode()
-               .await()
-               .onSuccess(nodeId -> log.info("CFM-PROBE: worker {}/{} joined as {}",
-                                             index, WORKER_COUNT, nodeId.id()))
-               .onFailure(CommunityFormationProbeTest::failScenario);
+        var nodeId = LifecycleAwait.nodeSettled("worker " + index + "/" + WORKER_COUNT + " join in addWorkerAndSettle()",
+                                                cluster,
+                                                cluster.addNode());
 
+        log.info("CFM-PROBE: worker {}/{} joined as {}", index, WORKER_COUNT, nodeId.id());
         var settled = pollUntil(SETTLE_TIMEOUT,
-                                () -> cluster.currentLeader().isPresent()
+                                () -> cluster.currentLeader()
+                                             .isPresent()
                                       && countedCores() == INITIAL_CORES
                                       && cluster.nodeCount() == expectedNodeCount);
+
         log.info("CFM-PROBE: after worker {}/{} settled={} leader={} countedCores={} (cap={}) nodeCount={}/{}",
-                 index, WORKER_COUNT, settled, cluster.currentLeader().or("none"),
-                 countedCores(), INITIAL_CORES, cluster.nodeCount(), expectedNodeCount);
+                 index,
+                 WORKER_COUNT,
+                 settled,
+                 cluster.currentLeader().or("none"),
+                 countedCores(),
+                 INITIAL_CORES,
+                 cluster.nodeCount(),
+                 expectedNodeCount);
     }
 
     /// Polls the committed community state until it reaches ACTIVE or the budget expires. Returns the
     /// first-observed convergence latency in ms, or -1 if ACTIVE was never observed.
     private long observeUntilActive(long t0) {
-        var latch = new long[]{-1L};
+        var latch = new long[]{ - 1L};
         var lastLog = new long[]{0L};
+
         await().pollInterval(POLL)
-               .pollDelay(Duration.ZERO)
-               .timeout(ACTIVE_TIMEOUT.plusSeconds(5))
-               .until(() -> recordTick(t0, latch, lastLog));
+             .pollDelay(Duration.ZERO)
+             .timeout(ACTIVE_TIMEOUT.plusSeconds(5))
+             .until(() -> recordTick(t0, latch, lastLog));
+
         return latch[0];
     }
 
     private boolean recordTick(long t0, long[] latch, long[] lastLog) {
         var elapsed = (System.nanoTime() - t0) / 1_000_000L;
-        if (communityState().filter(CommunityState.ACTIVE::equals).isPresent() && latch[0] < 0) {
+
+        if (communityState().filter(CommunityState.ACTIVE::equals).isPresent() && latch[0]< 0) {
             latch[0] = elapsed;
         }
+
         maybeLog(elapsed, lastLog);
-        return latch[0] >= 0 || elapsed >= ACTIVE_TIMEOUT.toMillis();
+
+        return latch[0]>= 0 || elapsed >= ACTIVE_TIMEOUT.toMillis();
     }
 
     private void maybeLog(long elapsedMs, long[] lastLog) {
-        if (elapsedMs - lastLog[0] < LOG_EVERY.toMillis()) {
+        if (elapsedMs - lastLog[0]< LOG_EVERY.toMillis()) {
             return;
         }
+
         lastLog[0] = elapsedMs;
         log.info("CFM-PROBE: t+{}ms community={} state={} governor={} announcedMembers={} "
-                 + "countedCores={} emberNodeCount={}",
+                + "countedCores={} emberNodeCount={}",
                  elapsedMs,
                  COMMUNITY_ID,
                  communityState().map(Enum::name).or("ABSENT"),
-                 governorAnnouncement().map(a -> a.governorId().id()).or("none"),
+                 governorAnnouncement().map(a -> a.governorId()
+                                                  .id()).or("none"),
                  governorAnnouncement().map(GovernorAnnouncementValue::memberCount).or(0),
                  countedCores(),
                  cluster.nodeCount());
     }
 
     // ----- in-process committed-state reads (off the leader KV store) -----
-
     private Option<Integer> committedCoreCount() {
-        return leaderOrAnyNode().flatMap(node -> node.kvStore().get(ClusterConfigKey.CURRENT))
-                                .filter(ClusterConfigValue.class::isInstance)
-                                .map(ClusterConfigValue.class::cast)
-                                .map(ClusterConfigValue::coreCount);
+        return leaderOrAnyNode().flatMap(node -> node.kvStore()
+                                                     .get(ClusterConfigKey.CURRENT))
+                              .filter(ClusterConfigValue.class::isInstance)
+                              .map(ClusterConfigValue.class::cast)
+                              .map(ClusterConfigValue::coreCount);
     }
 
     private Option<CommunityValue> communityValue() {
-        return leaderOrAnyNode().flatMap(node -> node.kvStore().get(CommunityKey.communityKey(COMMUNITY_ID)))
-                                .filter(CommunityValue.class::isInstance)
-                                .map(CommunityValue.class::cast);
+        return leaderOrAnyNode().flatMap(node -> node.kvStore()
+                                                     .get(CommunityKey.communityKey(COMMUNITY_ID)))
+                              .filter(CommunityValue.class::isInstance)
+                              .map(CommunityValue.class::cast);
     }
 
     private Option<CommunityState> communityState() {
@@ -246,13 +267,17 @@ class CommunityFormationProbeTest {
     }
 
     private Option<GovernorAnnouncementValue> governorAnnouncement() {
-        return leaderOrAnyNode().flatMap(node -> node.kvStore().get(GovernorAnnouncementKey.forCommunity(COMMUNITY_ID)))
-                                .filter(GovernorAnnouncementValue.class::isInstance)
-                                .map(GovernorAnnouncementValue.class::cast);
+        return leaderOrAnyNode().flatMap(node -> node.kvStore()
+                                                     .get(GovernorAnnouncementKey.forCommunity(COMMUNITY_ID)))
+                              .filter(GovernorAnnouncementValue.class::isInstance)
+                              .map(GovernorAnnouncementValue.class::cast);
     }
 
     private int countedCores() {
-        return leaderOrAnyNode().map(node -> node.membershipFsm().coreCountedMembers().size()).or(0);
+        return leaderOrAnyNode().map(node -> node.membershipFsm()
+                                                 .coreCountedMembers()
+                                                 .size())
+                              .or(0);
     }
 
     private Option<AetherNode> leaderOrAnyNode() {
@@ -266,6 +291,7 @@ class CommunityFormationProbeTest {
     private static boolean pollUntil(Duration timeout, java.util.concurrent.Callable<Boolean> condition) {
         try {
             await().atMost(timeout).pollInterval(POLL).until(condition);
+
             return true;
         } catch (org.awaitility.core.ConditionTimeoutException e) {
             return false;
@@ -273,33 +299,43 @@ class CommunityFormationProbeTest {
     }
 
     // ----- failure diagnostics -----
-
     @TerminalOperation
     private void dumpDiagnostics() {
         var leaderNode = leaderOrAnyNode();
-        var countedSet = leaderNode.map(node -> node.membershipFsm().coreCountedMembers()).or(Set.of());
+        var countedSet = leaderNode.map(node -> node.membershipFsm()
+                                                    .coreCountedMembers()).or(Set.of());
 
         log.info("CFM-PROBE DUMP: leader={} ember.nodeCount={} countedCores={} committedCap={}",
-                 cluster.currentLeader().or("none"), cluster.nodeCount(), countedSet.size(),
+                 cluster.currentLeader().or("none"),
+                 cluster.nodeCount(),
+                 countedSet.size(),
                  committedCoreCount().or(-1));
         log.info("CFM-PROBE DUMP: community '{}' value = {}",
-                 COMMUNITY_ID, communityValue().map(Object::toString).or("ABSENT"));
+                 COMMUNITY_ID,
+                 communityValue().map(Object::toString).or("ABSENT"));
         log.info("CFM-PROBE DUMP: governor announcement = {}",
                  governorAnnouncement().map(Object::toString).or("ABSENT"));
         log.info("CFM-PROBE DUMP: leader counted-core set = {}", idStrings(countedSet));
-
         cluster.allNodes().forEach(node -> dumpNode(node, countedSet));
     }
 
     private void dumpNode(AetherNode node, Set<NodeId> countedSet) {
         var id = node.self();
-        var inMesh = leaderOrAnyNode().map(leader -> leader.membershipView().isPresent(id)).or(false);
+        var inMesh = leaderOrAnyNode().map(leader -> leader.membershipView()
+                                                           .isPresent(id)).or(false);
+
         log.info("CFM-PROBE DUMP: node={} leader={} inLeaderSwimView={} countedAsCore={} (else=worker)",
-                 id.id(), node.isLeader(), inMesh, countedSet.contains(id));
+                 id.id(),
+                 node.isLeader(),
+                 inMesh,
+                 countedSet.contains(id));
     }
 
     private static String idStrings(Set<NodeId> ids) {
-        return ids.stream().map(NodeId::id).sorted().collect(Collectors.joining(","));
+        return ids.stream()
+                  .map(NodeId::id)
+                  .sorted()
+                  .collect(Collectors.joining(","));
     }
 
     private static void failStart(Cause cause) {

--- a/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/CommunityFormationProbeTest.java
+++ b/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/CommunityFormationProbeTest.java
@@ -2,13 +2,16 @@
 // Copyright (c) 2025 Pragmatica Labs - Sergiy Yevtushenko
 // Licensed under Business Source License 1.1. Change Date: 2030-01-01. Change License: Apache-2.0.
 // See LICENSE in the repository root for full terms.
+
 package org.pragmatica.aether.forge;
 
-import java.time.Duration;
-import java.util.Set;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
-
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.pragmatica.aether.ember.EmberCluster;
 import org.pragmatica.aether.node.AetherNode;
 import org.pragmatica.aether.slice.kvstore.AetherKey.ClusterConfigKey;
@@ -19,24 +22,19 @@ import org.pragmatica.aether.slice.kvstore.AetherValue.CommunityValue;
 import org.pragmatica.aether.slice.kvstore.AetherValue.GovernorAnnouncementValue;
 import org.pragmatica.aether.slice.kvstore.CommunityState;
 import org.pragmatica.consensus.NodeId;
-import org.pragmatica.lang.Cause;
 import org.pragmatica.lang.Option;
 import org.pragmatica.lang.TerminalOperation;
-
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.pragmatica.aether.ember.EmberCluster.emberCluster;
+import java.time.Duration;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
-
+import static org.pragmatica.aether.ember.EmberCluster.emberCluster;
 
 /// Integration proof for the #241 community-formation loop — does N (≥ RF=3) worker joins to one
 /// source drive that source's committed [`CommunityKey`] to `ACTIVE`, IN-JVM, with the Ember
@@ -79,14 +77,15 @@ import static org.awaitility.Awaitility.await;
 /// were promoted to core under churn, (b) were assigned but no governor announcement landed, or
 /// (c) were announced but the FSM never flipped the state.
 @Disabled("#336: invalid as an in-JVM gate — 8 nodes on 8 cores starves SWIM probe-acks, so nodes "
-         + "genuinely reach FAULTY (LHM sawtooth = late acks, not absent), not a product bug. The "
-         + "reachability-evidence fix is validated on real infra (02-chaos kill suite). See "
-         + "aether/docs/internal/progress/336-reachability-evidence-fix-2026-06-30.md. Re-enable only "
-         + "with relaxed in-JVM SWIM timeouts for single-JVM density.")
+          + "genuinely reach FAULTY (LHM sawtooth = late acks, not absent), not a product bug. The "
+          + "reachability-evidence fix is validated on real infra (02-chaos kill suite). See "
+          + "aether/docs/internal/progress/336-reachability-evidence-fix-2026-06-30.md. Re-enable only "
+          + "with relaxed in-JVM SWIM timeouts for single-JVM density.")
 @Execution(ExecutionMode.SAME_THREAD)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class CommunityFormationProbeTest {
     private static final Logger log = LoggerFactory.getLogger(CommunityFormationProbeTest.class);
+
     /// 5 cores (quorum 3) rather than 3 (quorum 2): a single worker-add flaps SWIM, and a 3-node
     /// quorum cannot survive two suspected members, so the leader is lost and the join fails. A
     /// 5-node quorum tolerates the churn — the same size `ScaleUpFiveToSevenProbeTest` forms stably.
@@ -95,9 +94,11 @@ class CommunityFormationProbeTest {
     private static final int WORKER_COUNT = 3;
     /// Deterministic single community for the default source: `<source>-w-0`.
     private static final String COMMUNITY_ID = "default-w-0";
+
     private static final int BASE_PORT = 5960;
     private static final int BASE_MGMT_PORT = 6060;
     private static final int BASE_APP_HTTP_PORT = 6160;
+
     private static final Duration FORM_TIMEOUT = Duration.ofSeconds(60);
     private static final Duration SETTLE_TIMEOUT = Duration.ofSeconds(20);
     private static final Duration ACTIVE_TIMEOUT = Duration.ofSeconds(120);
@@ -111,19 +112,17 @@ class CommunityFormationProbeTest {
     void setUp() {
         cluster = emberCluster(INITIAL_CORES, BASE_PORT, BASE_MGMT_PORT, BASE_APP_HTTP_PORT, "cfm");
         LifecycleAwait.settled("cluster start in setUp()", cluster, cluster.start());
-        await().atMost(FORM_TIMEOUT).pollInterval(POLL).until(() -> cluster.currentLeader()
-                                                                           .isPresent());
+
+        await().atMost(FORM_TIMEOUT).pollInterval(POLL).until(() -> cluster.currentLeader().isPresent());
         await().atMost(FORM_TIMEOUT).pollInterval(POLL).until(() -> countedCores() == INITIAL_CORES);
         log.info("CFM-PROBE: {}-core cluster formed, leader={}, countedCores={}",
-                 INITIAL_CORES,
-                 cluster.currentLeader().or("none"),
-                 countedCores());
+                 INITIAL_CORES, cluster.currentLeader().or("none"), countedCores());
     }
 
     @AfterAll
     @TerminalOperation
     void tearDown() {
-        Option.option(cluster).onPresent(c -> LifecycleAwait.settled("cluster stop in tearDown()", c, c.stop()));
+        Option.option(cluster).onPresent(c -> LifecycleAwait.bestEffort("cluster stop in tearDown()", c, c.stop()));
     }
 
     @Test
@@ -132,33 +131,26 @@ class CommunityFormationProbeTest {
         awaitCoreCapCommitted();
         IntStream.rangeClosed(1, WORKER_COUNT).forEach(this::addWorkerAndSettle);
         log.info("CFM-PROBE: {} workers added; ember.nodeCount={} countedCores={} (committed cap={})",
-                 WORKER_COUNT,
-                 cluster.nodeCount(),
-                 countedCores(),
-                 committedCoreCount().or(-1));
+                 WORKER_COUNT, cluster.nodeCount(), countedCores(), committedCoreCount().or(-1));
+
         var t0 = System.nanoTime();
         var reachedActiveMs = observeUntilActive(t0);
         var finalState = communityState().map(Enum::name).or("ABSENT");
 
         log.info("CFM-PROBE RESULT: community={} reachedActiveAtMs={} (-1=NOT within {}s) finalState={}",
-                 COMMUNITY_ID,
-                 reachedActiveMs,
-                 ACTIVE_TIMEOUT.toSeconds(),
-                 finalState);
+                 COMMUNITY_ID, reachedActiveMs, ACTIVE_TIMEOUT.toSeconds(), finalState);
         dumpDiagnostics();
-        assertThat(reachedActiveMs).as("EXPECTED: %d workers joining the 'default' source drive committed community '%s' to "
-                                      + "ACTIVE within %ds (leader FSM flips FORMING→ACTIVE when governor-announced "
-                                      + "liveMembers ≥ RF=%d). reachedActiveAtMs=%d, finalState=%s. -1 = STALL — the loop is "
-                                      + "wired but did not complete IN-JVM. See the diagnostic dump above for whether the "
-                                      + "workers were never assigned WORKER (promoted to core under churn), were assigned "
-                                      + "but no governor announcement landed, or were announced but the FSM never flipped.",
-                                       WORKER_COUNT,
-                                       COMMUNITY_ID,
-                                       ACTIVE_TIMEOUT.toSeconds(),
-                                       WORKER_COUNT,
-                                       reachedActiveMs,
-                                       finalState)
-                  .isGreaterThanOrEqualTo(0L);
+
+        assertThat(reachedActiveMs)
+            .as("EXPECTED: %d workers joining the 'default' source drive committed community '%s' to "
+                + "ACTIVE within %ds (leader FSM flips FORMING→ACTIVE when governor-announced "
+                + "liveMembers ≥ RF=%d). reachedActiveAtMs=%d, finalState=%s. -1 = STALL — the loop is "
+                + "wired but did not complete IN-JVM. See the diagnostic dump above for whether the "
+                + "workers were never assigned WORKER (promoted to core under churn), were assigned "
+                + "but no governor announcement landed, or were announced but the FSM never flipped.",
+                WORKER_COUNT, COMMUNITY_ID, ACTIVE_TIMEOUT.toSeconds(), WORKER_COUNT,
+                reachedActiveMs, finalState)
+            .isGreaterThanOrEqualTo(0L);
     }
 
     /// Wait for the leader's `BootstrapModule` to commit the auto-seeded `ClusterConfig.coreCount`
@@ -166,9 +158,8 @@ class CommunityFormationProbeTest {
     /// unlimited topology `coreMax`, and joiners would be promoted to core instead of worker.
     private void awaitCoreCapCommitted() {
         await().atMost(FORM_TIMEOUT)
-             .pollInterval(POLL)
-             .until(() -> committedCoreCount().filter(count -> count == INITIAL_CORES)
-                                            .isPresent());
+               .pollInterval(POLL)
+               .until(() -> committedCoreCount().filter(count -> count == INITIAL_CORES).isPresent());
         log.info("CFM-PROBE: committed core cap = {} (joiners beyond this are assigned WORKER)",
                  committedCoreCount().or(-1));
     }
@@ -185,81 +176,66 @@ class CommunityFormationProbeTest {
                                                 cluster.addNode());
 
         log.info("CFM-PROBE: worker {}/{} joined as {}", index, WORKER_COUNT, nodeId.id());
+
         var settled = pollUntil(SETTLE_TIMEOUT,
-                                () -> cluster.currentLeader()
-                                             .isPresent()
+                                () -> cluster.currentLeader().isPresent()
                                       && countedCores() == INITIAL_CORES
                                       && cluster.nodeCount() == expectedNodeCount);
-
         log.info("CFM-PROBE: after worker {}/{} settled={} leader={} countedCores={} (cap={}) nodeCount={}/{}",
-                 index,
-                 WORKER_COUNT,
-                 settled,
-                 cluster.currentLeader().or("none"),
-                 countedCores(),
-                 INITIAL_CORES,
-                 cluster.nodeCount(),
-                 expectedNodeCount);
+                 index, WORKER_COUNT, settled, cluster.currentLeader().or("none"),
+                 countedCores(), INITIAL_CORES, cluster.nodeCount(), expectedNodeCount);
     }
 
     /// Polls the committed community state until it reaches ACTIVE or the budget expires. Returns the
     /// first-observed convergence latency in ms, or -1 if ACTIVE was never observed.
     private long observeUntilActive(long t0) {
-        var latch = new long[]{ - 1L};
+        var latch = new long[]{-1L};
         var lastLog = new long[]{0L};
-
         await().pollInterval(POLL)
-             .pollDelay(Duration.ZERO)
-             .timeout(ACTIVE_TIMEOUT.plusSeconds(5))
-             .until(() -> recordTick(t0, latch, lastLog));
-
+               .pollDelay(Duration.ZERO)
+               .timeout(ACTIVE_TIMEOUT.plusSeconds(5))
+               .until(() -> recordTick(t0, latch, lastLog));
         return latch[0];
     }
 
     private boolean recordTick(long t0, long[] latch, long[] lastLog) {
         var elapsed = (System.nanoTime() - t0) / 1_000_000L;
-
-        if (communityState().filter(CommunityState.ACTIVE::equals).isPresent() && latch[0]< 0) {
+        if (communityState().filter(CommunityState.ACTIVE::equals).isPresent() && latch[0] < 0) {
             latch[0] = elapsed;
         }
-
         maybeLog(elapsed, lastLog);
-
-        return latch[0]>= 0 || elapsed >= ACTIVE_TIMEOUT.toMillis();
+        return latch[0] >= 0 || elapsed >= ACTIVE_TIMEOUT.toMillis();
     }
 
     private void maybeLog(long elapsedMs, long[] lastLog) {
-        if (elapsedMs - lastLog[0]< LOG_EVERY.toMillis()) {
+        if (elapsedMs - lastLog[0] < LOG_EVERY.toMillis()) {
             return;
         }
-
         lastLog[0] = elapsedMs;
         log.info("CFM-PROBE: t+{}ms community={} state={} governor={} announcedMembers={} "
-                + "countedCores={} emberNodeCount={}",
+                 + "countedCores={} emberNodeCount={}",
                  elapsedMs,
                  COMMUNITY_ID,
                  communityState().map(Enum::name).or("ABSENT"),
-                 governorAnnouncement().map(a -> a.governorId()
-                                                  .id()).or("none"),
+                 governorAnnouncement().map(a -> a.governorId().id()).or("none"),
                  governorAnnouncement().map(GovernorAnnouncementValue::memberCount).or(0),
                  countedCores(),
                  cluster.nodeCount());
     }
 
     // ----- in-process committed-state reads (off the leader KV store) -----
+
     private Option<Integer> committedCoreCount() {
-        return leaderOrAnyNode().flatMap(node -> node.kvStore()
-                                                     .get(ClusterConfigKey.CURRENT))
-                              .filter(ClusterConfigValue.class::isInstance)
-                              .map(ClusterConfigValue.class::cast)
-                              .map(ClusterConfigValue::coreCount);
+        return leaderOrAnyNode().flatMap(node -> node.kvStore().get(ClusterConfigKey.CURRENT))
+                                .filter(ClusterConfigValue.class::isInstance)
+                                .map(ClusterConfigValue.class::cast)
+                                .map(ClusterConfigValue::coreCount);
     }
 
     private Option<CommunityValue> communityValue() {
-        return leaderOrAnyNode().flatMap(node -> node.kvStore()
-                                                     .get(CommunityKey.communityKey(COMMUNITY_ID)))
-                              .filter(CommunityValue.class::isInstance)
-                              .map(CommunityValue.class::cast);
+        return leaderOrAnyNode().flatMap(node -> node.kvStore().get(CommunityKey.communityKey(COMMUNITY_ID)))
+                                .filter(CommunityValue.class::isInstance)
+                                .map(CommunityValue.class::cast);
     }
 
     private Option<CommunityState> communityState() {
@@ -267,17 +243,13 @@ class CommunityFormationProbeTest {
     }
 
     private Option<GovernorAnnouncementValue> governorAnnouncement() {
-        return leaderOrAnyNode().flatMap(node -> node.kvStore()
-                                                     .get(GovernorAnnouncementKey.forCommunity(COMMUNITY_ID)))
-                              .filter(GovernorAnnouncementValue.class::isInstance)
-                              .map(GovernorAnnouncementValue.class::cast);
+        return leaderOrAnyNode().flatMap(node -> node.kvStore().get(GovernorAnnouncementKey.forCommunity(COMMUNITY_ID)))
+                                .filter(GovernorAnnouncementValue.class::isInstance)
+                                .map(GovernorAnnouncementValue.class::cast);
     }
 
     private int countedCores() {
-        return leaderOrAnyNode().map(node -> node.membershipFsm()
-                                                 .coreCountedMembers()
-                                                 .size())
-                              .or(0);
+        return leaderOrAnyNode().map(node -> node.membershipFsm().coreCountedMembers().size()).or(0);
     }
 
     private Option<AetherNode> leaderOrAnyNode() {
@@ -291,7 +263,6 @@ class CommunityFormationProbeTest {
     private static boolean pollUntil(Duration timeout, java.util.concurrent.Callable<Boolean> condition) {
         try {
             await().atMost(timeout).pollInterval(POLL).until(condition);
-
             return true;
         } catch (org.awaitility.core.ConditionTimeoutException e) {
             return false;
@@ -299,50 +270,32 @@ class CommunityFormationProbeTest {
     }
 
     // ----- failure diagnostics -----
+
     @TerminalOperation
     private void dumpDiagnostics() {
         var leaderNode = leaderOrAnyNode();
-        var countedSet = leaderNode.map(node -> node.membershipFsm()
-                                                    .coreCountedMembers()).or(Set.of());
+        var countedSet = leaderNode.map(node -> node.membershipFsm().coreCountedMembers()).or(Set.of());
 
         log.info("CFM-PROBE DUMP: leader={} ember.nodeCount={} countedCores={} committedCap={}",
-                 cluster.currentLeader().or("none"),
-                 cluster.nodeCount(),
-                 countedSet.size(),
+                 cluster.currentLeader().or("none"), cluster.nodeCount(), countedSet.size(),
                  committedCoreCount().or(-1));
         log.info("CFM-PROBE DUMP: community '{}' value = {}",
-                 COMMUNITY_ID,
-                 communityValue().map(Object::toString).or("ABSENT"));
+                 COMMUNITY_ID, communityValue().map(Object::toString).or("ABSENT"));
         log.info("CFM-PROBE DUMP: governor announcement = {}",
                  governorAnnouncement().map(Object::toString).or("ABSENT"));
         log.info("CFM-PROBE DUMP: leader counted-core set = {}", idStrings(countedSet));
+
         cluster.allNodes().forEach(node -> dumpNode(node, countedSet));
     }
 
     private void dumpNode(AetherNode node, Set<NodeId> countedSet) {
         var id = node.self();
-        var inMesh = leaderOrAnyNode().map(leader -> leader.membershipView()
-                                                           .isPresent(id)).or(false);
-
+        var inMesh = leaderOrAnyNode().map(leader -> leader.membershipView().isPresent(id)).or(false);
         log.info("CFM-PROBE DUMP: node={} leader={} inLeaderSwimView={} countedAsCore={} (else=worker)",
-                 id.id(),
-                 node.isLeader(),
-                 inMesh,
-                 countedSet.contains(id));
+                 id.id(), node.isLeader(), inMesh, countedSet.contains(id));
     }
 
     private static String idStrings(Set<NodeId> ids) {
-        return ids.stream()
-                  .map(NodeId::id)
-                  .sorted()
-                  .collect(Collectors.joining(","));
-    }
-
-    private static void failStart(Cause cause) {
-        throw new AssertionError("Cluster start failed: " + cause.message());
-    }
-
-    private static void failScenario(Cause cause) {
-        throw new AssertionError("Worker join failed: " + cause.message());
+        return ids.stream().map(NodeId::id).sorted().collect(Collectors.joining(","));
     }
 }

--- a/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/CoordinationSlopeInstrumentTest.java
+++ b/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/CoordinationSlopeInstrumentTest.java
@@ -2,22 +2,7 @@
 // Copyright (c) 2025 Pragmatica Labs - Sergiy Yevtushenko
 // Licensed under Business Source License 1.1. Change Date: 2030-01-01. Change License: Apache-2.0.
 // See LICENSE in the repository root for full terms.
-
 package org.pragmatica.aether.forge;
-
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.Assumptions;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
-import org.pragmatica.aether.ember.EmberCluster;
-import org.pragmatica.http.HttpOperations;
-import org.pragmatica.http.HttpResult;
-import org.pragmatica.lang.Option;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.net.URI;
 import java.net.http.HttpRequest;
@@ -27,10 +12,26 @@ import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.awaitility.Awaitility.await;
+import org.pragmatica.aether.ember.EmberCluster;
+import org.pragmatica.http.HttpOperations;
+import org.pragmatica.http.HttpResult;
+import org.pragmatica.lang.Option;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import static org.pragmatica.aether.ember.EmberCluster.emberCluster;
 import static org.pragmatica.http.JdkHttpOperations.jdkHttpOperations;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
 
 /// #591 — validates the coordination-load INSTRUMENT against a live cluster.
 ///
@@ -59,19 +60,17 @@ import static org.pragmatica.http.JdkHttpOperations.jdkHttpOperations;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class CoordinationSlopeInstrumentTest {
     private static final Logger log = LoggerFactory.getLogger(CoordinationSlopeInstrumentTest.class);
-
     private static final int CORES = 3;
     private static final int BASE_PORT = 20000;
     private static final int BASE_MGMT_PORT = 20100;
     private static final int BASE_APP_HTTP_PORT = 20200;
-
     private static final Duration FORM_TIMEOUT = Duration.ofSeconds(60);
     private static final Duration POLL = Duration.ofMillis(500);
 
     /// The two counters the sampler differences. Named here so a rename breaks THIS test with a clear
     /// message rather than silently flattening the slope in a remote run weeks later.
-    private static final List<String> REQUIRED_TRANSPORT_KEYS =
-        List.of("quic_messages_sent_total", "quic_messages_received_total");
+    private static final List<String> REQUIRED_TRANSPORT_KEYS = List.of("quic_messages_sent_total",
+                                                                        "quic_messages_received_total");
 
     private static final List<String> REQUIRED_LOAD_KEYS = List.of("cpu.usage", "heap.used");
 
@@ -81,15 +80,14 @@ class CoordinationSlopeInstrumentTest {
     @BeforeAll
     void setUp() {
         cluster = emberCluster(CORES, BASE_PORT, BASE_MGMT_PORT, BASE_APP_HTTP_PORT, "cslope");
-        cluster.start().await().onFailure(cause -> {
-            throw new AssertionError("Cluster start failed: " + cause.message());
-        });
-        await().atMost(FORM_TIMEOUT).pollInterval(POLL).until(() -> cluster.currentLeader().isPresent());
+        LifecycleAwait.settled("cluster start in setUp()", cluster, cluster.start());
+        await().atMost(FORM_TIMEOUT).pollInterval(POLL).until(() -> cluster.currentLeader()
+                                                                           .isPresent());
     }
 
     @AfterAll
     void tearDown() {
-        Option.option(cluster).onPresent(c -> c.stop().await());
+        Option.option(cluster).onPresent(c -> LifecycleAwait.settled("cluster stop in tearDown()", c, c.stop()));
     }
 
     /// The sampler's contract with `GET /api/v1/metrics/transport`, checked on EVERY core because the
@@ -100,15 +98,13 @@ class CoordinationSlopeInstrumentTest {
         for (var node : cluster.status().nodes()) {
             var body = get(node.mgmtPort(), "/api/v1/metrics/transport");
 
-            assertThat(body)
-                .as("node %s must answer /api/v1/metrics/transport", node.id())
-                .isNotBlank();
-
+            assertThat(body).as("node %s must answer /api/v1/metrics/transport", node.id()).isNotBlank();
             for (var key : REQUIRED_TRANSPORT_KEYS) {
-                assertThat(body)
-                    .as("node %s: /api/v1/metrics/transport must carry %s — the sampler differences it, and "
-                        + "a missing key would make a busy node read as perfectly idle", node.id(), key)
-                    .contains("\"" + key + "\"");
+                assertThat(body).as("node %s: /api/v1/metrics/transport must carry %s — the sampler differences it, and "
+                                   + "a missing key would make a busy node read as perfectly idle",
+                                    node.id(),
+                                    key)
+                          .contains("\"" + key + "\"");
             }
         }
     }
@@ -120,14 +116,12 @@ class CoordinationSlopeInstrumentTest {
         for (var node : cluster.status().nodes()) {
             var body = get(node.mgmtPort(), "/api/v1/metrics");
 
-            assertThat(body)
-                .as("node %s: /api/v1/metrics must carry a load map", node.id())
-                .contains("\"load\"");
-
+            assertThat(body).as("node %s: /api/v1/metrics must carry a load map", node.id()).contains("\"load\"");
             for (var key : REQUIRED_LOAD_KEYS) {
-                assertThat(body)
-                    .as("node %s: /api/v1/metrics load entries must carry %s", node.id(), key)
-                    .contains("\"" + key + "\"");
+                assertThat(body).as("node %s: /api/v1/metrics load entries must carry %s",
+                                    node.id(),
+                                    key)
+                          .contains("\"" + key + "\"");
             }
         }
     }
@@ -142,13 +136,13 @@ class CoordinationSlopeInstrumentTest {
         var first = messagesTotal(port);
 
         await().pollDelay(Duration.ofSeconds(3)).timeout(Duration.ofSeconds(8)).until(() -> true);
-
         var second = messagesTotal(port);
 
-        assertThat(second)
-            .as("counters must not decrease between reads — the sampler differences them, which is only "
-                + "meaningful for cumulative counters (first=%d second=%d)", first, second)
-            .isGreaterThanOrEqualTo(first);
+        assertThat(second).as("counters must not decrease between reads — the sampler differences them, which is only "
+                             + "meaningful for cumulative counters (first=%d second=%d)",
+                              first,
+                              second)
+                  .isGreaterThanOrEqualTo(first);
         log.info("CSLOPE-INSTRUMENT: cumulative check first={} second={} delta={}", first, second, second - first);
     }
 
@@ -160,42 +154,33 @@ class CoordinationSlopeInstrumentTest {
 
         Assumptions.assumeTrue(Files.isRegularFile(script), "sampler not found at " + script);
         Assumptions.assumeTrue(python3Available(), "python3 unavailable — skipping the end-to-end sampler leg");
-
-        var endpoints = cluster.status()
-                               .nodes()
-                               .stream()
-                               .map(n -> "http://localhost:" + n.mgmtPort())
-                               .toList();
-        var nodeIds = cluster.status()
-                             .nodes()
-                             .stream()
-                             .map(EmberCluster.NodeStatus::id)
-                             .toList();
-
-        var process = new ProcessBuilder("python3", script.toString(),
-                                         "--cores", String.join(",", endpoints),
-                                         "--node-ids", String.join(",", nodeIds),
-                                         "--workers", "0",
-                                         "--window", "5")
-            .redirectErrorStream(true)
-            .start();
+        var endpoints = cluster.status().nodes().stream().map(n -> "http://localhost:" + n.mgmtPort()).toList();
+        var nodeIds = cluster.status().nodes().stream().map(EmberCluster.NodeStatus::id).toList();
+        var process = new ProcessBuilder("python3",
+                                         script.toString(),
+                                         "--cores",
+                                         String.join(",", endpoints),
+                                         "--node-ids",
+                                         String.join(",", nodeIds),
+                                         "--workers",
+                                         "0",
+                                         "--window",
+                                         "5").redirectErrorStream(true)
+                                             .start();
         var output = new String(process.getInputStream().readAllBytes());
         var finished = process.waitFor(90, TimeUnit.SECONDS);
 
         log.info("CSLOPE-INSTRUMENT sampler output:\n{}", output);
         assertThat(finished).as("sampler must terminate").isTrue();
-        assertThat(process.exitValue())
-            .as("sampler must exit 0 against a healthy cluster; output was:\n%s", output)
-            .isZero();
-        assertThat(output)
-            .as("sampler must emit the fields the slope table is built from")
-            .contains("totalCoreMessagesPerSecond")
-            .contains("perCoreMessagesPerSecond")
-            .contains("meanCoreCpuUsage")
-            .contains("anyCoreSaturated");
-        assertThat(output)
-            .as("the sampler must report the cores it was given, not a subset")
-            .contains("\"cores\": " + CORES);
+        assertThat(process.exitValue()).as("sampler must exit 0 against a healthy cluster; output was:\n%s", output)
+                  .isZero();
+        assertThat(output).as("sampler must emit the fields the slope table is built from")
+                  .contains("totalCoreMessagesPerSecond")
+                  .contains("perCoreMessagesPerSecond")
+                  .contains("meanCoreCpuUsage")
+                  .contains("anyCoreSaturated");
+        assertThat(output).as("the sampler must report the cores it was given, not a subset")
+                  .contains("\"cores\": " + CORES);
     }
 
     private long messagesTotal(int mgmtPort) {
@@ -216,9 +201,7 @@ class CoordinationSlopeInstrumentTest {
             throw new AssertionError("transport payload has no " + key + "; payload=" + json);
         }
 
-        var digits = json.substring(at + marker.length())
-                         .replaceFirst("^\\s*:\\s*", "")
-                         .split("[^0-9]", 2)[0];
+        var digits = json.substring(at + marker.length()).replaceFirst("^\\s*:\\s*", "").split("[^0-9]", 2) [0];
 
         if (digits.isEmpty()) {
             throw new AssertionError("value of " + key + " is not numeric; payload=" + json);
@@ -249,12 +232,15 @@ class CoordinationSlopeInstrumentTest {
             dir = dir.getParent();
         }
 
-        return dir == null ? Path.of("").toAbsolutePath() : dir;
+        return dir == null
+               ? Path.of("").toAbsolutePath()
+               : dir;
     }
 
     private static boolean python3Available() {
         try {
-            return new ProcessBuilder("python3", "--version").start().waitFor(10, TimeUnit.SECONDS);
+            return new ProcessBuilder("python3", "--version").start()
+                                                             .waitFor(10, TimeUnit.SECONDS);
         } catch (Exception e) {
             return false;
         }

--- a/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/CoordinationSlopeInstrumentTest.java
+++ b/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/CoordinationSlopeInstrumentTest.java
@@ -2,7 +2,22 @@
 // Copyright (c) 2025 Pragmatica Labs - Sergiy Yevtushenko
 // Licensed under Business Source License 1.1. Change Date: 2030-01-01. Change License: Apache-2.0.
 // See LICENSE in the repository root for full terms.
+
 package org.pragmatica.aether.forge;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.pragmatica.aether.ember.EmberCluster;
+import org.pragmatica.http.HttpOperations;
+import org.pragmatica.http.HttpResult;
+import org.pragmatica.lang.Option;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.net.URI;
 import java.net.http.HttpRequest;
@@ -12,26 +27,10 @@ import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-import org.pragmatica.aether.ember.EmberCluster;
-import org.pragmatica.http.HttpOperations;
-import org.pragmatica.http.HttpResult;
-import org.pragmatica.lang.Option;
-
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.Assumptions;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import static org.pragmatica.aether.ember.EmberCluster.emberCluster;
-import static org.pragmatica.http.JdkHttpOperations.jdkHttpOperations;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
-
+import static org.pragmatica.aether.ember.EmberCluster.emberCluster;
+import static org.pragmatica.http.JdkHttpOperations.jdkHttpOperations;
 
 /// #591 — validates the coordination-load INSTRUMENT against a live cluster.
 ///
@@ -60,17 +59,19 @@ import static org.awaitility.Awaitility.await;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class CoordinationSlopeInstrumentTest {
     private static final Logger log = LoggerFactory.getLogger(CoordinationSlopeInstrumentTest.class);
+
     private static final int CORES = 3;
     private static final int BASE_PORT = 20000;
     private static final int BASE_MGMT_PORT = 20100;
     private static final int BASE_APP_HTTP_PORT = 20200;
+
     private static final Duration FORM_TIMEOUT = Duration.ofSeconds(60);
     private static final Duration POLL = Duration.ofMillis(500);
 
     /// The two counters the sampler differences. Named here so a rename breaks THIS test with a clear
     /// message rather than silently flattening the slope in a remote run weeks later.
-    private static final List<String> REQUIRED_TRANSPORT_KEYS = List.of("quic_messages_sent_total",
-                                                                        "quic_messages_received_total");
+    private static final List<String> REQUIRED_TRANSPORT_KEYS =
+        List.of("quic_messages_sent_total", "quic_messages_received_total");
 
     private static final List<String> REQUIRED_LOAD_KEYS = List.of("cpu.usage", "heap.used");
 
@@ -81,13 +82,12 @@ class CoordinationSlopeInstrumentTest {
     void setUp() {
         cluster = emberCluster(CORES, BASE_PORT, BASE_MGMT_PORT, BASE_APP_HTTP_PORT, "cslope");
         LifecycleAwait.settled("cluster start in setUp()", cluster, cluster.start());
-        await().atMost(FORM_TIMEOUT).pollInterval(POLL).until(() -> cluster.currentLeader()
-                                                                           .isPresent());
+        await().atMost(FORM_TIMEOUT).pollInterval(POLL).until(() -> cluster.currentLeader().isPresent());
     }
 
     @AfterAll
     void tearDown() {
-        Option.option(cluster).onPresent(c -> LifecycleAwait.settled("cluster stop in tearDown()", c, c.stop()));
+        Option.option(cluster).onPresent(c -> LifecycleAwait.bestEffort("cluster stop in tearDown()", c, c.stop()));
     }
 
     /// The sampler's contract with `GET /api/v1/metrics/transport`, checked on EVERY core because the
@@ -98,13 +98,15 @@ class CoordinationSlopeInstrumentTest {
         for (var node : cluster.status().nodes()) {
             var body = get(node.mgmtPort(), "/api/v1/metrics/transport");
 
-            assertThat(body).as("node %s must answer /api/v1/metrics/transport", node.id()).isNotBlank();
+            assertThat(body)
+                .as("node %s must answer /api/v1/metrics/transport", node.id())
+                .isNotBlank();
+
             for (var key : REQUIRED_TRANSPORT_KEYS) {
-                assertThat(body).as("node %s: /api/v1/metrics/transport must carry %s — the sampler differences it, and "
-                                   + "a missing key would make a busy node read as perfectly idle",
-                                    node.id(),
-                                    key)
-                          .contains("\"" + key + "\"");
+                assertThat(body)
+                    .as("node %s: /api/v1/metrics/transport must carry %s — the sampler differences it, and "
+                        + "a missing key would make a busy node read as perfectly idle", node.id(), key)
+                    .contains("\"" + key + "\"");
             }
         }
     }
@@ -116,12 +118,14 @@ class CoordinationSlopeInstrumentTest {
         for (var node : cluster.status().nodes()) {
             var body = get(node.mgmtPort(), "/api/v1/metrics");
 
-            assertThat(body).as("node %s: /api/v1/metrics must carry a load map", node.id()).contains("\"load\"");
+            assertThat(body)
+                .as("node %s: /api/v1/metrics must carry a load map", node.id())
+                .contains("\"load\"");
+
             for (var key : REQUIRED_LOAD_KEYS) {
-                assertThat(body).as("node %s: /api/v1/metrics load entries must carry %s",
-                                    node.id(),
-                                    key)
-                          .contains("\"" + key + "\"");
+                assertThat(body)
+                    .as("node %s: /api/v1/metrics load entries must carry %s", node.id(), key)
+                    .contains("\"" + key + "\"");
             }
         }
     }
@@ -136,13 +140,13 @@ class CoordinationSlopeInstrumentTest {
         var first = messagesTotal(port);
 
         await().pollDelay(Duration.ofSeconds(3)).timeout(Duration.ofSeconds(8)).until(() -> true);
+
         var second = messagesTotal(port);
 
-        assertThat(second).as("counters must not decrease between reads — the sampler differences them, which is only "
-                             + "meaningful for cumulative counters (first=%d second=%d)",
-                              first,
-                              second)
-                  .isGreaterThanOrEqualTo(first);
+        assertThat(second)
+            .as("counters must not decrease between reads — the sampler differences them, which is only "
+                + "meaningful for cumulative counters (first=%d second=%d)", first, second)
+            .isGreaterThanOrEqualTo(first);
         log.info("CSLOPE-INSTRUMENT: cumulative check first={} second={} delta={}", first, second, second - first);
     }
 
@@ -154,33 +158,42 @@ class CoordinationSlopeInstrumentTest {
 
         Assumptions.assumeTrue(Files.isRegularFile(script), "sampler not found at " + script);
         Assumptions.assumeTrue(python3Available(), "python3 unavailable — skipping the end-to-end sampler leg");
-        var endpoints = cluster.status().nodes().stream().map(n -> "http://localhost:" + n.mgmtPort()).toList();
-        var nodeIds = cluster.status().nodes().stream().map(EmberCluster.NodeStatus::id).toList();
-        var process = new ProcessBuilder("python3",
-                                         script.toString(),
-                                         "--cores",
-                                         String.join(",", endpoints),
-                                         "--node-ids",
-                                         String.join(",", nodeIds),
-                                         "--workers",
-                                         "0",
-                                         "--window",
-                                         "5").redirectErrorStream(true)
-                                             .start();
+
+        var endpoints = cluster.status()
+                               .nodes()
+                               .stream()
+                               .map(n -> "http://localhost:" + n.mgmtPort())
+                               .toList();
+        var nodeIds = cluster.status()
+                             .nodes()
+                             .stream()
+                             .map(EmberCluster.NodeStatus::id)
+                             .toList();
+
+        var process = new ProcessBuilder("python3", script.toString(),
+                                         "--cores", String.join(",", endpoints),
+                                         "--node-ids", String.join(",", nodeIds),
+                                         "--workers", "0",
+                                         "--window", "5")
+            .redirectErrorStream(true)
+            .start();
         var output = new String(process.getInputStream().readAllBytes());
         var finished = process.waitFor(90, TimeUnit.SECONDS);
 
         log.info("CSLOPE-INSTRUMENT sampler output:\n{}", output);
         assertThat(finished).as("sampler must terminate").isTrue();
-        assertThat(process.exitValue()).as("sampler must exit 0 against a healthy cluster; output was:\n%s", output)
-                  .isZero();
-        assertThat(output).as("sampler must emit the fields the slope table is built from")
-                  .contains("totalCoreMessagesPerSecond")
-                  .contains("perCoreMessagesPerSecond")
-                  .contains("meanCoreCpuUsage")
-                  .contains("anyCoreSaturated");
-        assertThat(output).as("the sampler must report the cores it was given, not a subset")
-                  .contains("\"cores\": " + CORES);
+        assertThat(process.exitValue())
+            .as("sampler must exit 0 against a healthy cluster; output was:\n%s", output)
+            .isZero();
+        assertThat(output)
+            .as("sampler must emit the fields the slope table is built from")
+            .contains("totalCoreMessagesPerSecond")
+            .contains("perCoreMessagesPerSecond")
+            .contains("meanCoreCpuUsage")
+            .contains("anyCoreSaturated");
+        assertThat(output)
+            .as("the sampler must report the cores it was given, not a subset")
+            .contains("\"cores\": " + CORES);
     }
 
     private long messagesTotal(int mgmtPort) {
@@ -201,7 +214,9 @@ class CoordinationSlopeInstrumentTest {
             throw new AssertionError("transport payload has no " + key + "; payload=" + json);
         }
 
-        var digits = json.substring(at + marker.length()).replaceFirst("^\\s*:\\s*", "").split("[^0-9]", 2) [0];
+        var digits = json.substring(at + marker.length())
+                         .replaceFirst("^\\s*:\\s*", "")
+                         .split("[^0-9]", 2)[0];
 
         if (digits.isEmpty()) {
             throw new AssertionError("value of " + key + " is not numeric; payload=" + json);
@@ -232,15 +247,12 @@ class CoordinationSlopeInstrumentTest {
             dir = dir.getParent();
         }
 
-        return dir == null
-               ? Path.of("").toAbsolutePath()
-               : dir;
+        return dir == null ? Path.of("").toAbsolutePath() : dir;
     }
 
     private static boolean python3Available() {
         try {
-            return new ProcessBuilder("python3", "--version").start()
-                                                             .waitFor(10, TimeUnit.SECONDS);
+            return new ProcessBuilder("python3", "--version").start().waitFor(10, TimeUnit.SECONDS);
         } catch (Exception e) {
             return false;
         }

--- a/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/CoreAbsenceFenceOrderingTest.java
+++ b/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/CoreAbsenceFenceOrderingTest.java
@@ -2,19 +2,8 @@
 // Copyright (c) 2025 Pragmatica Labs - Sergiy Yevtushenko
 // Licensed under Business Source License 1.1. Change Date: 2030-01-01. Change License: Apache-2.0.
 // See LICENSE in the repository root for full terms.
+
 package org.pragmatica.aether.forge;
-
-import java.time.Duration;
-import java.util.concurrent.atomic.AtomicLong;
-
-import org.pragmatica.aether.ember.EmberCluster;
-import org.pragmatica.aether.node.AetherNode;
-import org.pragmatica.aether.slice.kvstore.AetherKey.ClusterConfigKey;
-import org.pragmatica.aether.slice.kvstore.AetherValue.ClusterConfigValue;
-import org.pragmatica.aether.worker.isolation.CoreAbsenceSnapshot;
-import org.pragmatica.lang.Cause;
-import org.pragmatica.lang.Option;
-import org.pragmatica.lang.TerminalOperation;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -23,13 +12,22 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.pragmatica.aether.ember.EmberCluster;
+import org.pragmatica.aether.node.AetherNode;
+import org.pragmatica.aether.slice.kvstore.AetherKey.ClusterConfigKey;
+import org.pragmatica.aether.slice.kvstore.AetherValue.ClusterConfigValue;
+import org.pragmatica.aether.worker.isolation.CoreAbsenceSnapshot;
+import org.pragmatica.lang.Option;
+import org.pragmatica.lang.TerminalOperation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.pragmatica.aether.ember.EmberCluster.emberCluster;
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicLong;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
-
+import static org.pragmatica.aether.ember.EmberCluster.emberCluster;
 
 /// #590 — the community tier's core-absence fence, and the ORDERING that keeps it safe.
 ///
@@ -113,10 +111,12 @@ import static org.awaitility.Awaitility.await;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class CoreAbsenceFenceOrderingTest {
     private static final Logger log = LoggerFactory.getLogger(CoreAbsenceFenceOrderingTest.class);
+
     private static final int INITIAL_CORES = 5;
     private static final int BASE_PORT = 21000;
     private static final int BASE_MGMT_PORT = 21100;
     private static final int BASE_APP_HTTP_PORT = 21200;
+
     /// Shipped defaults from `TimeoutsConfig.ClusterTimeouts`: multiples of the 1s `pingInterval` —
     /// 10s to fence locally, 20s before the core re-places. `ConfigValidator` REFUSES a config where
     /// `core_absence >= community_absence`, and that inequality is the invariant this class measures.
@@ -129,6 +129,7 @@ class CoreAbsenceFenceOrderingTest {
     /// core half of #590 keys on pong silence (`ClusterSyncCollector.sinceLastPongNanos`), not on SWIM.
     private static final Duration CORE_ABSENCE = Duration.ofSeconds(10);
     private static final Duration COMMUNITY_ABSENCE = Duration.ofSeconds(20);
+
     private static final Duration FORM_TIMEOUT = Duration.ofSeconds(240);
     private static final Duration WORKER_ARM_TIMEOUT = Duration.ofSeconds(120);
     /// Generous against the fence window so a slow poll cannot fail a fence that did fire; the
@@ -140,11 +141,11 @@ class CoreAbsenceFenceOrderingTest {
     /// node removes itself.
     private static final Duration FENCE_POLL = Duration.ofMillis(20);
 
-    private final java.util.concurrent.atomic.AtomicReference<CoreAbsenceSnapshot> fenceObservation = new java.util.concurrent.atomic.AtomicReference<>();
-
+    private final java.util.concurrent.atomic.AtomicReference<CoreAbsenceSnapshot> fenceObservation =
+        new java.util.concurrent.atomic.AtomicReference<>();
     private final AtomicLong lastProgressLog = new AtomicLong();
-
-    private final java.util.concurrent.atomic.AtomicReference<String> fenceEvidence = new java.util.concurrent.atomic.AtomicReference<>("none");
+    private final java.util.concurrent.atomic.AtomicReference<String> fenceEvidence =
+        new java.util.concurrent.atomic.AtomicReference<>("none");
 
     private EmberCluster cluster;
     private String worker;
@@ -155,14 +156,11 @@ class CoreAbsenceFenceOrderingTest {
         cluster = emberCluster(INITIAL_CORES, BASE_PORT, BASE_MGMT_PORT, BASE_APP_HTTP_PORT, "fence");
         cluster.withRaisedSwimTimeouts();
         LifecycleAwait.settled("cluster start in setUp()", cluster, cluster.start());
-        await().atMost(FORM_TIMEOUT).pollInterval(POLL).until(() -> cluster.currentLeader()
-                                                                           .isPresent());
-        await().atMost(FORM_TIMEOUT).pollInterval(POLL).until(() -> cluster.status()
-                                                                           .nodes()
-                                                                           .size() == INITIAL_CORES);
-        log.info("FENCE-PROBE: {}-core cluster formed, leader={}",
-                 INITIAL_CORES,
-                 cluster.currentLeader().or("none"));
+
+        await().atMost(FORM_TIMEOUT).pollInterval(POLL).until(() -> cluster.currentLeader().isPresent());
+        await().atMost(FORM_TIMEOUT).pollInterval(POLL).until(() -> cluster.status().nodes().size() == INITIAL_CORES);
+        log.info("FENCE-PROBE: {}-core cluster formed, leader={}", INITIAL_CORES, cluster.currentLeader().or("none"));
+
         // WAIT FOR THE COMMITTED CAP BEFORE ADDING. Role is leader-decided: `assignNodeRole` promotes a
         // joiner to CORE while `currentCoreCount < effectiveCoreMax`, and `effectiveCoreMax` reads the
         // COMMITTED `ClusterConfig.coreCount`, which `BootstrapModule` auto-seeds shortly after
@@ -172,68 +170,68 @@ class CoreAbsenceFenceOrderingTest {
         // fence then correctly refused to fire because a core may never fence this way. Without the
         // precondition below that would have been reported as "#590's fence is broken" — a false defect
         // against a working mechanism, with a confident 40-second proof behind it.
-        await().atMost(FORM_TIMEOUT).pollInterval(POLL).until(() -> committedCoreCount().or(0) == INITIAL_CORES);
+        await().atMost(FORM_TIMEOUT)
+               .pollInterval(POLL)
+               .until(() -> committedCoreCount().or(0) == INITIAL_CORES);
         log.info("FENCE-PROBE: committed ClusterConfig.coreCount={} — the cap is live, the next join exceeds it",
                  committedCoreCount().or(0));
+
         worker = LifecycleAwait.nodeSettled("worker node join in addWorkerBeyondTheCoreCap()",
                                             cluster,
                                             cluster.addWorkerNode())
                                .id();
         log.info("FENCE-PROBE: added node {} — expected to exceed the core cap and be minted a WORKER", worker);
+
         // CORRECTION (found by running it): `isArmed()` is `!lastPingNanos.isEmpty()` — "a core ping
         // has ever been accepted" — NOT "the suppressor released". Gating on it proves the node is
         // reachable, not that it is a WORKER, so a node mis-minted as a core would sail past this and
         // then never fence, reading as a defect in the fence rather than a defect in the premise.
         // The suppressor's REAL input is the node's own `topologyManager().coreNodes()`, checked below.
         await().atMost(WORKER_ARM_TIMEOUT)
-             .pollInterval(POLL)
-             .until(() -> snapshot(worker).map(CoreAbsenceSnapshot::armed)
-                                  .or(false));
+               .pollInterval(POLL)
+               .until(() -> snapshot(worker).map(CoreAbsenceSnapshot::armed).or(false));
         log.info("FENCE-PROBE: {} is ARMED — it has accepted at least one core ping", worker);
+
         // THE PRECONDITION THAT ACTUALLY MATTERS, and exactly what the suppressor samples at firing
         // time: `cores.isEmpty() || cores.contains(self)` SUPPRESSES. If this node was minted a CORE
         // rather than a worker, the fence is suppressed BY DESIGN and any non-fence says nothing about
         // the mechanism.
         var workerCoreView = cluster.getNode(worker)
-                                    .map(node -> node.topologyManager()
-                                                     .coreNodes()
-                                                     .toString())
+                                    .map(node -> node.topologyManager().coreNodes().toString())
                                     .or("<no node>");
         var suppressed = cluster.getNode(worker)
                                 .map(node -> {
-                                         var cores = node.topologyManager()
-                                                         .coreNodes();
+                                    var cores = node.topologyManager().coreNodes();
 
-                                         return cores.isEmpty() || cores.stream()
-                                                                        .anyMatch(id -> id.id()
-                                                                                          .equals(worker));
-                                     })
+                                    return cores.isEmpty() || cores.stream().anyMatch(id -> id.id().equals(worker));
+                                })
                                 .or(true);
 
         log.info("FENCE-PROBE PRECONDITION: {} coreNodes-as-seen-by-itself={} suppressorWouldSuppress={}",
-                 worker,
-                 workerCoreView,
-                 suppressed);
-        assertThat(suppressed).as("PRECONDITION: %s must be a genuine WORKER — its own coreNodes() view must be non-empty "
-                                 + "and must NOT contain itself, or the fence is suppressed by design and this test "
-                                 + "measures nothing. Saw coreNodes=%s",
-                                  worker,
-                                  workerCoreView)
-                  .isFalse();
+                 worker, workerCoreView, suppressed);
+        assertThat(suppressed)
+            .as("PRECONDITION: %s must be a genuine WORKER — its own coreNodes() view must be non-empty "
+                + "and must NOT contain itself, or the fence is suppressed by design and this test "
+                + "measures nothing. Saw coreNodes=%s", worker, workerCoreView)
+            .isFalse();
     }
 
     @AfterAll
     @TerminalOperation
     void tearDown() {
-        Option.option(cluster).onPresent(c -> LifecycleAwait.settled("cluster stop in tearDown()", c, c.stop()));
+        Option.option(cluster).onPresent(c -> LifecycleAwait.bestEffort("cluster stop in tearDown()", c, c.stop()));
     }
 
     @Test
     void isolatedWorkerFencesItselfLocally_strictlyBeforeTheCoreWouldReplaceIt() {
         var before = requireSnapshot(worker);
 
-        assertThat(before.fenced()).as("PRECONDITION: %s must not already be fenced before isolation", worker).isFalse();
+        assertThat(before.fenced())
+            .as("PRECONDITION: %s must not already be fenced before isolation", worker)
+            .isFalse();
+
         var t0 = System.nanoTime();
+
         // Total isolation: all cluster traffic to and from this node is dropped, connections left
         // open. The core's ClusterSyncPing stops arriving, which is the ONLY liveness signal this
         // fence consumes — and crucially the node cannot write to the core either, which is the whole
@@ -243,6 +241,7 @@ class CoreAbsenceFenceOrderingTest {
                                    cluster,
                                    cluster.blackhole(worker));
         log.info("FENCE-PROBE: black-holed {} at t0 — core pings stop, and it cannot reach consensus", worker);
+
         // CAPTURED at the moment the fence is observed, NOT re-read afterwards. Ember injects
         // `() -> handleSelfDrain(nodeId)` as the node's `jvmExit`, so the fence's drain STOPS this node
         // — a later read can find it already deregistered and throw, failing a run that actually
@@ -253,25 +252,28 @@ class CoreAbsenceFenceOrderingTest {
 
         log.info("FENCE-PROBE EVIDENCE: {}", fenceEvidence.get());
         log.info("FENCE-PROBE FINAL STATE: {}",
-                 snapshot(worker).map(s -> "armed=" + s.armed()
-                                          + " fenced=" + s.fenced()
-                                          + " sinceLastPingMs=" + s.sinceLastPingMs()
-                                          + " remainingMs=" + s.remainingMs())
-                         .or("NO SNAPSHOT — node already deregistered"));
-        assertThat(fenceMs).as("the isolated worker must fence within the %ds core-absence window. -1 means it NEVER "
-                              + "fenced in %ds — read the t+ progress lines above: `armed=false` means the suppressor "
-                              + "re-engaged (an isolated node's coreNodes() view emptying reads as SUPPRESS by "
-                              + "design), a resetting sinceLastPingMs means the isolation is not isolating",
-                               CORE_ABSENCE.toSeconds(),
-                               FENCE_BUDGET.toSeconds())
-                  .isNotEqualTo(-1L);
-        assertThat(fenceEvidence.get()).as("the fence must be evidenced either directly (snapshot.fenced) or by the drain "
-                                          + "completing (node deregistered)")
-                  .isNotEqualTo("none");
+                 snapshot(worker).map(s -> "armed=" + s.armed() + " fenced=" + s.fenced()
+                                           + " sinceLastPingMs=" + s.sinceLastPingMs()
+                                           + " remainingMs=" + s.remainingMs())
+                                 .or("NO SNAPSHOT — node already deregistered"));
+
+        assertThat(fenceMs)
+            .as("the isolated worker must fence within the %ds core-absence window. -1 means it NEVER "
+                + "fenced in %ds — read the t+ progress lines above: `armed=false` means the suppressor "
+                + "re-engaged (an isolated node's coreNodes() view emptying reads as SUPPRESS by "
+                + "design), a resetting sinceLastPingMs means the isolation is not isolating",
+                CORE_ABSENCE.toSeconds(), FENCE_BUDGET.toSeconds())
+            .isNotEqualTo(-1L);
+
+        assertThat(fenceEvidence.get())
+            .as("the fence must be evidenced either directly (snapshot.fenced) or by the drain "
+                + "completing (node deregistered)")
+            .isNotEqualTo("none");
+
         // `after` is null on the deregistration path — the node removed itself before a poll could
         // capture the flag, which is the normal outcome and not a failure.
         log.info("FENCE-PROBE RESULT: fence={}ms coreAbsenceWindow={}ms communityAbsence={}ms "
-                + "marginBeforeCoreWouldReplace={}ms evidence={} capturedSnapshot={}",
+                 + "marginBeforeCoreWouldReplace={}ms evidence={} capturedSnapshot={}",
                  fenceMs,
                  CORE_ABSENCE.toMillis(),
                  COMMUNITY_ABSENCE.toMillis(),
@@ -280,27 +282,31 @@ class CoreAbsenceFenceOrderingTest {
                  after == null
                  ? "none (node deregistered before capture)"
                  : "sinceLastPingMs=" + after.sinceLastPingMs() + " thresholdMs=" + after.thresholdMs());
-        assertThat(fenceMs).as("the isolated worker must fence itself within the %ds core-absence window (-1 = never "
-                              + "fenced within %ds). This is a LOCAL decision — no consensus write is reachable from "
-                              + "an isolated node, which is why the response cannot be a KV announcement",
-                               CORE_ABSENCE.toSeconds(),
-                               FENCE_BUDGET.toSeconds())
-                  .isBetween(0L,
-                             FENCE_BUDGET.toMillis());
+
+        assertThat(fenceMs)
+            .as("the isolated worker must fence itself within the %ds core-absence window (-1 = never "
+                + "fenced within %ds). This is a LOCAL decision — no consensus write is reachable from "
+                + "an isolated node, which is why the response cannot be a KV announcement",
+                CORE_ABSENCE.toSeconds(), FENCE_BUDGET.toSeconds())
+            .isBetween(0L, FENCE_BUDGET.toMillis());
+
         // THE ORDERING INVARIANT, measured rather than argued from the config inequality.
-        assertThat(fenceMs).as("NO-DOUBLE-ACTIVE: the worker must fence STRICTLY BEFORE %dms, the window after which "
-                              + "the core stops counting it and re-places its work. If these ever crossed, the "
-                              + "community would be live here and re-provisioned there at the same time — the exact "
-                              + "hazard `core_absence < community_absence` exists to prevent, and which ConfigValidator "
-                              + "refuses at load. Measured gap: %dms",
-                               COMMUNITY_ABSENCE.toMillis(),
-                               COMMUNITY_ABSENCE.toMillis() - fenceMs)
-                  .isLessThan(COMMUNITY_ABSENCE.toMillis());
+        assertThat(fenceMs)
+            .as("NO-DOUBLE-ACTIVE: the worker must fence STRICTLY BEFORE %dms, the window after which "
+                + "the core stops counting it and re-places its work. If these ever crossed, the "
+                + "community would be live here and re-provisioned there at the same time — the exact "
+                + "hazard `core_absence < community_absence` exists to prevent, and which ConfigValidator "
+                + "refuses at load. Measured gap: %dms",
+                COMMUNITY_ABSENCE.toMillis(), COMMUNITY_ABSENCE.toMillis() - fenceMs)
+            .isLessThan(COMMUNITY_ABSENCE.toMillis());
+
         // Only assertable when the direct observation won the race. On the deregistration path the
         // observer is gone by construction — the fence removes its own node — so demanding a captured
         // snapshot here would fail runs that succeeded. Which path was taken is reported above.
         if (after != null) {
-            assertThat(after.fenced()).as("when captured directly, the fence must read as a LATCHED state").isTrue();
+            assertThat(after.fenced())
+                .as("when captured directly, the fence must read as a LATCHED state")
+                .isTrue();
         }
     }
 
@@ -313,45 +319,42 @@ class CoreAbsenceFenceOrderingTest {
 
         try {
             await().atMost(FENCE_BUDGET.plusSeconds(10))
-                 .pollInterval(FENCE_POLL)
-                 .until(() -> {
-                            var current = snapshot(worker);
+                   .pollInterval(FENCE_POLL)
+                   .until(() -> {
+                       var current = snapshot(worker);
 
-                            if (current.map(CoreAbsenceSnapshot::fenced)
-                                       .or(false)) {
-                            fenceObservation.set(current.or((CoreAbsenceSnapshot) null));
-                            fenceEvidence.set("snapshot.fenced=true");
-                            latch.compareAndSet(-1,
-                                                (System.nanoTime() - t0) / 1_000_000);
+                       if (current.map(CoreAbsenceSnapshot::fenced).or(false)) {
+                           fenceObservation.set(current.or((CoreAbsenceSnapshot) null));
+                           fenceEvidence.set("snapshot.fenced=true");
+                           latch.compareAndSet(-1, (System.nanoTime() - t0) / 1_000_000);
 
-                            return true;
-                        }
-                            // THE FENCE REMOVES ITS OWN OBSERVER, so `fenced=true` is only visible in the
-                            // window between the flag being set and the drain completing — measured shorter
-                            // than a 250ms poll. Node DISAPPEARANCE is the durable evidence: in Ember the
-                            // only route out of the registry is `jvmExit` -> `handleSelfDrain`, and the only
-                            // thing that invokes `jvmExit` here is `DrainProcedure.initiate(...)`. This node
-                            // is not a core (precondition asserted), so QuorumLossDetector is not its path,
-                            // and nothing commanded a drain — leaving CORE_ABSENCE as the only reachable
-                            // cause. Recorded as such rather than claimed as a direct observation.
-                            if (deregistered()) {
-                            fenceEvidence.set("node deregistered (drain completed; CORE_ABSENCE is the "
+                           return true;
+                       }
+                       // THE FENCE REMOVES ITS OWN OBSERVER, so `fenced=true` is only visible in the
+                       // window between the flag being set and the drain completing — measured shorter
+                       // than a 250ms poll. Node DISAPPEARANCE is the durable evidence: in Ember the
+                       // only route out of the registry is `jvmExit` -> `handleSelfDrain`, and the only
+                       // thing that invokes `jvmExit` here is `DrainProcedure.initiate(...)`. This node
+                       // is not a core (precondition asserted), so QuorumLossDetector is not its path,
+                       // and nothing commanded a drain — leaving CORE_ABSENCE as the only reachable
+                       // cause. Recorded as such rather than claimed as a direct observation.
+                       if (deregistered()) {
+                           fenceEvidence.set("node deregistered (drain completed; CORE_ABSENCE is the "
                                              + "only reachable jvmExit cause for a non-core node here)");
-                            latch.compareAndSet(-1,
-                                                (System.nanoTime() - t0) / 1_000_000);
+                           latch.compareAndSet(-1, (System.nanoTime() - t0) / 1_000_000);
 
-                            return true;
-                        }
-                            // A non-fence must explain itself. `armed` false means the SUPPRESSOR re-engaged
-                            // — and since an isolated node's `coreNodes()` view can empty out, and an empty
-                            // view is documented to read as SUPPRESS, that is the interesting failure. A
-                            // `sinceLastPing` that keeps resetting means pings still arrive, i.e. the
-                            // isolation is not isolating. Without this line a silent 30s produces no
-                            // evidence at all, which is the failure shape this repo keeps paying for.
-                            logProgress(current, t0);
+                           return true;
+                       }
+                       // A non-fence must explain itself. `armed` false means the SUPPRESSOR re-engaged
+                       // — and since an isolated node's `coreNodes()` view can empty out, and an empty
+                       // view is documented to read as SUPPRESS, that is the interesting failure. A
+                       // `sinceLastPing` that keeps resetting means pings still arrive, i.e. the
+                       // isolation is not isolating. Without this line a silent 30s produces no
+                       // evidence at all, which is the failure shape this repo keeps paying for.
+                       logProgress(current, t0);
 
-                            return false;
-                        });
+                       return false;
+                   });
         } catch (Exception e) {
             log.warn("FENCE-PROBE: {} never fenced within {}s", worker, FENCE_BUDGET.toSeconds());
         }
@@ -363,10 +366,10 @@ class CoreAbsenceFenceOrderingTest {
     /// finding, so it fails loudly rather than degrading into a never-fences run.
     private CoreAbsenceSnapshot requireSnapshot(String nodeId) {
         return snapshot(nodeId).fold(() -> {
-                                         throw new AssertionError("no coreAbsence snapshot for " + nodeId
-                                                                 + " — the detector is unwired on that node");
-                                     },
-                                     s -> s);
+                                   throw new AssertionError("no coreAbsence snapshot for " + nodeId
+                                                            + " — the detector is unwired on that node");
+                               },
+                               s -> s);
     }
 
     private void logProgress(Option<CoreAbsenceSnapshot> current, long t0) {
@@ -375,26 +378,24 @@ class CoreAbsenceFenceOrderingTest {
         if (now - lastProgressLog.get() < 2_000_000_000L) {
             return;
         }
-
         lastProgressLog.set(now);
         log.info("FENCE-PROBE: t+{}ms {}",
                  (now - t0) / 1_000_000,
                  current.map(s -> "armed=" + s.armed()
-                                 + " fenced=" + s.fenced()
-                                 + " sinceLastPingMs=" + s.sinceLastPingMs()
-                                 + " remainingMs=" + s.remainingMs()
-                                 + " thresholdMs=" + s.thresholdMs())
+                                  + " fenced=" + s.fenced()
+                                  + " sinceLastPingMs=" + s.sinceLastPingMs()
+                                  + " remainingMs=" + s.remainingMs()
+                                  + " thresholdMs=" + s.thresholdMs())
                         .or("NO SNAPSHOT — node deregistered or detector unwired"));
     }
 
     /// Read in-process off the leader KV — the COMMITTED value is what role assignment reads, so an
     /// HTTP read of a not-yet-committed config would be the wrong signal.
     private Option<Integer> committedCoreCount() {
-        return leaderOrAnyNode().flatMap(node -> node.kvStore()
-                                                     .get(ClusterConfigKey.CURRENT))
-                              .filter(ClusterConfigValue.class::isInstance)
-                              .map(ClusterConfigValue.class::cast)
-                              .map(ClusterConfigValue::coreCount);
+        return leaderOrAnyNode().flatMap(node -> node.kvStore().get(ClusterConfigKey.CURRENT))
+                                .filter(ClusterConfigValue.class::isInstance)
+                                .map(ClusterConfigValue.class::cast)
+                                .map(ClusterConfigValue::coreCount);
     }
 
     private Option<AetherNode> leaderOrAnyNode() {
@@ -408,20 +409,11 @@ class CoreAbsenceFenceOrderingTest {
         return cluster.status()
                       .nodes()
                       .stream()
-                      .noneMatch(n -> n.id()
-                                       .equals(worker));
+                      .noneMatch(n -> n.id().equals(worker));
     }
 
     private Option<CoreAbsenceSnapshot> snapshot(String nodeId) {
         return cluster.getNode(nodeId)
                       .flatMap(node -> node.coreAbsenceSnapshot());
-    }
-
-    private static void failStart(Cause cause) {
-        throw new AssertionError("Cluster start failed: " + cause.message());
-    }
-
-    private static void failScenario(Cause cause) {
-        throw new AssertionError("Scenario step failed: " + cause.message());
     }
 }

--- a/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/CoreAbsenceFenceOrderingTest.java
+++ b/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/CoreAbsenceFenceOrderingTest.java
@@ -2,16 +2,11 @@
 // Copyright (c) 2025 Pragmatica Labs - Sergiy Yevtushenko
 // Licensed under Business Source License 1.1. Change Date: 2030-01-01. Change License: Apache-2.0.
 // See LICENSE in the repository root for full terms.
-
 package org.pragmatica.aether.forge;
 
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicLong;
+
 import org.pragmatica.aether.ember.EmberCluster;
 import org.pragmatica.aether.node.AetherNode;
 import org.pragmatica.aether.slice.kvstore.AetherKey.ClusterConfigKey;
@@ -20,15 +15,21 @@ import org.pragmatica.aether.worker.isolation.CoreAbsenceSnapshot;
 import org.pragmatica.lang.Cause;
 import org.pragmatica.lang.Option;
 import org.pragmatica.lang.TerminalOperation;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.time.Duration;
-import java.util.concurrent.atomic.AtomicLong;
-
+import static org.pragmatica.aether.ember.EmberCluster.emberCluster;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
-import static org.pragmatica.aether.ember.EmberCluster.emberCluster;
+
 
 /// #590 — the community tier's core-absence fence, and the ORDERING that keeps it safe.
 ///
@@ -112,12 +113,10 @@ import static org.pragmatica.aether.ember.EmberCluster.emberCluster;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class CoreAbsenceFenceOrderingTest {
     private static final Logger log = LoggerFactory.getLogger(CoreAbsenceFenceOrderingTest.class);
-
     private static final int INITIAL_CORES = 5;
     private static final int BASE_PORT = 21000;
     private static final int BASE_MGMT_PORT = 21100;
     private static final int BASE_APP_HTTP_PORT = 21200;
-
     /// Shipped defaults from `TimeoutsConfig.ClusterTimeouts`: multiples of the 1s `pingInterval` —
     /// 10s to fence locally, 20s before the core re-places. `ConfigValidator` REFUSES a config where
     /// `core_absence >= community_absence`, and that inequality is the invariant this class measures.
@@ -130,7 +129,6 @@ class CoreAbsenceFenceOrderingTest {
     /// core half of #590 keys on pong silence (`ClusterSyncCollector.sinceLastPongNanos`), not on SWIM.
     private static final Duration CORE_ABSENCE = Duration.ofSeconds(10);
     private static final Duration COMMUNITY_ABSENCE = Duration.ofSeconds(20);
-
     private static final Duration FORM_TIMEOUT = Duration.ofSeconds(240);
     private static final Duration WORKER_ARM_TIMEOUT = Duration.ofSeconds(120);
     /// Generous against the fence window so a slow poll cannot fail a fence that did fire; the
@@ -142,11 +140,11 @@ class CoreAbsenceFenceOrderingTest {
     /// node removes itself.
     private static final Duration FENCE_POLL = Duration.ofMillis(20);
 
-    private final java.util.concurrent.atomic.AtomicReference<CoreAbsenceSnapshot> fenceObservation =
-        new java.util.concurrent.atomic.AtomicReference<>();
+    private final java.util.concurrent.atomic.AtomicReference<CoreAbsenceSnapshot> fenceObservation = new java.util.concurrent.atomic.AtomicReference<>();
+
     private final AtomicLong lastProgressLog = new AtomicLong();
-    private final java.util.concurrent.atomic.AtomicReference<String> fenceEvidence =
-        new java.util.concurrent.atomic.AtomicReference<>("none");
+
+    private final java.util.concurrent.atomic.AtomicReference<String> fenceEvidence = new java.util.concurrent.atomic.AtomicReference<>("none");
 
     private EmberCluster cluster;
     private String worker;
@@ -156,12 +154,15 @@ class CoreAbsenceFenceOrderingTest {
     void setUp() {
         cluster = emberCluster(INITIAL_CORES, BASE_PORT, BASE_MGMT_PORT, BASE_APP_HTTP_PORT, "fence");
         cluster.withRaisedSwimTimeouts();
-        cluster.start().await().onFailure(CoreAbsenceFenceOrderingTest::failStart);
-
-        await().atMost(FORM_TIMEOUT).pollInterval(POLL).until(() -> cluster.currentLeader().isPresent());
-        await().atMost(FORM_TIMEOUT).pollInterval(POLL).until(() -> cluster.status().nodes().size() == INITIAL_CORES);
-        log.info("FENCE-PROBE: {}-core cluster formed, leader={}", INITIAL_CORES, cluster.currentLeader().or("none"));
-
+        LifecycleAwait.settled("cluster start in setUp()", cluster, cluster.start());
+        await().atMost(FORM_TIMEOUT).pollInterval(POLL).until(() -> cluster.currentLeader()
+                                                                           .isPresent());
+        await().atMost(FORM_TIMEOUT).pollInterval(POLL).until(() -> cluster.status()
+                                                                           .nodes()
+                                                                           .size() == INITIAL_CORES);
+        log.info("FENCE-PROBE: {}-core cluster formed, leader={}",
+                 INITIAL_CORES,
+                 cluster.currentLeader().or("none"));
         // WAIT FOR THE COMMITTED CAP BEFORE ADDING. Role is leader-decided: `assignNodeRole` promotes a
         // joiner to CORE while `currentCoreCount < effectiveCoreMax`, and `effectiveCoreMax` reads the
         // COMMITTED `ClusterConfig.coreCount`, which `BootstrapModule` auto-seeds shortly after
@@ -171,76 +172,77 @@ class CoreAbsenceFenceOrderingTest {
         // fence then correctly refused to fire because a core may never fence this way. Without the
         // precondition below that would have been reported as "#590's fence is broken" — a false defect
         // against a working mechanism, with a confident 40-second proof behind it.
-        await().atMost(FORM_TIMEOUT)
-               .pollInterval(POLL)
-               .until(() -> committedCoreCount().or(0) == INITIAL_CORES);
+        await().atMost(FORM_TIMEOUT).pollInterval(POLL).until(() -> committedCoreCount().or(0) == INITIAL_CORES);
         log.info("FENCE-PROBE: committed ClusterConfig.coreCount={} — the cap is live, the next join exceeds it",
                  committedCoreCount().or(0));
-
-        worker = cluster.addWorkerNode()
-                        .await()
-                        .onFailure(CoreAbsenceFenceOrderingTest::failScenario)
-                        .map(id -> id.id())
-                        .or("");
+        worker = LifecycleAwait.nodeSettled("worker node join in addWorkerBeyondTheCoreCap()",
+                                            cluster,
+                                            cluster.addWorkerNode())
+                               .id();
         log.info("FENCE-PROBE: added node {} — expected to exceed the core cap and be minted a WORKER", worker);
-
         // CORRECTION (found by running it): `isArmed()` is `!lastPingNanos.isEmpty()` — "a core ping
         // has ever been accepted" — NOT "the suppressor released". Gating on it proves the node is
         // reachable, not that it is a WORKER, so a node mis-minted as a core would sail past this and
         // then never fence, reading as a defect in the fence rather than a defect in the premise.
         // The suppressor's REAL input is the node's own `topologyManager().coreNodes()`, checked below.
         await().atMost(WORKER_ARM_TIMEOUT)
-               .pollInterval(POLL)
-               .until(() -> snapshot(worker).map(CoreAbsenceSnapshot::armed).or(false));
+             .pollInterval(POLL)
+             .until(() -> snapshot(worker).map(CoreAbsenceSnapshot::armed)
+                                  .or(false));
         log.info("FENCE-PROBE: {} is ARMED — it has accepted at least one core ping", worker);
-
         // THE PRECONDITION THAT ACTUALLY MATTERS, and exactly what the suppressor samples at firing
         // time: `cores.isEmpty() || cores.contains(self)` SUPPRESSES. If this node was minted a CORE
         // rather than a worker, the fence is suppressed BY DESIGN and any non-fence says nothing about
         // the mechanism.
         var workerCoreView = cluster.getNode(worker)
-                                    .map(node -> node.topologyManager().coreNodes().toString())
+                                    .map(node -> node.topologyManager()
+                                                     .coreNodes()
+                                                     .toString())
                                     .or("<no node>");
         var suppressed = cluster.getNode(worker)
                                 .map(node -> {
-                                    var cores = node.topologyManager().coreNodes();
+                                         var cores = node.topologyManager()
+                                                         .coreNodes();
 
-                                    return cores.isEmpty() || cores.stream().anyMatch(id -> id.id().equals(worker));
-                                })
+                                         return cores.isEmpty() || cores.stream()
+                                                                        .anyMatch(id -> id.id()
+                                                                                          .equals(worker));
+                                     })
                                 .or(true);
 
         log.info("FENCE-PROBE PRECONDITION: {} coreNodes-as-seen-by-itself={} suppressorWouldSuppress={}",
-                 worker, workerCoreView, suppressed);
-        assertThat(suppressed)
-            .as("PRECONDITION: %s must be a genuine WORKER — its own coreNodes() view must be non-empty "
-                + "and must NOT contain itself, or the fence is suppressed by design and this test "
-                + "measures nothing. Saw coreNodes=%s", worker, workerCoreView)
-            .isFalse();
+                 worker,
+                 workerCoreView,
+                 suppressed);
+        assertThat(suppressed).as("PRECONDITION: %s must be a genuine WORKER — its own coreNodes() view must be non-empty "
+                                 + "and must NOT contain itself, or the fence is suppressed by design and this test "
+                                 + "measures nothing. Saw coreNodes=%s",
+                                  worker,
+                                  workerCoreView)
+                  .isFalse();
     }
 
     @AfterAll
     @TerminalOperation
     void tearDown() {
-        Option.option(cluster).onPresent(c -> c.stop().await());
+        Option.option(cluster).onPresent(c -> LifecycleAwait.settled("cluster stop in tearDown()", c, c.stop()));
     }
 
     @Test
     void isolatedWorkerFencesItselfLocally_strictlyBeforeTheCoreWouldReplaceIt() {
         var before = requireSnapshot(worker);
 
-        assertThat(before.fenced())
-            .as("PRECONDITION: %s must not already be fenced before isolation", worker)
-            .isFalse();
-
+        assertThat(before.fenced()).as("PRECONDITION: %s must not already be fenced before isolation", worker).isFalse();
         var t0 = System.nanoTime();
-
         // Total isolation: all cluster traffic to and from this node is dropped, connections left
         // open. The core's ClusterSyncPing stops arriving, which is the ONLY liveness signal this
         // fence consumes — and crucially the node cannot write to the core either, which is the whole
         // reason the response has to be local.
-        cluster.blackhole(worker).await().onFailure(CoreAbsenceFenceOrderingTest::failScenario);
+        LifecycleAwait.nodeSettled("blackhole node " + worker
+                                  + " in isolatedWorkerFencesItselfLocally_strictlyBeforeTheCoreWouldReplaceIt()",
+                                   cluster,
+                                   cluster.blackhole(worker));
         log.info("FENCE-PROBE: black-holed {} at t0 — core pings stop, and it cannot reach consensus", worker);
-
         // CAPTURED at the moment the fence is observed, NOT re-read afterwards. Ember injects
         // `() -> handleSelfDrain(nodeId)` as the node's `jvmExit`, so the fence's drain STOPS this node
         // — a later read can find it already deregistered and throw, failing a run that actually
@@ -251,28 +253,25 @@ class CoreAbsenceFenceOrderingTest {
 
         log.info("FENCE-PROBE EVIDENCE: {}", fenceEvidence.get());
         log.info("FENCE-PROBE FINAL STATE: {}",
-                 snapshot(worker).map(s -> "armed=" + s.armed() + " fenced=" + s.fenced()
-                                           + " sinceLastPingMs=" + s.sinceLastPingMs()
-                                           + " remainingMs=" + s.remainingMs())
-                                 .or("NO SNAPSHOT — node already deregistered"));
-
-        assertThat(fenceMs)
-            .as("the isolated worker must fence within the %ds core-absence window. -1 means it NEVER "
-                + "fenced in %ds — read the t+ progress lines above: `armed=false` means the suppressor "
-                + "re-engaged (an isolated node's coreNodes() view emptying reads as SUPPRESS by "
-                + "design), a resetting sinceLastPingMs means the isolation is not isolating",
-                CORE_ABSENCE.toSeconds(), FENCE_BUDGET.toSeconds())
-            .isNotEqualTo(-1L);
-
-        assertThat(fenceEvidence.get())
-            .as("the fence must be evidenced either directly (snapshot.fenced) or by the drain "
-                + "completing (node deregistered)")
-            .isNotEqualTo("none");
-
+                 snapshot(worker).map(s -> "armed=" + s.armed()
+                                          + " fenced=" + s.fenced()
+                                          + " sinceLastPingMs=" + s.sinceLastPingMs()
+                                          + " remainingMs=" + s.remainingMs())
+                         .or("NO SNAPSHOT — node already deregistered"));
+        assertThat(fenceMs).as("the isolated worker must fence within the %ds core-absence window. -1 means it NEVER "
+                              + "fenced in %ds — read the t+ progress lines above: `armed=false` means the suppressor "
+                              + "re-engaged (an isolated node's coreNodes() view emptying reads as SUPPRESS by "
+                              + "design), a resetting sinceLastPingMs means the isolation is not isolating",
+                               CORE_ABSENCE.toSeconds(),
+                               FENCE_BUDGET.toSeconds())
+                  .isNotEqualTo(-1L);
+        assertThat(fenceEvidence.get()).as("the fence must be evidenced either directly (snapshot.fenced) or by the drain "
+                                          + "completing (node deregistered)")
+                  .isNotEqualTo("none");
         // `after` is null on the deregistration path — the node removed itself before a poll could
         // capture the flag, which is the normal outcome and not a failure.
         log.info("FENCE-PROBE RESULT: fence={}ms coreAbsenceWindow={}ms communityAbsence={}ms "
-                 + "marginBeforeCoreWouldReplace={}ms evidence={} capturedSnapshot={}",
+                + "marginBeforeCoreWouldReplace={}ms evidence={} capturedSnapshot={}",
                  fenceMs,
                  CORE_ABSENCE.toMillis(),
                  COMMUNITY_ABSENCE.toMillis(),
@@ -281,31 +280,27 @@ class CoreAbsenceFenceOrderingTest {
                  after == null
                  ? "none (node deregistered before capture)"
                  : "sinceLastPingMs=" + after.sinceLastPingMs() + " thresholdMs=" + after.thresholdMs());
-
-        assertThat(fenceMs)
-            .as("the isolated worker must fence itself within the %ds core-absence window (-1 = never "
-                + "fenced within %ds). This is a LOCAL decision — no consensus write is reachable from "
-                + "an isolated node, which is why the response cannot be a KV announcement",
-                CORE_ABSENCE.toSeconds(), FENCE_BUDGET.toSeconds())
-            .isBetween(0L, FENCE_BUDGET.toMillis());
-
+        assertThat(fenceMs).as("the isolated worker must fence itself within the %ds core-absence window (-1 = never "
+                              + "fenced within %ds). This is a LOCAL decision — no consensus write is reachable from "
+                              + "an isolated node, which is why the response cannot be a KV announcement",
+                               CORE_ABSENCE.toSeconds(),
+                               FENCE_BUDGET.toSeconds())
+                  .isBetween(0L,
+                             FENCE_BUDGET.toMillis());
         // THE ORDERING INVARIANT, measured rather than argued from the config inequality.
-        assertThat(fenceMs)
-            .as("NO-DOUBLE-ACTIVE: the worker must fence STRICTLY BEFORE %dms, the window after which "
-                + "the core stops counting it and re-places its work. If these ever crossed, the "
-                + "community would be live here and re-provisioned there at the same time — the exact "
-                + "hazard `core_absence < community_absence` exists to prevent, and which ConfigValidator "
-                + "refuses at load. Measured gap: %dms",
-                COMMUNITY_ABSENCE.toMillis(), COMMUNITY_ABSENCE.toMillis() - fenceMs)
-            .isLessThan(COMMUNITY_ABSENCE.toMillis());
-
+        assertThat(fenceMs).as("NO-DOUBLE-ACTIVE: the worker must fence STRICTLY BEFORE %dms, the window after which "
+                              + "the core stops counting it and re-places its work. If these ever crossed, the "
+                              + "community would be live here and re-provisioned there at the same time — the exact "
+                              + "hazard `core_absence < community_absence` exists to prevent, and which ConfigValidator "
+                              + "refuses at load. Measured gap: %dms",
+                               COMMUNITY_ABSENCE.toMillis(),
+                               COMMUNITY_ABSENCE.toMillis() - fenceMs)
+                  .isLessThan(COMMUNITY_ABSENCE.toMillis());
         // Only assertable when the direct observation won the race. On the deregistration path the
         // observer is gone by construction — the fence removes its own node — so demanding a captured
         // snapshot here would fail runs that succeeded. Which path was taken is reported above.
         if (after != null) {
-            assertThat(after.fenced())
-                .as("when captured directly, the fence must read as a LATCHED state")
-                .isTrue();
+            assertThat(after.fenced()).as("when captured directly, the fence must read as a LATCHED state").isTrue();
         }
     }
 
@@ -318,42 +313,45 @@ class CoreAbsenceFenceOrderingTest {
 
         try {
             await().atMost(FENCE_BUDGET.plusSeconds(10))
-                   .pollInterval(FENCE_POLL)
-                   .until(() -> {
-                       var current = snapshot(worker);
+                 .pollInterval(FENCE_POLL)
+                 .until(() -> {
+                            var current = snapshot(worker);
 
-                       if (current.map(CoreAbsenceSnapshot::fenced).or(false)) {
-                           fenceObservation.set(current.or((CoreAbsenceSnapshot) null));
-                           fenceEvidence.set("snapshot.fenced=true");
-                           latch.compareAndSet(-1, (System.nanoTime() - t0) / 1_000_000);
+                            if (current.map(CoreAbsenceSnapshot::fenced)
+                                       .or(false)) {
+                            fenceObservation.set(current.or((CoreAbsenceSnapshot) null));
+                            fenceEvidence.set("snapshot.fenced=true");
+                            latch.compareAndSet(-1,
+                                                (System.nanoTime() - t0) / 1_000_000);
 
-                           return true;
-                       }
-                       // THE FENCE REMOVES ITS OWN OBSERVER, so `fenced=true` is only visible in the
-                       // window between the flag being set and the drain completing — measured shorter
-                       // than a 250ms poll. Node DISAPPEARANCE is the durable evidence: in Ember the
-                       // only route out of the registry is `jvmExit` -> `handleSelfDrain`, and the only
-                       // thing that invokes `jvmExit` here is `DrainProcedure.initiate(...)`. This node
-                       // is not a core (precondition asserted), so QuorumLossDetector is not its path,
-                       // and nothing commanded a drain — leaving CORE_ABSENCE as the only reachable
-                       // cause. Recorded as such rather than claimed as a direct observation.
-                       if (deregistered()) {
-                           fenceEvidence.set("node deregistered (drain completed; CORE_ABSENCE is the "
+                            return true;
+                        }
+                            // THE FENCE REMOVES ITS OWN OBSERVER, so `fenced=true` is only visible in the
+                            // window between the flag being set and the drain completing — measured shorter
+                            // than a 250ms poll. Node DISAPPEARANCE is the durable evidence: in Ember the
+                            // only route out of the registry is `jvmExit` -> `handleSelfDrain`, and the only
+                            // thing that invokes `jvmExit` here is `DrainProcedure.initiate(...)`. This node
+                            // is not a core (precondition asserted), so QuorumLossDetector is not its path,
+                            // and nothing commanded a drain — leaving CORE_ABSENCE as the only reachable
+                            // cause. Recorded as such rather than claimed as a direct observation.
+                            if (deregistered()) {
+                            fenceEvidence.set("node deregistered (drain completed; CORE_ABSENCE is the "
                                              + "only reachable jvmExit cause for a non-core node here)");
-                           latch.compareAndSet(-1, (System.nanoTime() - t0) / 1_000_000);
+                            latch.compareAndSet(-1,
+                                                (System.nanoTime() - t0) / 1_000_000);
 
-                           return true;
-                       }
-                       // A non-fence must explain itself. `armed` false means the SUPPRESSOR re-engaged
-                       // — and since an isolated node's `coreNodes()` view can empty out, and an empty
-                       // view is documented to read as SUPPRESS, that is the interesting failure. A
-                       // `sinceLastPing` that keeps resetting means pings still arrive, i.e. the
-                       // isolation is not isolating. Without this line a silent 30s produces no
-                       // evidence at all, which is the failure shape this repo keeps paying for.
-                       logProgress(current, t0);
+                            return true;
+                        }
+                            // A non-fence must explain itself. `armed` false means the SUPPRESSOR re-engaged
+                            // — and since an isolated node's `coreNodes()` view can empty out, and an empty
+                            // view is documented to read as SUPPRESS, that is the interesting failure. A
+                            // `sinceLastPing` that keeps resetting means pings still arrive, i.e. the
+                            // isolation is not isolating. Without this line a silent 30s produces no
+                            // evidence at all, which is the failure shape this repo keeps paying for.
+                            logProgress(current, t0);
 
-                       return false;
-                   });
+                            return false;
+                        });
         } catch (Exception e) {
             log.warn("FENCE-PROBE: {} never fenced within {}s", worker, FENCE_BUDGET.toSeconds());
         }
@@ -365,10 +363,10 @@ class CoreAbsenceFenceOrderingTest {
     /// finding, so it fails loudly rather than degrading into a never-fences run.
     private CoreAbsenceSnapshot requireSnapshot(String nodeId) {
         return snapshot(nodeId).fold(() -> {
-                                   throw new AssertionError("no coreAbsence snapshot for " + nodeId
-                                                            + " — the detector is unwired on that node");
-                               },
-                               s -> s);
+                                         throw new AssertionError("no coreAbsence snapshot for " + nodeId
+                                                                 + " — the detector is unwired on that node");
+                                     },
+                                     s -> s);
     }
 
     private void logProgress(Option<CoreAbsenceSnapshot> current, long t0) {
@@ -377,24 +375,26 @@ class CoreAbsenceFenceOrderingTest {
         if (now - lastProgressLog.get() < 2_000_000_000L) {
             return;
         }
+
         lastProgressLog.set(now);
         log.info("FENCE-PROBE: t+{}ms {}",
                  (now - t0) / 1_000_000,
                  current.map(s -> "armed=" + s.armed()
-                                  + " fenced=" + s.fenced()
-                                  + " sinceLastPingMs=" + s.sinceLastPingMs()
-                                  + " remainingMs=" + s.remainingMs()
-                                  + " thresholdMs=" + s.thresholdMs())
+                                 + " fenced=" + s.fenced()
+                                 + " sinceLastPingMs=" + s.sinceLastPingMs()
+                                 + " remainingMs=" + s.remainingMs()
+                                 + " thresholdMs=" + s.thresholdMs())
                         .or("NO SNAPSHOT — node deregistered or detector unwired"));
     }
 
     /// Read in-process off the leader KV — the COMMITTED value is what role assignment reads, so an
     /// HTTP read of a not-yet-committed config would be the wrong signal.
     private Option<Integer> committedCoreCount() {
-        return leaderOrAnyNode().flatMap(node -> node.kvStore().get(ClusterConfigKey.CURRENT))
-                                .filter(ClusterConfigValue.class::isInstance)
-                                .map(ClusterConfigValue.class::cast)
-                                .map(ClusterConfigValue::coreCount);
+        return leaderOrAnyNode().flatMap(node -> node.kvStore()
+                                                     .get(ClusterConfigKey.CURRENT))
+                              .filter(ClusterConfigValue.class::isInstance)
+                              .map(ClusterConfigValue.class::cast)
+                              .map(ClusterConfigValue::coreCount);
     }
 
     private Option<AetherNode> leaderOrAnyNode() {
@@ -408,7 +408,8 @@ class CoreAbsenceFenceOrderingTest {
         return cluster.status()
                       .nodes()
                       .stream()
-                      .noneMatch(n -> n.id().equals(worker));
+                      .noneMatch(n -> n.id()
+                                       .equals(worker));
     }
 
     private Option<CoreAbsenceSnapshot> snapshot(String nodeId) {

--- a/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/DeclarativeConsumerPlacementTest.java
+++ b/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/DeclarativeConsumerPlacementTest.java
@@ -2,22 +2,7 @@
 // Copyright (c) 2025 Pragmatica Labs - Sergiy Yevtushenko
 // Licensed under Business Source License 1.1. Change Date: 2030-01-01. Change License: Apache-2.0.
 // See LICENSE in the repository root for full terms.
-
 package org.pragmatica.aether.forge;
-
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
-import org.pragmatica.aether.ember.EmberCluster;
-import org.pragmatica.config.ConfigurationProvider;
-import org.pragmatica.http.HttpOperations;
-import org.pragmatica.http.HttpResult;
-import org.pragmatica.lang.Option;
 
 import java.net.URI;
 import java.net.http.HttpRequest;
@@ -27,10 +12,26 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.regex.Pattern;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.awaitility.Awaitility.await;
+import org.pragmatica.aether.ember.EmberCluster;
+import org.pragmatica.config.ConfigurationProvider;
+import org.pragmatica.http.HttpOperations;
+import org.pragmatica.http.HttpResult;
+import org.pragmatica.lang.Option;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+
 import static org.pragmatica.aether.ember.EmberCluster.emberCluster;
 import static org.pragmatica.http.JdkHttpOperations.jdkHttpOperations;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
 
 /// #535 — a declarative consumer delivers under a DEFAULT placement, where the partition owner does
 /// not host the slice.
@@ -67,12 +68,10 @@ class DeclarativeConsumerPlacementTest {
     private static final int BASE_MGMT_PORT = 18600;
     private static final int BASE_APP_HTTP_PORT = 18700;
     private static final int NODES = 5;
-
     /// The whole point: ONE instance against a FIVE-partition stream. The single host can own at most
     /// one partition, so at least four must be consumed by reading through their owners.
     private static final int INSTANCES = 1;
     private static final int SPREAD_PARTITIONS = 5;
-
     /// Attachments expected cluster-wide once settled. The fixture slice declares THREE consumers —
     /// `consumer-events` (1 partition), `order-events` (1) and `spread-events` (5) — and with a single
     /// instance the sole candidate is assigned EVERY partition of all three, so the total is 7, not 5.
@@ -80,25 +79,20 @@ class DeclarativeConsumerPlacementTest {
     /// and the assignment was in fact correct the whole time.
     private static final int EXPECTED_ATTACHMENTS = 7;
     private static final int EVENT_COUNT = 25;
-
     private static final String SPREAD_EVENTS_STREAM = "spread-events";
-
     private static final Duration WAIT_TIMEOUT = Duration.ofSeconds(240);
     private static final Duration DELIVERY_TIMEOUT = Duration.ofSeconds(90);
     private static final Duration POLL_INTERVAL = Duration.ofMillis(500);
-
     private static final String CONSUMER_SLICE = TestArtifacts.STREAM_CONSUMER_SLICE;
     private static final String BLUEPRINT_ID = "forge.test:declarative-consumer-placement:1.0.0";
     private static final String ERROR_FALLBACK = "{\"error\":\"request failed\"}";
-
     private static final Pattern COUNT_FIELD = Pattern.compile("\"count\"\\s*:\\s*(\\d+)");
     private static final Pattern ATTACHED_FIELD = Pattern.compile("\"attachedSubscriptions\"\\s*:\\s*(\\d+)");
     private static final Pattern OWNER_NODE_FIELD = Pattern.compile("\"ownerNode\"");
 
     /// One `partitionAssignments` row. Field order follows the record's component order, so consumer
     /// and owner can be compared per partition without a JSON parser.
-    private static final Pattern ASSIGNMENT_ROW =
-        Pattern.compile("\\{\"partition\":\\d+,\"consumerNode\":\"([^\"]+)\",\"ownerNode\":\"([^\"]+)\"\\}");
+    private static final Pattern ASSIGNMENT_ROW = Pattern.compile("\\{\"partition\":\\d+,\"consumerNode\":\"([^\"]+)\",\"ownerNode\":\"([^\"]+)\"\\}");
 
     /// Matches `unassignedPartitions` carrying at least one partition. The serializer omits empty
     /// collections, so a healthy response has no such field at all and this must never match.
@@ -115,39 +109,26 @@ class DeclarativeConsumerPlacementTest {
                                                   .build();
 
         cluster = emberCluster(NODES, BASE_PORT, BASE_MGMT_PORT, BASE_APP_HTTP_PORT, "dcp", Option.some(configProvider));
-        cluster.start()
-               .await()
-               .onFailure(cause -> {
-                   throw new AssertionError("Cluster start failed: " + cause.message());
-               });
-
-        await().atMost(WAIT_TIMEOUT)
-               .pollInterval(POLL_INTERVAL)
-               .until(() -> cluster.currentLeader().isPresent());
-
-        await().atMost(WAIT_TIMEOUT)
-               .pollInterval(POLL_INTERVAL)
-               .until(this::allNodesHealthy);
-
+        LifecycleAwait.settled("cluster start in setUp()", cluster, cluster.start());
+        await().atMost(WAIT_TIMEOUT).pollInterval(POLL_INTERVAL).until(() -> cluster.currentLeader()
+                                                                                    .isPresent());
+        await().atMost(WAIT_TIMEOUT).pollInterval(POLL_INTERVAL).until(this::allNodesHealthy);
         deployConsumerSlice();
-
         await().atMost(WAIT_TIMEOUT)
-               .pollInterval(POLL_INTERVAL)
-               .failFast(this::failIfSliceFailed)
-               .until(this::appHttpReady);
-
+             .pollInterval(POLL_INTERVAL)
+             .failFast(this::failIfSliceFailed)
+             .until(this::appHttpReady);
         await().atMost(WAIT_TIMEOUT)
-               .pollInterval(POLL_INTERVAL)
-               .failFast(this::failIfSliceFailed)
-               .until(this::publishReady);
-
+             .pollInterval(POLL_INTERVAL)
+             .failFast(this::failIfSliceFailed)
+             .until(this::publishReady);
         // Gate on the consumer holding every partition of all three declared streams. With one instance
         // the sole candidate is assigned all of them, so anything less means the assignment has not
         // settled and a delivery assertion would be measuring attach timing.
         await().atMost(WAIT_TIMEOUT)
-               .pollInterval(POLL_INTERVAL)
-               .failFast(this::failIfSliceFailed)
-               .until(() -> totalAttachedSubscriptions() == EXPECTED_ATTACHMENTS);
+             .pollInterval(POLL_INTERVAL)
+             .failFast(this::failIfSliceFailed)
+             .until(() -> totalAttachedSubscriptions() == EXPECTED_ATTACHMENTS);
     }
 
     @AfterAll
@@ -156,8 +137,7 @@ class DeclarativeConsumerPlacementTest {
             var leaderPort = cluster.getLeaderManagementPort().or(anyMgmtPort());
 
             httpDelete(leaderPort, "/api/v1/blueprints/" + BLUEPRINT_ID);
-            cluster.stop()
-                   .await();
+            LifecycleAwait.settled("cluster stop in tearDown()", cluster, cluster.stop());
         }
     }
 
@@ -165,30 +145,29 @@ class DeclarativeConsumerPlacementTest {
     /// are what stop a co-located run from passing for free.
     @Nested
     class PlacementShape {
-
         @Test
         void placement_leavesMostPartitionOwnersWithoutTheSlice() {
             var hosts = cluster.slicesStatus()
                                .stream()
-                               .filter(status -> status.artifact().equals(CONSUMER_SLICE))
-                               .flatMap(status -> status.instances().stream())
+                               .filter(status -> status.artifact()
+                                                       .equals(CONSUMER_SLICE))
+                               .flatMap(status -> status.instances()
+                                                        .stream())
                                .toList();
 
             assertThat(hosts).describedAs("the pigeonhole depends on exactly one host against five partitions")
-                             .hasSize(INSTANCES);
-            assertThat(forwardedPartitionCount())
-                    .describedAs("one host cannot own five partitions, so at least four MUST be read through their owners — "
-                                 + "this is the case #488 could not express and the live cluster failed")
-                    .isGreaterThanOrEqualTo(SPREAD_PARTITIONS - INSTANCES);
+                      .hasSize(INSTANCES);
+            assertThat(forwardedPartitionCount()).describedAs("one host cannot own five partitions, so at least four MUST be read through their owners — "
+                                                             + "this is the case #488 could not express and the live cluster failed")
+                      .isGreaterThanOrEqualTo(SPREAD_PARTITIONS - INSTANCES);
         }
 
         @Test
         void declarativeConsumersEndpoint_namesConsumerAndOwnerForEveryPartition() {
             var fragment = spreadFragment();
 
-            assertThat(OWNER_NODE_FIELD.matcher(fragment).results().count())
-                    .describedAs("an operator must be able to answer 'who consumes partition 3' from any node")
-                    .isEqualTo(SPREAD_PARTITIONS);
+            assertThat(OWNER_NODE_FIELD.matcher(fragment).results().count()).describedAs("an operator must be able to answer 'who consumes partition 3' from any node")
+                      .isEqualTo(SPREAD_PARTITIONS);
         }
 
         /// The endpoint must not claim a gap that does not exist, and must not use its FAULT channel
@@ -199,19 +178,17 @@ class DeclarativeConsumerPlacementTest {
         void declarativeConsumersEndpoint_reportsNoUnassignedPartitions() {
             var fragment = spreadFragment();
 
-            assertThat(UNASSIGNED_NONEMPTY.matcher(fragment).find())
-                    .describedAs("the slice IS active somewhere, so no partition may be reported as consumed by nobody")
-                    .isFalse();
+            assertThat(UNASSIGNED_NONEMPTY.matcher(fragment).find()).describedAs("the slice IS active somewhere, so no partition may be reported as consumed by nobody")
+                      .isFalse();
             assertThat(fragment).doesNotContain("NOT being consumed by anyone")
-                                .doesNotContain("not being consumed YET")
-                                .describedAs("forwarding is normal operation and must not occupy the fault channel")
-                                .doesNotContain("forwarded to the owner");
+                      .doesNotContain("not being consumed YET")
+                      .describedAs("forwarding is normal operation and must not occupy the fault channel")
+                      .doesNotContain("forwarded to the owner");
         }
     }
 
     @Nested
     class Delivery {
-
         /// The headline #535 assertion: a default deployment delivers. Against the pre-fix runtime this
         /// stays at 0 forever for every partition whose owner lacks the slice — four of five here.
         @Test
@@ -219,12 +196,10 @@ class DeclarativeConsumerPlacementTest {
             var baseline = settledSpreadReceived();
 
             publishSpreadBatch(EVENT_COUNT);
-
             await().atMost(DELIVERY_TIMEOUT)
-                   .pollInterval(POLL_INTERVAL)
-                   .untilAsserted(() -> assertThat(spreadReceived() - baseline)
-                           .describedAs("every published event must arrive even though four of five owners cannot run the consumer")
-                           .isEqualTo(EVENT_COUNT));
+                 .pollInterval(POLL_INTERVAL)
+                 .untilAsserted(() -> assertThat(spreadReceived() - baseline).describedAs("every published event must arrive even though four of five owners cannot run the consumer")
+                                                .isEqualTo(EVENT_COUNT));
         }
 
         /// Reading through an owner must not turn one event into several. The hold past several
@@ -234,27 +209,24 @@ class DeclarativeConsumerPlacementTest {
             var baseline = settledSpreadReceived();
 
             publishSpreadBatch(EVENT_COUNT);
-
             await().atMost(DELIVERY_TIMEOUT)
-                   .pollInterval(POLL_INTERVAL)
-                   .untilAsserted(() -> assertThat(spreadReceived() - baseline).isEqualTo(EVENT_COUNT));
-
+                 .pollInterval(POLL_INTERVAL)
+                 .untilAsserted(() -> assertThat(spreadReceived() - baseline).isEqualTo(EVENT_COUNT));
             sleep(Duration.ofSeconds(12));
-
-            assertThat(spreadReceived() - baseline)
-                    .describedAs("exactly one node is assigned per partition, and it stays the only one")
-                    .isEqualTo(EVENT_COUNT);
+            assertThat(spreadReceived() - baseline).describedAs("exactly one node is assigned per partition, and it stays the only one")
+                      .isEqualTo(EVENT_COUNT);
         }
     }
 
     // --- publish / receive ---------------------------------------------------
-
     private void publishSpreadBatch(int count) {
         for (var i = 0; i < count; i++) {
-            var response = httpPost(appPort(), "/api/stream-consumer/publish-spread", "{\"payload\":\"spread-" + i + "\"}");
+            var response = httpPost(appPort(),
+                                    "/api/stream-consumer/publish-spread",
+                                    "{\"payload\":\"spread-" + i + "\"}");
 
             assertThat(response).describedAs("publish must succeed — it write-forwards to each partition owner")
-                                .contains("published");
+                      .contains("published");
         }
     }
 
@@ -278,8 +250,9 @@ class DeclarativeConsumerPlacementTest {
         var lastSample = new AtomicInteger(-1);
 
         await().atMost(DELIVERY_TIMEOUT)
-               .pollInterval(POLL_INTERVAL)
-               .until(() -> isRepeatSample(lastSample, spreadReceived()));
+             .pollInterval(POLL_INTERVAL)
+             .until(() -> isRepeatSample(lastSample,
+                                         spreadReceived()));
 
         return lastSample.get();
     }
@@ -290,9 +263,9 @@ class DeclarativeConsumerPlacementTest {
 
     private int totalAttachedSubscriptions() {
         return mgmtPorts().stream()
-                          .map(port -> httpGet(port, "/api/v1/streams/declarative-consumers"))
-                          .mapToInt(body -> firstInt(ATTACHED_FIELD, body))
-                          .sum();
+                        .map(port -> httpGet(port, "/api/v1/streams/declarative-consumers"))
+                        .mapToInt(body -> firstInt(ATTACHED_FIELD, body))
+                        .sum();
     }
 
     /// Partitions of spread-events whose assigned consumer is NOT the owner — i.e. whose reads are
@@ -301,7 +274,8 @@ class DeclarativeConsumerPlacementTest {
     private long forwardedPartitionCount() {
         return ASSIGNMENT_ROW.matcher(spreadFragment())
                              .results()
-                             .filter(match -> !match.group(1).equals(match.group(2)))
+                             .filter(match -> !match.group(1)
+                                                    .equals(match.group(2)))
                              .count();
     }
 
@@ -309,11 +283,11 @@ class DeclarativeConsumerPlacementTest {
     /// assignment, but only the host can report `sliceDeployedLocally` and the forwarding diagnostic.
     private String spreadFragment() {
         return mgmtPorts().stream()
-                          .map(port -> consumerFragment(httpGet(port, "/api/v1/streams/declarative-consumers"),
-                                                        SPREAD_EVENTS_STREAM))
-                          .filter(fragment -> fragment.contains("\"sliceDeployedLocally\":true"))
-                          .findFirst()
-                          .orElseThrow(() -> new AssertionError("No node reports hosting the declarative consumer slice"));
+                        .map(port -> consumerFragment(httpGet(port, "/api/v1/streams/declarative-consumers"),
+                                                      SPREAD_EVENTS_STREAM))
+                        .filter(fragment -> fragment.contains("\"sliceDeployedLocally\":true"))
+                        .findFirst()
+                        .orElseThrow(() -> new AssertionError("No node reports hosting the declarative consumer slice"));
     }
 
     /// The slice of the declarative-consumers JSON describing one stream. Substring-scoped rather than
@@ -335,7 +309,6 @@ class DeclarativeConsumerPlacementTest {
     }
 
     // --- deployment + readiness ---------------------------------------------
-
     private void deployConsumerSlice() {
         var blueprint = """
             id = "%s"
@@ -348,8 +321,8 @@ class DeclarativeConsumerPlacementTest {
         var response = httpPostToml(leaderPort, "/api/v1/blueprints", blueprint);
 
         assertThat(response).describedAs("placement-restricted consumer slice deployment")
-                            .doesNotContain("\"error\"")
-                            .contains("\"status\":\"applied\"");
+                  .doesNotContain("\"error\"")
+                  .contains("\"status\":\"applied\"");
     }
 
     private boolean appHttpReady() {
@@ -361,7 +334,7 @@ class DeclarativeConsumerPlacementTest {
 
         var body = httpPost(ports.getFirst(), "/api/stream-consumer/received-spread", "{}");
 
-        return !body.contains("\"error\"") && body.contains("count");
+        return ! body.contains("\"error\"") && body.contains("count");
     }
 
     private boolean publishReady() {
@@ -373,13 +346,15 @@ class DeclarativeConsumerPlacementTest {
 
         var response = httpPost(ports.getFirst(), "/api/stream-consumer/publish-spread", "{\"payload\":\"__warmup__\"}");
 
-        return !response.contains("\"error\"") && response.contains("published");
+        return ! response.contains("\"error\"") && response.contains("published");
     }
 
     private void failIfSliceFailed() {
         var failed = cluster.slicesStatus()
                             .stream()
-                            .anyMatch(status -> status.artifact().equals(CONSUMER_SLICE) && status.state().equals("FAILED"));
+                            .anyMatch(status -> status.artifact()
+                                                      .equals(CONSUMER_SLICE) && status.state()
+                                                                                       .equals("FAILED"));
 
         if (failed) {
             throw new AssertionError("Declarative-consumer slice deployment FAILED: " + CONSUMER_SLICE);
@@ -402,7 +377,10 @@ class DeclarativeConsumerPlacementTest {
     }
 
     private int anyMgmtPort() {
-        return cluster.status().nodes().getFirst().mgmtPort();
+        return cluster.status()
+                      .nodes()
+                      .getFirst()
+                      .mgmtPort();
     }
 
     private boolean allNodesHealthy() {
@@ -421,7 +399,8 @@ class DeclarativeConsumerPlacementTest {
 
         return http.sendString(request)
                    .await()
-                   .map(response -> response.statusCode() == 200 && response.body().contains("\"quorum\":true"))
+                   .map(response -> response.statusCode() == 200 && response.body()
+                                                                            .contains("\"quorum\":true"))
                    .or(false);
     }
 
@@ -430,7 +409,6 @@ class DeclarativeConsumerPlacementTest {
     }
 
     // --- HTTP ----------------------------------------------------------------
-
     private String httpPostToml(int port, String path, String body) {
         var request = HttpRequest.newBuilder()
                                  .uri(URI.create("http://localhost:" + port + path))

--- a/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/DeclarativeConsumerPlacementTest.java
+++ b/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/DeclarativeConsumerPlacementTest.java
@@ -2,21 +2,8 @@
 // Copyright (c) 2025 Pragmatica Labs - Sergiy Yevtushenko
 // Licensed under Business Source License 1.1. Change Date: 2030-01-01. Change License: Apache-2.0.
 // See LICENSE in the repository root for full terms.
+
 package org.pragmatica.aether.forge;
-
-import java.net.URI;
-import java.net.http.HttpRequest;
-import java.time.Duration;
-import java.util.Arrays;
-import java.util.List;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.regex.Pattern;
-
-import org.pragmatica.aether.ember.EmberCluster;
-import org.pragmatica.config.ConfigurationProvider;
-import org.pragmatica.http.HttpOperations;
-import org.pragmatica.http.HttpResult;
-import org.pragmatica.lang.Option;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -26,12 +13,24 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.pragmatica.aether.ember.EmberCluster;
+import org.pragmatica.config.ConfigurationProvider;
+import org.pragmatica.http.HttpOperations;
+import org.pragmatica.http.HttpResult;
+import org.pragmatica.lang.Option;
 
-import static org.pragmatica.aether.ember.EmberCluster.emberCluster;
-import static org.pragmatica.http.JdkHttpOperations.jdkHttpOperations;
+import java.net.URI;
+import java.net.http.HttpRequest;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.regex.Pattern;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
-
+import static org.pragmatica.aether.ember.EmberCluster.emberCluster;
+import static org.pragmatica.http.JdkHttpOperations.jdkHttpOperations;
 
 /// #535 — a declarative consumer delivers under a DEFAULT placement, where the partition owner does
 /// not host the slice.
@@ -68,10 +67,12 @@ class DeclarativeConsumerPlacementTest {
     private static final int BASE_MGMT_PORT = 18600;
     private static final int BASE_APP_HTTP_PORT = 18700;
     private static final int NODES = 5;
+
     /// The whole point: ONE instance against a FIVE-partition stream. The single host can own at most
     /// one partition, so at least four must be consumed by reading through their owners.
     private static final int INSTANCES = 1;
     private static final int SPREAD_PARTITIONS = 5;
+
     /// Attachments expected cluster-wide once settled. The fixture slice declares THREE consumers —
     /// `consumer-events` (1 partition), `order-events` (1) and `spread-events` (5) — and with a single
     /// instance the sole candidate is assigned EVERY partition of all three, so the total is 7, not 5.
@@ -79,20 +80,25 @@ class DeclarativeConsumerPlacementTest {
     /// and the assignment was in fact correct the whole time.
     private static final int EXPECTED_ATTACHMENTS = 7;
     private static final int EVENT_COUNT = 25;
+
     private static final String SPREAD_EVENTS_STREAM = "spread-events";
+
     private static final Duration WAIT_TIMEOUT = Duration.ofSeconds(240);
     private static final Duration DELIVERY_TIMEOUT = Duration.ofSeconds(90);
     private static final Duration POLL_INTERVAL = Duration.ofMillis(500);
+
     private static final String CONSUMER_SLICE = TestArtifacts.STREAM_CONSUMER_SLICE;
     private static final String BLUEPRINT_ID = "forge.test:declarative-consumer-placement:1.0.0";
     private static final String ERROR_FALLBACK = "{\"error\":\"request failed\"}";
+
     private static final Pattern COUNT_FIELD = Pattern.compile("\"count\"\\s*:\\s*(\\d+)");
     private static final Pattern ATTACHED_FIELD = Pattern.compile("\"attachedSubscriptions\"\\s*:\\s*(\\d+)");
     private static final Pattern OWNER_NODE_FIELD = Pattern.compile("\"ownerNode\"");
 
     /// One `partitionAssignments` row. Field order follows the record's component order, so consumer
     /// and owner can be compared per partition without a JSON parser.
-    private static final Pattern ASSIGNMENT_ROW = Pattern.compile("\\{\"partition\":\\d+,\"consumerNode\":\"([^\"]+)\",\"ownerNode\":\"([^\"]+)\"\\}");
+    private static final Pattern ASSIGNMENT_ROW =
+        Pattern.compile("\\{\"partition\":\\d+,\"consumerNode\":\"([^\"]+)\",\"ownerNode\":\"([^\"]+)\"\\}");
 
     /// Matches `unassignedPartitions` carrying at least one partition. The serializer omits empty
     /// collections, so a healthy response has no such field at all and this must never match.
@@ -110,25 +116,34 @@ class DeclarativeConsumerPlacementTest {
 
         cluster = emberCluster(NODES, BASE_PORT, BASE_MGMT_PORT, BASE_APP_HTTP_PORT, "dcp", Option.some(configProvider));
         LifecycleAwait.settled("cluster start in setUp()", cluster, cluster.start());
-        await().atMost(WAIT_TIMEOUT).pollInterval(POLL_INTERVAL).until(() -> cluster.currentLeader()
-                                                                                    .isPresent());
-        await().atMost(WAIT_TIMEOUT).pollInterval(POLL_INTERVAL).until(this::allNodesHealthy);
+
+        await().atMost(WAIT_TIMEOUT)
+               .pollInterval(POLL_INTERVAL)
+               .until(() -> cluster.currentLeader().isPresent());
+
+        await().atMost(WAIT_TIMEOUT)
+               .pollInterval(POLL_INTERVAL)
+               .until(this::allNodesHealthy);
+
         deployConsumerSlice();
+
         await().atMost(WAIT_TIMEOUT)
-             .pollInterval(POLL_INTERVAL)
-             .failFast(this::failIfSliceFailed)
-             .until(this::appHttpReady);
+               .pollInterval(POLL_INTERVAL)
+               .failFast(this::failIfSliceFailed)
+               .until(this::appHttpReady);
+
         await().atMost(WAIT_TIMEOUT)
-             .pollInterval(POLL_INTERVAL)
-             .failFast(this::failIfSliceFailed)
-             .until(this::publishReady);
+               .pollInterval(POLL_INTERVAL)
+               .failFast(this::failIfSliceFailed)
+               .until(this::publishReady);
+
         // Gate on the consumer holding every partition of all three declared streams. With one instance
         // the sole candidate is assigned all of them, so anything less means the assignment has not
         // settled and a delivery assertion would be measuring attach timing.
         await().atMost(WAIT_TIMEOUT)
-             .pollInterval(POLL_INTERVAL)
-             .failFast(this::failIfSliceFailed)
-             .until(() -> totalAttachedSubscriptions() == EXPECTED_ATTACHMENTS);
+               .pollInterval(POLL_INTERVAL)
+               .failFast(this::failIfSliceFailed)
+               .until(() -> totalAttachedSubscriptions() == EXPECTED_ATTACHMENTS);
     }
 
     @AfterAll
@@ -137,7 +152,7 @@ class DeclarativeConsumerPlacementTest {
             var leaderPort = cluster.getLeaderManagementPort().or(anyMgmtPort());
 
             httpDelete(leaderPort, "/api/v1/blueprints/" + BLUEPRINT_ID);
-            LifecycleAwait.settled("cluster stop in tearDown()", cluster, cluster.stop());
+            LifecycleAwait.bestEffort("cluster stop in tearDown()", cluster, cluster.stop());
         }
     }
 
@@ -145,29 +160,30 @@ class DeclarativeConsumerPlacementTest {
     /// are what stop a co-located run from passing for free.
     @Nested
     class PlacementShape {
+
         @Test
         void placement_leavesMostPartitionOwnersWithoutTheSlice() {
             var hosts = cluster.slicesStatus()
                                .stream()
-                               .filter(status -> status.artifact()
-                                                       .equals(CONSUMER_SLICE))
-                               .flatMap(status -> status.instances()
-                                                        .stream())
+                               .filter(status -> status.artifact().equals(CONSUMER_SLICE))
+                               .flatMap(status -> status.instances().stream())
                                .toList();
 
             assertThat(hosts).describedAs("the pigeonhole depends on exactly one host against five partitions")
-                      .hasSize(INSTANCES);
-            assertThat(forwardedPartitionCount()).describedAs("one host cannot own five partitions, so at least four MUST be read through their owners — "
-                                                             + "this is the case #488 could not express and the live cluster failed")
-                      .isGreaterThanOrEqualTo(SPREAD_PARTITIONS - INSTANCES);
+                             .hasSize(INSTANCES);
+            assertThat(forwardedPartitionCount())
+                    .describedAs("one host cannot own five partitions, so at least four MUST be read through their owners — "
+                                 + "this is the case #488 could not express and the live cluster failed")
+                    .isGreaterThanOrEqualTo(SPREAD_PARTITIONS - INSTANCES);
         }
 
         @Test
         void declarativeConsumersEndpoint_namesConsumerAndOwnerForEveryPartition() {
             var fragment = spreadFragment();
 
-            assertThat(OWNER_NODE_FIELD.matcher(fragment).results().count()).describedAs("an operator must be able to answer 'who consumes partition 3' from any node")
-                      .isEqualTo(SPREAD_PARTITIONS);
+            assertThat(OWNER_NODE_FIELD.matcher(fragment).results().count())
+                    .describedAs("an operator must be able to answer 'who consumes partition 3' from any node")
+                    .isEqualTo(SPREAD_PARTITIONS);
         }
 
         /// The endpoint must not claim a gap that does not exist, and must not use its FAULT channel
@@ -178,17 +194,19 @@ class DeclarativeConsumerPlacementTest {
         void declarativeConsumersEndpoint_reportsNoUnassignedPartitions() {
             var fragment = spreadFragment();
 
-            assertThat(UNASSIGNED_NONEMPTY.matcher(fragment).find()).describedAs("the slice IS active somewhere, so no partition may be reported as consumed by nobody")
-                      .isFalse();
+            assertThat(UNASSIGNED_NONEMPTY.matcher(fragment).find())
+                    .describedAs("the slice IS active somewhere, so no partition may be reported as consumed by nobody")
+                    .isFalse();
             assertThat(fragment).doesNotContain("NOT being consumed by anyone")
-                      .doesNotContain("not being consumed YET")
-                      .describedAs("forwarding is normal operation and must not occupy the fault channel")
-                      .doesNotContain("forwarded to the owner");
+                                .doesNotContain("not being consumed YET")
+                                .describedAs("forwarding is normal operation and must not occupy the fault channel")
+                                .doesNotContain("forwarded to the owner");
         }
     }
 
     @Nested
     class Delivery {
+
         /// The headline #535 assertion: a default deployment delivers. Against the pre-fix runtime this
         /// stays at 0 forever for every partition whose owner lacks the slice — four of five here.
         @Test
@@ -196,10 +214,12 @@ class DeclarativeConsumerPlacementTest {
             var baseline = settledSpreadReceived();
 
             publishSpreadBatch(EVENT_COUNT);
+
             await().atMost(DELIVERY_TIMEOUT)
-                 .pollInterval(POLL_INTERVAL)
-                 .untilAsserted(() -> assertThat(spreadReceived() - baseline).describedAs("every published event must arrive even though four of five owners cannot run the consumer")
-                                                .isEqualTo(EVENT_COUNT));
+                   .pollInterval(POLL_INTERVAL)
+                   .untilAsserted(() -> assertThat(spreadReceived() - baseline)
+                           .describedAs("every published event must arrive even though four of five owners cannot run the consumer")
+                           .isEqualTo(EVENT_COUNT));
         }
 
         /// Reading through an owner must not turn one event into several. The hold past several
@@ -209,24 +229,27 @@ class DeclarativeConsumerPlacementTest {
             var baseline = settledSpreadReceived();
 
             publishSpreadBatch(EVENT_COUNT);
+
             await().atMost(DELIVERY_TIMEOUT)
-                 .pollInterval(POLL_INTERVAL)
-                 .untilAsserted(() -> assertThat(spreadReceived() - baseline).isEqualTo(EVENT_COUNT));
+                   .pollInterval(POLL_INTERVAL)
+                   .untilAsserted(() -> assertThat(spreadReceived() - baseline).isEqualTo(EVENT_COUNT));
+
             sleep(Duration.ofSeconds(12));
-            assertThat(spreadReceived() - baseline).describedAs("exactly one node is assigned per partition, and it stays the only one")
-                      .isEqualTo(EVENT_COUNT);
+
+            assertThat(spreadReceived() - baseline)
+                    .describedAs("exactly one node is assigned per partition, and it stays the only one")
+                    .isEqualTo(EVENT_COUNT);
         }
     }
 
     // --- publish / receive ---------------------------------------------------
+
     private void publishSpreadBatch(int count) {
         for (var i = 0; i < count; i++) {
-            var response = httpPost(appPort(),
-                                    "/api/stream-consumer/publish-spread",
-                                    "{\"payload\":\"spread-" + i + "\"}");
+            var response = httpPost(appPort(), "/api/stream-consumer/publish-spread", "{\"payload\":\"spread-" + i + "\"}");
 
             assertThat(response).describedAs("publish must succeed — it write-forwards to each partition owner")
-                      .contains("published");
+                                .contains("published");
         }
     }
 
@@ -250,9 +273,8 @@ class DeclarativeConsumerPlacementTest {
         var lastSample = new AtomicInteger(-1);
 
         await().atMost(DELIVERY_TIMEOUT)
-             .pollInterval(POLL_INTERVAL)
-             .until(() -> isRepeatSample(lastSample,
-                                         spreadReceived()));
+               .pollInterval(POLL_INTERVAL)
+               .until(() -> isRepeatSample(lastSample, spreadReceived()));
 
         return lastSample.get();
     }
@@ -263,9 +285,9 @@ class DeclarativeConsumerPlacementTest {
 
     private int totalAttachedSubscriptions() {
         return mgmtPorts().stream()
-                        .map(port -> httpGet(port, "/api/v1/streams/declarative-consumers"))
-                        .mapToInt(body -> firstInt(ATTACHED_FIELD, body))
-                        .sum();
+                          .map(port -> httpGet(port, "/api/v1/streams/declarative-consumers"))
+                          .mapToInt(body -> firstInt(ATTACHED_FIELD, body))
+                          .sum();
     }
 
     /// Partitions of spread-events whose assigned consumer is NOT the owner — i.e. whose reads are
@@ -274,8 +296,7 @@ class DeclarativeConsumerPlacementTest {
     private long forwardedPartitionCount() {
         return ASSIGNMENT_ROW.matcher(spreadFragment())
                              .results()
-                             .filter(match -> !match.group(1)
-                                                    .equals(match.group(2)))
+                             .filter(match -> !match.group(1).equals(match.group(2)))
                              .count();
     }
 
@@ -283,11 +304,11 @@ class DeclarativeConsumerPlacementTest {
     /// assignment, but only the host can report `sliceDeployedLocally` and the forwarding diagnostic.
     private String spreadFragment() {
         return mgmtPorts().stream()
-                        .map(port -> consumerFragment(httpGet(port, "/api/v1/streams/declarative-consumers"),
-                                                      SPREAD_EVENTS_STREAM))
-                        .filter(fragment -> fragment.contains("\"sliceDeployedLocally\":true"))
-                        .findFirst()
-                        .orElseThrow(() -> new AssertionError("No node reports hosting the declarative consumer slice"));
+                          .map(port -> consumerFragment(httpGet(port, "/api/v1/streams/declarative-consumers"),
+                                                        SPREAD_EVENTS_STREAM))
+                          .filter(fragment -> fragment.contains("\"sliceDeployedLocally\":true"))
+                          .findFirst()
+                          .orElseThrow(() -> new AssertionError("No node reports hosting the declarative consumer slice"));
     }
 
     /// The slice of the declarative-consumers JSON describing one stream. Substring-scoped rather than
@@ -309,6 +330,7 @@ class DeclarativeConsumerPlacementTest {
     }
 
     // --- deployment + readiness ---------------------------------------------
+
     private void deployConsumerSlice() {
         var blueprint = """
             id = "%s"
@@ -321,8 +343,8 @@ class DeclarativeConsumerPlacementTest {
         var response = httpPostToml(leaderPort, "/api/v1/blueprints", blueprint);
 
         assertThat(response).describedAs("placement-restricted consumer slice deployment")
-                  .doesNotContain("\"error\"")
-                  .contains("\"status\":\"applied\"");
+                            .doesNotContain("\"error\"")
+                            .contains("\"status\":\"applied\"");
     }
 
     private boolean appHttpReady() {
@@ -334,7 +356,7 @@ class DeclarativeConsumerPlacementTest {
 
         var body = httpPost(ports.getFirst(), "/api/stream-consumer/received-spread", "{}");
 
-        return ! body.contains("\"error\"") && body.contains("count");
+        return !body.contains("\"error\"") && body.contains("count");
     }
 
     private boolean publishReady() {
@@ -346,15 +368,13 @@ class DeclarativeConsumerPlacementTest {
 
         var response = httpPost(ports.getFirst(), "/api/stream-consumer/publish-spread", "{\"payload\":\"__warmup__\"}");
 
-        return ! response.contains("\"error\"") && response.contains("published");
+        return !response.contains("\"error\"") && response.contains("published");
     }
 
     private void failIfSliceFailed() {
         var failed = cluster.slicesStatus()
                             .stream()
-                            .anyMatch(status -> status.artifact()
-                                                      .equals(CONSUMER_SLICE) && status.state()
-                                                                                       .equals("FAILED"));
+                            .anyMatch(status -> status.artifact().equals(CONSUMER_SLICE) && status.state().equals("FAILED"));
 
         if (failed) {
             throw new AssertionError("Declarative-consumer slice deployment FAILED: " + CONSUMER_SLICE);
@@ -377,10 +397,7 @@ class DeclarativeConsumerPlacementTest {
     }
 
     private int anyMgmtPort() {
-        return cluster.status()
-                      .nodes()
-                      .getFirst()
-                      .mgmtPort();
+        return cluster.status().nodes().getFirst().mgmtPort();
     }
 
     private boolean allNodesHealthy() {
@@ -399,8 +416,7 @@ class DeclarativeConsumerPlacementTest {
 
         return http.sendString(request)
                    .await()
-                   .map(response -> response.statusCode() == 200 && response.body()
-                                                                            .contains("\"quorum\":true"))
+                   .map(response -> response.statusCode() == 200 && response.body().contains("\"quorum\":true"))
                    .or(false);
     }
 
@@ -409,6 +425,7 @@ class DeclarativeConsumerPlacementTest {
     }
 
     // --- HTTP ----------------------------------------------------------------
+
     private String httpPostToml(int port, String path, String body) {
         var request = HttpRequest.newBuilder()
                                  .uri(URI.create("http://localhost:" + port + path))

--- a/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/DeclarativeStreamConsumerTest.java
+++ b/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/DeclarativeStreamConsumerTest.java
@@ -2,7 +2,22 @@
 // Copyright (c) 2025 Pragmatica Labs - Sergiy Yevtushenko
 // Licensed under Business Source License 1.1. Change Date: 2030-01-01. Change License: Apache-2.0.
 // See LICENSE in the repository root for full terms.
+
 package org.pragmatica.aether.forge;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.pragmatica.aether.ember.EmberCluster;
+import org.pragmatica.config.ConfigurationProvider;
+import org.pragmatica.http.HttpOperations;
+import org.pragmatica.http.HttpResult;
+import org.pragmatica.lang.Option;
 
 import java.net.URI;
 import java.net.http.HttpRequest;
@@ -13,26 +28,10 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.IntSupplier;
 import java.util.regex.Pattern;
 
-import org.pragmatica.aether.ember.EmberCluster;
-import org.pragmatica.config.ConfigurationProvider;
-import org.pragmatica.http.HttpOperations;
-import org.pragmatica.http.HttpResult;
-import org.pragmatica.lang.Option;
-
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
-
-import static org.pragmatica.aether.ember.EmberCluster.emberCluster;
-import static org.pragmatica.http.JdkHttpOperations.jdkHttpOperations;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
-
+import static org.pragmatica.aether.ember.EmberCluster.emberCluster;
+import static org.pragmatica.http.JdkHttpOperations.jdkHttpOperations;
 
 /// #488 — the declarative `[streams.X]` consumer actually receives published events.
 ///
@@ -81,20 +80,25 @@ class DeclarativeStreamConsumerTest {
     private static final int INSTANCES = 5;
     private static final int EVENT_COUNT = 30;
     private static final int ORDER_COUNT = 10;
+
     private static final String CONSUMER_EVENTS_STREAM = "consumer-events";
     private static final String ORDER_EVENTS_STREAM = "order-events";
     private static final String SPREAD_EVENTS_STREAM = "spread-events";
+
     /// Attachments expected cluster-wide once settled: one partition each for consumer-events and
     /// order-events, plus the five of spread-events. With the slice on EVERY node each partition's own
     /// owner is a candidate, so owner-preference assigns every partition to its owner and the total is
     /// the stream's partition count summed — never more, which is what a duplicate attach looks like.
     private static final int EXPECTED_ATTACHMENTS = 7;
+
     private static final Duration WAIT_TIMEOUT = Duration.ofSeconds(240);
     private static final Duration DELIVERY_TIMEOUT = Duration.ofSeconds(90);
     private static final Duration POLL_INTERVAL = Duration.ofMillis(500);
+
     private static final String CONSUMER_SLICE = TestArtifacts.STREAM_CONSUMER_SLICE;
     private static final String BLUEPRINT_ID = "forge.test:declarative-consumer:1.0.0";
     private static final String ERROR_FALLBACK = "{\"error\":\"request failed\"}";
+
     private static final Pattern COUNT_FIELD = Pattern.compile("\"count\"\\s*:\\s*(\\d+)");
     private static final Pattern ATTACHED_FIELD = Pattern.compile("\"attachedSubscriptions\"\\s*:\\s*(\\d+)");
 
@@ -110,39 +114,48 @@ class DeclarativeStreamConsumerTest {
                                                   .withSystemProperties("aether.")
                                                   .withEnvironment("AETHER_")
                                                   .build();
-
         cluster = emberCluster(NODES, BASE_PORT, BASE_MGMT_PORT, BASE_APP_HTTP_PORT, "dsc", Option.some(configProvider));
         LifecycleAwait.settled("cluster start in setUp()", cluster, cluster.start());
-        await().atMost(WAIT_TIMEOUT).pollInterval(POLL_INTERVAL).until(() -> cluster.currentLeader()
-                                                                                    .isPresent());
-        await().atMost(WAIT_TIMEOUT).pollInterval(POLL_INTERVAL).until(this::allNodesHealthy);
-        deployConsumerSlice();
+
         await().atMost(WAIT_TIMEOUT)
-             .pollInterval(POLL_INTERVAL)
-             .failFast(this::failIfSliceFailed)
-             .until(this::appHttpReady);
+               .pollInterval(POLL_INTERVAL)
+               .until(() -> cluster.currentLeader().isPresent());
+
+        await().atMost(WAIT_TIMEOUT)
+               .pollInterval(POLL_INTERVAL)
+               .until(this::allNodesHealthy);
+
+        deployConsumerSlice();
+
+        await().atMost(WAIT_TIMEOUT)
+               .pollInterval(POLL_INTERVAL)
+               .failFast(this::failIfSliceFailed)
+               .until(this::appHttpReady);
+
         // A publish can land before the partition owner has materialized its ring, so gate on a real
         // publish succeeding before any test runs.
         await().atMost(WAIT_TIMEOUT)
-             .pollInterval(POLL_INTERVAL)
-             .failFast(this::failIfSliceFailed)
-             .until(this::publishReady);
+               .pollInterval(POLL_INTERVAL)
+               .failFast(this::failIfSliceFailed)
+               .until(this::publishReady);
+
         // The consumer attaches on the manager's ownership tick, which is independent of publish
         // readiness — gate on the registration actually having produced a subscription somewhere.
         await().atMost(WAIT_TIMEOUT)
-             .pollInterval(POLL_INTERVAL)
-             .failFast(this::failIfSliceFailed)
-             .until(() -> totalAttachedSubscriptions() > 0);
+               .pollInterval(POLL_INTERVAL)
+               .failFast(this::failIfSliceFailed)
+               .until(() -> totalAttachedSubscriptions() > 0);
+
         // Gate on EACH stream separately. A subscription attaches at the stream TAIL, so an event
         // published before its consumer attached is skipped, not queued — and with two streams the
         // aggregate gate above is satisfied by whichever attaches first. Waiting per stream is what
         // makes the delivery assertions measure delivery rather than attach timing.
         await().atMost(WAIT_TIMEOUT)
-             .pollInterval(POLL_INTERVAL)
-             .failFast(this::failIfSliceFailed)
-             .until(() -> consumerAttachedFor(CONSUMER_EVENTS_STREAM)
-                          && consumerAttachedFor(ORDER_EVENTS_STREAM)
-                          && consumerAttachedFor(SPREAD_EVENTS_STREAM));
+               .pollInterval(POLL_INTERVAL)
+               .failFast(this::failIfSliceFailed)
+               .until(() -> consumerAttachedFor(CONSUMER_EVENTS_STREAM)
+                            && consumerAttachedFor(ORDER_EVENTS_STREAM)
+                            && consumerAttachedFor(SPREAD_EVENTS_STREAM));
     }
 
     @AfterAll
@@ -151,12 +164,13 @@ class DeclarativeStreamConsumerTest {
             var leaderPort = cluster.getLeaderManagementPort().or(anyMgmtPort());
 
             httpDelete(leaderPort, "/api/v1/blueprints/" + BLUEPRINT_ID);
-            LifecycleAwait.settled("cluster stop in tearDown()", cluster, cluster.stop());
+            LifecycleAwait.bestEffort("cluster stop in tearDown()", cluster, cluster.stop());
         }
     }
 
     @Nested
     class Delivery {
+
         /// The headline #488 assertion, stated as the guarantee actually promises it: every published
         /// payload arrives AT LEAST once.
         ///
@@ -167,10 +181,12 @@ class DeclarativeStreamConsumerTest {
         @Test
         void declaredConsumer_receivesPublishedEvents_withoutAnyExplicitSubscribe() {
             publishBatch("first-batch", EVENT_COUNT);
+
             await().atMost(DELIVERY_TIMEOUT)
-                 .pollInterval(POLL_INTERVAL)
-                 .untilAsserted(() -> assertThat(distinctReceivedMatching("first-batch")).describedAs("every published event must arrive at least once — before #488 this stayed at 0 forever")
-                                                .isEqualTo(EVENT_COUNT));
+                   .pollInterval(POLL_INTERVAL)
+                   .untilAsserted(() -> assertThat(distinctReceivedMatching("first-batch"))
+                           .describedAs("every published event must arrive at least once — before #488 this stayed at 0 forever")
+                           .isEqualTo(EVENT_COUNT));
         }
 
         /// The duplication sensor, and the reason the count assertion stays EXACT.
@@ -184,26 +200,32 @@ class DeclarativeStreamConsumerTest {
         @Test
         void declaredConsumer_deliversEachEventExactlyOnceClusterWide() {
             publishBatch("once-batch", EVENT_COUNT);
+
             await().atMost(DELIVERY_TIMEOUT)
-                 .pollInterval(POLL_INTERVAL)
-                 .untilAsserted(() -> assertThat(distinctReceivedMatching("once-batch")).isEqualTo(EVENT_COUNT));
+                   .pollInterval(POLL_INTERVAL)
+                   .untilAsserted(() -> assertThat(distinctReceivedMatching("once-batch")).isEqualTo(EVENT_COUNT));
+
             // Hold past several reconcile ticks: a second node attaching late would push the total above
             // EVENT_COUNT, which a single sampled assertion would miss.
             sleep(Duration.ofSeconds(12));
-            assertThat(receivedMatching("once-batch")).describedAs("no duplicate observed — exactly one node is assigned, and it stays the only one")
-                      .isEqualTo(EVENT_COUNT);
+
+            assertThat(receivedMatching("once-batch"))
+                    .describedAs("no duplicate observed — exactly one node is assigned, and it stays the only one")
+                    .isEqualTo(EVENT_COUNT);
         }
     }
 
     @Nested
     class Observability {
+
         /// The operator surface must agree with reality: one attached subscription per PARTITION of
         /// each declared consumer's stream. With the slice on every node, owner-preference puts each
         /// partition on its own owner — never more, which is what a duplicate attach would look like.
         @Test
         void declarativeConsumersEndpoint_reportsOneAttachedSubscriptionPerPartition() {
-            assertThat(totalAttachedSubscriptions()).describedAs("one partition each for consumer-events and order-events, five for spread-events")
-                      .isEqualTo(EXPECTED_ATTACHMENTS);
+            assertThat(totalAttachedSubscriptions())
+                    .describedAs("one partition each for consumer-events and order-events, five for spread-events")
+                    .isEqualTo(EXPECTED_ATTACHMENTS);
         }
 
         /// Every node knows the declaration (it is cluster-wide KV), and the endpoint answers on all of
@@ -211,8 +233,8 @@ class DeclarativeStreamConsumerTest {
         @Test
         void declarativeConsumersEndpoint_answersOnEveryNode_namingStreamAndMethod() {
             var bodies = mgmtPorts().stream()
-                                  .map(port -> httpGet(port, "/api/v1/streams/declarative-consumers"))
-                                  .toList();
+                                    .map(port -> httpGet(port, "/api/v1/streams/declarative-consumers"))
+                                    .toList();
 
             assertThat(bodies).allSatisfy(body -> {
                 assertThat(body).doesNotContain("\"error\"");
@@ -240,6 +262,7 @@ class DeclarativeStreamConsumerTest {
     /// with "No codec registered for class" — before delivery is ever reached.
     @Nested
     class ApplicationTypedDelivery {
+
         /// The headline #526 assertion: publishing an app-defined record succeeds at all.
         @Test
         void publishOrder_succeeds_forApplicationDefinedEventType() {
@@ -248,9 +271,9 @@ class DeclarativeStreamConsumerTest {
                                     "{\"orderId\":\"order-probe\",\"customer\":\"acme\",\"amount\":7}");
 
             assertThat(response).describedAs("app-typed publish must succeed — before #526 this threw "
-                                            + "'No codec registered for class' because the publisher held the node codec")
-                      .doesNotContain("\"error\"")
-                      .contains("published");
+                                             + "'No codec registered for class' because the publisher held the node codec")
+                                .doesNotContain("\"error\"")
+                                .contains("published");
         }
 
         /// Both ends of the stream must resolve the slice codec: the publisher to ENCODE the record
@@ -260,10 +283,12 @@ class DeclarativeStreamConsumerTest {
             var baseline = settledCount(DeclarativeStreamConsumerTest.this::totalOrdersReceived);
 
             publishOrderBatch(ORDER_COUNT);
+
             await().atMost(DELIVERY_TIMEOUT)
-                 .pollInterval(POLL_INTERVAL)
-                 .untilAsserted(() -> assertThat(totalOrdersReceived() - baseline).describedAs("every app-typed event must round-trip through the slice codec")
-                                                .isEqualTo(ORDER_COUNT));
+                   .pollInterval(POLL_INTERVAL)
+                   .untilAsserted(() -> assertThat(totalOrdersReceived() - baseline)
+                           .describedAs("every app-typed event must round-trip through the slice codec")
+                           .isEqualTo(ORDER_COUNT));
         }
 
         /// The record's fields must survive encode/decode intact — delivery of a corrupted or
@@ -271,39 +296,40 @@ class DeclarativeStreamConsumerTest {
         @Test
         void declaredConsumer_preservesEveryRecordComponent_throughTheStream() {
             publishOrderBatch(ORDER_COUNT);
+
             await().atMost(DELIVERY_TIMEOUT)
-                 .pollInterval(POLL_INTERVAL)
-                 .untilAsserted(() -> assertThat(receivedOrdersBody()).describedAs("the decoded record must carry the published field values, not defaults")
-                                                .contains("\"orderId\":\"order-0\"")
-                                                .contains("\"customer\":\"customer-0\"")
-                                                .contains("\"amount\":100"));
+                   .pollInterval(POLL_INTERVAL)
+                   .untilAsserted(() -> assertThat(receivedOrdersBody())
+                           .describedAs("the decoded record must carry the published field values, not defaults")
+                           .contains("\"orderId\":\"order-0\"")
+                           .contains("\"customer\":\"customer-0\"")
+                           .contains("\"amount\":100"));
         }
 
         /// The operator surface must stop warning about app types now that they genuinely publish.
         @Test
         void declarativeConsumersEndpoint_reportsEventTypePublishable_forApplicationType() {
             var fragments = mgmtPorts().stream()
-                                     .map(port -> consumerFragment(httpGet(port, "/api/v1/streams/declarative-consumers"),
-                                                                   ORDER_EVENTS_STREAM))
-                                     .filter(fragment -> !fragment.isEmpty())
-                                     .toList();
+                                       .map(port -> consumerFragment(httpGet(port, "/api/v1/streams/declarative-consumers"),
+                                                                     ORDER_EVENTS_STREAM))
+                                       .filter(fragment -> !fragment.isEmpty())
+                                       .toList();
 
             assertThat(fragments).describedAs("every node knows the app-typed declaration — it is cluster-wide KV")
-                      .isNotEmpty();
+                                 .isNotEmpty();
             assertThat(fragments).allSatisfy(fragment -> {
                 assertThat(fragment).describedAs("the slice's own codec registers OrderPlaced, so it IS publishable")
-                          .contains("\"eventTypePublishable\":true");
+                                    .contains("\"eventTypePublishable\":true");
                 assertThat(fragment).doesNotContain("cannot be PUBLISHED");
             });
         }
     }
 
     // --- publish / receive ---------------------------------------------------
+
     private void publishBatch(String prefix, int count) {
         for (var i = 0; i < count; i++) {
-            var response = httpPost(appPort(),
-                                    "/api/stream-consumer/publish",
-                                    "{\"payload\":\"" + prefix + "-" + i + "\"}");
+            var response = httpPost(appPort(), "/api/stream-consumer/publish", "{\"payload\":\"" + prefix + "-" + i + "\"}");
 
             assertThat(response).describedAs("publish must succeed").contains("published");
         }
@@ -328,8 +354,7 @@ class DeclarativeStreamConsumerTest {
         return (int) cluster.getAvailableAppHttpPorts()
                             .stream()
                             .map(port -> httpPost(port, "/api/stream-consumer/received", "{}"))
-                            .flatMap(body -> pattern.matcher(body)
-                                                    .results())
+                            .flatMap(body -> pattern.matcher(body).results())
                             .map(match -> match.group(1))
                             .distinct()
                             .count();
@@ -349,10 +374,7 @@ class DeclarativeStreamConsumerTest {
 
     private void publishOrderBatch(int count) {
         for (var i = 0; i < count; i++) {
-            var body = "{\"orderId\":\"order-" + i
-                     + "\",\"customer\":\"customer-" + i
-                     + "\",\"amount\":" + (100 + i)
-                     + "}";
+            var body = "{\"orderId\":\"order-" + i + "\",\"customer\":\"customer-" + i + "\",\"amount\":" + (100 + i) + "}";
             var response = httpPost(appPort(), "/api/stream-consumer/publish-order", body);
 
             assertThat(response).describedAs("app-typed publish must succeed").contains("published");
@@ -388,9 +410,8 @@ class DeclarativeStreamConsumerTest {
         var lastSample = new AtomicInteger(-1);
 
         await().atMost(DELIVERY_TIMEOUT)
-             .pollInterval(POLL_INTERVAL)
-             .until(() -> isRepeatSample(lastSample,
-                                         counter.getAsInt()));
+               .pollInterval(POLL_INTERVAL)
+               .until(() -> isRepeatSample(lastSample, counter.getAsInt()));
 
         return lastSample.get();
     }
@@ -401,18 +422,17 @@ class DeclarativeStreamConsumerTest {
 
     private int totalAttachedSubscriptions() {
         return mgmtPorts().stream()
-                        .map(port -> httpGet(port, "/api/v1/streams/declarative-consumers"))
-                        .mapToInt(body -> firstInt(ATTACHED_FIELD, body))
-                        .sum();
+                          .map(port -> httpGet(port, "/api/v1/streams/declarative-consumers"))
+                          .mapToInt(body -> firstInt(ATTACHED_FIELD, body))
+                          .sum();
     }
 
     /// True once SOME node reports a live subscription for `stream`. Per-stream, because the
     /// aggregate count cannot distinguish "both consumers attached" from "one attached twice".
     private boolean consumerAttachedFor(String stream) {
         return mgmtPorts().stream()
-                        .map(port -> consumerFragment(httpGet(port, "/api/v1/streams/declarative-consumers"),
-                                                      stream))
-                        .anyMatch(fragment -> fragment.contains("\"assignedPartitions\""));
+                          .map(port -> consumerFragment(httpGet(port, "/api/v1/streams/declarative-consumers"), stream))
+                          .anyMatch(fragment -> fragment.contains("\"assignedPartitions\""));
     }
 
     /// The slice of the declarative-consumers JSON describing one stream. Substring-scoped rather than
@@ -427,10 +447,9 @@ class DeclarativeStreamConsumerTest {
 
     private int ownerMgmtPort() {
         return mgmtPorts().stream()
-                        .filter(port -> firstInt(ATTACHED_FIELD,
-                                                 httpGet(port, "/api/v1/streams/declarative-consumers")) > 0)
-                        .findFirst()
-                        .orElseThrow(() -> new AssertionError("No node reports an attached declarative consumer"));
+                          .filter(port -> firstInt(ATTACHED_FIELD, httpGet(port, "/api/v1/streams/declarative-consumers")) > 0)
+                          .findFirst()
+                          .orElseThrow(() -> new AssertionError("No node reports an attached declarative consumer"));
     }
 
     private static int firstInt(Pattern pattern, String body) {
@@ -442,6 +461,7 @@ class DeclarativeStreamConsumerTest {
     }
 
     // --- deployment + readiness ---------------------------------------------
+
     private void deployConsumerSlice() {
         var blueprint = """
             id = "%s"
@@ -454,8 +474,8 @@ class DeclarativeStreamConsumerTest {
         var response = httpPostToml(leaderPort, "/api/v1/blueprints", blueprint);
 
         assertThat(response).describedAs("declarative-consumer slice deployment")
-                  .doesNotContain("\"error\"")
-                  .contains("\"status\":\"applied\"");
+                            .doesNotContain("\"error\"")
+                            .contains("\"status\":\"applied\"");
     }
 
     private boolean appHttpReady() {
@@ -467,7 +487,7 @@ class DeclarativeStreamConsumerTest {
 
         var body = httpPost(ports.getFirst(), "/api/stream-consumer/received", "{}");
 
-        return ! body.contains("\"error\"") && body.contains("count");
+        return !body.contains("\"error\"") && body.contains("count");
     }
 
     private boolean publishReady() {
@@ -479,15 +499,13 @@ class DeclarativeStreamConsumerTest {
 
         var response = httpPost(ports.getFirst(), "/api/stream-consumer/publish", "{\"payload\":\"__warmup__\"}");
 
-        return ! response.contains("\"error\"") && response.contains("published");
+        return !response.contains("\"error\"") && response.contains("published");
     }
 
     private void failIfSliceFailed() {
         var failed = cluster.slicesStatus()
                             .stream()
-                            .anyMatch(status -> status.artifact()
-                                                      .equals(CONSUMER_SLICE) && status.state()
-                                                                                       .equals("FAILED"));
+                            .anyMatch(status -> status.artifact().equals(CONSUMER_SLICE) && status.state().equals("FAILED"));
 
         if (failed) {
             throw new AssertionError("Declarative-consumer slice deployment FAILED: " + CONSUMER_SLICE);
@@ -510,10 +528,7 @@ class DeclarativeStreamConsumerTest {
     }
 
     private int anyMgmtPort() {
-        return cluster.status()
-                      .nodes()
-                      .getFirst()
-                      .mgmtPort();
+        return cluster.status().nodes().getFirst().mgmtPort();
     }
 
     private boolean allNodesHealthy() {
@@ -532,8 +547,7 @@ class DeclarativeStreamConsumerTest {
 
         return http.sendString(request)
                    .await()
-                   .map(response -> response.statusCode() == 200 && response.body()
-                                                                            .contains("\"quorum\":true"))
+                   .map(response -> response.statusCode() == 200 && response.body().contains("\"quorum\":true"))
                    .or(false);
     }
 
@@ -542,6 +556,7 @@ class DeclarativeStreamConsumerTest {
     }
 
     // --- HTTP ----------------------------------------------------------------
+
     private String httpPostToml(int port, String path, String body) {
         var request = HttpRequest.newBuilder()
                                  .uri(URI.create("http://localhost:" + port + path))

--- a/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/DeclarativeStreamConsumerTest.java
+++ b/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/DeclarativeStreamConsumerTest.java
@@ -2,22 +2,7 @@
 // Copyright (c) 2025 Pragmatica Labs - Sergiy Yevtushenko
 // Licensed under Business Source License 1.1. Change Date: 2030-01-01. Change License: Apache-2.0.
 // See LICENSE in the repository root for full terms.
-
 package org.pragmatica.aether.forge;
-
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
-import org.pragmatica.aether.ember.EmberCluster;
-import org.pragmatica.config.ConfigurationProvider;
-import org.pragmatica.http.HttpOperations;
-import org.pragmatica.http.HttpResult;
-import org.pragmatica.lang.Option;
 
 import java.net.URI;
 import java.net.http.HttpRequest;
@@ -28,10 +13,26 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.IntSupplier;
 import java.util.regex.Pattern;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.awaitility.Awaitility.await;
+import org.pragmatica.aether.ember.EmberCluster;
+import org.pragmatica.config.ConfigurationProvider;
+import org.pragmatica.http.HttpOperations;
+import org.pragmatica.http.HttpResult;
+import org.pragmatica.lang.Option;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+
 import static org.pragmatica.aether.ember.EmberCluster.emberCluster;
 import static org.pragmatica.http.JdkHttpOperations.jdkHttpOperations;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
 
 /// #488 — the declarative `[streams.X]` consumer actually receives published events.
 ///
@@ -80,25 +81,20 @@ class DeclarativeStreamConsumerTest {
     private static final int INSTANCES = 5;
     private static final int EVENT_COUNT = 30;
     private static final int ORDER_COUNT = 10;
-
     private static final String CONSUMER_EVENTS_STREAM = "consumer-events";
     private static final String ORDER_EVENTS_STREAM = "order-events";
     private static final String SPREAD_EVENTS_STREAM = "spread-events";
-
     /// Attachments expected cluster-wide once settled: one partition each for consumer-events and
     /// order-events, plus the five of spread-events. With the slice on EVERY node each partition's own
     /// owner is a candidate, so owner-preference assigns every partition to its owner and the total is
     /// the stream's partition count summed — never more, which is what a duplicate attach looks like.
     private static final int EXPECTED_ATTACHMENTS = 7;
-
     private static final Duration WAIT_TIMEOUT = Duration.ofSeconds(240);
     private static final Duration DELIVERY_TIMEOUT = Duration.ofSeconds(90);
     private static final Duration POLL_INTERVAL = Duration.ofMillis(500);
-
     private static final String CONSUMER_SLICE = TestArtifacts.STREAM_CONSUMER_SLICE;
     private static final String BLUEPRINT_ID = "forge.test:declarative-consumer:1.0.0";
     private static final String ERROR_FALLBACK = "{\"error\":\"request failed\"}";
-
     private static final Pattern COUNT_FIELD = Pattern.compile("\"count\"\\s*:\\s*(\\d+)");
     private static final Pattern ATTACHED_FIELD = Pattern.compile("\"attachedSubscriptions\"\\s*:\\s*(\\d+)");
 
@@ -114,52 +110,39 @@ class DeclarativeStreamConsumerTest {
                                                   .withSystemProperties("aether.")
                                                   .withEnvironment("AETHER_")
                                                   .build();
+
         cluster = emberCluster(NODES, BASE_PORT, BASE_MGMT_PORT, BASE_APP_HTTP_PORT, "dsc", Option.some(configProvider));
-        cluster.start()
-               .await()
-               .onFailure(cause -> {
-                   throw new AssertionError("Cluster start failed: " + cause.message());
-               });
-
-        await().atMost(WAIT_TIMEOUT)
-               .pollInterval(POLL_INTERVAL)
-               .until(() -> cluster.currentLeader().isPresent());
-
-        await().atMost(WAIT_TIMEOUT)
-               .pollInterval(POLL_INTERVAL)
-               .until(this::allNodesHealthy);
-
+        LifecycleAwait.settled("cluster start in setUp()", cluster, cluster.start());
+        await().atMost(WAIT_TIMEOUT).pollInterval(POLL_INTERVAL).until(() -> cluster.currentLeader()
+                                                                                    .isPresent());
+        await().atMost(WAIT_TIMEOUT).pollInterval(POLL_INTERVAL).until(this::allNodesHealthy);
         deployConsumerSlice();
-
         await().atMost(WAIT_TIMEOUT)
-               .pollInterval(POLL_INTERVAL)
-               .failFast(this::failIfSliceFailed)
-               .until(this::appHttpReady);
-
+             .pollInterval(POLL_INTERVAL)
+             .failFast(this::failIfSliceFailed)
+             .until(this::appHttpReady);
         // A publish can land before the partition owner has materialized its ring, so gate on a real
         // publish succeeding before any test runs.
         await().atMost(WAIT_TIMEOUT)
-               .pollInterval(POLL_INTERVAL)
-               .failFast(this::failIfSliceFailed)
-               .until(this::publishReady);
-
+             .pollInterval(POLL_INTERVAL)
+             .failFast(this::failIfSliceFailed)
+             .until(this::publishReady);
         // The consumer attaches on the manager's ownership tick, which is independent of publish
         // readiness — gate on the registration actually having produced a subscription somewhere.
         await().atMost(WAIT_TIMEOUT)
-               .pollInterval(POLL_INTERVAL)
-               .failFast(this::failIfSliceFailed)
-               .until(() -> totalAttachedSubscriptions() > 0);
-
+             .pollInterval(POLL_INTERVAL)
+             .failFast(this::failIfSliceFailed)
+             .until(() -> totalAttachedSubscriptions() > 0);
         // Gate on EACH stream separately. A subscription attaches at the stream TAIL, so an event
         // published before its consumer attached is skipped, not queued — and with two streams the
         // aggregate gate above is satisfied by whichever attaches first. Waiting per stream is what
         // makes the delivery assertions measure delivery rather than attach timing.
         await().atMost(WAIT_TIMEOUT)
-               .pollInterval(POLL_INTERVAL)
-               .failFast(this::failIfSliceFailed)
-               .until(() -> consumerAttachedFor(CONSUMER_EVENTS_STREAM)
-                            && consumerAttachedFor(ORDER_EVENTS_STREAM)
-                            && consumerAttachedFor(SPREAD_EVENTS_STREAM));
+             .pollInterval(POLL_INTERVAL)
+             .failFast(this::failIfSliceFailed)
+             .until(() -> consumerAttachedFor(CONSUMER_EVENTS_STREAM)
+                          && consumerAttachedFor(ORDER_EVENTS_STREAM)
+                          && consumerAttachedFor(SPREAD_EVENTS_STREAM));
     }
 
     @AfterAll
@@ -168,14 +151,12 @@ class DeclarativeStreamConsumerTest {
             var leaderPort = cluster.getLeaderManagementPort().or(anyMgmtPort());
 
             httpDelete(leaderPort, "/api/v1/blueprints/" + BLUEPRINT_ID);
-            cluster.stop()
-                   .await();
+            LifecycleAwait.settled("cluster stop in tearDown()", cluster, cluster.stop());
         }
     }
 
     @Nested
     class Delivery {
-
         /// The headline #488 assertion, stated as the guarantee actually promises it: every published
         /// payload arrives AT LEAST once.
         ///
@@ -186,12 +167,10 @@ class DeclarativeStreamConsumerTest {
         @Test
         void declaredConsumer_receivesPublishedEvents_withoutAnyExplicitSubscribe() {
             publishBatch("first-batch", EVENT_COUNT);
-
             await().atMost(DELIVERY_TIMEOUT)
-                   .pollInterval(POLL_INTERVAL)
-                   .untilAsserted(() -> assertThat(distinctReceivedMatching("first-batch"))
-                           .describedAs("every published event must arrive at least once — before #488 this stayed at 0 forever")
-                           .isEqualTo(EVENT_COUNT));
+                 .pollInterval(POLL_INTERVAL)
+                 .untilAsserted(() -> assertThat(distinctReceivedMatching("first-batch")).describedAs("every published event must arrive at least once — before #488 this stayed at 0 forever")
+                                                .isEqualTo(EVENT_COUNT));
         }
 
         /// The duplication sensor, and the reason the count assertion stays EXACT.
@@ -205,32 +184,26 @@ class DeclarativeStreamConsumerTest {
         @Test
         void declaredConsumer_deliversEachEventExactlyOnceClusterWide() {
             publishBatch("once-batch", EVENT_COUNT);
-
             await().atMost(DELIVERY_TIMEOUT)
-                   .pollInterval(POLL_INTERVAL)
-                   .untilAsserted(() -> assertThat(distinctReceivedMatching("once-batch")).isEqualTo(EVENT_COUNT));
-
+                 .pollInterval(POLL_INTERVAL)
+                 .untilAsserted(() -> assertThat(distinctReceivedMatching("once-batch")).isEqualTo(EVENT_COUNT));
             // Hold past several reconcile ticks: a second node attaching late would push the total above
             // EVENT_COUNT, which a single sampled assertion would miss.
             sleep(Duration.ofSeconds(12));
-
-            assertThat(receivedMatching("once-batch"))
-                    .describedAs("no duplicate observed — exactly one node is assigned, and it stays the only one")
-                    .isEqualTo(EVENT_COUNT);
+            assertThat(receivedMatching("once-batch")).describedAs("no duplicate observed — exactly one node is assigned, and it stays the only one")
+                      .isEqualTo(EVENT_COUNT);
         }
     }
 
     @Nested
     class Observability {
-
         /// The operator surface must agree with reality: one attached subscription per PARTITION of
         /// each declared consumer's stream. With the slice on every node, owner-preference puts each
         /// partition on its own owner — never more, which is what a duplicate attach would look like.
         @Test
         void declarativeConsumersEndpoint_reportsOneAttachedSubscriptionPerPartition() {
-            assertThat(totalAttachedSubscriptions())
-                    .describedAs("one partition each for consumer-events and order-events, five for spread-events")
-                    .isEqualTo(EXPECTED_ATTACHMENTS);
+            assertThat(totalAttachedSubscriptions()).describedAs("one partition each for consumer-events and order-events, five for spread-events")
+                      .isEqualTo(EXPECTED_ATTACHMENTS);
         }
 
         /// Every node knows the declaration (it is cluster-wide KV), and the endpoint answers on all of
@@ -238,8 +211,8 @@ class DeclarativeStreamConsumerTest {
         @Test
         void declarativeConsumersEndpoint_answersOnEveryNode_namingStreamAndMethod() {
             var bodies = mgmtPorts().stream()
-                                    .map(port -> httpGet(port, "/api/v1/streams/declarative-consumers"))
-                                    .toList();
+                                  .map(port -> httpGet(port, "/api/v1/streams/declarative-consumers"))
+                                  .toList();
 
             assertThat(bodies).allSatisfy(body -> {
                 assertThat(body).doesNotContain("\"error\"");
@@ -267,7 +240,6 @@ class DeclarativeStreamConsumerTest {
     /// with "No codec registered for class" — before delivery is ever reached.
     @Nested
     class ApplicationTypedDelivery {
-
         /// The headline #526 assertion: publishing an app-defined record succeeds at all.
         @Test
         void publishOrder_succeeds_forApplicationDefinedEventType() {
@@ -276,9 +248,9 @@ class DeclarativeStreamConsumerTest {
                                     "{\"orderId\":\"order-probe\",\"customer\":\"acme\",\"amount\":7}");
 
             assertThat(response).describedAs("app-typed publish must succeed — before #526 this threw "
-                                             + "'No codec registered for class' because the publisher held the node codec")
-                                .doesNotContain("\"error\"")
-                                .contains("published");
+                                            + "'No codec registered for class' because the publisher held the node codec")
+                      .doesNotContain("\"error\"")
+                      .contains("published");
         }
 
         /// Both ends of the stream must resolve the slice codec: the publisher to ENCODE the record
@@ -288,12 +260,10 @@ class DeclarativeStreamConsumerTest {
             var baseline = settledCount(DeclarativeStreamConsumerTest.this::totalOrdersReceived);
 
             publishOrderBatch(ORDER_COUNT);
-
             await().atMost(DELIVERY_TIMEOUT)
-                   .pollInterval(POLL_INTERVAL)
-                   .untilAsserted(() -> assertThat(totalOrdersReceived() - baseline)
-                           .describedAs("every app-typed event must round-trip through the slice codec")
-                           .isEqualTo(ORDER_COUNT));
+                 .pollInterval(POLL_INTERVAL)
+                 .untilAsserted(() -> assertThat(totalOrdersReceived() - baseline).describedAs("every app-typed event must round-trip through the slice codec")
+                                                .isEqualTo(ORDER_COUNT));
         }
 
         /// The record's fields must survive encode/decode intact — delivery of a corrupted or
@@ -301,40 +271,39 @@ class DeclarativeStreamConsumerTest {
         @Test
         void declaredConsumer_preservesEveryRecordComponent_throughTheStream() {
             publishOrderBatch(ORDER_COUNT);
-
             await().atMost(DELIVERY_TIMEOUT)
-                   .pollInterval(POLL_INTERVAL)
-                   .untilAsserted(() -> assertThat(receivedOrdersBody())
-                           .describedAs("the decoded record must carry the published field values, not defaults")
-                           .contains("\"orderId\":\"order-0\"")
-                           .contains("\"customer\":\"customer-0\"")
-                           .contains("\"amount\":100"));
+                 .pollInterval(POLL_INTERVAL)
+                 .untilAsserted(() -> assertThat(receivedOrdersBody()).describedAs("the decoded record must carry the published field values, not defaults")
+                                                .contains("\"orderId\":\"order-0\"")
+                                                .contains("\"customer\":\"customer-0\"")
+                                                .contains("\"amount\":100"));
         }
 
         /// The operator surface must stop warning about app types now that they genuinely publish.
         @Test
         void declarativeConsumersEndpoint_reportsEventTypePublishable_forApplicationType() {
             var fragments = mgmtPorts().stream()
-                                       .map(port -> consumerFragment(httpGet(port, "/api/v1/streams/declarative-consumers"),
-                                                                     ORDER_EVENTS_STREAM))
-                                       .filter(fragment -> !fragment.isEmpty())
-                                       .toList();
+                                     .map(port -> consumerFragment(httpGet(port, "/api/v1/streams/declarative-consumers"),
+                                                                   ORDER_EVENTS_STREAM))
+                                     .filter(fragment -> !fragment.isEmpty())
+                                     .toList();
 
             assertThat(fragments).describedAs("every node knows the app-typed declaration — it is cluster-wide KV")
-                                 .isNotEmpty();
+                      .isNotEmpty();
             assertThat(fragments).allSatisfy(fragment -> {
                 assertThat(fragment).describedAs("the slice's own codec registers OrderPlaced, so it IS publishable")
-                                    .contains("\"eventTypePublishable\":true");
+                          .contains("\"eventTypePublishable\":true");
                 assertThat(fragment).doesNotContain("cannot be PUBLISHED");
             });
         }
     }
 
     // --- publish / receive ---------------------------------------------------
-
     private void publishBatch(String prefix, int count) {
         for (var i = 0; i < count; i++) {
-            var response = httpPost(appPort(), "/api/stream-consumer/publish", "{\"payload\":\"" + prefix + "-" + i + "\"}");
+            var response = httpPost(appPort(),
+                                    "/api/stream-consumer/publish",
+                                    "{\"payload\":\"" + prefix + "-" + i + "\"}");
 
             assertThat(response).describedAs("publish must succeed").contains("published");
         }
@@ -359,7 +328,8 @@ class DeclarativeStreamConsumerTest {
         return (int) cluster.getAvailableAppHttpPorts()
                             .stream()
                             .map(port -> httpPost(port, "/api/stream-consumer/received", "{}"))
-                            .flatMap(body -> pattern.matcher(body).results())
+                            .flatMap(body -> pattern.matcher(body)
+                                                    .results())
                             .map(match -> match.group(1))
                             .distinct()
                             .count();
@@ -379,7 +349,10 @@ class DeclarativeStreamConsumerTest {
 
     private void publishOrderBatch(int count) {
         for (var i = 0; i < count; i++) {
-            var body = "{\"orderId\":\"order-" + i + "\",\"customer\":\"customer-" + i + "\",\"amount\":" + (100 + i) + "}";
+            var body = "{\"orderId\":\"order-" + i
+                     + "\",\"customer\":\"customer-" + i
+                     + "\",\"amount\":" + (100 + i)
+                     + "}";
             var response = httpPost(appPort(), "/api/stream-consumer/publish-order", body);
 
             assertThat(response).describedAs("app-typed publish must succeed").contains("published");
@@ -415,8 +388,9 @@ class DeclarativeStreamConsumerTest {
         var lastSample = new AtomicInteger(-1);
 
         await().atMost(DELIVERY_TIMEOUT)
-               .pollInterval(POLL_INTERVAL)
-               .until(() -> isRepeatSample(lastSample, counter.getAsInt()));
+             .pollInterval(POLL_INTERVAL)
+             .until(() -> isRepeatSample(lastSample,
+                                         counter.getAsInt()));
 
         return lastSample.get();
     }
@@ -427,17 +401,18 @@ class DeclarativeStreamConsumerTest {
 
     private int totalAttachedSubscriptions() {
         return mgmtPorts().stream()
-                          .map(port -> httpGet(port, "/api/v1/streams/declarative-consumers"))
-                          .mapToInt(body -> firstInt(ATTACHED_FIELD, body))
-                          .sum();
+                        .map(port -> httpGet(port, "/api/v1/streams/declarative-consumers"))
+                        .mapToInt(body -> firstInt(ATTACHED_FIELD, body))
+                        .sum();
     }
 
     /// True once SOME node reports a live subscription for `stream`. Per-stream, because the
     /// aggregate count cannot distinguish "both consumers attached" from "one attached twice".
     private boolean consumerAttachedFor(String stream) {
         return mgmtPorts().stream()
-                          .map(port -> consumerFragment(httpGet(port, "/api/v1/streams/declarative-consumers"), stream))
-                          .anyMatch(fragment -> fragment.contains("\"assignedPartitions\""));
+                        .map(port -> consumerFragment(httpGet(port, "/api/v1/streams/declarative-consumers"),
+                                                      stream))
+                        .anyMatch(fragment -> fragment.contains("\"assignedPartitions\""));
     }
 
     /// The slice of the declarative-consumers JSON describing one stream. Substring-scoped rather than
@@ -452,9 +427,10 @@ class DeclarativeStreamConsumerTest {
 
     private int ownerMgmtPort() {
         return mgmtPorts().stream()
-                          .filter(port -> firstInt(ATTACHED_FIELD, httpGet(port, "/api/v1/streams/declarative-consumers")) > 0)
-                          .findFirst()
-                          .orElseThrow(() -> new AssertionError("No node reports an attached declarative consumer"));
+                        .filter(port -> firstInt(ATTACHED_FIELD,
+                                                 httpGet(port, "/api/v1/streams/declarative-consumers")) > 0)
+                        .findFirst()
+                        .orElseThrow(() -> new AssertionError("No node reports an attached declarative consumer"));
     }
 
     private static int firstInt(Pattern pattern, String body) {
@@ -466,7 +442,6 @@ class DeclarativeStreamConsumerTest {
     }
 
     // --- deployment + readiness ---------------------------------------------
-
     private void deployConsumerSlice() {
         var blueprint = """
             id = "%s"
@@ -479,8 +454,8 @@ class DeclarativeStreamConsumerTest {
         var response = httpPostToml(leaderPort, "/api/v1/blueprints", blueprint);
 
         assertThat(response).describedAs("declarative-consumer slice deployment")
-                            .doesNotContain("\"error\"")
-                            .contains("\"status\":\"applied\"");
+                  .doesNotContain("\"error\"")
+                  .contains("\"status\":\"applied\"");
     }
 
     private boolean appHttpReady() {
@@ -492,7 +467,7 @@ class DeclarativeStreamConsumerTest {
 
         var body = httpPost(ports.getFirst(), "/api/stream-consumer/received", "{}");
 
-        return !body.contains("\"error\"") && body.contains("count");
+        return ! body.contains("\"error\"") && body.contains("count");
     }
 
     private boolean publishReady() {
@@ -504,13 +479,15 @@ class DeclarativeStreamConsumerTest {
 
         var response = httpPost(ports.getFirst(), "/api/stream-consumer/publish", "{\"payload\":\"__warmup__\"}");
 
-        return !response.contains("\"error\"") && response.contains("published");
+        return ! response.contains("\"error\"") && response.contains("published");
     }
 
     private void failIfSliceFailed() {
         var failed = cluster.slicesStatus()
                             .stream()
-                            .anyMatch(status -> status.artifact().equals(CONSUMER_SLICE) && status.state().equals("FAILED"));
+                            .anyMatch(status -> status.artifact()
+                                                      .equals(CONSUMER_SLICE) && status.state()
+                                                                                       .equals("FAILED"));
 
         if (failed) {
             throw new AssertionError("Declarative-consumer slice deployment FAILED: " + CONSUMER_SLICE);
@@ -533,7 +510,10 @@ class DeclarativeStreamConsumerTest {
     }
 
     private int anyMgmtPort() {
-        return cluster.status().nodes().getFirst().mgmtPort();
+        return cluster.status()
+                      .nodes()
+                      .getFirst()
+                      .mgmtPort();
     }
 
     private boolean allNodesHealthy() {
@@ -552,7 +532,8 @@ class DeclarativeStreamConsumerTest {
 
         return http.sendString(request)
                    .await()
-                   .map(response -> response.statusCode() == 200 && response.body().contains("\"quorum\":true"))
+                   .map(response -> response.statusCode() == 200 && response.body()
+                                                                            .contains("\"quorum\":true"))
                    .or(false);
     }
 
@@ -561,7 +542,6 @@ class DeclarativeStreamConsumerTest {
     }
 
     // --- HTTP ----------------------------------------------------------------
-
     private String httpPostToml(int port, String path, String body) {
         var request = HttpRequest.newBuilder()
                                  .uri(URI.create("http://localhost:" + port + path))

--- a/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/DurableEntityForgeTest.java
+++ b/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/DurableEntityForgeTest.java
@@ -2,26 +2,7 @@
 // Copyright (c) 2025 Pragmatica Labs - Sergiy Yevtushenko
 // Licensed under Business Source License 1.1. Change Date: 2030-01-01. Change License: Apache-2.0.
 // See LICENSE in the repository root for full terms.
-
 package org.pragmatica.aether.forge;
-
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.MethodOrderer;
-import org.junit.jupiter.api.Order;
-import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
-import org.junit.jupiter.api.TestMethodOrder;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
-import org.pragmatica.aether.dht.EntityPartitionArc;
-import org.pragmatica.aether.ember.EmberCluster;
-import org.pragmatica.config.ConfigurationProvider;
-import org.pragmatica.http.HttpOperations;
-import org.pragmatica.http.HttpResult;
-import org.awaitility.core.ConditionTimeoutException;
-import org.pragmatica.lang.Option;
 
 import java.net.URI;
 import java.net.http.HttpRequest;
@@ -37,10 +18,30 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.LockSupport;
 import java.util.regex.Pattern;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.awaitility.Awaitility.await;
+import org.pragmatica.aether.dht.EntityPartitionArc;
+import org.pragmatica.aether.ember.EmberCluster;
+import org.pragmatica.config.ConfigurationProvider;
+import org.pragmatica.http.HttpOperations;
+import org.pragmatica.http.HttpResult;
+import org.pragmatica.lang.Option;
+
+import org.awaitility.core.ConditionTimeoutException;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+
 import static org.pragmatica.aether.ember.EmberCluster.emberCluster;
 import static org.pragmatica.http.JdkHttpOperations.jdkHttpOperations;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
 
 /// #345 increment I0 — a `DurableEntity` that actually RUNS inside a node, and a measured baseline
 /// of what it does today.
@@ -118,7 +119,6 @@ import static org.pragmatica.http.JdkHttpOperations.jdkHttpOperations;
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 class DurableEntityForgeTest {
     private static final System.Logger LOG = System.getLogger(DurableEntityForgeTest.class.getName());
-
     private static final int BASE_PORT = 19000;
     private static final int BASE_MGMT_PORT = 19100;
     private static final int BASE_APP_HTTP_PORT = 19200;
@@ -135,28 +135,25 @@ class DurableEntityForgeTest {
 
     /// The SAME partition function production uses, so a key can be mapped to the arc whose committed owner
     /// [#entityArcOwners] reports. Re-deriving it here would only test this test's own arithmetic.
-    private static final EntityPartitionArc ENTITY_ARC = EntityPartitionArc.entityPartitionArc("orders", ENTITY_PARTITIONS);
+    private static final EntityPartitionArc ENTITY_ARC = EntityPartitionArc.entityPartitionArc("orders",
+                                                                                               ENTITY_PARTITIONS);
 
     private static final Duration WAIT_TIMEOUT = Duration.ofSeconds(240);
     private static final Duration POLL_INTERVAL = Duration.ofMillis(500);
-
     /// The delay [#scheduleTimer_appliesTheEffectExactlyOnce_whenTheSameTokenIsResent] schedules under. It
     /// only has to outlive the five presentations of the one token — the timer must still be pending when
     /// the last of them arrives, or that one plants a fresh timer and the gate measures the wrong thing.
     /// Five sequential localhost posts (four of them forwarded a hop) measure 5-15 ms, so 8s is nearly three
     /// orders of magnitude of margin, and the test asserts the measured figure against a quarter of it.
     private static final long RESEND_DELAY_MILLIS = 8_000L;
-
     /// Ticks to wait out before declaring a fire exactly-once. `ENTITY_TIMER_INTERVAL` is one second, so a
     /// duplicate timer planted alongside the first would come due within one tick of it; five gives four
     /// spare ticks for the second fire that must not happen to happen.
     private static final Duration EXACTLY_ONCE_SETTLE = Duration.ofSeconds(5);
-
     private static final String ENTITY_SLICE = TestArtifacts.ENTITY_SLICE;
     private static final String BLUEPRINT_ID = "forge.test:durable-entity:1.0.0";
     private static final String ERROR_FALLBACK = "{\"error\":\"request failed\"}";
     private static final int REASON_EXCERPT_LIMIT = 300;
-
     /// Distinct probe keys per convergence round. The fixture declares 8 partitions, and these keys hash
     /// across them, so readiness reflects the whole keyspace rather than whichever partition one key
     /// happened to land on.
@@ -176,27 +173,17 @@ class DurableEntityForgeTest {
                                                   .withSystemProperties("aether.")
                                                   .withEnvironment("AETHER_")
                                                   .build();
+
         cluster = emberCluster(NODES, BASE_PORT, BASE_MGMT_PORT, BASE_APP_HTTP_PORT, "dur", Option.some(configProvider));
-        cluster.start()
-               .await()
-               .onFailure(cause -> {
-                   throw new AssertionError("Cluster start failed: " + cause.message());
-               });
-
-        await().atMost(WAIT_TIMEOUT)
-               .pollInterval(POLL_INTERVAL)
-               .until(() -> cluster.currentLeader().isPresent());
-
-        await().atMost(WAIT_TIMEOUT)
-               .pollInterval(POLL_INTERVAL)
-               .until(this::allNodesHealthy);
-
+        LifecycleAwait.settled("cluster start in setUp()", cluster, cluster.start());
+        await().atMost(WAIT_TIMEOUT).pollInterval(POLL_INTERVAL).until(() -> cluster.currentLeader()
+                                                                                    .isPresent());
+        await().atMost(WAIT_TIMEOUT).pollInterval(POLL_INTERVAL).until(this::allNodesHealthy);
         deployEntitySlice();
-
         await().atMost(WAIT_TIMEOUT)
-               .pollInterval(POLL_INTERVAL)
-               .failFast(this::failIfSliceFailed)
-               .until(this::entityReadyOnEveryNode);
+             .pollInterval(POLL_INTERVAL)
+             .failFast(this::failIfSliceFailed)
+             .until(this::entityReadyOnEveryNode);
         // Placement converges LATER than entity readiness, and the gap is wide enough to be read as a
         // defect. Measured on 2026-08-27: the scheduler's first pass placed 2 of the 3 requested instances,
         // the reconciler logged "has 2 instances, desired 3 - adjusting" 52s after deploy, and the third
@@ -219,12 +206,13 @@ class DurableEntityForgeTest {
     private void awaitFullSlicePlacement() {
         try {
             await().atMost(WAIT_TIMEOUT)
-                   .pollInterval(POLL_INTERVAL)
-                   .failFast(this::failIfSliceFailed)
-                   .until(() -> activeSliceHosts().size() == INSTANCES);
+                 .pollInterval(POLL_INTERVAL)
+                 .failFast(this::failIfSliceFailed)
+                 .until(() -> activeSliceHosts().size() == INSTANCES);
         } catch (ConditionTimeoutException e) {
-            throw new AssertionError("Slice placement never reached " + INSTANCES + " ACTIVE instances; hosts seen: "
-                                     + activeSliceHosts(), e);
+            throw new AssertionError("Slice placement never reached " + INSTANCES
+                                    + " ACTIVE instances; hosts seen: " + activeSliceHosts(),
+                                     e);
         }
     }
 
@@ -237,11 +225,12 @@ class DurableEntityForgeTest {
     private void awaitOwnershipConvergence() {
         try {
             await().atMost(WAIT_TIMEOUT)
-                   .pollInterval(POLL_INTERVAL)
-                   .failFast(this::failIfSliceFailed)
-                   .until(this::ownershipHasConverged);
+                 .pollInterval(POLL_INTERVAL)
+                 .failFast(this::failIfSliceFailed)
+                 .until(this::ownershipHasConverged);
         } catch (ConditionTimeoutException e) {
-            throw new AssertionError("Entity ownership never converged; last probe answers: " + lastProbeAnswers.get(), e);
+            throw new AssertionError("Entity ownership never converged; last probe answers: " + lastProbeAnswers.get(),
+                                     e);
         }
     }
 
@@ -251,13 +240,11 @@ class DurableEntityForgeTest {
             var leaderPort = cluster.getLeaderManagementPort().or(anyMgmtPort());
 
             httpDelete(leaderPort, "/api/v1/blueprints/" + BLUEPRINT_ID);
-            cluster.stop()
-                   .await();
+            LifecycleAwait.settled("cluster stop in tearDown()", cluster, cluster.stop());
         }
     }
 
     // --- the API surface actually executes ------------------------------------
-
     /// The 02w hosting-set pin, asserted directly: every committed `entity:orders` arc owner is a node
     /// hosting an ACTIVE instance of the entity slice. Before the fix the leader minted owners over ALL
     /// members, so with 3 instances on 5 nodes roughly two-fifths of the arcs landed on nodes with no
@@ -272,13 +259,13 @@ class DurableEntityForgeTest {
         var owners = entityArcOwners();
 
         assertThat(hosts).describedAs("the blueprint places fewer instances than nodes, else this pin is vacuous")
-                         .hasSize(INSTANCES);
+                  .hasSize(INSTANCES);
         assertThat(owners).describedAs("every entity partition must carry a committed ownership record")
-                          .hasSize(ENTITY_PARTITIONS);
+                  .hasSize(ENTITY_PARTITIONS);
         assertThat(owners.entrySet()).describedAs("every arc owner must host the declaring slice; owners=%s hosts=%s",
                                                   owners,
                                                   hosts)
-                                     .allSatisfy(entry -> assertThat(hosts).contains(entry.getValue()));
+                  .allSatisfy(entry -> assertThat(hosts).contains(entry.getValue()));
     }
 
     /// The headline I0 assertion: a durable entity provisioned from `resources.toml` accepts a
@@ -299,7 +286,6 @@ class DurableEntityForgeTest {
     @Order(2)
     void get_returnsTheCreatedState_onTheSameNode() {
         var owner = createOnOwner("order-get", "placed", 250).port();
-
         var response = get(owner, "order-get");
 
         assertThat(outcome(response)).isEqualTo("found");
@@ -313,14 +299,14 @@ class DurableEntityForgeTest {
     @Order(3)
     void update_commitsTheMutatedState_forExistingKey() {
         var owner = createOnOwner("order-update", "placed", 10).port();
-
         var updated = update(owner, "order-update", 999);
 
         assertThat(outcome(updated)).isEqualTo("updated");
         assertThat(number(updated, "amount")).isEqualTo(999);
         assertThat(text(updated, "status")).describedAs("the mutator changes amount only").isEqualTo("placed");
-        assertThat(number(get(owner, "order-update"), "amount")).describedAs("the mutation is committed, not just returned")
-                                                                 .isEqualTo(999);
+        assertThat(number(get(owner, "order-update"),
+                          "amount")).describedAs("the mutation is committed, not just returned")
+                  .isEqualTo(999);
     }
 
     /// Delete removes the instance, and the subsequent read reports absence rather than failing.
@@ -334,7 +320,6 @@ class DurableEntityForgeTest {
     }
 
     // --- typed failures are real, not decorative -------------------------------
-
     /// `EntityAlreadyExists` is enforced, so the entity genuinely holds state rather than accepting
     /// every write. This is the sensor that stops the whole suite from passing against a no-op
     /// implementation.
@@ -342,7 +327,6 @@ class DurableEntityForgeTest {
     @Order(5)
     void create_failsWithKeyAlreadyExists_forDuplicateKeyOnOneNode() {
         var owner = createOnOwner("order-duplicate", "placed", 1).port();
-
         var duplicate = create(owner, "order-duplicate", "placed", 2);
 
         assertThat(outcome(duplicate)).isEqualTo("failed");
@@ -357,11 +341,12 @@ class DurableEntityForgeTest {
     @Order(6)
     void update_failsWithKeyNotFound_forUnknownKey() {
         var failureTypes = appPorts().stream()
-                                     .map(port -> text(update(port, "order-never-created", 1), "failureType"))
-                                     .toList();
+                                   .map(port -> text(update(port, "order-never-created", 1),
+                                                     "failureType"))
+                                   .toList();
 
         assertThat(failureTypes).describedAs("every caller receives the owner's typed verdict through the forward (#596)")
-                                .containsOnly("EntityNotFound");
+                  .containsOnly("EntityNotFound");
     }
 
     @Test
@@ -370,7 +355,6 @@ class DurableEntityForgeTest {
         var owner = createOnOwner("order-double-delete", "placed", 1).port();
 
         delete(owner, "order-double-delete");
-
         var repeated = delete(owner, "order-double-delete");
 
         assertThat(outcome(repeated)).isEqualTo("failed");
@@ -402,52 +386,39 @@ class DurableEntityForgeTest {
     @Order(8)
     void scheduleTimer_succeedsOnEveryNode_includingInstancesThatCannotBeTheCommittedOwner() {
         createOnOwner("order-timer", "placed", 1);
-
         var partition = ENTITY_ARC.partitionOf("order-timer");
 
         assertThat(entityArcOwners()).describedAs("the key's partition must carry a committed owner, else 'an instance "
-                                                  + "that cannot be the owner' names nothing")
-                                     .containsKey(partition);
-
-        var responses = appPorts().stream()
-                                  .map(port -> scheduleTimer(port, "order-timer"))
-                                  .toList();
+                                                 + "that cannot be the owner' names nothing")
+                  .containsKey(partition);
+        var responses = appPorts().stream().map(port -> scheduleTimer(port, "order-timer")).toList();
 
         assertThat(responses).describedAs("every node must answer a schedule, the owner locally and the rest by forwarding")
-                             .hasSize(NODES);
+                  .hasSize(NODES);
         assertThat(responses).allSatisfy(response -> {
             assertThat(outcome(response)).describedAs("timers are real after I4 — a refusal here is the regression")
-                                         .isEqualTo("scheduled");
+                      .isEqualTo("scheduled");
             assertThat(text(response, "token")).describedAs("a scheduled timer must come back with the handle that cancels it")
-                                               .isNotEmpty();
+                      .isNotEmpty();
         });
-
-        var tokens = responses.stream()
-                              .map(response -> text(response, "token"))
-                              .distinct()
-                              .toList();
+        var tokens = responses.stream().map(response -> text(response, "token")).distinct().toList();
 
         assertThat(tokens).describedAs("five schedules with no caller token are five timers, each with its own handle")
-                          .hasSize(NODES);
-
-        var instances = responses.stream()
-                                 .map(response -> text(response, "instance"))
-                                 .distinct()
-                                 .toList();
+                  .hasSize(NODES);
+        var instances = responses.stream().map(response -> text(response, "instance")).distinct().toList();
 
         LOG.log(System.Logger.Level.INFO,
                 "I4 forwarding gate: nodes={0} committedOwner={1} distinctServingInstances={2}",
                 NODES,
                 entityArcOwners().get(partition),
                 instances.size());
-
         assertThat(instances).describedAs("more than one slice instance must have answered: a node hosts at most one, and "
-                                          + "the partition asserted above has a single committed owner, so a second "
-                                          + "instance answering 'scheduled' is a non-owner that relayed instead of "
-                                          + "refusing. All five served by one instance would leave that untested; "
-                                          + "instances=%s",
+                                         + "the partition asserted above has a single committed owner, so a second "
+                                         + "instance answering 'scheduled' is a non-owner that relayed instead of "
+                                         + "refusing. All five served by one instance would leave that untested; "
+                                         + "instances=%s",
                                           instances)
-                             .hasSizeGreaterThan(1);
+                  .hasSizeGreaterThan(1);
     }
 
     /// The retry-after-lost-ack gate, at cluster level: a schedule RE-SENT under the same token is the same
@@ -481,33 +452,29 @@ class DurableEntityForgeTest {
     @Order(9)
     void scheduleTimer_appliesTheEffectExactlyOnce_whenTheSameTokenIsResent() {
         createOnOwner("order-timer-resend", "placed", 500);
-
         var token = "resent-" + UUID.randomUUID();
         var startNanos = System.nanoTime();
         var responses = appPorts().stream()
-                                  .map(port -> scheduleTimer(port, "order-timer-resend", RESEND_DELAY_MILLIS, token))
-                                  .toList();
+                                .map(port -> scheduleTimer(port, "order-timer-resend", RESEND_DELAY_MILLIS, token))
+                                .toList();
         var presentationMillis = Duration.ofNanos(System.nanoTime() - startNanos).toMillis();
 
         assertThat(presentationMillis).describedAs("all five presentations must land while the timer is still pending, "
-                                                   + "else the later ones plant fresh timers and prove nothing")
-                                      .isLessThan(RESEND_DELAY_MILLIS / 4);
-
+                                                  + "else the later ones plant fresh timers and prove nothing")
+                  .isLessThan(RESEND_DELAY_MILLIS / 4);
         LOG.log(System.Logger.Level.INFO,
                 "I4 resend gate: delay={0}ms fivePresentations={1}ms",
                 RESEND_DELAY_MILLIS,
                 presentationMillis);
         assertThat(responses).allSatisfy(response -> {
             assertThat(outcome(response)).describedAs("a re-sent schedule is the same schedule, and answers success")
-                                         .isEqualTo("scheduled");
+                      .isEqualTo("scheduled");
             assertThat(text(response, "token")).describedAs("the owner must echo the CALLER's token, not one of its own")
-                                               .isEqualTo(token);
+                      .isEqualTo(token);
         });
-
         await().atMost(WAIT_TIMEOUT)
-               .pollInterval(POLL_INTERVAL)
-               .until(() -> expiriesAcrossCluster("order-timer-resend").contains(1));
-
+             .pollInterval(POLL_INTERVAL)
+             .until(() -> expiriesAcrossCluster("order-timer-resend").contains(1));
         // A duplicate arrives on a LATER tick, so a reading taken at the moment of the fire cannot tell
         // exactly-once from not-yet-twice. There is no condition to poll for the absence of a second fire —
         // only elapsed ticks — so this waits out a quiet period and then re-reads.
@@ -516,20 +483,18 @@ class DurableEntityForgeTest {
 
         assertThat(counts).describedAs("at least one node must serve the key after the fire").isNotEmpty();
         assertThat(counts).describedAs("five presentations of ONE token are one timer, so Expire lands once — "
-                                       + "a second timer would show as 2 on whichever node folded both fires")
-                          .allSatisfy(count -> assertThat(count).isLessThanOrEqualTo(1));
+                                      + "a second timer would show as 2 on whichever node folded both fires")
+                  .allSatisfy(count -> assertThat(count).isLessThanOrEqualTo(1));
         assertThat(counts).describedAs("and the fire did land, on some node's committed view").contains(1);
-
         var settled = servedView("order-timer-resend");
 
         assertThat(text(settled, "status")).describedAs("the fire is a real mutation, applied through the ordinary update path")
-                                           .isEqualTo("expired");
+                  .isEqualTo("expired");
         assertThat(number(settled, "amount")).describedAs("Expire touches the counter and the status only")
-                                             .isEqualTo(500);
+                  .isEqualTo(500);
     }
 
     // --- replication and durability, across nodes --------------------------------
-
     /// More than ONE slice instance answers a key with the value that was written, after a create on a
     /// single node.
     ///
@@ -552,30 +517,21 @@ class DurableEntityForgeTest {
     void get_isServedByMoreThanOneNode_afterCreateOnOne() {
         var accepted = createOnOwner("order-isolated", "placed", 42);
         var ownerInstance = text(accepted.response(), "instance");
-
         // Polled, not sampled: a replica serves only once it has folded the partition, and taking one
         // reading immediately after the create would measure the fold's latency rather than whether the
         // key is answerable cluster-wide at all.
-        await().atMost(WAIT_TIMEOUT)
-               .pollInterval(POLL_INTERVAL)
-               .until(() -> serversOf("order-isolated").size() > 1);
-
+        await().atMost(WAIT_TIMEOUT).pollInterval(POLL_INTERVAL).until(() -> serversOf("order-isolated").size() > 1);
         var servers = serversOf("order-isolated");
 
         assertThat(servers).describedAs("more than the accepting node must answer the key — from its own fold if it "
-                                        + "holds the partition, by forwarding to the owner if it does not")
-                           .hasSizeGreaterThan(1);
-
-        var instances = servers.stream()
-                               .map(response -> text(response, "instance"))
-                               .distinct()
-                               .toList();
+                                       + "holds the partition, by forwarding to the owner if it does not")
+                  .hasSizeGreaterThan(1);
+        var instances = servers.stream().map(response -> text(response, "instance")).distinct().toList();
 
         assertThat(instances).describedAs("the answers must come from DIFFERENT slice instances, else the test is vacuous")
-                             .hasSizeGreaterThan(1);
+                  .hasSizeGreaterThan(1);
         assertThat(instances).describedAs("and one of them is not the node that accepted the write")
-                             .anySatisfy(instance -> assertThat(instance).isNotEqualTo(ownerInstance));
-
+                  .anySatisfy(instance -> assertThat(instance).isNotEqualTo(ownerInstance));
         // The value is the assertion. A replica that answered with anything other than what was written
         // would be worse than one that refused.
         assertThat(servers).allSatisfy(response -> {
@@ -591,9 +547,9 @@ class DurableEntityForgeTest {
     /// names a node that answered, not necessarily one that holds the state.
     private List<String> serversOf(String key) {
         return appPorts().stream()
-                         .map(port -> get(port, key))
-                         .filter(response -> response.contains("\"outcome\":\"found\""))
-                         .toList();
+                       .map(port -> get(port, key))
+                       .filter(response -> response.contains("\"outcome\":\"found\""))
+                       .toList();
     }
 
     /// The I1 gate, flipped — then flipped once more by #596. At I0 all five nodes accepted a create for
@@ -632,60 +588,53 @@ class DurableEntityForgeTest {
         var ownerPort = createOnOwner("order-durability", "placed", 77).port();
 
         assertThat(outcome(get(ownerPort, "order-durability"))).isEqualTo("found");
-
         var ownerNodeId = nodeIdForAppPort(ownerPort);
 
-        cluster.killNode(ownerNodeId)
-               .await()
-               .onFailure(cause -> {
-                   throw new AssertionError("Failed to stop node " + ownerNodeId + ": " + cause.message());
-               });
-
-        await().atMost(WAIT_TIMEOUT)
-               .pollInterval(POLL_INTERVAL)
-               .until(() -> !appPorts().contains(ownerPort));
-
+        LifecycleAwait.nodeSettled("kill node " + ownerNodeId + " in state_survivesTheLossOfTheNodeThatOwnedIt()",
+                                   cluster,
+                                   cluster.killNode(ownerNodeId));
+        await().atMost(WAIT_TIMEOUT).pollInterval(POLL_INTERVAL).until(() -> !appPorts().contains(ownerPort));
         // Ownership must move and the new owner must rebuild the partition from the log before it can
         // answer, so the read is POLLED rather than taken once. A fold in progress reports itself as a
         // transient refusal — polling is what distinguishes "still replaying" from "gone", and taking a
         // single reading immediately after the kill would conflate them.
         await().atMost(WAIT_TIMEOUT)
-               .pollInterval(POLL_INTERVAL)
-               .until(() -> survivorsAnswering("order-durability").contains("found"));
-
+             .pollInterval(POLL_INTERVAL)
+             .until(() -> survivorsAnswering("order-durability").contains("found"));
         // Assert on the DATA, not on a status field. #508 passed throughout a run in which a status-gated
         // test failed on the same cluster at the same moment; the value is the thing that either survived
         // or did not.
         var recovered = appPorts().stream()
-                                  .map(port -> get(port, "order-durability"))
-                                  .filter(response -> "found".equals(outcome(response)))
-                                  .toList();
+                                .map(port -> get(port, "order-durability"))
+                                .filter(response -> "found".equals(outcome(response)))
+                                .toList();
 
         assertThat(recovered).describedAs("at least one surviving node must serve the entity after failover")
-                             .isNotEmpty();
+                  .isNotEmpty();
         assertThat(recovered).allSatisfy(response -> {
             assertThat(text(response, "status")).describedAs("the recovered state must be the state that was written")
-                                                .isEqualTo("placed");
+                      .isEqualTo("placed");
             assertThat(number(response, "amount")).describedAs("the recovered amount must be the amount that was written")
-                                                  .isEqualTo(77);
+                      .isEqualTo(77);
         });
     }
 
     private List<String> survivorsAnswering(String key) {
         return appPorts().stream()
-                         .map(port -> get(port, key))
-                         .map(DurableEntityForgeTest::outcomeOrPending)
-                         .toList();
+                       .map(port -> get(port, key))
+                       .map(DurableEntityForgeTest::outcomeOrPending)
+                       .toList();
     }
 
     /// `outcome` throws on a transport-level error body, and this runs while ownership is still moving, so
     /// a node mid-handover would abort the poll instead of simply reporting "not yet".
     private static String outcomeOrPending(String response) {
-        return response.contains("\"outcome\":\"found\"") ? "found" : "pending";
+        return response.contains("\"outcome\":\"found\"")
+               ? "found"
+               : "pending";
     }
 
     // --- the fence invariant, asserted on every create ---------------------------
-
     /// The port that accepted a create, plus its response body.
     private record Accepted(int port, String response) {}
 
@@ -707,20 +656,16 @@ class DurableEntityForgeTest {
     /// committed owner — a real defect once setUp has waited for convergence — and `containsOnly`
     /// fails it explicitly rather than lumping it in with "not created".
     private Accepted createOnOwner(String key, String status, int amount) {
-        var responses = appPorts().stream()
-                                  .map(port -> new Accepted(port, create(port, key, status, amount)))
-                                  .toList();
-        var accepted = responses.stream()
-                                .filter(entry -> "created".equals(outcome(entry.response())))
-                                .toList();
+        var responses = appPorts().stream().map(port -> new Accepted(port, create(port, key, status, amount))).toList();
+        var accepted = responses.stream().filter(entry -> "created".equals(outcome(entry.response()))).toList();
 
         assertThat(responses).describedAs("every node must have answered").hasSize(NODES);
         assertThat(accepted).describedAs("exactly one attempt may create '%s'; got %s",
-                                          key,
-                                          outcomesOf(responses))
-                            .hasSize(1);
+                                         key,
+                                         outcomesOf(responses))
+                  .hasSize(1);
         assertThat(rejectionTypesOf(responses)).describedAs("every later attempt must surface the duplicate as EntityAlreadyExists — its forward reached the owner and the single-writer invariant held (#596)")
-                                               .containsOnly("EntityAlreadyExists");
+                  .containsOnly("EntityAlreadyExists");
 
         return accepted.getFirst();
     }
@@ -734,7 +679,8 @@ class DurableEntityForgeTest {
     private static List<String> rejectionTypesOf(List<Accepted> responses) {
         return responses.stream()
                         .filter(entry -> !"created".equals(outcome(entry.response())))
-                        .map(entry -> text(entry.response(), "failureType"))
+                        .map(entry -> text(entry.response(),
+                                           "failureType"))
                         .toList();
     }
 
@@ -754,26 +700,25 @@ class DurableEntityForgeTest {
         var round = ownershipProbe.incrementAndGet();
 
         return java.util.stream.IntStream.range(0, PARTITION_PROBE_KEYS)
-                                         .allMatch(index -> probeAccepted("__ownership_probe_" + round + "_" + index + "__"));
+                                         .allMatch(index -> probeAccepted("__ownership_probe_" + round
+                                                                         + "_" + index
+                                                                         + "__"));
     }
 
     private boolean probeAccepted(String key) {
-
         // Deliberately NOT via outcome(): that throws on a transport-level error body, and this predicate
         // runs while the cluster is still settling, so one slow node would abort setUp instead of simply
         // reporting "not converged yet". A failed request is not-yet-converged; only a literal accepted
         // create counts.
-        var answers = appPorts().stream()
-                                .map(port -> create(port, key, "probe", 0))
-                                .toList();
+        var answers = appPorts().stream().map(port -> create(port, key, "probe", 0)).toList();
 
         lastProbeAnswers.set(answers);
 
-        return answers.stream().anyMatch(response -> response.contains("\"outcome\":\"created\""));
+        return answers.stream()
+                      .anyMatch(response -> response.contains("\"outcome\":\"created\""));
     }
 
     // --- entity operations -----------------------------------------------------
-
     private String create(int port, String key, String status, int amount) {
         return httpPost(port,
                         "/api/v1/entity/create",
@@ -816,15 +761,15 @@ class DurableEntityForgeTest {
     /// and this sees all of them.
     private List<Integer> expiriesAcrossCluster(String key) {
         return serversOf(key).stream()
-                             .map(response -> number(response, "expiries"))
-                             .toList();
+                        .map(response -> number(response, "expiries"))
+                        .toList();
     }
 
     /// One serving node's view of `key`, for reading components other than the count.
     private String servedView(String key) {
         return serversOf(key).stream()
-                             .findFirst()
-                             .orElseThrow(() -> new AssertionError("No node serves '" + key + "'"));
+                        .findFirst()
+                        .orElseThrow(() -> new AssertionError("No node serves '" + key + "'"));
     }
 
     /// Wait out a fixed span. Deliberately a sleep and not a poll: what is being waited for is the ABSENCE
@@ -854,15 +799,13 @@ class DurableEntityForgeTest {
                 "I4 quiet period: requested={0}ms elapsed={1}ms",
                 span.toMillis(),
                 elapsedMillis);
-
         assertThat(elapsedMillis).describedAs("the quiet period must actually elapse — a residual unpark permit left by "
-                                              + "Promise.await() makes a bare park return at once, which would reduce the "
-                                              + "exactly-once assertion below to a re-read of the value just polled for")
-                                 .isGreaterThanOrEqualTo(span.toMillis());
+                                             + "Promise.await() makes a bare park return at once, which would reduce the "
+                                             + "exactly-once assertion below to a re-read of the value just polled for")
+                  .isGreaterThanOrEqualTo(span.toMillis());
     }
 
     // --- response reading -------------------------------------------------------
-
     /// Fails loudly on a missing field rather than returning "": a renamed component would otherwise
     /// turn every `isEqualTo` into a silent comparison against the empty string.
     private static String text(String body, String field) {
@@ -896,7 +839,6 @@ class DurableEntityForgeTest {
     }
 
     // --- cluster addressing ------------------------------------------------------
-
     /// Node ids hosting an ACTIVE instance of the entity slice, from the cluster-wide slice view. The
     /// suite deploys exactly one slice, so every `nodeId` in the filtered response belongs to it.
     private Set<String> activeSliceHosts() {
@@ -915,12 +857,12 @@ class DurableEntityForgeTest {
     /// arcs ride the stream record family under the `entity:` namespace).
     private Map<Integer, String> entityArcOwners() {
         var body = httpGet(anyMgmtPort(), "/api/v1/ownership/stream");
-        var matcher = Pattern.compile("\"identity\"\\s*:\\s*\"entity:orders:(\\d+)\"[^}]*\"owner\"\\s*:\\s*\"([^\"]+)\"")
-                             .matcher(body);
+        var matcher = Pattern.compile("\"identity\"\\s*:\\s*\"entity:orders:(\\d+)\"[^}]*\"owner\"\\s*:\\s*\"([^\"]+)\"").matcher(body);
         var owners = new HashMap<Integer, String>();
 
         while (matcher.find()) {
-            owners.put(Integer.parseInt(matcher.group(1)), matcher.group(2));
+            owners.put(Integer.parseInt(matcher.group(1)),
+                       matcher.group(2));
         }
 
         return owners;
@@ -932,8 +874,8 @@ class DurableEntityForgeTest {
 
     private int firstPort() {
         return appPorts().stream()
-                         .findFirst()
-                         .orElseThrow(() -> new AssertionError("No app-http route is ready"));
+                       .findFirst()
+                       .orElseThrow(() -> new AssertionError("No app-http route is ready"));
     }
 
     /// The node id behind an app-http port. Both ports are assigned from the same per-node slot
@@ -959,11 +901,13 @@ class DurableEntityForgeTest {
     }
 
     private int anyMgmtPort() {
-        return cluster.status().nodes().getFirst().mgmtPort();
+        return cluster.status()
+                      .nodes()
+                      .getFirst()
+                      .mgmtPort();
     }
 
     // --- deployment + readiness ----------------------------------------------------
-
     private void deployEntitySlice() {
         var blueprint = """
             id = "%s"
@@ -976,8 +920,8 @@ class DurableEntityForgeTest {
         var response = httpPostToml(leaderPort, "/api/v1/blueprints", blueprint);
 
         assertThat(response).describedAs("durable-entity slice deployment")
-                            .doesNotContain("\"error\"")
-                            .contains("\"status\":\"applied\"");
+                  .doesNotContain("\"error\"")
+                  .contains("\"status\":\"applied\"");
     }
 
     /// Every node must serve the entity before any test runs: the cross-node assertions compare
@@ -985,7 +929,8 @@ class DurableEntityForgeTest {
     private boolean entityReadyOnEveryNode() {
         var ports = appPorts();
 
-        return ports.size() == NODES && ports.stream().allMatch(this::entityReady);
+        return ports.size() == NODES && ports.stream()
+                                             .allMatch(this::entityReady);
     }
 
     /// A node is ready once its entity resource ANSWERS — either with a state verdict, or by saying
@@ -1001,10 +946,7 @@ class DurableEntityForgeTest {
     private boolean entityReady(int port) {
         var body = get(port, "__readiness_probe__");
 
-        return !body.contains("\"error\"")
-               && (body.contains("\"outcome\":\"absent\"")
-                   || body.contains("\"outcome\":\"found\"")
-                   || body.contains("PartitionNotHeld"));
+        return ! body.contains("\"error\"") && (body.contains("\"outcome\":\"absent\"") || body.contains("\"outcome\":\"found\"") || body.contains("PartitionNotHeld"));
     }
 
     /// `slicesStatus()` cannot detect this failure: under `ALL_OR_NOTHING` a deterministic slice
@@ -1018,7 +960,8 @@ class DurableEntityForgeTest {
             var reason = deploymentFailedReason(httpGet(port, "/api/v1/events"));
 
             if (reason != null) {
-                throw new AssertionError("Deployment of " + ENTITY_SLICE + " FAILED — event surface reason: " + excerpt(reason));
+                throw new AssertionError("Deployment of " + ENTITY_SLICE
+                                        + " FAILED — event surface reason: " + excerpt(reason));
             }
         }
     }
@@ -1026,22 +969,27 @@ class DurableEntityForgeTest {
     /// Extracts `details.reason` from a `DEPLOYMENT_FAILED` cluster event for {@link #ENTITY_SLICE}
     /// in an `/api/v1/events` response body, or null if no such event is present (yet).
     private static String deploymentFailedReason(String eventsBody) {
-        var matcher = Pattern.compile("\"type\"\\s*:\\s*\"DEPLOYMENT_FAILED\".*?\"artifact\"\\s*:\\s*\""
-                                      + Pattern.quote(ENTITY_SLICE)
-                                      + "\".*?\"reason\"\\s*:\\s*\"([^\"]*)\"", Pattern.DOTALL)
-                                .matcher(eventsBody);
+        var matcher = Pattern.compile("\"type\"\\s*:\\s*\"DEPLOYMENT_FAILED\".*?\"artifact\"\\s*:\\s*\"" + Pattern.quote(ENTITY_SLICE)
+                                     + "\".*?\"reason\"\\s*:\\s*\"([^\"]*)\"",
+                                      Pattern.DOTALL)
+                             .matcher(eventsBody);
 
-        return matcher.find() ? matcher.group(1) : null;
+        return matcher.find()
+               ? matcher.group(1)
+               : null;
     }
 
     /// Caps a raw event reason to {@link #REASON_EXCERPT_LIMIT} characters so a large nested
     /// exception chain in `details.reason` cannot blow up the assertion message.
     private static String excerpt(String reason) {
-        return reason.length() <= REASON_EXCERPT_LIMIT ? reason : reason.substring(0, REASON_EXCERPT_LIMIT) + "...";
+        return reason.length() <= REASON_EXCERPT_LIMIT
+               ? reason
+               : reason.substring(0, REASON_EXCERPT_LIMIT) + "...";
     }
 
     private boolean allNodesHealthy() {
-        return mgmtPorts().stream().allMatch(this::checkNodeHealth);
+        return mgmtPorts().stream()
+                        .allMatch(this::checkNodeHealth);
     }
 
     private boolean checkNodeHealth(int port) {
@@ -1053,12 +1001,12 @@ class DurableEntityForgeTest {
 
         return http.sendString(request)
                    .await()
-                   .map(response -> response.statusCode() == 200 && response.body().contains("\"quorum\":true"))
+                   .map(response -> response.statusCode() == 200 && response.body()
+                                                                            .contains("\"quorum\":true"))
                    .or(false);
     }
 
     // --- HTTP ------------------------------------------------------------------------
-
     private String httpPostToml(int port, String path, String body) {
         var request = HttpRequest.newBuilder()
                                  .uri(URI.create("http://localhost:" + port + path))

--- a/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/DurableEntityForgeTest.java
+++ b/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/DurableEntityForgeTest.java
@@ -2,7 +2,26 @@
 // Copyright (c) 2025 Pragmatica Labs - Sergiy Yevtushenko
 // Licensed under Business Source License 1.1. Change Date: 2030-01-01. Change License: Apache-2.0.
 // See LICENSE in the repository root for full terms.
+
 package org.pragmatica.aether.forge;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.pragmatica.aether.dht.EntityPartitionArc;
+import org.pragmatica.aether.ember.EmberCluster;
+import org.pragmatica.config.ConfigurationProvider;
+import org.pragmatica.http.HttpOperations;
+import org.pragmatica.http.HttpResult;
+import org.awaitility.core.ConditionTimeoutException;
+import org.pragmatica.lang.Option;
 
 import java.net.URI;
 import java.net.http.HttpRequest;
@@ -18,30 +37,10 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.LockSupport;
 import java.util.regex.Pattern;
 
-import org.pragmatica.aether.dht.EntityPartitionArc;
-import org.pragmatica.aether.ember.EmberCluster;
-import org.pragmatica.config.ConfigurationProvider;
-import org.pragmatica.http.HttpOperations;
-import org.pragmatica.http.HttpResult;
-import org.pragmatica.lang.Option;
-
-import org.awaitility.core.ConditionTimeoutException;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.MethodOrderer;
-import org.junit.jupiter.api.Order;
-import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
-import org.junit.jupiter.api.TestMethodOrder;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
-
-import static org.pragmatica.aether.ember.EmberCluster.emberCluster;
-import static org.pragmatica.http.JdkHttpOperations.jdkHttpOperations;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
-
+import static org.pragmatica.aether.ember.EmberCluster.emberCluster;
+import static org.pragmatica.http.JdkHttpOperations.jdkHttpOperations;
 
 /// #345 increment I0 — a `DurableEntity` that actually RUNS inside a node, and a measured baseline
 /// of what it does today.
@@ -119,6 +118,7 @@ import static org.awaitility.Awaitility.await;
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 class DurableEntityForgeTest {
     private static final System.Logger LOG = System.getLogger(DurableEntityForgeTest.class.getName());
+
     private static final int BASE_PORT = 19000;
     private static final int BASE_MGMT_PORT = 19100;
     private static final int BASE_APP_HTTP_PORT = 19200;
@@ -135,25 +135,28 @@ class DurableEntityForgeTest {
 
     /// The SAME partition function production uses, so a key can be mapped to the arc whose committed owner
     /// [#entityArcOwners] reports. Re-deriving it here would only test this test's own arithmetic.
-    private static final EntityPartitionArc ENTITY_ARC = EntityPartitionArc.entityPartitionArc("orders",
-                                                                                               ENTITY_PARTITIONS);
+    private static final EntityPartitionArc ENTITY_ARC = EntityPartitionArc.entityPartitionArc("orders", ENTITY_PARTITIONS);
 
     private static final Duration WAIT_TIMEOUT = Duration.ofSeconds(240);
     private static final Duration POLL_INTERVAL = Duration.ofMillis(500);
+
     /// The delay [#scheduleTimer_appliesTheEffectExactlyOnce_whenTheSameTokenIsResent] schedules under. It
     /// only has to outlive the five presentations of the one token — the timer must still be pending when
     /// the last of them arrives, or that one plants a fresh timer and the gate measures the wrong thing.
     /// Five sequential localhost posts (four of them forwarded a hop) measure 5-15 ms, so 8s is nearly three
     /// orders of magnitude of margin, and the test asserts the measured figure against a quarter of it.
     private static final long RESEND_DELAY_MILLIS = 8_000L;
+
     /// Ticks to wait out before declaring a fire exactly-once. `ENTITY_TIMER_INTERVAL` is one second, so a
     /// duplicate timer planted alongside the first would come due within one tick of it; five gives four
     /// spare ticks for the second fire that must not happen to happen.
     private static final Duration EXACTLY_ONCE_SETTLE = Duration.ofSeconds(5);
+
     private static final String ENTITY_SLICE = TestArtifacts.ENTITY_SLICE;
     private static final String BLUEPRINT_ID = "forge.test:durable-entity:1.0.0";
     private static final String ERROR_FALLBACK = "{\"error\":\"request failed\"}";
     private static final int REASON_EXCERPT_LIMIT = 300;
+
     /// Distinct probe keys per convergence round. The fixture declares 8 partitions, and these keys hash
     /// across them, so readiness reflects the whole keyspace rather than whichever partition one key
     /// happened to land on.
@@ -173,17 +176,23 @@ class DurableEntityForgeTest {
                                                   .withSystemProperties("aether.")
                                                   .withEnvironment("AETHER_")
                                                   .build();
-
         cluster = emberCluster(NODES, BASE_PORT, BASE_MGMT_PORT, BASE_APP_HTTP_PORT, "dur", Option.some(configProvider));
         LifecycleAwait.settled("cluster start in setUp()", cluster, cluster.start());
-        await().atMost(WAIT_TIMEOUT).pollInterval(POLL_INTERVAL).until(() -> cluster.currentLeader()
-                                                                                    .isPresent());
-        await().atMost(WAIT_TIMEOUT).pollInterval(POLL_INTERVAL).until(this::allNodesHealthy);
-        deployEntitySlice();
+
         await().atMost(WAIT_TIMEOUT)
-             .pollInterval(POLL_INTERVAL)
-             .failFast(this::failIfSliceFailed)
-             .until(this::entityReadyOnEveryNode);
+               .pollInterval(POLL_INTERVAL)
+               .until(() -> cluster.currentLeader().isPresent());
+
+        await().atMost(WAIT_TIMEOUT)
+               .pollInterval(POLL_INTERVAL)
+               .until(this::allNodesHealthy);
+
+        deployEntitySlice();
+
+        await().atMost(WAIT_TIMEOUT)
+               .pollInterval(POLL_INTERVAL)
+               .failFast(this::failIfSliceFailed)
+               .until(this::entityReadyOnEveryNode);
         // Placement converges LATER than entity readiness, and the gap is wide enough to be read as a
         // defect. Measured on 2026-08-27: the scheduler's first pass placed 2 of the 3 requested instances,
         // the reconciler logged "has 2 instances, desired 3 - adjusting" 52s after deploy, and the third
@@ -206,13 +215,12 @@ class DurableEntityForgeTest {
     private void awaitFullSlicePlacement() {
         try {
             await().atMost(WAIT_TIMEOUT)
-                 .pollInterval(POLL_INTERVAL)
-                 .failFast(this::failIfSliceFailed)
-                 .until(() -> activeSliceHosts().size() == INSTANCES);
+                   .pollInterval(POLL_INTERVAL)
+                   .failFast(this::failIfSliceFailed)
+                   .until(() -> activeSliceHosts().size() == INSTANCES);
         } catch (ConditionTimeoutException e) {
-            throw new AssertionError("Slice placement never reached " + INSTANCES
-                                    + " ACTIVE instances; hosts seen: " + activeSliceHosts(),
-                                     e);
+            throw new AssertionError("Slice placement never reached " + INSTANCES + " ACTIVE instances; hosts seen: "
+                                     + activeSliceHosts(), e);
         }
     }
 
@@ -225,12 +233,11 @@ class DurableEntityForgeTest {
     private void awaitOwnershipConvergence() {
         try {
             await().atMost(WAIT_TIMEOUT)
-                 .pollInterval(POLL_INTERVAL)
-                 .failFast(this::failIfSliceFailed)
-                 .until(this::ownershipHasConverged);
+                   .pollInterval(POLL_INTERVAL)
+                   .failFast(this::failIfSliceFailed)
+                   .until(this::ownershipHasConverged);
         } catch (ConditionTimeoutException e) {
-            throw new AssertionError("Entity ownership never converged; last probe answers: " + lastProbeAnswers.get(),
-                                     e);
+            throw new AssertionError("Entity ownership never converged; last probe answers: " + lastProbeAnswers.get(), e);
         }
     }
 
@@ -240,11 +247,12 @@ class DurableEntityForgeTest {
             var leaderPort = cluster.getLeaderManagementPort().or(anyMgmtPort());
 
             httpDelete(leaderPort, "/api/v1/blueprints/" + BLUEPRINT_ID);
-            LifecycleAwait.settled("cluster stop in tearDown()", cluster, cluster.stop());
+            LifecycleAwait.bestEffort("cluster stop in tearDown()", cluster, cluster.stop());
         }
     }
 
     // --- the API surface actually executes ------------------------------------
+
     /// The 02w hosting-set pin, asserted directly: every committed `entity:orders` arc owner is a node
     /// hosting an ACTIVE instance of the entity slice. Before the fix the leader minted owners over ALL
     /// members, so with 3 instances on 5 nodes roughly two-fifths of the arcs landed on nodes with no
@@ -259,13 +267,13 @@ class DurableEntityForgeTest {
         var owners = entityArcOwners();
 
         assertThat(hosts).describedAs("the blueprint places fewer instances than nodes, else this pin is vacuous")
-                  .hasSize(INSTANCES);
+                         .hasSize(INSTANCES);
         assertThat(owners).describedAs("every entity partition must carry a committed ownership record")
-                  .hasSize(ENTITY_PARTITIONS);
+                          .hasSize(ENTITY_PARTITIONS);
         assertThat(owners.entrySet()).describedAs("every arc owner must host the declaring slice; owners=%s hosts=%s",
                                                   owners,
                                                   hosts)
-                  .allSatisfy(entry -> assertThat(hosts).contains(entry.getValue()));
+                                     .allSatisfy(entry -> assertThat(hosts).contains(entry.getValue()));
     }
 
     /// The headline I0 assertion: a durable entity provisioned from `resources.toml` accepts a
@@ -286,6 +294,7 @@ class DurableEntityForgeTest {
     @Order(2)
     void get_returnsTheCreatedState_onTheSameNode() {
         var owner = createOnOwner("order-get", "placed", 250).port();
+
         var response = get(owner, "order-get");
 
         assertThat(outcome(response)).isEqualTo("found");
@@ -299,14 +308,14 @@ class DurableEntityForgeTest {
     @Order(3)
     void update_commitsTheMutatedState_forExistingKey() {
         var owner = createOnOwner("order-update", "placed", 10).port();
+
         var updated = update(owner, "order-update", 999);
 
         assertThat(outcome(updated)).isEqualTo("updated");
         assertThat(number(updated, "amount")).isEqualTo(999);
         assertThat(text(updated, "status")).describedAs("the mutator changes amount only").isEqualTo("placed");
-        assertThat(number(get(owner, "order-update"),
-                          "amount")).describedAs("the mutation is committed, not just returned")
-                  .isEqualTo(999);
+        assertThat(number(get(owner, "order-update"), "amount")).describedAs("the mutation is committed, not just returned")
+                                                                 .isEqualTo(999);
     }
 
     /// Delete removes the instance, and the subsequent read reports absence rather than failing.
@@ -320,6 +329,7 @@ class DurableEntityForgeTest {
     }
 
     // --- typed failures are real, not decorative -------------------------------
+
     /// `EntityAlreadyExists` is enforced, so the entity genuinely holds state rather than accepting
     /// every write. This is the sensor that stops the whole suite from passing against a no-op
     /// implementation.
@@ -327,6 +337,7 @@ class DurableEntityForgeTest {
     @Order(5)
     void create_failsWithKeyAlreadyExists_forDuplicateKeyOnOneNode() {
         var owner = createOnOwner("order-duplicate", "placed", 1).port();
+
         var duplicate = create(owner, "order-duplicate", "placed", 2);
 
         assertThat(outcome(duplicate)).isEqualTo("failed");
@@ -341,12 +352,11 @@ class DurableEntityForgeTest {
     @Order(6)
     void update_failsWithKeyNotFound_forUnknownKey() {
         var failureTypes = appPorts().stream()
-                                   .map(port -> text(update(port, "order-never-created", 1),
-                                                     "failureType"))
-                                   .toList();
+                                     .map(port -> text(update(port, "order-never-created", 1), "failureType"))
+                                     .toList();
 
         assertThat(failureTypes).describedAs("every caller receives the owner's typed verdict through the forward (#596)")
-                  .containsOnly("EntityNotFound");
+                                .containsOnly("EntityNotFound");
     }
 
     @Test
@@ -355,6 +365,7 @@ class DurableEntityForgeTest {
         var owner = createOnOwner("order-double-delete", "placed", 1).port();
 
         delete(owner, "order-double-delete");
+
         var repeated = delete(owner, "order-double-delete");
 
         assertThat(outcome(repeated)).isEqualTo("failed");
@@ -386,39 +397,52 @@ class DurableEntityForgeTest {
     @Order(8)
     void scheduleTimer_succeedsOnEveryNode_includingInstancesThatCannotBeTheCommittedOwner() {
         createOnOwner("order-timer", "placed", 1);
+
         var partition = ENTITY_ARC.partitionOf("order-timer");
 
         assertThat(entityArcOwners()).describedAs("the key's partition must carry a committed owner, else 'an instance "
-                                                 + "that cannot be the owner' names nothing")
-                  .containsKey(partition);
-        var responses = appPorts().stream().map(port -> scheduleTimer(port, "order-timer")).toList();
+                                                  + "that cannot be the owner' names nothing")
+                                     .containsKey(partition);
+
+        var responses = appPorts().stream()
+                                  .map(port -> scheduleTimer(port, "order-timer"))
+                                  .toList();
 
         assertThat(responses).describedAs("every node must answer a schedule, the owner locally and the rest by forwarding")
-                  .hasSize(NODES);
+                             .hasSize(NODES);
         assertThat(responses).allSatisfy(response -> {
             assertThat(outcome(response)).describedAs("timers are real after I4 — a refusal here is the regression")
-                      .isEqualTo("scheduled");
+                                         .isEqualTo("scheduled");
             assertThat(text(response, "token")).describedAs("a scheduled timer must come back with the handle that cancels it")
-                      .isNotEmpty();
+                                               .isNotEmpty();
         });
-        var tokens = responses.stream().map(response -> text(response, "token")).distinct().toList();
+
+        var tokens = responses.stream()
+                              .map(response -> text(response, "token"))
+                              .distinct()
+                              .toList();
 
         assertThat(tokens).describedAs("five schedules with no caller token are five timers, each with its own handle")
-                  .hasSize(NODES);
-        var instances = responses.stream().map(response -> text(response, "instance")).distinct().toList();
+                          .hasSize(NODES);
+
+        var instances = responses.stream()
+                                 .map(response -> text(response, "instance"))
+                                 .distinct()
+                                 .toList();
 
         LOG.log(System.Logger.Level.INFO,
                 "I4 forwarding gate: nodes={0} committedOwner={1} distinctServingInstances={2}",
                 NODES,
                 entityArcOwners().get(partition),
                 instances.size());
+
         assertThat(instances).describedAs("more than one slice instance must have answered: a node hosts at most one, and "
-                                         + "the partition asserted above has a single committed owner, so a second "
-                                         + "instance answering 'scheduled' is a non-owner that relayed instead of "
-                                         + "refusing. All five served by one instance would leave that untested; "
-                                         + "instances=%s",
+                                          + "the partition asserted above has a single committed owner, so a second "
+                                          + "instance answering 'scheduled' is a non-owner that relayed instead of "
+                                          + "refusing. All five served by one instance would leave that untested; "
+                                          + "instances=%s",
                                           instances)
-                  .hasSizeGreaterThan(1);
+                             .hasSizeGreaterThan(1);
     }
 
     /// The retry-after-lost-ack gate, at cluster level: a schedule RE-SENT under the same token is the same
@@ -452,29 +476,33 @@ class DurableEntityForgeTest {
     @Order(9)
     void scheduleTimer_appliesTheEffectExactlyOnce_whenTheSameTokenIsResent() {
         createOnOwner("order-timer-resend", "placed", 500);
+
         var token = "resent-" + UUID.randomUUID();
         var startNanos = System.nanoTime();
         var responses = appPorts().stream()
-                                .map(port -> scheduleTimer(port, "order-timer-resend", RESEND_DELAY_MILLIS, token))
-                                .toList();
+                                  .map(port -> scheduleTimer(port, "order-timer-resend", RESEND_DELAY_MILLIS, token))
+                                  .toList();
         var presentationMillis = Duration.ofNanos(System.nanoTime() - startNanos).toMillis();
 
         assertThat(presentationMillis).describedAs("all five presentations must land while the timer is still pending, "
-                                                  + "else the later ones plant fresh timers and prove nothing")
-                  .isLessThan(RESEND_DELAY_MILLIS / 4);
+                                                   + "else the later ones plant fresh timers and prove nothing")
+                                      .isLessThan(RESEND_DELAY_MILLIS / 4);
+
         LOG.log(System.Logger.Level.INFO,
                 "I4 resend gate: delay={0}ms fivePresentations={1}ms",
                 RESEND_DELAY_MILLIS,
                 presentationMillis);
         assertThat(responses).allSatisfy(response -> {
             assertThat(outcome(response)).describedAs("a re-sent schedule is the same schedule, and answers success")
-                      .isEqualTo("scheduled");
+                                         .isEqualTo("scheduled");
             assertThat(text(response, "token")).describedAs("the owner must echo the CALLER's token, not one of its own")
-                      .isEqualTo(token);
+                                               .isEqualTo(token);
         });
+
         await().atMost(WAIT_TIMEOUT)
-             .pollInterval(POLL_INTERVAL)
-             .until(() -> expiriesAcrossCluster("order-timer-resend").contains(1));
+               .pollInterval(POLL_INTERVAL)
+               .until(() -> expiriesAcrossCluster("order-timer-resend").contains(1));
+
         // A duplicate arrives on a LATER tick, so a reading taken at the moment of the fire cannot tell
         // exactly-once from not-yet-twice. There is no condition to poll for the absence of a second fire —
         // only elapsed ticks — so this waits out a quiet period and then re-reads.
@@ -483,18 +511,20 @@ class DurableEntityForgeTest {
 
         assertThat(counts).describedAs("at least one node must serve the key after the fire").isNotEmpty();
         assertThat(counts).describedAs("five presentations of ONE token are one timer, so Expire lands once — "
-                                      + "a second timer would show as 2 on whichever node folded both fires")
-                  .allSatisfy(count -> assertThat(count).isLessThanOrEqualTo(1));
+                                       + "a second timer would show as 2 on whichever node folded both fires")
+                          .allSatisfy(count -> assertThat(count).isLessThanOrEqualTo(1));
         assertThat(counts).describedAs("and the fire did land, on some node's committed view").contains(1);
+
         var settled = servedView("order-timer-resend");
 
         assertThat(text(settled, "status")).describedAs("the fire is a real mutation, applied through the ordinary update path")
-                  .isEqualTo("expired");
+                                           .isEqualTo("expired");
         assertThat(number(settled, "amount")).describedAs("Expire touches the counter and the status only")
-                  .isEqualTo(500);
+                                             .isEqualTo(500);
     }
 
     // --- replication and durability, across nodes --------------------------------
+
     /// More than ONE slice instance answers a key with the value that was written, after a create on a
     /// single node.
     ///
@@ -517,21 +547,30 @@ class DurableEntityForgeTest {
     void get_isServedByMoreThanOneNode_afterCreateOnOne() {
         var accepted = createOnOwner("order-isolated", "placed", 42);
         var ownerInstance = text(accepted.response(), "instance");
+
         // Polled, not sampled: a replica serves only once it has folded the partition, and taking one
         // reading immediately after the create would measure the fold's latency rather than whether the
         // key is answerable cluster-wide at all.
-        await().atMost(WAIT_TIMEOUT).pollInterval(POLL_INTERVAL).until(() -> serversOf("order-isolated").size() > 1);
+        await().atMost(WAIT_TIMEOUT)
+               .pollInterval(POLL_INTERVAL)
+               .until(() -> serversOf("order-isolated").size() > 1);
+
         var servers = serversOf("order-isolated");
 
         assertThat(servers).describedAs("more than the accepting node must answer the key — from its own fold if it "
-                                       + "holds the partition, by forwarding to the owner if it does not")
-                  .hasSizeGreaterThan(1);
-        var instances = servers.stream().map(response -> text(response, "instance")).distinct().toList();
+                                        + "holds the partition, by forwarding to the owner if it does not")
+                           .hasSizeGreaterThan(1);
+
+        var instances = servers.stream()
+                               .map(response -> text(response, "instance"))
+                               .distinct()
+                               .toList();
 
         assertThat(instances).describedAs("the answers must come from DIFFERENT slice instances, else the test is vacuous")
-                  .hasSizeGreaterThan(1);
+                             .hasSizeGreaterThan(1);
         assertThat(instances).describedAs("and one of them is not the node that accepted the write")
-                  .anySatisfy(instance -> assertThat(instance).isNotEqualTo(ownerInstance));
+                             .anySatisfy(instance -> assertThat(instance).isNotEqualTo(ownerInstance));
+
         // The value is the assertion. A replica that answered with anything other than what was written
         // would be worse than one that refused.
         assertThat(servers).allSatisfy(response -> {
@@ -547,9 +586,9 @@ class DurableEntityForgeTest {
     /// names a node that answered, not necessarily one that holds the state.
     private List<String> serversOf(String key) {
         return appPorts().stream()
-                       .map(port -> get(port, key))
-                       .filter(response -> response.contains("\"outcome\":\"found\""))
-                       .toList();
+                         .map(port -> get(port, key))
+                         .filter(response -> response.contains("\"outcome\":\"found\""))
+                         .toList();
     }
 
     /// The I1 gate, flipped — then flipped once more by #596. At I0 all five nodes accepted a create for
@@ -588,53 +627,58 @@ class DurableEntityForgeTest {
         var ownerPort = createOnOwner("order-durability", "placed", 77).port();
 
         assertThat(outcome(get(ownerPort, "order-durability"))).isEqualTo("found");
+
         var ownerNodeId = nodeIdForAppPort(ownerPort);
 
         LifecycleAwait.nodeSettled("kill node " + ownerNodeId + " in state_survivesTheLossOfTheNodeThatOwnedIt()",
                                    cluster,
                                    cluster.killNode(ownerNodeId));
-        await().atMost(WAIT_TIMEOUT).pollInterval(POLL_INTERVAL).until(() -> !appPorts().contains(ownerPort));
+
+        await().atMost(WAIT_TIMEOUT)
+               .pollInterval(POLL_INTERVAL)
+               .until(() -> !appPorts().contains(ownerPort));
+
         // Ownership must move and the new owner must rebuild the partition from the log before it can
         // answer, so the read is POLLED rather than taken once. A fold in progress reports itself as a
         // transient refusal — polling is what distinguishes "still replaying" from "gone", and taking a
         // single reading immediately after the kill would conflate them.
         await().atMost(WAIT_TIMEOUT)
-             .pollInterval(POLL_INTERVAL)
-             .until(() -> survivorsAnswering("order-durability").contains("found"));
+               .pollInterval(POLL_INTERVAL)
+               .until(() -> survivorsAnswering("order-durability").contains("found"));
+
         // Assert on the DATA, not on a status field. #508 passed throughout a run in which a status-gated
         // test failed on the same cluster at the same moment; the value is the thing that either survived
         // or did not.
         var recovered = appPorts().stream()
-                                .map(port -> get(port, "order-durability"))
-                                .filter(response -> "found".equals(outcome(response)))
-                                .toList();
+                                  .map(port -> get(port, "order-durability"))
+                                  .filter(response -> "found".equals(outcome(response)))
+                                  .toList();
 
         assertThat(recovered).describedAs("at least one surviving node must serve the entity after failover")
-                  .isNotEmpty();
+                             .isNotEmpty();
         assertThat(recovered).allSatisfy(response -> {
             assertThat(text(response, "status")).describedAs("the recovered state must be the state that was written")
-                      .isEqualTo("placed");
+                                                .isEqualTo("placed");
             assertThat(number(response, "amount")).describedAs("the recovered amount must be the amount that was written")
-                      .isEqualTo(77);
+                                                  .isEqualTo(77);
         });
     }
 
     private List<String> survivorsAnswering(String key) {
         return appPorts().stream()
-                       .map(port -> get(port, key))
-                       .map(DurableEntityForgeTest::outcomeOrPending)
-                       .toList();
+                         .map(port -> get(port, key))
+                         .map(DurableEntityForgeTest::outcomeOrPending)
+                         .toList();
     }
 
     /// `outcome` throws on a transport-level error body, and this runs while ownership is still moving, so
     /// a node mid-handover would abort the poll instead of simply reporting "not yet".
     private static String outcomeOrPending(String response) {
-        return response.contains("\"outcome\":\"found\"")
-               ? "found"
-               : "pending";
+        return response.contains("\"outcome\":\"found\"") ? "found" : "pending";
     }
 
     // --- the fence invariant, asserted on every create ---------------------------
+
     /// The port that accepted a create, plus its response body.
     private record Accepted(int port, String response) {}
 
@@ -656,16 +700,20 @@ class DurableEntityForgeTest {
     /// committed owner — a real defect once setUp has waited for convergence — and `containsOnly`
     /// fails it explicitly rather than lumping it in with "not created".
     private Accepted createOnOwner(String key, String status, int amount) {
-        var responses = appPorts().stream().map(port -> new Accepted(port, create(port, key, status, amount))).toList();
-        var accepted = responses.stream().filter(entry -> "created".equals(outcome(entry.response()))).toList();
+        var responses = appPorts().stream()
+                                  .map(port -> new Accepted(port, create(port, key, status, amount)))
+                                  .toList();
+        var accepted = responses.stream()
+                                .filter(entry -> "created".equals(outcome(entry.response())))
+                                .toList();
 
         assertThat(responses).describedAs("every node must have answered").hasSize(NODES);
         assertThat(accepted).describedAs("exactly one attempt may create '%s'; got %s",
-                                         key,
-                                         outcomesOf(responses))
-                  .hasSize(1);
+                                          key,
+                                          outcomesOf(responses))
+                            .hasSize(1);
         assertThat(rejectionTypesOf(responses)).describedAs("every later attempt must surface the duplicate as EntityAlreadyExists — its forward reached the owner and the single-writer invariant held (#596)")
-                  .containsOnly("EntityAlreadyExists");
+                                               .containsOnly("EntityAlreadyExists");
 
         return accepted.getFirst();
     }
@@ -679,8 +727,7 @@ class DurableEntityForgeTest {
     private static List<String> rejectionTypesOf(List<Accepted> responses) {
         return responses.stream()
                         .filter(entry -> !"created".equals(outcome(entry.response())))
-                        .map(entry -> text(entry.response(),
-                                           "failureType"))
+                        .map(entry -> text(entry.response(), "failureType"))
                         .toList();
     }
 
@@ -700,25 +747,26 @@ class DurableEntityForgeTest {
         var round = ownershipProbe.incrementAndGet();
 
         return java.util.stream.IntStream.range(0, PARTITION_PROBE_KEYS)
-                                         .allMatch(index -> probeAccepted("__ownership_probe_" + round
-                                                                         + "_" + index
-                                                                         + "__"));
+                                         .allMatch(index -> probeAccepted("__ownership_probe_" + round + "_" + index + "__"));
     }
 
     private boolean probeAccepted(String key) {
+
         // Deliberately NOT via outcome(): that throws on a transport-level error body, and this predicate
         // runs while the cluster is still settling, so one slow node would abort setUp instead of simply
         // reporting "not converged yet". A failed request is not-yet-converged; only a literal accepted
         // create counts.
-        var answers = appPorts().stream().map(port -> create(port, key, "probe", 0)).toList();
+        var answers = appPorts().stream()
+                                .map(port -> create(port, key, "probe", 0))
+                                .toList();
 
         lastProbeAnswers.set(answers);
 
-        return answers.stream()
-                      .anyMatch(response -> response.contains("\"outcome\":\"created\""));
+        return answers.stream().anyMatch(response -> response.contains("\"outcome\":\"created\""));
     }
 
     // --- entity operations -----------------------------------------------------
+
     private String create(int port, String key, String status, int amount) {
         return httpPost(port,
                         "/api/v1/entity/create",
@@ -761,15 +809,15 @@ class DurableEntityForgeTest {
     /// and this sees all of them.
     private List<Integer> expiriesAcrossCluster(String key) {
         return serversOf(key).stream()
-                        .map(response -> number(response, "expiries"))
-                        .toList();
+                             .map(response -> number(response, "expiries"))
+                             .toList();
     }
 
     /// One serving node's view of `key`, for reading components other than the count.
     private String servedView(String key) {
         return serversOf(key).stream()
-                        .findFirst()
-                        .orElseThrow(() -> new AssertionError("No node serves '" + key + "'"));
+                             .findFirst()
+                             .orElseThrow(() -> new AssertionError("No node serves '" + key + "'"));
     }
 
     /// Wait out a fixed span. Deliberately a sleep and not a poll: what is being waited for is the ABSENCE
@@ -799,13 +847,15 @@ class DurableEntityForgeTest {
                 "I4 quiet period: requested={0}ms elapsed={1}ms",
                 span.toMillis(),
                 elapsedMillis);
+
         assertThat(elapsedMillis).describedAs("the quiet period must actually elapse — a residual unpark permit left by "
-                                             + "Promise.await() makes a bare park return at once, which would reduce the "
-                                             + "exactly-once assertion below to a re-read of the value just polled for")
-                  .isGreaterThanOrEqualTo(span.toMillis());
+                                              + "Promise.await() makes a bare park return at once, which would reduce the "
+                                              + "exactly-once assertion below to a re-read of the value just polled for")
+                                 .isGreaterThanOrEqualTo(span.toMillis());
     }
 
     // --- response reading -------------------------------------------------------
+
     /// Fails loudly on a missing field rather than returning "": a renamed component would otherwise
     /// turn every `isEqualTo` into a silent comparison against the empty string.
     private static String text(String body, String field) {
@@ -839,6 +889,7 @@ class DurableEntityForgeTest {
     }
 
     // --- cluster addressing ------------------------------------------------------
+
     /// Node ids hosting an ACTIVE instance of the entity slice, from the cluster-wide slice view. The
     /// suite deploys exactly one slice, so every `nodeId` in the filtered response belongs to it.
     private Set<String> activeSliceHosts() {
@@ -857,12 +908,12 @@ class DurableEntityForgeTest {
     /// arcs ride the stream record family under the `entity:` namespace).
     private Map<Integer, String> entityArcOwners() {
         var body = httpGet(anyMgmtPort(), "/api/v1/ownership/stream");
-        var matcher = Pattern.compile("\"identity\"\\s*:\\s*\"entity:orders:(\\d+)\"[^}]*\"owner\"\\s*:\\s*\"([^\"]+)\"").matcher(body);
+        var matcher = Pattern.compile("\"identity\"\\s*:\\s*\"entity:orders:(\\d+)\"[^}]*\"owner\"\\s*:\\s*\"([^\"]+)\"")
+                             .matcher(body);
         var owners = new HashMap<Integer, String>();
 
         while (matcher.find()) {
-            owners.put(Integer.parseInt(matcher.group(1)),
-                       matcher.group(2));
+            owners.put(Integer.parseInt(matcher.group(1)), matcher.group(2));
         }
 
         return owners;
@@ -874,8 +925,8 @@ class DurableEntityForgeTest {
 
     private int firstPort() {
         return appPorts().stream()
-                       .findFirst()
-                       .orElseThrow(() -> new AssertionError("No app-http route is ready"));
+                         .findFirst()
+                         .orElseThrow(() -> new AssertionError("No app-http route is ready"));
     }
 
     /// The node id behind an app-http port. Both ports are assigned from the same per-node slot
@@ -901,13 +952,11 @@ class DurableEntityForgeTest {
     }
 
     private int anyMgmtPort() {
-        return cluster.status()
-                      .nodes()
-                      .getFirst()
-                      .mgmtPort();
+        return cluster.status().nodes().getFirst().mgmtPort();
     }
 
     // --- deployment + readiness ----------------------------------------------------
+
     private void deployEntitySlice() {
         var blueprint = """
             id = "%s"
@@ -920,8 +969,8 @@ class DurableEntityForgeTest {
         var response = httpPostToml(leaderPort, "/api/v1/blueprints", blueprint);
 
         assertThat(response).describedAs("durable-entity slice deployment")
-                  .doesNotContain("\"error\"")
-                  .contains("\"status\":\"applied\"");
+                            .doesNotContain("\"error\"")
+                            .contains("\"status\":\"applied\"");
     }
 
     /// Every node must serve the entity before any test runs: the cross-node assertions compare
@@ -929,8 +978,7 @@ class DurableEntityForgeTest {
     private boolean entityReadyOnEveryNode() {
         var ports = appPorts();
 
-        return ports.size() == NODES && ports.stream()
-                                             .allMatch(this::entityReady);
+        return ports.size() == NODES && ports.stream().allMatch(this::entityReady);
     }
 
     /// A node is ready once its entity resource ANSWERS — either with a state verdict, or by saying
@@ -946,7 +994,10 @@ class DurableEntityForgeTest {
     private boolean entityReady(int port) {
         var body = get(port, "__readiness_probe__");
 
-        return ! body.contains("\"error\"") && (body.contains("\"outcome\":\"absent\"") || body.contains("\"outcome\":\"found\"") || body.contains("PartitionNotHeld"));
+        return !body.contains("\"error\"")
+               && (body.contains("\"outcome\":\"absent\"")
+                   || body.contains("\"outcome\":\"found\"")
+                   || body.contains("PartitionNotHeld"));
     }
 
     /// `slicesStatus()` cannot detect this failure: under `ALL_OR_NOTHING` a deterministic slice
@@ -960,8 +1011,7 @@ class DurableEntityForgeTest {
             var reason = deploymentFailedReason(httpGet(port, "/api/v1/events"));
 
             if (reason != null) {
-                throw new AssertionError("Deployment of " + ENTITY_SLICE
-                                        + " FAILED — event surface reason: " + excerpt(reason));
+                throw new AssertionError("Deployment of " + ENTITY_SLICE + " FAILED — event surface reason: " + excerpt(reason));
             }
         }
     }
@@ -969,27 +1019,22 @@ class DurableEntityForgeTest {
     /// Extracts `details.reason` from a `DEPLOYMENT_FAILED` cluster event for {@link #ENTITY_SLICE}
     /// in an `/api/v1/events` response body, or null if no such event is present (yet).
     private static String deploymentFailedReason(String eventsBody) {
-        var matcher = Pattern.compile("\"type\"\\s*:\\s*\"DEPLOYMENT_FAILED\".*?\"artifact\"\\s*:\\s*\"" + Pattern.quote(ENTITY_SLICE)
-                                     + "\".*?\"reason\"\\s*:\\s*\"([^\"]*)\"",
-                                      Pattern.DOTALL)
-                             .matcher(eventsBody);
+        var matcher = Pattern.compile("\"type\"\\s*:\\s*\"DEPLOYMENT_FAILED\".*?\"artifact\"\\s*:\\s*\""
+                                      + Pattern.quote(ENTITY_SLICE)
+                                      + "\".*?\"reason\"\\s*:\\s*\"([^\"]*)\"", Pattern.DOTALL)
+                                .matcher(eventsBody);
 
-        return matcher.find()
-               ? matcher.group(1)
-               : null;
+        return matcher.find() ? matcher.group(1) : null;
     }
 
     /// Caps a raw event reason to {@link #REASON_EXCERPT_LIMIT} characters so a large nested
     /// exception chain in `details.reason` cannot blow up the assertion message.
     private static String excerpt(String reason) {
-        return reason.length() <= REASON_EXCERPT_LIMIT
-               ? reason
-               : reason.substring(0, REASON_EXCERPT_LIMIT) + "...";
+        return reason.length() <= REASON_EXCERPT_LIMIT ? reason : reason.substring(0, REASON_EXCERPT_LIMIT) + "...";
     }
 
     private boolean allNodesHealthy() {
-        return mgmtPorts().stream()
-                        .allMatch(this::checkNodeHealth);
+        return mgmtPorts().stream().allMatch(this::checkNodeHealth);
     }
 
     private boolean checkNodeHealth(int port) {
@@ -1001,12 +1046,12 @@ class DurableEntityForgeTest {
 
         return http.sendString(request)
                    .await()
-                   .map(response -> response.statusCode() == 200 && response.body()
-                                                                            .contains("\"quorum\":true"))
+                   .map(response -> response.statusCode() == 200 && response.body().contains("\"quorum\":true"))
                    .or(false);
     }
 
     // --- HTTP ------------------------------------------------------------------------
+
     private String httpPostToml(int port, String path, String body) {
         var request = HttpRequest.newBuilder()
                                  .uri(URI.create("http://localhost:" + port + path))

--- a/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/DurableEntityTimerDurabilityTest.java
+++ b/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/DurableEntityTimerDurabilityTest.java
@@ -2,7 +2,27 @@
 // Copyright (c) 2025 Pragmatica Labs - Sergiy Yevtushenko
 // Licensed under Business Source License 1.1. Change Date: 2030-01-01. Change License: Apache-2.0.
 // See LICENSE in the repository root for full terms.
+
 package org.pragmatica.aether.forge;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.awaitility.core.ConditionTimeoutException;
+import org.pragmatica.aether.dht.EntityPartitionArc;
+import org.pragmatica.aether.ember.EmberCluster;
+import org.pragmatica.config.ConfigurationProvider;
+import org.pragmatica.http.HttpOperations;
+import org.pragmatica.http.HttpResult;
+import org.pragmatica.lang.Option;
 
 import java.net.URI;
 import java.net.http.HttpRequest;
@@ -19,31 +39,10 @@ import java.util.concurrent.locks.LockSupport;
 import java.util.regex.Pattern;
 import java.util.stream.IntStream;
 
-import org.pragmatica.aether.dht.EntityPartitionArc;
-import org.pragmatica.aether.ember.EmberCluster;
-import org.pragmatica.config.ConfigurationProvider;
-import org.pragmatica.http.HttpOperations;
-import org.pragmatica.http.HttpResult;
-import org.pragmatica.lang.Option;
-
-import org.awaitility.core.ConditionTimeoutException;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.MethodOrderer;
-import org.junit.jupiter.api.Order;
-import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
-import org.junit.jupiter.api.TestMethodOrder;
-import org.junit.jupiter.api.io.TempDir;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
-
-import static org.pragmatica.aether.ember.EmberCluster.emberCluster;
-import static org.pragmatica.http.JdkHttpOperations.jdkHttpOperations;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
-
+import static org.pragmatica.aether.ember.EmberCluster.emberCluster;
+import static org.pragmatica.http.JdkHttpOperations.jdkHttpOperations;
 
 /// #345 increment I4 — the two gates that make a durable timer DURABLE (#351).
 ///
@@ -136,6 +135,7 @@ class DurableEntityTimerDurabilityTest {
 
     private static final Duration WAIT_TIMEOUT = Duration.ofSeconds(240);
     private static final Duration POLL_INTERVAL = Duration.ofMillis(500);
+
     /// The handover gate's delay. It must comfortably outlive create + schedule + the pre-kill read — the
     /// timer has to be provably still pending when its owner dies, or a fire on the OLD owner would satisfy
     /// the gate for the wrong reason. That prelude measures 25 ms, so 45s is a 1,800x margin and the gate
@@ -144,6 +144,7 @@ class DurableEntityTimerDurabilityTest {
     /// ~35s of the delay to run, and the timer fires on its original instant. That is the more interesting
     /// of the two legal outcomes, and it is why this delay is deliberately larger than the restart gate's.
     private static final long HANDOVER_DELAY_MILLIS = 45_000L;
+
     /// The restart gate's delay, and it is deliberately SHORTER than the handover gate's rather than longer.
     /// It only has to outlive create + schedule + the pre-stop read (27 ms measured); it does NOT have to
     /// outlive the restart, because no process is alive during a restart that could fire anything. Measured,
@@ -152,18 +153,22 @@ class DurableEntityTimerDurabilityTest {
     /// never lost" clause being exercised head-on. Sizing this to span the whole restart would have cost a
     /// minute per run and measured nothing extra.
     private static final long RESTART_DELAY_MILLIS = 30_000L;
+
     /// Quiet period before declaring a fire exactly-once. The entity timer tick is one second, so a
     /// duplicate timer planted alongside the original comes due within a tick of it; five ticks gives four
     /// spare for a second fire that must not happen to happen.
     private static final Duration EXACTLY_ONCE_SETTLE = Duration.ofSeconds(5);
+
     private static final String ENTITY_SLICE = TestArtifacts.ENTITY_SLICE;
     private static final String BLUEPRINT_ID = "forge.test:durable-entity-timers:1.0.0";
     private static final String ERROR_FALLBACK = "{\"error\":\"request failed\"}";
     private static final int REASON_EXCERPT_LIMIT = 300;
     private static final int PARTITION_PROBE_KEYS = 12;
+
     private static final Pattern NODE_COUNT_FIELD = Pattern.compile("\"nodeCount\"\\s*:\\s*(\\d+)");
 
     Path baseDir;
+
     private EmberCluster cluster;
     private final HttpOperations http = jdkHttpOperations();
     private final AtomicInteger ownershipProbe = new AtomicInteger();
@@ -172,6 +177,7 @@ class DurableEntityTimerDurabilityTest {
     @BeforeAll
     void setUp(@TempDir Path tempDir) {
         this.baseDir = tempDir;
+
         // Resource provisioning is gated on a ConfigurationProvider being present; without it the node
         // installs a no-op facade and every resource-backed slice fails to load.
         var configProvider = ConfigurationProvider.builder()
@@ -184,6 +190,7 @@ class DurableEntityTimerDurabilityTest {
         // entity log's backing per-partition WAL on. Without it a full-cluster restart would lose the log
         // and the gate would be measuring the harness rather than the entity.
         cluster.withDataBaseDir(baseDir);
+
         startAndAwaitReady();
     }
 
@@ -193,11 +200,12 @@ class DurableEntityTimerDurabilityTest {
             var leaderPort = cluster.getLeaderManagementPort().or(anyMgmtPort());
 
             httpDelete(leaderPort, "/api/v1/blueprints/" + BLUEPRINT_ID);
-            LifecycleAwait.settled("cluster stop in tearDown()", cluster, cluster.stop());
+            LifecycleAwait.bestEffort("cluster stop in tearDown()", cluster, cluster.stop());
         }
     }
 
     // --- gate 1: the timer survives the whole cluster going away ----------------
+
     /// GATE — a pending timer survives a full-cluster restart and fires afterwards.
     ///
     /// The state and the pending timer both live in the entity's log, which is backed by a per-partition
@@ -226,28 +234,35 @@ class DurableEntityTimerDurabilityTest {
         var key = "order-timer-restart";
 
         createOnOwner(key, "placed", 700);
+
         var scheduledAt = System.nanoTime();
         var scheduled = scheduleTimer(firstPort(), key, RESTART_DELAY_MILLIS);
 
         assertThat(outcome(scheduled)).describedAs("the schedule must be accepted before there is anything to survive")
-                  .isEqualTo("scheduled");
+                                      .isEqualTo("scheduled");
         assertThat(text(scheduled, "token")).describedAs("a scheduled timer answers with its handle").isNotEmpty();
         assertThat(expiriesAcrossCluster(key)).describedAs("the timer must still be PENDING when the cluster goes down; "
-                                                          + "a fire before the restart would prove nothing")
-                  .isNotEmpty()
-                  .allSatisfy(count -> assertThat(count).isZero());
+                                                           + "a fire before the restart would prove nothing")
+                                              .isNotEmpty()
+                                              .allSatisfy(count -> assertThat(count).isZero());
+
         var scheduleToStopMillis = elapsedMillis(scheduledAt);
 
         assertThat(scheduleToStopMillis).describedAs("the delay must comfortably outlive the prelude, else the pending-ness "
-                                                    + "above is a coin flip rather than a margin")
-                  .isLessThan(RESTART_DELAY_MILLIS / 4);
+                                                     + "above is a coin flip rather than a margin")
+                                        .isLessThan(RESTART_DELAY_MILLIS / 4);
+
         var restartStartedAt = System.nanoTime();
 
         restartCluster();
+
         var restartMillis = elapsedMillis(restartStartedAt);
         var firedAt = System.nanoTime();
 
-        await().atMost(WAIT_TIMEOUT).pollInterval(POLL_INTERVAL).until(() -> expiriesAcrossCluster(key).contains(1));
+        await().atMost(WAIT_TIMEOUT)
+               .pollInterval(POLL_INTERVAL)
+               .until(() -> expiriesAcrossCluster(key).contains(1));
+
         var fireLatencyMillis = elapsedMillis(firedAt);
 
         LOG.log(System.Logger.Level.INFO,
@@ -256,10 +271,12 @@ class DurableEntityTimerDurabilityTest {
                 scheduleToStopMillis,
                 restartMillis,
                 fireLatencyMillis);
+
         assertExactlyOneFire(key, 700);
     }
 
     // --- gate 2: the timer survives its owner being replaced --------------------
+
     /// GATE — a pending timer survives its partition's owner being replaced, and the new owner applies it
     /// exactly once.
     ///
@@ -288,25 +305,29 @@ class DurableEntityTimerDurabilityTest {
         var partition = ARC.partitionOf(key);
 
         createOnOwner(key, "placed", 300);
+
         var ownerBefore = arcOwner(partition);
 
         assertThat(ownerBefore).describedAs("the key's arc must carry a committed owner before it can lose one")
-                  .isNotEmpty();
+                               .isNotEmpty();
+
         var scheduledAt = System.nanoTime();
         var scheduled = scheduleTimer(firstPort(), key, HANDOVER_DELAY_MILLIS);
 
         assertThat(outcome(scheduled)).describedAs("the schedule must be accepted before there is anything to hand over")
-                  .isEqualTo("scheduled");
+                                      .isEqualTo("scheduled");
         assertThat(expiriesAcrossCluster(key)).describedAs("the timer must still be PENDING when its owner dies; a fire on "
-                                                          + "the OLD owner would satisfy every later assertion for the "
-                                                          + "wrong reason")
-                  .isNotEmpty()
-                  .allSatisfy(count -> assertThat(count).isZero());
+                                                           + "the OLD owner would satisfy every later assertion for the "
+                                                           + "wrong reason")
+                                              .isNotEmpty()
+                                              .allSatisfy(count -> assertThat(count).isZero());
+
         var scheduleToKillMillis = elapsedMillis(scheduledAt);
 
         assertThat(scheduleToKillMillis).describedAs("the delay must comfortably outlive the prelude, else the pending-ness "
-                                                    + "above is a coin flip rather than a margin")
-                  .isLessThan(HANDOVER_DELAY_MILLIS / 4);
+                                                     + "above is a coin flip rather than a margin")
+                                        .isLessThan(HANDOVER_DELAY_MILLIS / 4);
+
         var ownerPort = appPortForNodeId(ownerBefore);
         var killedAt = System.nanoTime();
 
@@ -314,14 +335,24 @@ class DurableEntityTimerDurabilityTest {
                                   + " in timerFires_afterOwnerHandover_appliedOnceByTheNewOwner()",
                                    cluster,
                                    cluster.killNode(ownerBefore));
-        await().atMost(WAIT_TIMEOUT).pollInterval(POLL_INTERVAL).until(() -> !appPorts().contains(ownerPort));
+
+        await().atMost(WAIT_TIMEOUT)
+               .pollInterval(POLL_INTERVAL)
+               .until(() -> !appPorts().contains(ownerPort));
+
         // The handover itself, asserted rather than assumed. Until this flips, the key's partition still
         // names a dead node as its owner and nothing can fire.
-        await().atMost(WAIT_TIMEOUT).pollInterval(POLL_INTERVAL).until(() -> hasNewOwner(partition, ownerBefore));
+        await().atMost(WAIT_TIMEOUT)
+               .pollInterval(POLL_INTERVAL)
+               .until(() -> hasNewOwner(partition, ownerBefore));
+
         var handoverMillis = elapsedMillis(killedAt);
         var firedAt = System.nanoTime();
 
-        await().atMost(WAIT_TIMEOUT).pollInterval(POLL_INTERVAL).until(() -> expiriesAcrossCluster(key).contains(1));
+        await().atMost(WAIT_TIMEOUT)
+               .pollInterval(POLL_INTERVAL)
+               .until(() -> expiriesAcrossCluster(key).contains(1));
+
         var fireLatencyMillis = elapsedMillis(firedAt);
 
         LOG.log(System.Logger.Level.INFO,
@@ -330,12 +361,15 @@ class DurableEntityTimerDurabilityTest {
                 scheduleToKillMillis,
                 handoverMillis,
                 fireLatencyMillis);
+
         assertThat(arcOwner(partition)).describedAs("the key's arc must have moved, else no handover was tested")
-                  .isNotEqualTo(ownerBefore);
+                                       .isNotEqualTo(ownerBefore);
+
         assertExactlyOneFire(key, 300);
     }
 
     // --- the shared post-fire assertion -----------------------------------------
+
     /// The exactly-once assertion both gates end on.
     ///
     /// A duplicate fire arrives on a LATER tick, so a reading taken the instant the first one lands cannot
@@ -348,50 +382,66 @@ class DurableEntityTimerDurabilityTest {
     /// defect — hence "no node above 1, and at least one at exactly 1" rather than "all equal 1".
     private void assertExactlyOneFire(String key, int originalAmount) {
         awaitQuietPeriod(EXACTLY_ONCE_SETTLE);
+
         var counts = expiriesAcrossCluster(key);
 
         assertThat(counts).describedAs("at least one node must serve '%s' after the fire", key).isNotEmpty();
         assertThat(counts).describedAs("the timer fires ONCE — a node reading 2 folded two fires of one schedule")
-                  .allSatisfy(count -> assertThat(count).isLessThanOrEqualTo(1));
+                          .allSatisfy(count -> assertThat(count).isLessThanOrEqualTo(1));
         assertThat(counts).describedAs("and it did fire, on some node's committed view").contains(1);
+
         var settled = servedView(key);
 
         assertThat(text(settled, "status")).describedAs("the fire is a real mutation applied through the ordinary update path")
-                  .isEqualTo("expired");
+                                           .isEqualTo("expired");
         assertThat(number(settled, "amount")).describedAs("the state itself survived: Expire leaves 'amount' alone, so a "
-                                                         + "default-constructed state would show here")
-                  .isEqualTo(originalAmount);
+                                                          + "default-constructed state would show here")
+                                             .isEqualTo(originalAmount);
     }
 
     // --- restart ------------------------------------------------------------------
+
     private void restartCluster() {
         LifecycleAwait.settled("cluster stop in restartCluster()", cluster, cluster.stop());
+
         startAndAwaitReady();
     }
 
     private void startAndAwaitReady() {
         LifecycleAwait.settled("cluster start in startAndAwaitReady()", cluster, cluster.start());
-        await().atMost(WAIT_TIMEOUT).pollInterval(POLL_INTERVAL).until(() -> cluster.currentLeader()
-                                                                                    .isPresent());
-        await().atMost(WAIT_TIMEOUT).pollInterval(POLL_INTERVAL).until(this::allNodesHealthy);
+
+        await().atMost(WAIT_TIMEOUT)
+               .pollInterval(POLL_INTERVAL)
+               .until(() -> cluster.currentLeader().isPresent());
+
+        await().atMost(WAIT_TIMEOUT)
+               .pollInterval(POLL_INTERVAL)
+               .until(this::allNodesHealthy);
+
         // Gate on FULL membership, not merely on local quorum. After a cold restart the entity arcs are
         // re-minted over whichever nodes have rejoined, and an arc placed on a straggler-free subset would
         // hand the key's partition to a node whose WAL never held it.
-        await().atMost(WAIT_TIMEOUT).pollInterval(POLL_INTERVAL).until(() -> allNodesAreMembers(NODES));
+        await().atMost(WAIT_TIMEOUT)
+               .pollInterval(POLL_INTERVAL)
+               .until(() -> allNodesAreMembers(NODES));
+
         // Forge's Rabia persistence is in-memory, so a full-cluster restart wipes the blueprint and with it
         // the keyspace registration. Re-deploying restores ONLY that: no state, no timers. Both come back
         // from the WAL-backed entity log when the new owner folds its partitions.
         deployEntitySlice();
+
         await().atMost(WAIT_TIMEOUT)
-             .pollInterval(POLL_INTERVAL)
-             .failFast(this::failIfSliceFailed)
-             .until(this::entityReadyOnEveryNode);
+               .pollInterval(POLL_INTERVAL)
+               .failFast(this::failIfSliceFailed)
+               .until(this::entityReadyOnEveryNode);
+
         // Placement converges LATER than entity readiness — measured 2026-08-27, the scheduler's first pass
         // placed 2 of the 3 requested instances and the reconciler took a further ~52s to add the third.
         // The handover gate depends on this: it kills a host, and re-placement has room only if the full
         // three were there to begin with. Waiting here also keeps the gates measuring a converged cluster
         // rather than a mid-reconcile one.
         awaitFullSlicePlacement();
+
         awaitOwnershipConvergence();
     }
 
@@ -400,13 +450,12 @@ class DurableEntityTimerDurabilityTest {
     private void awaitFullSlicePlacement() {
         try {
             await().atMost(WAIT_TIMEOUT)
-                 .pollInterval(POLL_INTERVAL)
-                 .failFast(this::failIfSliceFailed)
-                 .until(() -> activeSliceHosts().size() == INSTANCES);
+                   .pollInterval(POLL_INTERVAL)
+                   .failFast(this::failIfSliceFailed)
+                   .until(() -> activeSliceHosts().size() == INSTANCES);
         } catch (ConditionTimeoutException e) {
-            throw new AssertionError("Slice placement never reached " + INSTANCES
-                                    + " ACTIVE instances; hosts seen: " + activeSliceHosts(),
-                                     e);
+            throw new AssertionError("Slice placement never reached " + INSTANCES + " ACTIVE instances; hosts seen: "
+                                     + activeSliceHosts(), e);
         }
     }
 
@@ -429,32 +478,34 @@ class DurableEntityTimerDurabilityTest {
     private void awaitOwnershipConvergence() {
         try {
             await().atMost(WAIT_TIMEOUT)
-                 .pollInterval(POLL_INTERVAL)
-                 .failFast(this::failIfSliceFailed)
-                 .until(this::ownershipHasConverged);
+                   .pollInterval(POLL_INTERVAL)
+                   .failFast(this::failIfSliceFailed)
+                   .until(this::ownershipHasConverged);
         } catch (ConditionTimeoutException e) {
-            throw new AssertionError("Entity ownership never converged; last probe answers: " + lastProbeAnswers.get(),
-                                     e);
+            throw new AssertionError("Entity ownership never converged; last probe answers: " + lastProbeAnswers.get(), e);
         }
     }
 
     // --- the fence invariant, asserted on every create ---------------------------
+
     /// Create `key` by offering it to EVERY node and requiring that exactly one creates it — the same helper
     /// [DurableEntityForgeTest] uses, and for the same reason: it is independent of production's own owner
     /// resolution, so it cannot be fooled by that resolution being wrong the same way on both sides. Under
     /// owner-forwarding every node ACCEPTS and relays, so the single-writer invariant shows as exactly one
     /// CREATE and four `EntityAlreadyExists` carrying the owner's verdict back across the wire.
     private void createOnOwner(String key, String status, int amount) {
-        var responses = appPorts().stream().map(port -> create(port, key, status, amount)).toList();
-        var created = responses.stream().filter(response -> "created".equals(outcome(response))).toList();
+        var responses = appPorts().stream()
+                                  .map(port -> create(port, key, status, amount))
+                                  .toList();
+        var created = responses.stream()
+                               .filter(response -> "created".equals(outcome(response)))
+                               .toList();
 
         assertThat(responses).describedAs("every node must have answered").hasSize(NODES);
-        assertThat(created).describedAs("exactly one attempt may create '%s'; got %s",
-                                        key,
-                                        outcomesOf(responses))
-                  .hasSize(1);
+        assertThat(created).describedAs("exactly one attempt may create '%s'; got %s", key, outcomesOf(responses))
+                           .hasSize(1);
         assertThat(rejectionTypesOf(responses)).describedAs("every later attempt must surface the owner's duplicate refusal (#596)")
-                  .containsOnly("EntityAlreadyExists");
+                                               .containsOnly("EntityAlreadyExists");
     }
 
     private static List<String> outcomesOf(List<String> responses) {
@@ -476,23 +527,24 @@ class DurableEntityTimerDurabilityTest {
     private boolean ownershipHasConverged() {
         var round = ownershipProbe.incrementAndGet();
 
-        return IntStream.range(0, PARTITION_PROBE_KEYS).allMatch(index -> probeAccepted("__timer_probe_" + round
-                                                                                       + "_" + index
-                                                                                       + "__"));
+        return IntStream.range(0, PARTITION_PROBE_KEYS)
+                        .allMatch(index -> probeAccepted("__timer_probe_" + round + "_" + index + "__"));
     }
 
     /// Deliberately NOT via [#outcome]: that throws on a transport-level error body, and this runs while the
     /// cluster is still settling, so one slow node would abort setUp instead of reporting "not yet".
     private boolean probeAccepted(String key) {
-        var answers = appPorts().stream().map(port -> create(port, key, "probe", 0)).toList();
+        var answers = appPorts().stream()
+                                .map(port -> create(port, key, "probe", 0))
+                                .toList();
 
         lastProbeAnswers.set(answers);
 
-        return answers.stream()
-                      .anyMatch(response -> response.contains("\"outcome\":\"created\""));
+        return answers.stream().anyMatch(response -> response.contains("\"outcome\":\"created\""));
     }
 
     // --- entity operations -----------------------------------------------------
+
     private String create(int port, String key, String status, int amount) {
         return httpPost(port,
                         "/api/v1/entity/create",
@@ -514,15 +566,15 @@ class DurableEntityTimerDurabilityTest {
     /// Every currently-serving node's `expiries` for `key` — the multiplicity of applied `Expire` commands.
     private List<Integer> expiriesAcrossCluster(String key) {
         return serversOf(key).stream()
-                        .map(response -> number(response, "expiries"))
-                        .toList();
+                             .map(response -> number(response, "expiries"))
+                             .toList();
     }
 
     /// One serving node's view of `key`, for reading components other than the count.
     private String servedView(String key) {
         return serversOf(key).stream()
-                        .findFirst()
-                        .orElseThrow(() -> new AssertionError("No node serves '" + key + "'"));
+                             .findFirst()
+                             .orElseThrow(() -> new AssertionError("No node serves '" + key + "'"));
     }
 
     /// Every node currently serving `key`, by response body. Filters on a POSITIVE answer rather than
@@ -532,12 +584,13 @@ class DurableEntityTimerDurabilityTest {
     /// owner, so a "found" here names a node that answered, not necessarily one that holds the state.
     private List<String> serversOf(String key) {
         return appPorts().stream()
-                       .map(port -> get(port, key))
-                       .filter(response -> response.contains("\"outcome\":\"found\""))
-                       .toList();
+                         .map(port -> get(port, key))
+                         .filter(response -> response.contains("\"outcome\":\"found\""))
+                         .toList();
     }
 
     // --- ownership --------------------------------------------------------------
+
     /// The committed owner of one `entity:orders` arc, or `""` when the arc carries no record yet.
     private String arcOwner(int partition) {
         return Option.option(entityArcOwners().get(partition)).or("");
@@ -546,7 +599,7 @@ class DurableEntityTimerDurabilityTest {
     private boolean hasNewOwner(int partition, String previousOwner) {
         var owner = arcOwner(partition);
 
-        return ! owner.isEmpty() && !owner.equals(previousOwner);
+        return !owner.isEmpty() && !owner.equals(previousOwner);
     }
 
     /// Committed `entity:orders` arc owners by partition, read from whichever management port answers — the
@@ -554,13 +607,12 @@ class DurableEntityTimerDurabilityTest {
     /// the time.
     private Map<Integer, String> entityArcOwners() {
         var body = anyManagementAnswer("/api/v1/ownership/stream");
-        var matcher = Pattern.compile("\"identity\"\\s*:\\s*\"entity:" + KEYSPACE
-                                     + ":(\\d+)\"[^}]*\"owner\"\\s*:\\s*\"([^\"]+)\"").matcher(body);
+        var matcher = Pattern.compile("\"identity\"\\s*:\\s*\"entity:" + KEYSPACE + ":(\\d+)\"[^}]*\"owner\"\\s*:\\s*\"([^\"]+)\"")
+                             .matcher(body);
         var owners = new HashMap<Integer, String>();
 
         while (matcher.find()) {
-            owners.put(Integer.parseInt(matcher.group(1)),
-                       matcher.group(2));
+            owners.put(Integer.parseInt(matcher.group(1)), matcher.group(2));
         }
 
         return owners;
@@ -568,21 +620,22 @@ class DurableEntityTimerDurabilityTest {
 
     private String anyManagementAnswer(String path) {
         return mgmtPorts().stream()
-                        .map(port -> httpGet(port, path))
-                        .filter(body -> !body.contains("\"error\""))
-                        .findFirst()
-                        .orElse(ERROR_FALLBACK);
+                          .map(port -> httpGet(port, path))
+                          .filter(body -> !body.contains("\"error\""))
+                          .findFirst()
+                          .orElse(ERROR_FALLBACK);
     }
 
     // --- cluster addressing ------------------------------------------------------
+
     private List<Integer> appPorts() {
         return cluster.getAvailableAppHttpPorts();
     }
 
     private int firstPort() {
         return appPorts().stream()
-                       .findFirst()
-                       .orElseThrow(() -> new AssertionError("No app-http route is ready"));
+                         .findFirst()
+                         .orElseThrow(() -> new AssertionError("No app-http route is ready"));
     }
 
     /// The app-http port of a node id. Both ports are assigned from the same per-node slot (`base + slot`),
@@ -591,8 +644,7 @@ class DurableEntityTimerDurabilityTest {
         return cluster.status()
                       .nodes()
                       .stream()
-                      .filter(node -> node.id()
-                                          .equals(nodeId))
+                      .filter(node -> node.id().equals(nodeId))
                       .map(node -> BASE_APP_HTTP_PORT + (node.mgmtPort() - BASE_MGMT_PORT))
                       .findFirst()
                       .orElseThrow(() -> new AssertionError("No node with id " + nodeId));
@@ -607,13 +659,11 @@ class DurableEntityTimerDurabilityTest {
     }
 
     private int anyMgmtPort() {
-        return cluster.status()
-                      .nodes()
-                      .getFirst()
-                      .mgmtPort();
+        return cluster.status().nodes().getFirst().mgmtPort();
     }
 
     // --- deployment + readiness ----------------------------------------------------
+
     private void deployEntitySlice() {
         var blueprint = """
             id = "%s"
@@ -626,15 +676,14 @@ class DurableEntityTimerDurabilityTest {
         var response = postBlueprintWithRetry(leaderPort, blueprint);
 
         assertThat(response).describedAs("durable-entity slice deployment")
-                  .doesNotContain("\"error\"")
-                  .contains("\"status\":\"applied\"");
+                            .doesNotContain("\"error\"")
+                            .contains("\"status\":\"applied\"");
     }
 
     private boolean entityReadyOnEveryNode() {
         var ports = appPorts();
 
-        return ports.size() == NODES && ports.stream()
-                                             .allMatch(this::entityReady);
+        return ports.size() == NODES && ports.stream().allMatch(this::entityReady);
     }
 
     /// A node is ready once its entity resource ANSWERS — with a state verdict, or by saying plainly that it
@@ -644,7 +693,10 @@ class DurableEntityTimerDurabilityTest {
     private boolean entityReady(int port) {
         var body = get(port, "__readiness_probe__");
 
-        return ! body.contains("\"error\"") && (body.contains("\"outcome\":\"absent\"") || body.contains("\"outcome\":\"found\"") || body.contains("PartitionNotHeld"));
+        return !body.contains("\"error\"")
+               && (body.contains("\"outcome\":\"absent\"")
+                   || body.contains("\"outcome\":\"found\"")
+                   || body.contains("PartitionNotHeld"));
     }
 
     /// `slicesStatus()` cannot detect this failure: under `ALL_OR_NOTHING` a deterministic slice failure
@@ -656,37 +708,30 @@ class DurableEntityTimerDurabilityTest {
             var reason = deploymentFailedReason(httpGet(port, "/api/v1/events"));
 
             if (reason != null) {
-                throw new AssertionError("Deployment of " + ENTITY_SLICE
-                                        + " FAILED — event surface reason: " + excerpt(reason));
+                throw new AssertionError("Deployment of " + ENTITY_SLICE + " FAILED — event surface reason: " + excerpt(reason));
             }
         }
     }
 
     private static String deploymentFailedReason(String eventsBody) {
-        var matcher = Pattern.compile("\"type\"\\s*:\\s*\"DEPLOYMENT_FAILED\".*?\"artifact\"\\s*:\\s*\"" + Pattern.quote(ENTITY_SLICE)
-                                     + "\".*?\"reason\"\\s*:\\s*\"([^\"]*)\"",
-                                      Pattern.DOTALL)
+        var matcher = Pattern.compile("\"type\"\\s*:\\s*\"DEPLOYMENT_FAILED\".*?\"artifact\"\\s*:\\s*\""
+                                      + Pattern.quote(ENTITY_SLICE)
+                                      + "\".*?\"reason\"\\s*:\\s*\"([^\"]*)\"", Pattern.DOTALL)
                              .matcher(eventsBody);
 
-        return matcher.find()
-               ? matcher.group(1)
-               : null;
+        return matcher.find() ? matcher.group(1) : null;
     }
 
     private static String excerpt(String reason) {
-        return reason.length() <= REASON_EXCERPT_LIMIT
-               ? reason
-               : reason.substring(0, REASON_EXCERPT_LIMIT) + "...";
+        return reason.length() <= REASON_EXCERPT_LIMIT ? reason : reason.substring(0, REASON_EXCERPT_LIMIT) + "...";
     }
 
     private boolean allNodesHealthy() {
-        return mgmtPorts().stream()
-                        .allMatch(this::checkNodeHealth);
+        return mgmtPorts().stream().allMatch(this::checkNodeHealth);
     }
 
     private boolean checkNodeHealth(int port) {
-        return healthBody(port).map(body -> body.contains("\"quorum\":true"))
-                         .or(false);
+        return healthBody(port).map(body -> body.contains("\"quorum\":true")).or(false);
     }
 
     /// Full-membership gate: [#allNodesHealthy] only checks each node's LOCAL quorum flag, which turns true
@@ -695,8 +740,7 @@ class DurableEntityTimerDurabilityTest {
     private boolean allNodesAreMembers(int expected) {
         var leaderPort = cluster.getLeaderManagementPort().or(anyMgmtPort());
 
-        return healthBody(leaderPort).map(body -> healthHasFullMembership(body, expected))
-                         .or(false);
+        return healthBody(leaderPort).map(body -> healthHasFullMembership(body, expected)).or(false);
     }
 
     private Option<String> healthBody(int port) {
@@ -724,6 +768,7 @@ class DurableEntityTimerDurabilityTest {
     }
 
     // --- response reading -------------------------------------------------------
+
     /// Fails loudly on a missing field rather than returning "": a renamed component would otherwise turn
     /// every `isEqualTo` into a silent comparison against the empty string.
     private static String text(String body, String field) {
@@ -757,6 +802,7 @@ class DurableEntityTimerDurabilityTest {
     }
 
     // --- timing ------------------------------------------------------------------
+
     private static long elapsedMillis(long sinceNanos) {
         return Duration.ofNanos(System.nanoTime() - sinceNanos).toMillis();
     }
@@ -788,18 +834,21 @@ class DurableEntityTimerDurabilityTest {
                 "I4 quiet period: requested={0}ms elapsed={1}ms",
                 span.toMillis(),
                 elapsedMillis);
+
         assertThat(elapsedMillis).describedAs("the quiet period must actually elapse — a residual unpark permit left by "
-                                             + "Promise.await() makes a bare park return at once, which would reduce the "
-                                             + "exactly-once assertion below to a re-read of the value just polled for")
-                  .isGreaterThanOrEqualTo(span.toMillis());
+                                              + "Promise.await() makes a bare park return at once, which would reduce the "
+                                              + "exactly-once assertion below to a re-read of the value just polled for")
+                                 .isGreaterThanOrEqualTo(span.toMillis());
     }
 
     // --- HTTP ------------------------------------------------------------------------
+
     private String postBlueprintWithRetry(int port, String body) {
         var lastResponse = ERROR_FALLBACK;
 
         for (int attempt = 1; attempt <= 3; attempt++) {
             lastResponse = httpPostToml(port, "/api/v1/blueprints", body);
+
             if (!lastResponse.contains("\"error\"")) {
                 return lastResponse;
             }

--- a/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/DurableEntityTimerDurabilityTest.java
+++ b/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/DurableEntityTimerDurabilityTest.java
@@ -2,27 +2,7 @@
 // Copyright (c) 2025 Pragmatica Labs - Sergiy Yevtushenko
 // Licensed under Business Source License 1.1. Change Date: 2030-01-01. Change License: Apache-2.0.
 // See LICENSE in the repository root for full terms.
-
 package org.pragmatica.aether.forge;
-
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.MethodOrderer;
-import org.junit.jupiter.api.Order;
-import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
-import org.junit.jupiter.api.TestMethodOrder;
-import org.junit.jupiter.api.io.TempDir;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
-import org.awaitility.core.ConditionTimeoutException;
-import org.pragmatica.aether.dht.EntityPartitionArc;
-import org.pragmatica.aether.ember.EmberCluster;
-import org.pragmatica.config.ConfigurationProvider;
-import org.pragmatica.http.HttpOperations;
-import org.pragmatica.http.HttpResult;
-import org.pragmatica.lang.Option;
 
 import java.net.URI;
 import java.net.http.HttpRequest;
@@ -39,10 +19,31 @@ import java.util.concurrent.locks.LockSupport;
 import java.util.regex.Pattern;
 import java.util.stream.IntStream;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.awaitility.Awaitility.await;
+import org.pragmatica.aether.dht.EntityPartitionArc;
+import org.pragmatica.aether.ember.EmberCluster;
+import org.pragmatica.config.ConfigurationProvider;
+import org.pragmatica.http.HttpOperations;
+import org.pragmatica.http.HttpResult;
+import org.pragmatica.lang.Option;
+
+import org.awaitility.core.ConditionTimeoutException;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+
 import static org.pragmatica.aether.ember.EmberCluster.emberCluster;
 import static org.pragmatica.http.JdkHttpOperations.jdkHttpOperations;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
 
 /// #345 increment I4 — the two gates that make a durable timer DURABLE (#351).
 ///
@@ -135,7 +136,6 @@ class DurableEntityTimerDurabilityTest {
 
     private static final Duration WAIT_TIMEOUT = Duration.ofSeconds(240);
     private static final Duration POLL_INTERVAL = Duration.ofMillis(500);
-
     /// The handover gate's delay. It must comfortably outlive create + schedule + the pre-kill read — the
     /// timer has to be provably still pending when its owner dies, or a fire on the OLD owner would satisfy
     /// the gate for the wrong reason. That prelude measures 25 ms, so 45s is a 1,800x margin and the gate
@@ -144,7 +144,6 @@ class DurableEntityTimerDurabilityTest {
     /// ~35s of the delay to run, and the timer fires on its original instant. That is the more interesting
     /// of the two legal outcomes, and it is why this delay is deliberately larger than the restart gate's.
     private static final long HANDOVER_DELAY_MILLIS = 45_000L;
-
     /// The restart gate's delay, and it is deliberately SHORTER than the handover gate's rather than longer.
     /// It only has to outlive create + schedule + the pre-stop read (27 ms measured); it does NOT have to
     /// outlive the restart, because no process is alive during a restart that could fire anything. Measured,
@@ -153,22 +152,18 @@ class DurableEntityTimerDurabilityTest {
     /// never lost" clause being exercised head-on. Sizing this to span the whole restart would have cost a
     /// minute per run and measured nothing extra.
     private static final long RESTART_DELAY_MILLIS = 30_000L;
-
     /// Quiet period before declaring a fire exactly-once. The entity timer tick is one second, so a
     /// duplicate timer planted alongside the original comes due within a tick of it; five ticks gives four
     /// spare for a second fire that must not happen to happen.
     private static final Duration EXACTLY_ONCE_SETTLE = Duration.ofSeconds(5);
-
     private static final String ENTITY_SLICE = TestArtifacts.ENTITY_SLICE;
     private static final String BLUEPRINT_ID = "forge.test:durable-entity-timers:1.0.0";
     private static final String ERROR_FALLBACK = "{\"error\":\"request failed\"}";
     private static final int REASON_EXCERPT_LIMIT = 300;
     private static final int PARTITION_PROBE_KEYS = 12;
-
     private static final Pattern NODE_COUNT_FIELD = Pattern.compile("\"nodeCount\"\\s*:\\s*(\\d+)");
 
     Path baseDir;
-
     private EmberCluster cluster;
     private final HttpOperations http = jdkHttpOperations();
     private final AtomicInteger ownershipProbe = new AtomicInteger();
@@ -177,7 +172,6 @@ class DurableEntityTimerDurabilityTest {
     @BeforeAll
     void setUp(@TempDir Path tempDir) {
         this.baseDir = tempDir;
-
         // Resource provisioning is gated on a ConfigurationProvider being present; without it the node
         // installs a no-op facade and every resource-backed slice fails to load.
         var configProvider = ConfigurationProvider.builder()
@@ -190,7 +184,6 @@ class DurableEntityTimerDurabilityTest {
         // entity log's backing per-partition WAL on. Without it a full-cluster restart would lose the log
         // and the gate would be measuring the harness rather than the entity.
         cluster.withDataBaseDir(baseDir);
-
         startAndAwaitReady();
     }
 
@@ -200,13 +193,11 @@ class DurableEntityTimerDurabilityTest {
             var leaderPort = cluster.getLeaderManagementPort().or(anyMgmtPort());
 
             httpDelete(leaderPort, "/api/v1/blueprints/" + BLUEPRINT_ID);
-            cluster.stop()
-                   .await();
+            LifecycleAwait.settled("cluster stop in tearDown()", cluster, cluster.stop());
         }
     }
 
     // --- gate 1: the timer survives the whole cluster going away ----------------
-
     /// GATE — a pending timer survives a full-cluster restart and fires afterwards.
     ///
     /// The state and the pending timer both live in the entity's log, which is backed by a per-partition
@@ -235,35 +226,28 @@ class DurableEntityTimerDurabilityTest {
         var key = "order-timer-restart";
 
         createOnOwner(key, "placed", 700);
-
         var scheduledAt = System.nanoTime();
         var scheduled = scheduleTimer(firstPort(), key, RESTART_DELAY_MILLIS);
 
         assertThat(outcome(scheduled)).describedAs("the schedule must be accepted before there is anything to survive")
-                                      .isEqualTo("scheduled");
+                  .isEqualTo("scheduled");
         assertThat(text(scheduled, "token")).describedAs("a scheduled timer answers with its handle").isNotEmpty();
         assertThat(expiriesAcrossCluster(key)).describedAs("the timer must still be PENDING when the cluster goes down; "
-                                                           + "a fire before the restart would prove nothing")
-                                              .isNotEmpty()
-                                              .allSatisfy(count -> assertThat(count).isZero());
-
+                                                          + "a fire before the restart would prove nothing")
+                  .isNotEmpty()
+                  .allSatisfy(count -> assertThat(count).isZero());
         var scheduleToStopMillis = elapsedMillis(scheduledAt);
 
         assertThat(scheduleToStopMillis).describedAs("the delay must comfortably outlive the prelude, else the pending-ness "
-                                                     + "above is a coin flip rather than a margin")
-                                        .isLessThan(RESTART_DELAY_MILLIS / 4);
-
+                                                    + "above is a coin flip rather than a margin")
+                  .isLessThan(RESTART_DELAY_MILLIS / 4);
         var restartStartedAt = System.nanoTime();
 
         restartCluster();
-
         var restartMillis = elapsedMillis(restartStartedAt);
         var firedAt = System.nanoTime();
 
-        await().atMost(WAIT_TIMEOUT)
-               .pollInterval(POLL_INTERVAL)
-               .until(() -> expiriesAcrossCluster(key).contains(1));
-
+        await().atMost(WAIT_TIMEOUT).pollInterval(POLL_INTERVAL).until(() -> expiriesAcrossCluster(key).contains(1));
         var fireLatencyMillis = elapsedMillis(firedAt);
 
         LOG.log(System.Logger.Level.INFO,
@@ -272,12 +256,10 @@ class DurableEntityTimerDurabilityTest {
                 scheduleToStopMillis,
                 restartMillis,
                 fireLatencyMillis);
-
         assertExactlyOneFire(key, 700);
     }
 
     // --- gate 2: the timer survives its owner being replaced --------------------
-
     /// GATE — a pending timer survives its partition's owner being replaced, and the new owner applies it
     /// exactly once.
     ///
@@ -306,55 +288,40 @@ class DurableEntityTimerDurabilityTest {
         var partition = ARC.partitionOf(key);
 
         createOnOwner(key, "placed", 300);
-
         var ownerBefore = arcOwner(partition);
 
         assertThat(ownerBefore).describedAs("the key's arc must carry a committed owner before it can lose one")
-                               .isNotEmpty();
-
+                  .isNotEmpty();
         var scheduledAt = System.nanoTime();
         var scheduled = scheduleTimer(firstPort(), key, HANDOVER_DELAY_MILLIS);
 
         assertThat(outcome(scheduled)).describedAs("the schedule must be accepted before there is anything to hand over")
-                                      .isEqualTo("scheduled");
+                  .isEqualTo("scheduled");
         assertThat(expiriesAcrossCluster(key)).describedAs("the timer must still be PENDING when its owner dies; a fire on "
-                                                           + "the OLD owner would satisfy every later assertion for the "
-                                                           + "wrong reason")
-                                              .isNotEmpty()
-                                              .allSatisfy(count -> assertThat(count).isZero());
-
+                                                          + "the OLD owner would satisfy every later assertion for the "
+                                                          + "wrong reason")
+                  .isNotEmpty()
+                  .allSatisfy(count -> assertThat(count).isZero());
         var scheduleToKillMillis = elapsedMillis(scheduledAt);
 
         assertThat(scheduleToKillMillis).describedAs("the delay must comfortably outlive the prelude, else the pending-ness "
-                                                     + "above is a coin flip rather than a margin")
-                                        .isLessThan(HANDOVER_DELAY_MILLIS / 4);
-
+                                                    + "above is a coin flip rather than a margin")
+                  .isLessThan(HANDOVER_DELAY_MILLIS / 4);
         var ownerPort = appPortForNodeId(ownerBefore);
         var killedAt = System.nanoTime();
 
-        cluster.killNode(ownerBefore)
-               .await()
-               .onFailure(cause -> {
-                   throw new AssertionError("Failed to stop the owner " + ownerBefore + ": " + cause.message());
-               });
-
-        await().atMost(WAIT_TIMEOUT)
-               .pollInterval(POLL_INTERVAL)
-               .until(() -> !appPorts().contains(ownerPort));
-
+        LifecycleAwait.nodeSettled("kill node " + ownerBefore
+                                  + " in timerFires_afterOwnerHandover_appliedOnceByTheNewOwner()",
+                                   cluster,
+                                   cluster.killNode(ownerBefore));
+        await().atMost(WAIT_TIMEOUT).pollInterval(POLL_INTERVAL).until(() -> !appPorts().contains(ownerPort));
         // The handover itself, asserted rather than assumed. Until this flips, the key's partition still
         // names a dead node as its owner and nothing can fire.
-        await().atMost(WAIT_TIMEOUT)
-               .pollInterval(POLL_INTERVAL)
-               .until(() -> hasNewOwner(partition, ownerBefore));
-
+        await().atMost(WAIT_TIMEOUT).pollInterval(POLL_INTERVAL).until(() -> hasNewOwner(partition, ownerBefore));
         var handoverMillis = elapsedMillis(killedAt);
         var firedAt = System.nanoTime();
 
-        await().atMost(WAIT_TIMEOUT)
-               .pollInterval(POLL_INTERVAL)
-               .until(() -> expiriesAcrossCluster(key).contains(1));
-
+        await().atMost(WAIT_TIMEOUT).pollInterval(POLL_INTERVAL).until(() -> expiriesAcrossCluster(key).contains(1));
         var fireLatencyMillis = elapsedMillis(firedAt);
 
         LOG.log(System.Logger.Level.INFO,
@@ -363,15 +330,12 @@ class DurableEntityTimerDurabilityTest {
                 scheduleToKillMillis,
                 handoverMillis,
                 fireLatencyMillis);
-
         assertThat(arcOwner(partition)).describedAs("the key's arc must have moved, else no handover was tested")
-                                       .isNotEqualTo(ownerBefore);
-
+                  .isNotEqualTo(ownerBefore);
         assertExactlyOneFire(key, 300);
     }
 
     // --- the shared post-fire assertion -----------------------------------------
-
     /// The exactly-once assertion both gates end on.
     ///
     /// A duplicate fire arrives on a LATER tick, so a reading taken the instant the first one lands cannot
@@ -384,74 +348,50 @@ class DurableEntityTimerDurabilityTest {
     /// defect — hence "no node above 1, and at least one at exactly 1" rather than "all equal 1".
     private void assertExactlyOneFire(String key, int originalAmount) {
         awaitQuietPeriod(EXACTLY_ONCE_SETTLE);
-
         var counts = expiriesAcrossCluster(key);
 
         assertThat(counts).describedAs("at least one node must serve '%s' after the fire", key).isNotEmpty();
         assertThat(counts).describedAs("the timer fires ONCE — a node reading 2 folded two fires of one schedule")
-                          .allSatisfy(count -> assertThat(count).isLessThanOrEqualTo(1));
+                  .allSatisfy(count -> assertThat(count).isLessThanOrEqualTo(1));
         assertThat(counts).describedAs("and it did fire, on some node's committed view").contains(1);
-
         var settled = servedView(key);
 
         assertThat(text(settled, "status")).describedAs("the fire is a real mutation applied through the ordinary update path")
-                                           .isEqualTo("expired");
+                  .isEqualTo("expired");
         assertThat(number(settled, "amount")).describedAs("the state itself survived: Expire leaves 'amount' alone, so a "
-                                                          + "default-constructed state would show here")
-                                             .isEqualTo(originalAmount);
+                                                         + "default-constructed state would show here")
+                  .isEqualTo(originalAmount);
     }
 
     // --- restart ------------------------------------------------------------------
-
     private void restartCluster() {
-        cluster.stop()
-               .await()
-               .onFailure(cause -> {
-                   throw new AssertionError("Cluster stop failed: " + cause.message());
-               });
-
+        LifecycleAwait.settled("cluster stop in restartCluster()", cluster, cluster.stop());
         startAndAwaitReady();
     }
 
     private void startAndAwaitReady() {
-        cluster.start()
-               .await()
-               .onFailure(cause -> {
-                   throw new AssertionError("Cluster start failed: " + cause.message());
-               });
-
-        await().atMost(WAIT_TIMEOUT)
-               .pollInterval(POLL_INTERVAL)
-               .until(() -> cluster.currentLeader().isPresent());
-
-        await().atMost(WAIT_TIMEOUT)
-               .pollInterval(POLL_INTERVAL)
-               .until(this::allNodesHealthy);
-
+        LifecycleAwait.settled("cluster start in startAndAwaitReady()", cluster, cluster.start());
+        await().atMost(WAIT_TIMEOUT).pollInterval(POLL_INTERVAL).until(() -> cluster.currentLeader()
+                                                                                    .isPresent());
+        await().atMost(WAIT_TIMEOUT).pollInterval(POLL_INTERVAL).until(this::allNodesHealthy);
         // Gate on FULL membership, not merely on local quorum. After a cold restart the entity arcs are
         // re-minted over whichever nodes have rejoined, and an arc placed on a straggler-free subset would
         // hand the key's partition to a node whose WAL never held it.
-        await().atMost(WAIT_TIMEOUT)
-               .pollInterval(POLL_INTERVAL)
-               .until(() -> allNodesAreMembers(NODES));
-
+        await().atMost(WAIT_TIMEOUT).pollInterval(POLL_INTERVAL).until(() -> allNodesAreMembers(NODES));
         // Forge's Rabia persistence is in-memory, so a full-cluster restart wipes the blueprint and with it
         // the keyspace registration. Re-deploying restores ONLY that: no state, no timers. Both come back
         // from the WAL-backed entity log when the new owner folds its partitions.
         deployEntitySlice();
-
         await().atMost(WAIT_TIMEOUT)
-               .pollInterval(POLL_INTERVAL)
-               .failFast(this::failIfSliceFailed)
-               .until(this::entityReadyOnEveryNode);
-
+             .pollInterval(POLL_INTERVAL)
+             .failFast(this::failIfSliceFailed)
+             .until(this::entityReadyOnEveryNode);
         // Placement converges LATER than entity readiness — measured 2026-08-27, the scheduler's first pass
         // placed 2 of the 3 requested instances and the reconciler took a further ~52s to add the third.
         // The handover gate depends on this: it kills a host, and re-placement has room only if the full
         // three were there to begin with. Waiting here also keeps the gates measuring a converged cluster
         // rather than a mid-reconcile one.
         awaitFullSlicePlacement();
-
         awaitOwnershipConvergence();
     }
 
@@ -460,12 +400,13 @@ class DurableEntityTimerDurabilityTest {
     private void awaitFullSlicePlacement() {
         try {
             await().atMost(WAIT_TIMEOUT)
-                   .pollInterval(POLL_INTERVAL)
-                   .failFast(this::failIfSliceFailed)
-                   .until(() -> activeSliceHosts().size() == INSTANCES);
+                 .pollInterval(POLL_INTERVAL)
+                 .failFast(this::failIfSliceFailed)
+                 .until(() -> activeSliceHosts().size() == INSTANCES);
         } catch (ConditionTimeoutException e) {
-            throw new AssertionError("Slice placement never reached " + INSTANCES + " ACTIVE instances; hosts seen: "
-                                     + activeSliceHosts(), e);
+            throw new AssertionError("Slice placement never reached " + INSTANCES
+                                    + " ACTIVE instances; hosts seen: " + activeSliceHosts(),
+                                     e);
         }
     }
 
@@ -488,34 +429,32 @@ class DurableEntityTimerDurabilityTest {
     private void awaitOwnershipConvergence() {
         try {
             await().atMost(WAIT_TIMEOUT)
-                   .pollInterval(POLL_INTERVAL)
-                   .failFast(this::failIfSliceFailed)
-                   .until(this::ownershipHasConverged);
+                 .pollInterval(POLL_INTERVAL)
+                 .failFast(this::failIfSliceFailed)
+                 .until(this::ownershipHasConverged);
         } catch (ConditionTimeoutException e) {
-            throw new AssertionError("Entity ownership never converged; last probe answers: " + lastProbeAnswers.get(), e);
+            throw new AssertionError("Entity ownership never converged; last probe answers: " + lastProbeAnswers.get(),
+                                     e);
         }
     }
 
     // --- the fence invariant, asserted on every create ---------------------------
-
     /// Create `key` by offering it to EVERY node and requiring that exactly one creates it — the same helper
     /// [DurableEntityForgeTest] uses, and for the same reason: it is independent of production's own owner
     /// resolution, so it cannot be fooled by that resolution being wrong the same way on both sides. Under
     /// owner-forwarding every node ACCEPTS and relays, so the single-writer invariant shows as exactly one
     /// CREATE and four `EntityAlreadyExists` carrying the owner's verdict back across the wire.
     private void createOnOwner(String key, String status, int amount) {
-        var responses = appPorts().stream()
-                                  .map(port -> create(port, key, status, amount))
-                                  .toList();
-        var created = responses.stream()
-                               .filter(response -> "created".equals(outcome(response)))
-                               .toList();
+        var responses = appPorts().stream().map(port -> create(port, key, status, amount)).toList();
+        var created = responses.stream().filter(response -> "created".equals(outcome(response))).toList();
 
         assertThat(responses).describedAs("every node must have answered").hasSize(NODES);
-        assertThat(created).describedAs("exactly one attempt may create '%s'; got %s", key, outcomesOf(responses))
-                           .hasSize(1);
+        assertThat(created).describedAs("exactly one attempt may create '%s'; got %s",
+                                        key,
+                                        outcomesOf(responses))
+                  .hasSize(1);
         assertThat(rejectionTypesOf(responses)).describedAs("every later attempt must surface the owner's duplicate refusal (#596)")
-                                               .containsOnly("EntityAlreadyExists");
+                  .containsOnly("EntityAlreadyExists");
     }
 
     private static List<String> outcomesOf(List<String> responses) {
@@ -537,24 +476,23 @@ class DurableEntityTimerDurabilityTest {
     private boolean ownershipHasConverged() {
         var round = ownershipProbe.incrementAndGet();
 
-        return IntStream.range(0, PARTITION_PROBE_KEYS)
-                        .allMatch(index -> probeAccepted("__timer_probe_" + round + "_" + index + "__"));
+        return IntStream.range(0, PARTITION_PROBE_KEYS).allMatch(index -> probeAccepted("__timer_probe_" + round
+                                                                                       + "_" + index
+                                                                                       + "__"));
     }
 
     /// Deliberately NOT via [#outcome]: that throws on a transport-level error body, and this runs while the
     /// cluster is still settling, so one slow node would abort setUp instead of reporting "not yet".
     private boolean probeAccepted(String key) {
-        var answers = appPorts().stream()
-                                .map(port -> create(port, key, "probe", 0))
-                                .toList();
+        var answers = appPorts().stream().map(port -> create(port, key, "probe", 0)).toList();
 
         lastProbeAnswers.set(answers);
 
-        return answers.stream().anyMatch(response -> response.contains("\"outcome\":\"created\""));
+        return answers.stream()
+                      .anyMatch(response -> response.contains("\"outcome\":\"created\""));
     }
 
     // --- entity operations -----------------------------------------------------
-
     private String create(int port, String key, String status, int amount) {
         return httpPost(port,
                         "/api/v1/entity/create",
@@ -576,15 +514,15 @@ class DurableEntityTimerDurabilityTest {
     /// Every currently-serving node's `expiries` for `key` — the multiplicity of applied `Expire` commands.
     private List<Integer> expiriesAcrossCluster(String key) {
         return serversOf(key).stream()
-                             .map(response -> number(response, "expiries"))
-                             .toList();
+                        .map(response -> number(response, "expiries"))
+                        .toList();
     }
 
     /// One serving node's view of `key`, for reading components other than the count.
     private String servedView(String key) {
         return serversOf(key).stream()
-                             .findFirst()
-                             .orElseThrow(() -> new AssertionError("No node serves '" + key + "'"));
+                        .findFirst()
+                        .orElseThrow(() -> new AssertionError("No node serves '" + key + "'"));
     }
 
     /// Every node currently serving `key`, by response body. Filters on a POSITIVE answer rather than
@@ -594,13 +532,12 @@ class DurableEntityTimerDurabilityTest {
     /// owner, so a "found" here names a node that answered, not necessarily one that holds the state.
     private List<String> serversOf(String key) {
         return appPorts().stream()
-                         .map(port -> get(port, key))
-                         .filter(response -> response.contains("\"outcome\":\"found\""))
-                         .toList();
+                       .map(port -> get(port, key))
+                       .filter(response -> response.contains("\"outcome\":\"found\""))
+                       .toList();
     }
 
     // --- ownership --------------------------------------------------------------
-
     /// The committed owner of one `entity:orders` arc, or `""` when the arc carries no record yet.
     private String arcOwner(int partition) {
         return Option.option(entityArcOwners().get(partition)).or("");
@@ -609,7 +546,7 @@ class DurableEntityTimerDurabilityTest {
     private boolean hasNewOwner(int partition, String previousOwner) {
         var owner = arcOwner(partition);
 
-        return !owner.isEmpty() && !owner.equals(previousOwner);
+        return ! owner.isEmpty() && !owner.equals(previousOwner);
     }
 
     /// Committed `entity:orders` arc owners by partition, read from whichever management port answers — the
@@ -617,12 +554,13 @@ class DurableEntityTimerDurabilityTest {
     /// the time.
     private Map<Integer, String> entityArcOwners() {
         var body = anyManagementAnswer("/api/v1/ownership/stream");
-        var matcher = Pattern.compile("\"identity\"\\s*:\\s*\"entity:" + KEYSPACE + ":(\\d+)\"[^}]*\"owner\"\\s*:\\s*\"([^\"]+)\"")
-                             .matcher(body);
+        var matcher = Pattern.compile("\"identity\"\\s*:\\s*\"entity:" + KEYSPACE
+                                     + ":(\\d+)\"[^}]*\"owner\"\\s*:\\s*\"([^\"]+)\"").matcher(body);
         var owners = new HashMap<Integer, String>();
 
         while (matcher.find()) {
-            owners.put(Integer.parseInt(matcher.group(1)), matcher.group(2));
+            owners.put(Integer.parseInt(matcher.group(1)),
+                       matcher.group(2));
         }
 
         return owners;
@@ -630,22 +568,21 @@ class DurableEntityTimerDurabilityTest {
 
     private String anyManagementAnswer(String path) {
         return mgmtPorts().stream()
-                          .map(port -> httpGet(port, path))
-                          .filter(body -> !body.contains("\"error\""))
-                          .findFirst()
-                          .orElse(ERROR_FALLBACK);
+                        .map(port -> httpGet(port, path))
+                        .filter(body -> !body.contains("\"error\""))
+                        .findFirst()
+                        .orElse(ERROR_FALLBACK);
     }
 
     // --- cluster addressing ------------------------------------------------------
-
     private List<Integer> appPorts() {
         return cluster.getAvailableAppHttpPorts();
     }
 
     private int firstPort() {
         return appPorts().stream()
-                         .findFirst()
-                         .orElseThrow(() -> new AssertionError("No app-http route is ready"));
+                       .findFirst()
+                       .orElseThrow(() -> new AssertionError("No app-http route is ready"));
     }
 
     /// The app-http port of a node id. Both ports are assigned from the same per-node slot (`base + slot`),
@@ -654,7 +591,8 @@ class DurableEntityTimerDurabilityTest {
         return cluster.status()
                       .nodes()
                       .stream()
-                      .filter(node -> node.id().equals(nodeId))
+                      .filter(node -> node.id()
+                                          .equals(nodeId))
                       .map(node -> BASE_APP_HTTP_PORT + (node.mgmtPort() - BASE_MGMT_PORT))
                       .findFirst()
                       .orElseThrow(() -> new AssertionError("No node with id " + nodeId));
@@ -669,11 +607,13 @@ class DurableEntityTimerDurabilityTest {
     }
 
     private int anyMgmtPort() {
-        return cluster.status().nodes().getFirst().mgmtPort();
+        return cluster.status()
+                      .nodes()
+                      .getFirst()
+                      .mgmtPort();
     }
 
     // --- deployment + readiness ----------------------------------------------------
-
     private void deployEntitySlice() {
         var blueprint = """
             id = "%s"
@@ -686,14 +626,15 @@ class DurableEntityTimerDurabilityTest {
         var response = postBlueprintWithRetry(leaderPort, blueprint);
 
         assertThat(response).describedAs("durable-entity slice deployment")
-                            .doesNotContain("\"error\"")
-                            .contains("\"status\":\"applied\"");
+                  .doesNotContain("\"error\"")
+                  .contains("\"status\":\"applied\"");
     }
 
     private boolean entityReadyOnEveryNode() {
         var ports = appPorts();
 
-        return ports.size() == NODES && ports.stream().allMatch(this::entityReady);
+        return ports.size() == NODES && ports.stream()
+                                             .allMatch(this::entityReady);
     }
 
     /// A node is ready once its entity resource ANSWERS — with a state verdict, or by saying plainly that it
@@ -703,10 +644,7 @@ class DurableEntityTimerDurabilityTest {
     private boolean entityReady(int port) {
         var body = get(port, "__readiness_probe__");
 
-        return !body.contains("\"error\"")
-               && (body.contains("\"outcome\":\"absent\"")
-                   || body.contains("\"outcome\":\"found\"")
-                   || body.contains("PartitionNotHeld"));
+        return ! body.contains("\"error\"") && (body.contains("\"outcome\":\"absent\"") || body.contains("\"outcome\":\"found\"") || body.contains("PartitionNotHeld"));
     }
 
     /// `slicesStatus()` cannot detect this failure: under `ALL_OR_NOTHING` a deterministic slice failure
@@ -718,30 +656,37 @@ class DurableEntityTimerDurabilityTest {
             var reason = deploymentFailedReason(httpGet(port, "/api/v1/events"));
 
             if (reason != null) {
-                throw new AssertionError("Deployment of " + ENTITY_SLICE + " FAILED — event surface reason: " + excerpt(reason));
+                throw new AssertionError("Deployment of " + ENTITY_SLICE
+                                        + " FAILED — event surface reason: " + excerpt(reason));
             }
         }
     }
 
     private static String deploymentFailedReason(String eventsBody) {
-        var matcher = Pattern.compile("\"type\"\\s*:\\s*\"DEPLOYMENT_FAILED\".*?\"artifact\"\\s*:\\s*\""
-                                      + Pattern.quote(ENTITY_SLICE)
-                                      + "\".*?\"reason\"\\s*:\\s*\"([^\"]*)\"", Pattern.DOTALL)
+        var matcher = Pattern.compile("\"type\"\\s*:\\s*\"DEPLOYMENT_FAILED\".*?\"artifact\"\\s*:\\s*\"" + Pattern.quote(ENTITY_SLICE)
+                                     + "\".*?\"reason\"\\s*:\\s*\"([^\"]*)\"",
+                                      Pattern.DOTALL)
                              .matcher(eventsBody);
 
-        return matcher.find() ? matcher.group(1) : null;
+        return matcher.find()
+               ? matcher.group(1)
+               : null;
     }
 
     private static String excerpt(String reason) {
-        return reason.length() <= REASON_EXCERPT_LIMIT ? reason : reason.substring(0, REASON_EXCERPT_LIMIT) + "...";
+        return reason.length() <= REASON_EXCERPT_LIMIT
+               ? reason
+               : reason.substring(0, REASON_EXCERPT_LIMIT) + "...";
     }
 
     private boolean allNodesHealthy() {
-        return mgmtPorts().stream().allMatch(this::checkNodeHealth);
+        return mgmtPorts().stream()
+                        .allMatch(this::checkNodeHealth);
     }
 
     private boolean checkNodeHealth(int port) {
-        return healthBody(port).map(body -> body.contains("\"quorum\":true")).or(false);
+        return healthBody(port).map(body -> body.contains("\"quorum\":true"))
+                         .or(false);
     }
 
     /// Full-membership gate: [#allNodesHealthy] only checks each node's LOCAL quorum flag, which turns true
@@ -750,7 +695,8 @@ class DurableEntityTimerDurabilityTest {
     private boolean allNodesAreMembers(int expected) {
         var leaderPort = cluster.getLeaderManagementPort().or(anyMgmtPort());
 
-        return healthBody(leaderPort).map(body -> healthHasFullMembership(body, expected)).or(false);
+        return healthBody(leaderPort).map(body -> healthHasFullMembership(body, expected))
+                         .or(false);
     }
 
     private Option<String> healthBody(int port) {
@@ -778,7 +724,6 @@ class DurableEntityTimerDurabilityTest {
     }
 
     // --- response reading -------------------------------------------------------
-
     /// Fails loudly on a missing field rather than returning "": a renamed component would otherwise turn
     /// every `isEqualTo` into a silent comparison against the empty string.
     private static String text(String body, String field) {
@@ -812,7 +757,6 @@ class DurableEntityTimerDurabilityTest {
     }
 
     // --- timing ------------------------------------------------------------------
-
     private static long elapsedMillis(long sinceNanos) {
         return Duration.ofNanos(System.nanoTime() - sinceNanos).toMillis();
     }
@@ -844,21 +788,18 @@ class DurableEntityTimerDurabilityTest {
                 "I4 quiet period: requested={0}ms elapsed={1}ms",
                 span.toMillis(),
                 elapsedMillis);
-
         assertThat(elapsedMillis).describedAs("the quiet period must actually elapse — a residual unpark permit left by "
-                                              + "Promise.await() makes a bare park return at once, which would reduce the "
-                                              + "exactly-once assertion below to a re-read of the value just polled for")
-                                 .isGreaterThanOrEqualTo(span.toMillis());
+                                             + "Promise.await() makes a bare park return at once, which would reduce the "
+                                             + "exactly-once assertion below to a re-read of the value just polled for")
+                  .isGreaterThanOrEqualTo(span.toMillis());
     }
 
     // --- HTTP ------------------------------------------------------------------------
-
     private String postBlueprintWithRetry(int port, String body) {
         var lastResponse = ERROR_FALLBACK;
 
         for (int attempt = 1; attempt <= 3; attempt++) {
             lastResponse = httpPostToml(port, "/api/v1/blueprints", body);
-
             if (!lastResponse.contains("\"error\"")) {
                 return lastResponse;
             }

--- a/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/DurableTopicDeliveryForgeTest.java
+++ b/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/DurableTopicDeliveryForgeTest.java
@@ -2,26 +2,13 @@
 // Copyright (c) 2025 Pragmatica Labs - Sergiy Yevtushenko
 // Licensed under Business Source License 1.1. Change Date: 2030-01-01. Change License: Apache-2.0.
 // See LICENSE in the repository root for full terms.
+
 package org.pragmatica.aether.forge;
-
-import java.net.URI;
-import java.net.http.HttpRequest;
-import java.nio.file.Path;
-import java.time.Duration;
-import java.util.List;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
-import org.pragmatica.aether.ember.EmberCluster;
-import org.pragmatica.config.ConfigurationProvider;
-import org.pragmatica.http.HttpOperations;
-import org.pragmatica.http.HttpResult;
-import org.pragmatica.lang.Option;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.ClassOrderer;
 import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.ClassOrderer;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Tag;
@@ -31,12 +18,24 @@ import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.pragmatica.aether.ember.EmberCluster;
+import org.pragmatica.config.ConfigurationProvider;
+import org.pragmatica.http.HttpOperations;
+import org.pragmatica.http.HttpResult;
+import org.pragmatica.lang.Option;
 
-import static org.pragmatica.aether.ember.EmberCluster.emberCluster;
-import static org.pragmatica.http.JdkHttpOperations.jdkHttpOperations;
+import java.net.URI;
+import java.net.http.HttpRequest;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
-
+import static org.pragmatica.aether.ember.EmberCluster.emberCluster;
+import static org.pragmatica.http.JdkHttpOperations.jdkHttpOperations;
 
 /// #386 — the COMPOSED durable pub/sub path, end to end on a real multi-node cluster.
 ///
@@ -95,9 +94,9 @@ import static org.awaitility.Awaitility.await;
 ///     does not prove survival of a partition owner's death.
 @Tag("Heavy")
 @Disabled("never observed fully green; enable on first green run — run 2 executed all five arms and"
-         + " proved the durable tier is dispatching (20 retries where ephemeral gives 1), but three"
-         + " arms failed on test-side baseline carryover and the group-isolation arm was vacuous."
-         + " Enabling it IS the acceptance criterion.")
+          + " proved the durable tier is dispatching (20 retries where ephemeral gives 1), but three"
+          + " arms failed on test-side baseline carryover and the group-isolation arm was vacuous."
+          + " Enabling it IS the acceptance criterion.")
 @Execution(ExecutionMode.SAME_THREAD)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @TestClassOrder(ClassOrderer.OrderAnnotation.class)
@@ -107,18 +106,23 @@ class DurableTopicDeliveryForgeTest {
     private static final int BASE_APP_HTTP_PORT = 19200;
     private static final int NODES = 5;
     private static final int INSTANCES = 5;
+
     private static final int ORDER_COUNT = 20;
     private static final int POISON_COUNT = 2;
+
     /// durable-pubsub-spec §7: bounded retries before the dead-letter hop. The fixture's failing
     /// handler records every invocation, so this is observed rather than assumed.
     private static final int EXPECTED_ATTEMPTS_PER_EVENT = 5;
+
     /// Declared alongside every other fixture coordinate in [TestArtifacts], where its rationale lives.
     private static final String DURABLE_TOPIC_SLICE = TestArtifacts.DURABLE_TOPIC_SLICE;
     private static final String BLUEPRINT_ID = "forge.test:durable-topic:1.0.0";
     private static final String ERROR_FALLBACK = "{\"error\":\"request failed\"}";
+
     private static final Duration WAIT_TIMEOUT = Duration.ofSeconds(240);
     private static final Duration DELIVERY_TIMEOUT = Duration.ofSeconds(120);
     private static final Duration POLL_INTERVAL = Duration.ofMillis(500);
+
     private static final Pattern COUNT_FIELD = Pattern.compile("\"count\"\\s*:\\s*(\\d+)");
     private static final Pattern FAILING_ATTEMPTS = Pattern.compile("\"failingAttempts\"\\s*:\\s*(\\d+)");
     private static final Pattern HEALTHY_COUNT = Pattern.compile("\"healthyCount\"\\s*:\\s*(\\d+)");
@@ -139,20 +143,29 @@ class DurableTopicDeliveryForgeTest {
         // backing streams are memory-only and "durable" would be measuring nothing.
         cluster.withDataBaseDir(baseDir);
         LifecycleAwait.settled("cluster start in setUp()", cluster, cluster.start());
-        await().atMost(WAIT_TIMEOUT).pollInterval(POLL_INTERVAL).until(() -> cluster.currentLeader()
-                                                                                    .isPresent());
-        await().atMost(WAIT_TIMEOUT).pollInterval(POLL_INTERVAL).until(this::allNodesHealthy);
-        deployDurableTopicSlice();
+
         await().atMost(WAIT_TIMEOUT)
-             .pollInterval(POLL_INTERVAL)
-             .failFast(this::failIfSliceFailed)
-             .until(this::appHttpReady);
+               .pollInterval(POLL_INTERVAL)
+               .until(() -> cluster.currentLeader().isPresent());
+
+        await().atMost(WAIT_TIMEOUT)
+               .pollInterval(POLL_INTERVAL)
+               .until(this::allNodesHealthy);
+
+        deployDurableTopicSlice();
+
+        await().atMost(WAIT_TIMEOUT)
+               .pollInterval(POLL_INTERVAL)
+               .failFast(this::failIfSliceFailed)
+               .until(this::appHttpReady);
+
         // A publish can land before the backing stream's owner has materialized its ring, so gate on a
         // real publish resolving before any assertion runs.
         await().atMost(WAIT_TIMEOUT)
-             .pollInterval(POLL_INTERVAL)
-             .failFast(this::failIfSliceFailed)
-             .until(this::publishReady);
+               .pollInterval(POLL_INTERVAL)
+               .failFast(this::failIfSliceFailed)
+               .until(this::publishReady);
+
         // Durable subscriptions attach on the manager's ownership tick, independently of publish
         // readiness. A never-committed consumer group starts at offset 0 — EARLIEST, permanently, per
         // the #478 ruling (StreamResourceValidator rejects any other auto-offset-reset as inert) — so
@@ -166,9 +179,10 @@ class DurableTopicDeliveryForgeTest {
         // all four delivered including the three published before attach) and confirmed here against
         // the #478 ruling in the validator.
         await().atMost(WAIT_TIMEOUT)
-             .pollInterval(POLL_INTERVAL)
-             .failFast(this::failIfSliceFailed)
-             .until(this::poisonPublishReady);
+               .pollInterval(POLL_INTERVAL)
+               .failFast(this::failIfSliceFailed)
+               .until(this::poisonPublishReady);
+
         // DRAIN BOTH WARM-UPS BEFORE ANY ARM RUNS. The two gates above publish REAL events, and the
         // first run of this suite failed three arms because those events were still in flight when the
         // arms captured their baselines — the warm-up order landed inside arm 2's window (21 delivered
@@ -185,19 +199,22 @@ class DurableTopicDeliveryForgeTest {
         // invocations while order-events flowed): if it recurs, THIS gate fails naming it directly,
         // instead of scattering the symptom across three arms that each blame something else.
         await().atMost(WAIT_TIMEOUT)
-             .pollInterval(POLL_INTERVAL)
-             .failFast(this::failIfSliceFailed)
-             .untilAsserted(() -> assertThat(totalOrdersDelivered()).describedAs("the order-events warm-up must be delivered before any arm measures"
-                                                                                + " delivery")
-                                            .isGreaterThanOrEqualTo(1));
+               .pollInterval(POLL_INTERVAL)
+               .failFast(this::failIfSliceFailed)
+               .untilAsserted(() -> assertThat(totalOrdersDelivered())
+                       .describedAs("the order-events warm-up must be delivered before any arm measures"
+                                    + " delivery")
+                       .isGreaterThanOrEqualTo(1));
+
         await().atMost(WAIT_TIMEOUT)
-             .pollInterval(POLL_INTERVAL)
-             .failFast(this::failIfSliceFailed)
-             .untilAsserted(() -> assertThat(failingAttempts()).describedAs("the poison-events warm-up must exhaust its %d-attempt budget before"
-                                                                           + " any arm measures retries — if this times out, poison dispatch"
-                                                                           + " stalled, which is a RUNTIME signal and not a baseline problem",
-                                                                            EXPECTED_ATTEMPTS_PER_EVENT)
-                                            .isGreaterThanOrEqualTo(EXPECTED_ATTEMPTS_PER_EVENT));
+               .pollInterval(POLL_INTERVAL)
+               .failFast(this::failIfSliceFailed)
+               .untilAsserted(() -> assertThat(failingAttempts())
+                       .describedAs("the poison-events warm-up must exhaust its %d-attempt budget before"
+                                    + " any arm measures retries — if this times out, poison dispatch"
+                                    + " stalled, which is a RUNTIME signal and not a baseline problem",
+                                    EXPECTED_ATTEMPTS_PER_EVENT)
+                       .isGreaterThanOrEqualTo(EXPECTED_ATTEMPTS_PER_EVENT));
     }
 
     @AfterAll
@@ -206,7 +223,7 @@ class DurableTopicDeliveryForgeTest {
             var leaderPort = cluster.getLeaderManagementPort().or(anyMgmtPort());
 
             httpDelete(leaderPort, "/api/v1/blueprints/" + BLUEPRINT_ID);
-            LifecycleAwait.settled("cluster stop in tearDown()", cluster, cluster.stop());
+            LifecycleAwait.bestEffort("cluster stop in tearDown()", cluster, cluster.stop());
         }
     }
 
@@ -235,14 +252,16 @@ class DurableTopicDeliveryForgeTest {
             var baseline = failingAttempts();
 
             publishPoison("tier-probe");
+
             await().atMost(DELIVERY_TIMEOUT)
-                 .pollInterval(POLL_INTERVAL)
-                 .failFast(DurableTopicDeliveryForgeTest.this::failIfSliceFailed)
-                 .untilAsserted(() -> assertThat(failingAttempts() - baseline).describedAs("the durable tier retries a failing handler %d times; ephemeral"
-                                                                                          + " delivery invokes it ONCE and never retries, so anything above"
-                                                                                          + " 1 proves the durable tier is dispatching",
-                                                                                           EXPECTED_ATTEMPTS_PER_EVENT)
-                                                .isEqualTo(EXPECTED_ATTEMPTS_PER_EVENT));
+                   .pollInterval(POLL_INTERVAL)
+                   .failFast(DurableTopicDeliveryForgeTest.this::failIfSliceFailed)
+                   .untilAsserted(() -> assertThat(failingAttempts() - baseline)
+                           .describedAs("the durable tier retries a failing handler %d times; ephemeral"
+                                        + " delivery invokes it ONCE and never retries, so anything above"
+                                        + " 1 proves the durable tier is dispatching",
+                                        EXPECTED_ATTEMPTS_PER_EVENT)
+                           .isEqualTo(EXPECTED_ATTEMPTS_PER_EVENT));
         }
     }
 
@@ -260,12 +279,12 @@ class DurableTopicDeliveryForgeTest {
             }
 
             await().atMost(DELIVERY_TIMEOUT)
-                 .pollInterval(POLL_INTERVAL)
-                 .failFast(DurableTopicDeliveryForgeTest.this::failIfSliceFailed)
-                 .untilAsserted(() -> assertThat(totalOrdersDelivered() - baseline).describedAs("each event delivered exactly once cluster-wide — a multiple of"
-                                                                                               + " %d would mean ungated per-node delivery",
-                                                                                                ORDER_COUNT)
-                                                .isEqualTo(ORDER_COUNT));
+                   .pollInterval(POLL_INTERVAL)
+                   .failFast(DurableTopicDeliveryForgeTest.this::failIfSliceFailed)
+                   .untilAsserted(() -> assertThat(totalOrdersDelivered() - baseline)
+                           .describedAs("each event delivered exactly once cluster-wide — a multiple of"
+                                        + " %d would mean ungated per-node delivery", ORDER_COUNT)
+                           .isEqualTo(ORDER_COUNT));
         }
 
         /// The only ordering guarantee §5 makes: serial per (group x partition). The topic has ONE
@@ -274,12 +293,15 @@ class DurableTopicDeliveryForgeTest {
         /// design does not promise.
         @Test
         void eventsArriveInPublishedOrder_withinTheSinglePartition() {
-            await().atMost(DELIVERY_TIMEOUT).pollInterval(POLL_INTERVAL).until(() -> !deliveredSequences().isEmpty());
+            await().atMost(DELIVERY_TIMEOUT)
+                   .pollInterval(POLL_INTERVAL)
+                   .until(() -> !deliveredSequences().isEmpty());
+
             var sequences = deliveredSequences();
 
             assertThat(sequences).describedAs("serial per-(group x partition) dispatch over one partition"
-                                             + " means arrival order IS offset order")
-                      .isSorted();
+                                              + " means arrival order IS offset order")
+                                 .isSorted();
         }
     }
 
@@ -308,20 +330,24 @@ class DurableTopicDeliveryForgeTest {
             }
 
             await().atMost(DELIVERY_TIMEOUT)
-                 .pollInterval(POLL_INTERVAL)
-                 .failFast(DurableTopicDeliveryForgeTest.this::failIfSliceFailed)
-                 .untilAsserted(() -> assertThat(failingAttempts() - baseline).describedAs("the never-acking handler must be retried a BOUNDED number of"
-                                                                                          + " times (%d per event), not forever and not once",
-                                                                                           EXPECTED_ATTEMPTS_PER_EVENT)
-                                                .isEqualTo(POISON_COUNT * EXPECTED_ATTEMPTS_PER_EVENT));
+                   .pollInterval(POLL_INTERVAL)
+                   .failFast(DurableTopicDeliveryForgeTest.this::failIfSliceFailed)
+                   .untilAsserted(() -> assertThat(failingAttempts() - baseline)
+                           .describedAs("the never-acking handler must be retried a BOUNDED number of"
+                                        + " times (%d per event), not forever and not once",
+                                        EXPECTED_ATTEMPTS_PER_EVENT)
+                           .isEqualTo(POISON_COUNT * EXPECTED_ATTEMPTS_PER_EVENT));
+
             // The boundary HOLDS: having given up, the runtime must not resume retrying. A count that
             // keeps climbing here would mean the event was never dead-lettered, only endlessly retried.
             var settled = failingAttempts();
 
             sleep(Duration.ofSeconds(10));
-            assertThat(failingAttempts()).describedAs("retries must STOP once the budget is exhausted — a climbing count means"
-                                                     + " the event was never moved aside")
-                      .isEqualTo(settled);
+
+            assertThat(failingAttempts())
+                    .describedAs("retries must STOP once the budget is exhausted — a climbing count means"
+                                 + " the event was never moved aside")
+                    .isEqualTo(settled);
         }
 
         /// Group attribution: the failing group's exhaustion must not touch the healthy group's
@@ -341,34 +367,39 @@ class DurableTopicDeliveryForgeTest {
             var healthyBaseline = healthyCount();
 
             publishPoison("isolation-probe");
+
             // Dispatch is happening: the failing group has been invoked for this arm's event. Until
             // this holds, a zero healthyCount says nothing about the healthy group.
             await().atMost(DELIVERY_TIMEOUT)
-                 .pollInterval(POLL_INTERVAL)
-                 .failFast(DurableTopicDeliveryForgeTest.this::failIfSliceFailed)
-                 .untilAsserted(() -> assertThat(failingAttempts() - failingBaseline).describedAs("poison-events dispatch must be observed BEFORE the healthy"
-                                                                                                 + " group's progress can be judged — otherwise a zero below is"
-                                                                                                 + " indistinguishable from 'not started yet'")
-                                                .isGreaterThan(0));
+                   .pollInterval(POLL_INTERVAL)
+                   .failFast(DurableTopicDeliveryForgeTest.this::failIfSliceFailed)
+                   .untilAsserted(() -> assertThat(failingAttempts() - failingBaseline)
+                           .describedAs("poison-events dispatch must be observed BEFORE the healthy"
+                                        + " group's progress can be judged — otherwise a zero below is"
+                                        + " indistinguishable from 'not started yet'")
+                           .isGreaterThan(0));
+
             // Now it is attributable: the same event reached the failing group, so the healthy group
             // must see it too. A stall here is a real isolation failure, not a timing artefact.
             await().atMost(DELIVERY_TIMEOUT)
-                 .pollInterval(POLL_INTERVAL)
-                 .failFast(DurableTopicDeliveryForgeTest.this::failIfSliceFailed)
-                 .untilAsserted(() -> assertThat(healthyCount() - healthyBaseline).describedAs("the healthy group shares the topic with a group that can never"
-                                                                                              + " ack; separate cursors and retry budgets mean it must still"
-                                                                                              + " process the event the failing group is choking on")
-                                                .isGreaterThanOrEqualTo(1));
+                   .pollInterval(POLL_INTERVAL)
+                   .failFast(DurableTopicDeliveryForgeTest.this::failIfSliceFailed)
+                   .untilAsserted(() -> assertThat(healthyCount() - healthyBaseline)
+                           .describedAs("the healthy group shares the topic with a group that can never"
+                                        + " ack; separate cursors and retry budgets mean it must still"
+                                        + " process the event the failing group is choking on")
+                           .isGreaterThanOrEqualTo(1));
         }
     }
 
     // --- fixture driving -----------------------------------------------------
+
     private void publishOrder(String orderId, int sequence) {
         var body = "{\"orderId\":\"%s\",\"sequence\":%d}".formatted(orderId, sequence);
         var response = httpPost(appPort(), "/api/durable-topic/publish-order", body);
 
         assertThat(response).describedAs("durable publish must resolve at the min-sync floor")
-                  .doesNotContain("\"error\"");
+                            .doesNotContain("\"error\"");
     }
 
     private void publishPoison(String payload) {
@@ -382,8 +413,7 @@ class DurableTopicDeliveryForgeTest {
     private int totalOrdersDelivered() {
         return cluster.getAvailableAppHttpPorts()
                       .stream()
-                      .mapToInt(port -> firstInt(COUNT_FIELD,
-                                                 httpPost(port, "/api/durable-topic/order-status", "{}")))
+                      .mapToInt(port -> firstInt(COUNT_FIELD, httpPost(port, "/api/durable-topic/order-status", "{}")))
                       .sum();
     }
 
@@ -423,6 +453,7 @@ class DurableTopicDeliveryForgeTest {
     }
 
     // --- cluster plumbing ----------------------------------------------------
+
     private void deployDurableTopicSlice() {
         var blueprint = """
             id = "%s"
@@ -435,8 +466,8 @@ class DurableTopicDeliveryForgeTest {
         var response = httpPostToml(leaderPort, "/api/v1/blueprints", blueprint);
 
         assertThat(response).describedAs("durable-topic slice deployment")
-                  .doesNotContain("\"error\"")
-                  .contains("\"status\":\"applied\"");
+                            .doesNotContain("\"error\"")
+                            .contains("\"status\":\"applied\"");
     }
 
     private boolean appHttpReady() {
@@ -448,7 +479,7 @@ class DurableTopicDeliveryForgeTest {
 
         var body = httpPost(ports.getFirst(), "/api/durable-topic/order-status", "{}");
 
-        return ! body.contains("\"error\"") && body.contains("count");
+        return !body.contains("\"error\"") && body.contains("count");
     }
 
     private boolean publishReady() {
@@ -462,7 +493,7 @@ class DurableTopicDeliveryForgeTest {
                                 "/api/durable-topic/publish-order",
                                 "{\"orderId\":\"__warmup__\",\"sequence\":0}");
 
-        return ! response.contains("\"error\"") && response.contains("published");
+        return !response.contains("\"error\"") && response.contains("published");
     }
 
     /// The `poison-events` half of the readiness gate. Its warm-up event WILL be dead-lettered by the
@@ -477,7 +508,7 @@ class DurableTopicDeliveryForgeTest {
 
         var response = httpPost(ports.getFirst(), "/api/durable-topic/publish-poison", "{\"payload\":\"__warmup__\"}");
 
-        return ! response.contains("\"error\"") && response.contains("published");
+        return !response.contains("\"error\"") && response.contains("published");
     }
 
     /// Deliberately a park rather than an awaitility gate: the assertion it serves is that a count does
@@ -490,9 +521,8 @@ class DurableTopicDeliveryForgeTest {
     private void failIfSliceFailed() {
         var failed = cluster.slicesStatus()
                             .stream()
-                            .anyMatch(status -> status.artifact()
-                                                      .equals(DURABLE_TOPIC_SLICE) && status.state()
-                                                                                            .equals("FAILED"));
+                            .anyMatch(status -> status.artifact().equals(DURABLE_TOPIC_SLICE)
+                                                && status.state().equals("FAILED"));
 
         if (failed) {
             throw new AssertionError("Durable-topic slice deployment FAILED: " + DURABLE_TOPIC_SLICE);
@@ -507,10 +537,7 @@ class DurableTopicDeliveryForgeTest {
     }
 
     private int anyMgmtPort() {
-        return cluster.status()
-                      .nodes()
-                      .getFirst()
-                      .mgmtPort();
+        return cluster.status().nodes().getFirst().mgmtPort();
     }
 
     private boolean allNodesHealthy() {
@@ -529,8 +556,7 @@ class DurableTopicDeliveryForgeTest {
 
         return http.sendString(request)
                    .await()
-                   .map(response -> response.statusCode() == 200 && response.body()
-                                                                            .contains("\"quorum\":true"))
+                   .map(response -> response.statusCode() == 200 && response.body().contains("\"quorum\":true"))
                    .or(false);
     }
 
@@ -543,6 +569,7 @@ class DurableTopicDeliveryForgeTest {
     }
 
     // --- HTTP ----------------------------------------------------------------
+
     private String httpPostToml(int port, String path, String body) {
         var request = HttpRequest.newBuilder()
                                  .uri(URI.create("http://localhost:" + port + path))

--- a/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/DurableTopicDeliveryForgeTest.java
+++ b/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/DurableTopicDeliveryForgeTest.java
@@ -2,27 +2,7 @@
 // Copyright (c) 2025 Pragmatica Labs - Sergiy Yevtushenko
 // Licensed under Business Source License 1.1. Change Date: 2030-01-01. Change License: Apache-2.0.
 // See LICENSE in the repository root for full terms.
-
 package org.pragmatica.aether.forge;
-
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.ClassOrderer;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Order;
-import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestClassOrder;
-import org.junit.jupiter.api.TestInstance;
-import org.junit.jupiter.api.io.TempDir;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
-import org.pragmatica.aether.ember.EmberCluster;
-import org.pragmatica.config.ConfigurationProvider;
-import org.pragmatica.http.HttpOperations;
-import org.pragmatica.http.HttpResult;
-import org.pragmatica.lang.Option;
 
 import java.net.URI;
 import java.net.http.HttpRequest;
@@ -32,10 +12,31 @@ import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.awaitility.Awaitility.await;
+import org.pragmatica.aether.ember.EmberCluster;
+import org.pragmatica.config.ConfigurationProvider;
+import org.pragmatica.http.HttpOperations;
+import org.pragmatica.http.HttpResult;
+import org.pragmatica.lang.Option;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.ClassOrderer;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestClassOrder;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+
 import static org.pragmatica.aether.ember.EmberCluster.emberCluster;
 import static org.pragmatica.http.JdkHttpOperations.jdkHttpOperations;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
 
 /// #386 — the COMPOSED durable pub/sub path, end to end on a real multi-node cluster.
 ///
@@ -94,9 +95,9 @@ import static org.pragmatica.http.JdkHttpOperations.jdkHttpOperations;
 ///     does not prove survival of a partition owner's death.
 @Tag("Heavy")
 @Disabled("never observed fully green; enable on first green run — run 2 executed all five arms and"
-          + " proved the durable tier is dispatching (20 retries where ephemeral gives 1), but three"
-          + " arms failed on test-side baseline carryover and the group-isolation arm was vacuous."
-          + " Enabling it IS the acceptance criterion.")
+         + " proved the durable tier is dispatching (20 retries where ephemeral gives 1), but three"
+         + " arms failed on test-side baseline carryover and the group-isolation arm was vacuous."
+         + " Enabling it IS the acceptance criterion.")
 @Execution(ExecutionMode.SAME_THREAD)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @TestClassOrder(ClassOrderer.OrderAnnotation.class)
@@ -106,23 +107,18 @@ class DurableTopicDeliveryForgeTest {
     private static final int BASE_APP_HTTP_PORT = 19200;
     private static final int NODES = 5;
     private static final int INSTANCES = 5;
-
     private static final int ORDER_COUNT = 20;
     private static final int POISON_COUNT = 2;
-
     /// durable-pubsub-spec §7: bounded retries before the dead-letter hop. The fixture's failing
     /// handler records every invocation, so this is observed rather than assumed.
     private static final int EXPECTED_ATTEMPTS_PER_EVENT = 5;
-
     /// Declared alongside every other fixture coordinate in [TestArtifacts], where its rationale lives.
     private static final String DURABLE_TOPIC_SLICE = TestArtifacts.DURABLE_TOPIC_SLICE;
     private static final String BLUEPRINT_ID = "forge.test:durable-topic:1.0.0";
     private static final String ERROR_FALLBACK = "{\"error\":\"request failed\"}";
-
     private static final Duration WAIT_TIMEOUT = Duration.ofSeconds(240);
     private static final Duration DELIVERY_TIMEOUT = Duration.ofSeconds(120);
     private static final Duration POLL_INTERVAL = Duration.ofMillis(500);
-
     private static final Pattern COUNT_FIELD = Pattern.compile("\"count\"\\s*:\\s*(\\d+)");
     private static final Pattern FAILING_ATTEMPTS = Pattern.compile("\"failingAttempts\"\\s*:\\s*(\\d+)");
     private static final Pattern HEALTHY_COUNT = Pattern.compile("\"healthyCount\"\\s*:\\s*(\\d+)");
@@ -142,34 +138,21 @@ class DurableTopicDeliveryForgeTest {
         // The durable tier writes envelopes through per-partition WALs. Without an on-disk data dir the
         // backing streams are memory-only and "durable" would be measuring nothing.
         cluster.withDataBaseDir(baseDir);
-        cluster.start()
-               .await()
-               .onFailure(cause -> {
-                   throw new AssertionError("Cluster start failed: " + cause.message());
-               });
-
-        await().atMost(WAIT_TIMEOUT)
-               .pollInterval(POLL_INTERVAL)
-               .until(() -> cluster.currentLeader().isPresent());
-
-        await().atMost(WAIT_TIMEOUT)
-               .pollInterval(POLL_INTERVAL)
-               .until(this::allNodesHealthy);
-
+        LifecycleAwait.settled("cluster start in setUp()", cluster, cluster.start());
+        await().atMost(WAIT_TIMEOUT).pollInterval(POLL_INTERVAL).until(() -> cluster.currentLeader()
+                                                                                    .isPresent());
+        await().atMost(WAIT_TIMEOUT).pollInterval(POLL_INTERVAL).until(this::allNodesHealthy);
         deployDurableTopicSlice();
-
         await().atMost(WAIT_TIMEOUT)
-               .pollInterval(POLL_INTERVAL)
-               .failFast(this::failIfSliceFailed)
-               .until(this::appHttpReady);
-
+             .pollInterval(POLL_INTERVAL)
+             .failFast(this::failIfSliceFailed)
+             .until(this::appHttpReady);
         // A publish can land before the backing stream's owner has materialized its ring, so gate on a
         // real publish resolving before any assertion runs.
         await().atMost(WAIT_TIMEOUT)
-               .pollInterval(POLL_INTERVAL)
-               .failFast(this::failIfSliceFailed)
-               .until(this::publishReady);
-
+             .pollInterval(POLL_INTERVAL)
+             .failFast(this::failIfSliceFailed)
+             .until(this::publishReady);
         // Durable subscriptions attach on the manager's ownership tick, independently of publish
         // readiness. A never-committed consumer group starts at offset 0 — EARLIEST, permanently, per
         // the #478 ruling (StreamResourceValidator rejects any other auto-offset-reset as inert) — so
@@ -183,10 +166,9 @@ class DurableTopicDeliveryForgeTest {
         // all four delivered including the three published before attach) and confirmed here against
         // the #478 ruling in the validator.
         await().atMost(WAIT_TIMEOUT)
-               .pollInterval(POLL_INTERVAL)
-               .failFast(this::failIfSliceFailed)
-               .until(this::poisonPublishReady);
-
+             .pollInterval(POLL_INTERVAL)
+             .failFast(this::failIfSliceFailed)
+             .until(this::poisonPublishReady);
         // DRAIN BOTH WARM-UPS BEFORE ANY ARM RUNS. The two gates above publish REAL events, and the
         // first run of this suite failed three arms because those events were still in flight when the
         // arms captured their baselines — the warm-up order landed inside arm 2's window (21 delivered
@@ -203,22 +185,19 @@ class DurableTopicDeliveryForgeTest {
         // invocations while order-events flowed): if it recurs, THIS gate fails naming it directly,
         // instead of scattering the symptom across three arms that each blame something else.
         await().atMost(WAIT_TIMEOUT)
-               .pollInterval(POLL_INTERVAL)
-               .failFast(this::failIfSliceFailed)
-               .untilAsserted(() -> assertThat(totalOrdersDelivered())
-                       .describedAs("the order-events warm-up must be delivered before any arm measures"
-                                    + " delivery")
-                       .isGreaterThanOrEqualTo(1));
-
+             .pollInterval(POLL_INTERVAL)
+             .failFast(this::failIfSliceFailed)
+             .untilAsserted(() -> assertThat(totalOrdersDelivered()).describedAs("the order-events warm-up must be delivered before any arm measures"
+                                                                                + " delivery")
+                                            .isGreaterThanOrEqualTo(1));
         await().atMost(WAIT_TIMEOUT)
-               .pollInterval(POLL_INTERVAL)
-               .failFast(this::failIfSliceFailed)
-               .untilAsserted(() -> assertThat(failingAttempts())
-                       .describedAs("the poison-events warm-up must exhaust its %d-attempt budget before"
-                                    + " any arm measures retries — if this times out, poison dispatch"
-                                    + " stalled, which is a RUNTIME signal and not a baseline problem",
-                                    EXPECTED_ATTEMPTS_PER_EVENT)
-                       .isGreaterThanOrEqualTo(EXPECTED_ATTEMPTS_PER_EVENT));
+             .pollInterval(POLL_INTERVAL)
+             .failFast(this::failIfSliceFailed)
+             .untilAsserted(() -> assertThat(failingAttempts()).describedAs("the poison-events warm-up must exhaust its %d-attempt budget before"
+                                                                           + " any arm measures retries — if this times out, poison dispatch"
+                                                                           + " stalled, which is a RUNTIME signal and not a baseline problem",
+                                                                            EXPECTED_ATTEMPTS_PER_EVENT)
+                                            .isGreaterThanOrEqualTo(EXPECTED_ATTEMPTS_PER_EVENT));
     }
 
     @AfterAll
@@ -227,8 +206,7 @@ class DurableTopicDeliveryForgeTest {
             var leaderPort = cluster.getLeaderManagementPort().or(anyMgmtPort());
 
             httpDelete(leaderPort, "/api/v1/blueprints/" + BLUEPRINT_ID);
-            cluster.stop()
-                   .await();
+            LifecycleAwait.settled("cluster stop in tearDown()", cluster, cluster.stop());
         }
     }
 
@@ -257,16 +235,14 @@ class DurableTopicDeliveryForgeTest {
             var baseline = failingAttempts();
 
             publishPoison("tier-probe");
-
             await().atMost(DELIVERY_TIMEOUT)
-                   .pollInterval(POLL_INTERVAL)
-                   .failFast(DurableTopicDeliveryForgeTest.this::failIfSliceFailed)
-                   .untilAsserted(() -> assertThat(failingAttempts() - baseline)
-                           .describedAs("the durable tier retries a failing handler %d times; ephemeral"
-                                        + " delivery invokes it ONCE and never retries, so anything above"
-                                        + " 1 proves the durable tier is dispatching",
-                                        EXPECTED_ATTEMPTS_PER_EVENT)
-                           .isEqualTo(EXPECTED_ATTEMPTS_PER_EVENT));
+                 .pollInterval(POLL_INTERVAL)
+                 .failFast(DurableTopicDeliveryForgeTest.this::failIfSliceFailed)
+                 .untilAsserted(() -> assertThat(failingAttempts() - baseline).describedAs("the durable tier retries a failing handler %d times; ephemeral"
+                                                                                          + " delivery invokes it ONCE and never retries, so anything above"
+                                                                                          + " 1 proves the durable tier is dispatching",
+                                                                                           EXPECTED_ATTEMPTS_PER_EVENT)
+                                                .isEqualTo(EXPECTED_ATTEMPTS_PER_EVENT));
         }
     }
 
@@ -284,12 +260,12 @@ class DurableTopicDeliveryForgeTest {
             }
 
             await().atMost(DELIVERY_TIMEOUT)
-                   .pollInterval(POLL_INTERVAL)
-                   .failFast(DurableTopicDeliveryForgeTest.this::failIfSliceFailed)
-                   .untilAsserted(() -> assertThat(totalOrdersDelivered() - baseline)
-                           .describedAs("each event delivered exactly once cluster-wide — a multiple of"
-                                        + " %d would mean ungated per-node delivery", ORDER_COUNT)
-                           .isEqualTo(ORDER_COUNT));
+                 .pollInterval(POLL_INTERVAL)
+                 .failFast(DurableTopicDeliveryForgeTest.this::failIfSliceFailed)
+                 .untilAsserted(() -> assertThat(totalOrdersDelivered() - baseline).describedAs("each event delivered exactly once cluster-wide — a multiple of"
+                                                                                               + " %d would mean ungated per-node delivery",
+                                                                                                ORDER_COUNT)
+                                                .isEqualTo(ORDER_COUNT));
         }
 
         /// The only ordering guarantee §5 makes: serial per (group x partition). The topic has ONE
@@ -298,15 +274,12 @@ class DurableTopicDeliveryForgeTest {
         /// design does not promise.
         @Test
         void eventsArriveInPublishedOrder_withinTheSinglePartition() {
-            await().atMost(DELIVERY_TIMEOUT)
-                   .pollInterval(POLL_INTERVAL)
-                   .until(() -> !deliveredSequences().isEmpty());
-
+            await().atMost(DELIVERY_TIMEOUT).pollInterval(POLL_INTERVAL).until(() -> !deliveredSequences().isEmpty());
             var sequences = deliveredSequences();
 
             assertThat(sequences).describedAs("serial per-(group x partition) dispatch over one partition"
-                                              + " means arrival order IS offset order")
-                                 .isSorted();
+                                             + " means arrival order IS offset order")
+                      .isSorted();
         }
     }
 
@@ -335,24 +308,20 @@ class DurableTopicDeliveryForgeTest {
             }
 
             await().atMost(DELIVERY_TIMEOUT)
-                   .pollInterval(POLL_INTERVAL)
-                   .failFast(DurableTopicDeliveryForgeTest.this::failIfSliceFailed)
-                   .untilAsserted(() -> assertThat(failingAttempts() - baseline)
-                           .describedAs("the never-acking handler must be retried a BOUNDED number of"
-                                        + " times (%d per event), not forever and not once",
-                                        EXPECTED_ATTEMPTS_PER_EVENT)
-                           .isEqualTo(POISON_COUNT * EXPECTED_ATTEMPTS_PER_EVENT));
-
+                 .pollInterval(POLL_INTERVAL)
+                 .failFast(DurableTopicDeliveryForgeTest.this::failIfSliceFailed)
+                 .untilAsserted(() -> assertThat(failingAttempts() - baseline).describedAs("the never-acking handler must be retried a BOUNDED number of"
+                                                                                          + " times (%d per event), not forever and not once",
+                                                                                           EXPECTED_ATTEMPTS_PER_EVENT)
+                                                .isEqualTo(POISON_COUNT * EXPECTED_ATTEMPTS_PER_EVENT));
             // The boundary HOLDS: having given up, the runtime must not resume retrying. A count that
             // keeps climbing here would mean the event was never dead-lettered, only endlessly retried.
             var settled = failingAttempts();
 
             sleep(Duration.ofSeconds(10));
-
-            assertThat(failingAttempts())
-                    .describedAs("retries must STOP once the budget is exhausted — a climbing count means"
-                                 + " the event was never moved aside")
-                    .isEqualTo(settled);
+            assertThat(failingAttempts()).describedAs("retries must STOP once the budget is exhausted — a climbing count means"
+                                                     + " the event was never moved aside")
+                      .isEqualTo(settled);
         }
 
         /// Group attribution: the failing group's exhaustion must not touch the healthy group's
@@ -372,39 +341,34 @@ class DurableTopicDeliveryForgeTest {
             var healthyBaseline = healthyCount();
 
             publishPoison("isolation-probe");
-
             // Dispatch is happening: the failing group has been invoked for this arm's event. Until
             // this holds, a zero healthyCount says nothing about the healthy group.
             await().atMost(DELIVERY_TIMEOUT)
-                   .pollInterval(POLL_INTERVAL)
-                   .failFast(DurableTopicDeliveryForgeTest.this::failIfSliceFailed)
-                   .untilAsserted(() -> assertThat(failingAttempts() - failingBaseline)
-                           .describedAs("poison-events dispatch must be observed BEFORE the healthy"
-                                        + " group's progress can be judged — otherwise a zero below is"
-                                        + " indistinguishable from 'not started yet'")
-                           .isGreaterThan(0));
-
+                 .pollInterval(POLL_INTERVAL)
+                 .failFast(DurableTopicDeliveryForgeTest.this::failIfSliceFailed)
+                 .untilAsserted(() -> assertThat(failingAttempts() - failingBaseline).describedAs("poison-events dispatch must be observed BEFORE the healthy"
+                                                                                                 + " group's progress can be judged — otherwise a zero below is"
+                                                                                                 + " indistinguishable from 'not started yet'")
+                                                .isGreaterThan(0));
             // Now it is attributable: the same event reached the failing group, so the healthy group
             // must see it too. A stall here is a real isolation failure, not a timing artefact.
             await().atMost(DELIVERY_TIMEOUT)
-                   .pollInterval(POLL_INTERVAL)
-                   .failFast(DurableTopicDeliveryForgeTest.this::failIfSliceFailed)
-                   .untilAsserted(() -> assertThat(healthyCount() - healthyBaseline)
-                           .describedAs("the healthy group shares the topic with a group that can never"
-                                        + " ack; separate cursors and retry budgets mean it must still"
-                                        + " process the event the failing group is choking on")
-                           .isGreaterThanOrEqualTo(1));
+                 .pollInterval(POLL_INTERVAL)
+                 .failFast(DurableTopicDeliveryForgeTest.this::failIfSliceFailed)
+                 .untilAsserted(() -> assertThat(healthyCount() - healthyBaseline).describedAs("the healthy group shares the topic with a group that can never"
+                                                                                              + " ack; separate cursors and retry budgets mean it must still"
+                                                                                              + " process the event the failing group is choking on")
+                                                .isGreaterThanOrEqualTo(1));
         }
     }
 
     // --- fixture driving -----------------------------------------------------
-
     private void publishOrder(String orderId, int sequence) {
         var body = "{\"orderId\":\"%s\",\"sequence\":%d}".formatted(orderId, sequence);
         var response = httpPost(appPort(), "/api/durable-topic/publish-order", body);
 
         assertThat(response).describedAs("durable publish must resolve at the min-sync floor")
-                            .doesNotContain("\"error\"");
+                  .doesNotContain("\"error\"");
     }
 
     private void publishPoison(String payload) {
@@ -418,7 +382,8 @@ class DurableTopicDeliveryForgeTest {
     private int totalOrdersDelivered() {
         return cluster.getAvailableAppHttpPorts()
                       .stream()
-                      .mapToInt(port -> firstInt(COUNT_FIELD, httpPost(port, "/api/durable-topic/order-status", "{}")))
+                      .mapToInt(port -> firstInt(COUNT_FIELD,
+                                                 httpPost(port, "/api/durable-topic/order-status", "{}")))
                       .sum();
     }
 
@@ -458,7 +423,6 @@ class DurableTopicDeliveryForgeTest {
     }
 
     // --- cluster plumbing ----------------------------------------------------
-
     private void deployDurableTopicSlice() {
         var blueprint = """
             id = "%s"
@@ -471,8 +435,8 @@ class DurableTopicDeliveryForgeTest {
         var response = httpPostToml(leaderPort, "/api/v1/blueprints", blueprint);
 
         assertThat(response).describedAs("durable-topic slice deployment")
-                            .doesNotContain("\"error\"")
-                            .contains("\"status\":\"applied\"");
+                  .doesNotContain("\"error\"")
+                  .contains("\"status\":\"applied\"");
     }
 
     private boolean appHttpReady() {
@@ -484,7 +448,7 @@ class DurableTopicDeliveryForgeTest {
 
         var body = httpPost(ports.getFirst(), "/api/durable-topic/order-status", "{}");
 
-        return !body.contains("\"error\"") && body.contains("count");
+        return ! body.contains("\"error\"") && body.contains("count");
     }
 
     private boolean publishReady() {
@@ -498,7 +462,7 @@ class DurableTopicDeliveryForgeTest {
                                 "/api/durable-topic/publish-order",
                                 "{\"orderId\":\"__warmup__\",\"sequence\":0}");
 
-        return !response.contains("\"error\"") && response.contains("published");
+        return ! response.contains("\"error\"") && response.contains("published");
     }
 
     /// The `poison-events` half of the readiness gate. Its warm-up event WILL be dead-lettered by the
@@ -513,7 +477,7 @@ class DurableTopicDeliveryForgeTest {
 
         var response = httpPost(ports.getFirst(), "/api/durable-topic/publish-poison", "{\"payload\":\"__warmup__\"}");
 
-        return !response.contains("\"error\"") && response.contains("published");
+        return ! response.contains("\"error\"") && response.contains("published");
     }
 
     /// Deliberately a park rather than an awaitility gate: the assertion it serves is that a count does
@@ -526,8 +490,9 @@ class DurableTopicDeliveryForgeTest {
     private void failIfSliceFailed() {
         var failed = cluster.slicesStatus()
                             .stream()
-                            .anyMatch(status -> status.artifact().equals(DURABLE_TOPIC_SLICE)
-                                                && status.state().equals("FAILED"));
+                            .anyMatch(status -> status.artifact()
+                                                      .equals(DURABLE_TOPIC_SLICE) && status.state()
+                                                                                            .equals("FAILED"));
 
         if (failed) {
             throw new AssertionError("Durable-topic slice deployment FAILED: " + DURABLE_TOPIC_SLICE);
@@ -542,7 +507,10 @@ class DurableTopicDeliveryForgeTest {
     }
 
     private int anyMgmtPort() {
-        return cluster.status().nodes().getFirst().mgmtPort();
+        return cluster.status()
+                      .nodes()
+                      .getFirst()
+                      .mgmtPort();
     }
 
     private boolean allNodesHealthy() {
@@ -561,7 +529,8 @@ class DurableTopicDeliveryForgeTest {
 
         return http.sendString(request)
                    .await()
-                   .map(response -> response.statusCode() == 200 && response.body().contains("\"quorum\":true"))
+                   .map(response -> response.statusCode() == 200 && response.body()
+                                                                            .contains("\"quorum\":true"))
                    .or(false);
     }
 
@@ -574,7 +543,6 @@ class DurableTopicDeliveryForgeTest {
     }
 
     // --- HTTP ----------------------------------------------------------------
-
     private String httpPostToml(int port, String path, String body) {
         var request = HttpRequest.newBuilder()
                                  .uri(URI.create("http://localhost:" + port + path))

--- a/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/EmberAddNodeRoleLabelTest.java
+++ b/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/EmberAddNodeRoleLabelTest.java
@@ -2,17 +2,14 @@
 // Copyright (c) 2025 Pragmatica Labs - Sergiy Yevtushenko
 // Licensed under Business Source License 1.1. Change Date: 2030-01-01. Change License: Apache-2.0.
 // See LICENSE in the repository root for full terms.
-
 package org.pragmatica.aether.forge;
 
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicReference;
+
 import org.pragmatica.aether.deployment.membership.fsm.MemberDescriptor;
 import org.pragmatica.aether.ember.EmberCluster;
 import org.pragmatica.aether.environment.ComputeProvider;
@@ -27,18 +24,22 @@ import org.pragmatica.consensus.net.NodeInfo;
 import org.pragmatica.lang.Cause;
 import org.pragmatica.lang.Option;
 import org.pragmatica.lang.TerminalOperation;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.time.Duration;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.concurrent.atomic.AtomicReference;
-
+import static org.pragmatica.aether.ember.EmberCluster.emberCluster;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
-import static org.pragmatica.aether.ember.EmberCluster.emberCluster;
+
 
 /// #590 — the guard on Ember's role labels: on the opt-in `addWorkerNode()`, on the DEFAULT
 /// `addNode()` staying untouched, and on the provisioned path stamping the role it is handed.
@@ -85,21 +86,17 @@ import static org.pragmatica.aether.ember.EmberCluster.emberCluster;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class EmberAddNodeRoleLabelTest {
     private static final Logger log = LoggerFactory.getLogger(EmberAddNodeRoleLabelTest.class);
-
     private static final int INITIAL_CORES = 3;
     private static final int BASE_PORT = 21500;
     private static final int BASE_MGMT_PORT = 21600;
     private static final int BASE_APP_HTTP_PORT = 21700;
-
     private static final Duration FORM_TIMEOUT = Duration.ofSeconds(120);
     private static final Duration OBSERVE_TIMEOUT = Duration.ofSeconds(60);
     private static final Duration POLL = Duration.ofMillis(250);
 
     private EmberCluster cluster;
-
     /// The base [EmberCluster] provider, captured by an identity decorator installed before `start()`.
     private final AtomicReference<ComputeProvider> baseProvider = new AtomicReference<>();
-
     /// Nodes added by the test that just ran, killed in [#releaseAddedNodes]. Ember's slot pool is
     /// `2 * initialSize` = 6, of which 3 are taken by the initial cores — three spare for five tests.
     /// Killing returns the slot, so each test is slot-neutral and the class is order-independent.
@@ -116,20 +113,23 @@ class EmberAddNodeRoleLabelTest {
 
             return provider;
         });
-        cluster.start().await().onFailure(EmberAddNodeRoleLabelTest::fail);
-        await().atMost(FORM_TIMEOUT).pollInterval(POLL).until(() -> cluster.currentLeader().isPresent());
+        LifecycleAwait.settled("cluster start in setUp()", cluster, cluster.start());
+        await().atMost(FORM_TIMEOUT).pollInterval(POLL).until(() -> cluster.currentLeader()
+                                                                           .isPresent());
     }
 
     @AfterEach
     void releaseAddedNodes() {
-        addedNodes.forEach(id -> cluster.killNode(id).await());
+        addedNodes.forEach(id -> LifecycleAwait.nodeSettled("kill node " + id + " in releaseAddedNodes()",
+                                                            cluster,
+                                                            cluster.killNode(id)));
         addedNodes.clear();
     }
 
     @AfterAll
     @TerminalOperation
     void tearDown() {
-        Option.option(cluster).onPresent(c -> c.stop().await());
+        Option.option(cluster).onPresent(c -> LifecycleAwait.settled("cluster stop in tearDown()", c, c.stop()));
     }
 
     /// THE REGRESSION GUARD. Every existing forge test calls `addNode()`, and a node that started
@@ -137,33 +137,39 @@ class EmberAddNodeRoleLabelTest {
     /// must stay exactly as it was: no role label at all.
     @Test
     void addNode_advertisesNoRoleLabel_soExistingBehaviourIsUnchanged() {
-        var added = add(cluster.addNode().await().onFailure(EmberAddNodeRoleLabelTest::fail).map(NodeId::id).or(""));
+        var added = add(LifecycleAwait.nodeSettled("default addNode join in addNode_advertisesNoRoleLabel_soExistingBehaviourIsUnchanged()",
+                                                   cluster,
+                                                   cluster.addNode())
+                                      .id());
         var labels = advertisedLabels(added);
 
-        log.info("ROLE-LABEL: default addNode -> {} labels={}", added, labels);
-        assertThat(labels.containsKey(NodeInfo.LABEL_ROLE))
-            .as("default addNode() must advertise NO role label — blank classifies as CORE, which is the "
-                + "long-standing behaviour every forge test is written against. Saw labels=%s", labels)
-            .isFalse();
+        log.info("ROLE-LABEL: default addNode -> {} labels={}",
+                 added,
+                 labels);
+        assertThat(labels.containsKey(NodeInfo.LABEL_ROLE)).as("default addNode() must advertise NO role label — blank classifies as CORE, which is the "
+                                                              + "long-standing behaviour every forge test is written against. Saw labels=%s",
+                                                               labels)
+                  .isFalse();
     }
 
     /// The opt-in. Without this label the node classifies as a core and every community-tier mechanism
     /// is suppressed on it, which is exactly what made #590's fence unobservable in-JVM.
     @Test
     void addWorkerNode_advertisesTheWorkerRole_soCommunityTierMechanismsApply() {
-        var added = add(cluster.addWorkerNode()
-                               .await()
-                               .onFailure(EmberAddNodeRoleLabelTest::fail)
-                               .map(NodeId::id)
-                               .or(""));
+        var added = add(LifecycleAwait.nodeSettled("addWorkerNode join in addWorkerNode_advertisesTheWorkerRole_soCommunityTierMechanismsApply()",
+                                                   cluster,
+                                                   cluster.addWorkerNode())
+                                      .id());
         var labels = advertisedLabels(added);
 
-        log.info("ROLE-LABEL: addWorkerNode -> {} labels={}", added, labels);
-        assertThat(labels.get(NodeInfo.LABEL_ROLE))
-            .as("addWorkerNode() must advertise exactly the literal `MemberDescriptor.isCoreRole` tests "
-                + "against — anything else, INCLUDING a near-miss like \"WORKER\", classifies as core and "
-                + "silently restores the suppression this method exists to lift. Saw labels=%s", labels)
-            .isEqualTo("worker");
+        log.info("ROLE-LABEL: addWorkerNode -> {} labels={}",
+                 added,
+                 labels);
+        assertThat(labels.get(NodeInfo.LABEL_ROLE)).as("addWorkerNode() must advertise exactly the literal `MemberDescriptor.isCoreRole` tests "
+                                                      + "against — anything else, INCLUDING a near-miss like \"WORKER\", classifies as core and "
+                                                      + "silently restores the suppression this method exists to lift. Saw labels=%s",
+                                                       labels)
+                  .isEqualTo("worker");
     }
 
     /// The provisioned worker: the case the harness could not previously produce at all. A CTM worker
@@ -178,15 +184,16 @@ class EmberAddNodeRoleLabelTest {
         var added = provisionWithRole("worker");
         var labels = advertisedLabels(added);
 
-        log.info("ROLE-LABEL: provisioned role=worker -> {} labels={}", added, labels);
-        assertThat(labels.get(NodeInfo.LABEL_ROLE))
-            .as("a node provisioned with role=worker must advertise it — the provider is the ONLY place "
-                + "that role can enter an in-JVM node, and dropping it silently re-creates the #590 "
-                + "suppression on a path no test can opt out of. Saw labels=%s", labels)
-            .isEqualTo("worker");
-        assertThat(classifiedCoreByPeer(added))
-            .as("a provisioned worker must classify as NON-core in a peer's membership FSM")
-            .isFalse();
+        log.info("ROLE-LABEL: provisioned role=worker -> {} labels={}",
+                 added,
+                 labels);
+        assertThat(labels.get(NodeInfo.LABEL_ROLE)).as("a node provisioned with role=worker must advertise it — the provider is the ONLY place "
+                                                      + "that role can enter an in-JVM node, and dropping it silently re-creates the #590 "
+                                                      + "suppression on a path no test can opt out of. Saw labels=%s",
+                                                       labels)
+                  .isEqualTo("worker");
+        assertThat(classifiedCoreByPeer(added)).as("a provisioned worker must classify as NON-core in a peer's membership FSM")
+                  .isFalse();
     }
 
     /// The unchanged half, stated on the live path rather than inferred. `core` is the role the CTM
@@ -199,14 +206,15 @@ class EmberAddNodeRoleLabelTest {
         var added = provisionWithRole("core");
         var labels = advertisedLabels(added);
 
-        log.info("ROLE-LABEL: provisioned role=core -> {} labels={}", added, labels);
-        assertThat(labels.get(NodeInfo.LABEL_ROLE))
-            .as("a node provisioned with role=core must advertise it verbatim. Saw labels=%s", labels)
-            .isEqualTo("core");
-        assertThat(classifiedCoreByPeer(added))
-            .as("stamping role=core must leave the classification exactly where blank left it — this is "
-                + "the property that keeps every existing core-provisioning test unaffected")
-            .isTrue();
+        log.info("ROLE-LABEL: provisioned role=core -> {} labels={}",
+                 added,
+                 labels);
+        assertThat(labels.get(NodeInfo.LABEL_ROLE)).as("a node provisioned with role=core must advertise it verbatim. Saw labels=%s",
+                                                       labels)
+                  .isEqualTo("core");
+        assertThat(classifiedCoreByPeer(added)).as("stamping role=core must leave the classification exactly where blank left it — this is "
+                                                  + "the property that keeps every existing core-provisioning test unaffected")
+                  .isTrue();
     }
 
     /// A role that never resolved stamps NO label, rather than `role=""`. Production reaches this shape
@@ -217,10 +225,12 @@ class EmberAddNodeRoleLabelTest {
         var added = provisionWithRole("");
         var labels = advertisedLabels(added);
 
-        log.info("ROLE-LABEL: provisioned role=<blank> -> {} labels={}", added, labels);
-        assertThat(labels.containsKey(NodeInfo.LABEL_ROLE))
-            .as("an unresolved role must stamp no label at all, not an empty-string one. Saw labels=%s", labels)
-            .isFalse();
+        log.info("ROLE-LABEL: provisioned role=<blank> -> {} labels={}",
+                 added,
+                 labels);
+        assertThat(labels.containsKey(NodeInfo.LABEL_ROLE)).as("an unresolved role must stamp no label at all, not an empty-string one. Saw labels=%s",
+                                                               labels)
+                  .isFalse();
     }
 
     /// The equivalence the propagation rests on, asserted directly against the single predicate that
@@ -228,14 +238,12 @@ class EmberAddNodeRoleLabelTest {
     /// no-op and every core-provisioning path needs re-reading.
     @Test
     void coreRoleAndBlank_areEquivalent_soExistingCoreProvisioningIsUnchanged() {
-        assertThat(MemberDescriptor.isCoreRole("core"))
-            .as("`core` must classify as core")
-            .isEqualTo(MemberDescriptor.isCoreRole(""))
-            .isTrue();
-        assertThat(MemberDescriptor.isCoreRole("worker"))
-            .as("`worker` is the ONLY literal that classifies as non-core — the rule the whole "
-                + "community tier is gated on")
-            .isFalse();
+        assertThat(MemberDescriptor.isCoreRole("core")).as("`core` must classify as core")
+                  .isEqualTo(MemberDescriptor.isCoreRole(""))
+                  .isTrue();
+        assertThat(MemberDescriptor.isCoreRole("worker")).as("`worker` is the ONLY literal that classifies as non-core — the rule the whole "
+                                                            + "community tier is gated on")
+                  .isFalse();
     }
 
     /// Provisions through the production boundary: `provision(spec)` runs the static
@@ -243,11 +251,10 @@ class EmberAddNodeRoleLabelTest {
     /// `default` sentinel the CTM auto-heal path always passes, so the provider's own `in-jvm` default
     /// resolves it — the same resolution production performs.
     private String provisionWithRole(String role) {
-        var provider = Option.option(baseProvider.get())
-                             .or(() -> {
-                                 throw new AssertionError("compute provider was never captured — the decorator "
-                                                          + "must be installed before start()");
-                             });
+        var provider = Option.option(baseProvider.get()).or(() -> {
+            throw new AssertionError("compute provider was never captured — the decorator "
+                                    + "must be installed before start()");
+        });
         var context = ProvisionContext.provisionContext(Option.empty(),
                                                         role,
                                                         SourceName.DEFAULT,
@@ -255,13 +262,13 @@ class EmberAddNodeRoleLabelTest {
         var spec = ProvisionSpec.provisionSpec(InstanceType.ON_DEMAND,
                                                ProvisionRequest.DEFAULT_INSTANCE_SIZE_SENTINEL,
                                                "",
-                                               context)
-                                .unwrap();
+                                               context).unwrap();
 
         return add(provider.provision(spec)
                            .await()
                            .onFailure(EmberAddNodeRoleLabelTest::fail)
-                           .map(info -> info.nodeId().or(""))
+                           .map(info -> info.nodeId()
+                                            .or(""))
                            .or(""));
     }
 
@@ -271,22 +278,23 @@ class EmberAddNodeRoleLabelTest {
     private boolean classifiedCoreByPeer(String nodeIdStr) {
         var id = NodeId.nodeId(nodeIdStr).unwrap();
 
-        await().atMost(OBSERVE_TIMEOUT)
-               .pollInterval(POLL)
-               .until(() -> peerDescriptorOf(nodeIdStr, id).isPresent());
+        await().atMost(OBSERVE_TIMEOUT).pollInterval(POLL).until(() -> peerDescriptorOf(nodeIdStr, id).isPresent());
 
         return peerDescriptorOf(nodeIdStr, id).map(MemberDescriptor::isCore)
-                                              .or(() -> {
-                                                  throw new AssertionError("no peer holds a descriptor for "
-                                                                           + nodeIdStr);
-                                              });
+                               .or(() -> {
+                                   throw new AssertionError("no peer holds a descriptor for " + nodeIdStr);
+                               });
     }
 
     /// First descriptor for `id` held by any node OTHER than the subject itself.
     private Option<MemberDescriptor> peerDescriptorOf(String nodeIdStr, NodeId id) {
         return cluster.allNodes()
                       .stream()
-                      .filter(node -> !node.topologyManager().self().id().id().equals(nodeIdStr))
+                      .filter(node -> !node.topologyManager()
+                                           .self()
+                                           .id()
+                                           .id()
+                                           .equals(nodeIdStr))
                       .map(node -> descriptorFrom(node, id))
                       .flatMap(Option::stream)
                       .findFirst()
@@ -295,7 +303,8 @@ class EmberAddNodeRoleLabelTest {
     }
 
     private static Option<MemberDescriptor> descriptorFrom(AetherNode node, NodeId id) {
-        return node.membershipFsm().memberDescriptor(id);
+        return node.membershipFsm()
+                   .memberDescriptor(id);
     }
 
     /// Reads the node's OWN advertised `NodeInfo` — the field peers and its own `MemberDescriptor`

--- a/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/EmberAddNodeRoleLabelTest.java
+++ b/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/EmberAddNodeRoleLabelTest.java
@@ -2,14 +2,17 @@
 // Copyright (c) 2025 Pragmatica Labs - Sergiy Yevtushenko
 // Licensed under Business Source License 1.1. Change Date: 2030-01-01. Change License: Apache-2.0.
 // See LICENSE in the repository root for full terms.
+
 package org.pragmatica.aether.forge;
 
-import java.time.Duration;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.concurrent.atomic.AtomicReference;
-
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.pragmatica.aether.deployment.membership.fsm.MemberDescriptor;
 import org.pragmatica.aether.ember.EmberCluster;
 import org.pragmatica.aether.environment.ComputeProvider;
@@ -24,22 +27,18 @@ import org.pragmatica.consensus.net.NodeInfo;
 import org.pragmatica.lang.Cause;
 import org.pragmatica.lang.Option;
 import org.pragmatica.lang.TerminalOperation;
-
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.pragmatica.aether.ember.EmberCluster.emberCluster;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicReference;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
-
+import static org.pragmatica.aether.ember.EmberCluster.emberCluster;
 
 /// #590 — the guard on Ember's role labels: on the opt-in `addWorkerNode()`, on the DEFAULT
 /// `addNode()` staying untouched, and on the provisioned path stamping the role it is handed.
@@ -86,17 +85,21 @@ import static org.awaitility.Awaitility.await;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class EmberAddNodeRoleLabelTest {
     private static final Logger log = LoggerFactory.getLogger(EmberAddNodeRoleLabelTest.class);
+
     private static final int INITIAL_CORES = 3;
     private static final int BASE_PORT = 21500;
     private static final int BASE_MGMT_PORT = 21600;
     private static final int BASE_APP_HTTP_PORT = 21700;
+
     private static final Duration FORM_TIMEOUT = Duration.ofSeconds(120);
     private static final Duration OBSERVE_TIMEOUT = Duration.ofSeconds(60);
     private static final Duration POLL = Duration.ofMillis(250);
 
     private EmberCluster cluster;
+
     /// The base [EmberCluster] provider, captured by an identity decorator installed before `start()`.
     private final AtomicReference<ComputeProvider> baseProvider = new AtomicReference<>();
+
     /// Nodes added by the test that just ran, killed in [#releaseAddedNodes]. Ember's slot pool is
     /// `2 * initialSize` = 6, of which 3 are taken by the initial cores — three spare for five tests.
     /// Killing returns the slot, so each test is slot-neutral and the class is order-independent.
@@ -114,13 +117,12 @@ class EmberAddNodeRoleLabelTest {
             return provider;
         });
         LifecycleAwait.settled("cluster start in setUp()", cluster, cluster.start());
-        await().atMost(FORM_TIMEOUT).pollInterval(POLL).until(() -> cluster.currentLeader()
-                                                                           .isPresent());
+        await().atMost(FORM_TIMEOUT).pollInterval(POLL).until(() -> cluster.currentLeader().isPresent());
     }
 
     @AfterEach
     void releaseAddedNodes() {
-        addedNodes.forEach(id -> LifecycleAwait.nodeSettled("kill node " + id + " in releaseAddedNodes()",
+        addedNodes.forEach(id -> LifecycleAwait.nodeBestEffort("kill node " + id + " in releaseAddedNodes()",
                                                             cluster,
                                                             cluster.killNode(id)));
         addedNodes.clear();
@@ -129,7 +131,7 @@ class EmberAddNodeRoleLabelTest {
     @AfterAll
     @TerminalOperation
     void tearDown() {
-        Option.option(cluster).onPresent(c -> LifecycleAwait.settled("cluster stop in tearDown()", c, c.stop()));
+        Option.option(cluster).onPresent(c -> LifecycleAwait.bestEffort("cluster stop in tearDown()", c, c.stop()));
     }
 
     /// THE REGRESSION GUARD. Every existing forge test calls `addNode()`, and a node that started
@@ -143,13 +145,11 @@ class EmberAddNodeRoleLabelTest {
                                       .id());
         var labels = advertisedLabels(added);
 
-        log.info("ROLE-LABEL: default addNode -> {} labels={}",
-                 added,
-                 labels);
-        assertThat(labels.containsKey(NodeInfo.LABEL_ROLE)).as("default addNode() must advertise NO role label — blank classifies as CORE, which is the "
-                                                              + "long-standing behaviour every forge test is written against. Saw labels=%s",
-                                                               labels)
-                  .isFalse();
+        log.info("ROLE-LABEL: default addNode -> {} labels={}", added, labels);
+        assertThat(labels.containsKey(NodeInfo.LABEL_ROLE))
+            .as("default addNode() must advertise NO role label — blank classifies as CORE, which is the "
+                + "long-standing behaviour every forge test is written against. Saw labels=%s", labels)
+            .isFalse();
     }
 
     /// The opt-in. Without this label the node classifies as a core and every community-tier mechanism
@@ -162,14 +162,12 @@ class EmberAddNodeRoleLabelTest {
                                       .id());
         var labels = advertisedLabels(added);
 
-        log.info("ROLE-LABEL: addWorkerNode -> {} labels={}",
-                 added,
-                 labels);
-        assertThat(labels.get(NodeInfo.LABEL_ROLE)).as("addWorkerNode() must advertise exactly the literal `MemberDescriptor.isCoreRole` tests "
-                                                      + "against — anything else, INCLUDING a near-miss like \"WORKER\", classifies as core and "
-                                                      + "silently restores the suppression this method exists to lift. Saw labels=%s",
-                                                       labels)
-                  .isEqualTo("worker");
+        log.info("ROLE-LABEL: addWorkerNode -> {} labels={}", added, labels);
+        assertThat(labels.get(NodeInfo.LABEL_ROLE))
+            .as("addWorkerNode() must advertise exactly the literal `MemberDescriptor.isCoreRole` tests "
+                + "against — anything else, INCLUDING a near-miss like \"WORKER\", classifies as core and "
+                + "silently restores the suppression this method exists to lift. Saw labels=%s", labels)
+            .isEqualTo("worker");
     }
 
     /// The provisioned worker: the case the harness could not previously produce at all. A CTM worker
@@ -184,16 +182,15 @@ class EmberAddNodeRoleLabelTest {
         var added = provisionWithRole("worker");
         var labels = advertisedLabels(added);
 
-        log.info("ROLE-LABEL: provisioned role=worker -> {} labels={}",
-                 added,
-                 labels);
-        assertThat(labels.get(NodeInfo.LABEL_ROLE)).as("a node provisioned with role=worker must advertise it — the provider is the ONLY place "
-                                                      + "that role can enter an in-JVM node, and dropping it silently re-creates the #590 "
-                                                      + "suppression on a path no test can opt out of. Saw labels=%s",
-                                                       labels)
-                  .isEqualTo("worker");
-        assertThat(classifiedCoreByPeer(added)).as("a provisioned worker must classify as NON-core in a peer's membership FSM")
-                  .isFalse();
+        log.info("ROLE-LABEL: provisioned role=worker -> {} labels={}", added, labels);
+        assertThat(labels.get(NodeInfo.LABEL_ROLE))
+            .as("a node provisioned with role=worker must advertise it — the provider is the ONLY place "
+                + "that role can enter an in-JVM node, and dropping it silently re-creates the #590 "
+                + "suppression on a path no test can opt out of. Saw labels=%s", labels)
+            .isEqualTo("worker");
+        assertThat(classifiedCoreByPeer(added))
+            .as("a provisioned worker must classify as NON-core in a peer's membership FSM")
+            .isFalse();
     }
 
     /// The unchanged half, stated on the live path rather than inferred. `core` is the role the CTM
@@ -206,15 +203,14 @@ class EmberAddNodeRoleLabelTest {
         var added = provisionWithRole("core");
         var labels = advertisedLabels(added);
 
-        log.info("ROLE-LABEL: provisioned role=core -> {} labels={}",
-                 added,
-                 labels);
-        assertThat(labels.get(NodeInfo.LABEL_ROLE)).as("a node provisioned with role=core must advertise it verbatim. Saw labels=%s",
-                                                       labels)
-                  .isEqualTo("core");
-        assertThat(classifiedCoreByPeer(added)).as("stamping role=core must leave the classification exactly where blank left it — this is "
-                                                  + "the property that keeps every existing core-provisioning test unaffected")
-                  .isTrue();
+        log.info("ROLE-LABEL: provisioned role=core -> {} labels={}", added, labels);
+        assertThat(labels.get(NodeInfo.LABEL_ROLE))
+            .as("a node provisioned with role=core must advertise it verbatim. Saw labels=%s", labels)
+            .isEqualTo("core");
+        assertThat(classifiedCoreByPeer(added))
+            .as("stamping role=core must leave the classification exactly where blank left it — this is "
+                + "the property that keeps every existing core-provisioning test unaffected")
+            .isTrue();
     }
 
     /// A role that never resolved stamps NO label, rather than `role=""`. Production reaches this shape
@@ -225,12 +221,10 @@ class EmberAddNodeRoleLabelTest {
         var added = provisionWithRole("");
         var labels = advertisedLabels(added);
 
-        log.info("ROLE-LABEL: provisioned role=<blank> -> {} labels={}",
-                 added,
-                 labels);
-        assertThat(labels.containsKey(NodeInfo.LABEL_ROLE)).as("an unresolved role must stamp no label at all, not an empty-string one. Saw labels=%s",
-                                                               labels)
-                  .isFalse();
+        log.info("ROLE-LABEL: provisioned role=<blank> -> {} labels={}", added, labels);
+        assertThat(labels.containsKey(NodeInfo.LABEL_ROLE))
+            .as("an unresolved role must stamp no label at all, not an empty-string one. Saw labels=%s", labels)
+            .isFalse();
     }
 
     /// The equivalence the propagation rests on, asserted directly against the single predicate that
@@ -238,12 +232,14 @@ class EmberAddNodeRoleLabelTest {
     /// no-op and every core-provisioning path needs re-reading.
     @Test
     void coreRoleAndBlank_areEquivalent_soExistingCoreProvisioningIsUnchanged() {
-        assertThat(MemberDescriptor.isCoreRole("core")).as("`core` must classify as core")
-                  .isEqualTo(MemberDescriptor.isCoreRole(""))
-                  .isTrue();
-        assertThat(MemberDescriptor.isCoreRole("worker")).as("`worker` is the ONLY literal that classifies as non-core — the rule the whole "
-                                                            + "community tier is gated on")
-                  .isFalse();
+        assertThat(MemberDescriptor.isCoreRole("core"))
+            .as("`core` must classify as core")
+            .isEqualTo(MemberDescriptor.isCoreRole(""))
+            .isTrue();
+        assertThat(MemberDescriptor.isCoreRole("worker"))
+            .as("`worker` is the ONLY literal that classifies as non-core — the rule the whole "
+                + "community tier is gated on")
+            .isFalse();
     }
 
     /// Provisions through the production boundary: `provision(spec)` runs the static
@@ -251,10 +247,11 @@ class EmberAddNodeRoleLabelTest {
     /// `default` sentinel the CTM auto-heal path always passes, so the provider's own `in-jvm` default
     /// resolves it — the same resolution production performs.
     private String provisionWithRole(String role) {
-        var provider = Option.option(baseProvider.get()).or(() -> {
-            throw new AssertionError("compute provider was never captured — the decorator "
-                                    + "must be installed before start()");
-        });
+        var provider = Option.option(baseProvider.get())
+                             .or(() -> {
+                                 throw new AssertionError("compute provider was never captured — the decorator "
+                                                          + "must be installed before start()");
+                             });
         var context = ProvisionContext.provisionContext(Option.empty(),
                                                         role,
                                                         SourceName.DEFAULT,
@@ -262,13 +259,13 @@ class EmberAddNodeRoleLabelTest {
         var spec = ProvisionSpec.provisionSpec(InstanceType.ON_DEMAND,
                                                ProvisionRequest.DEFAULT_INSTANCE_SIZE_SENTINEL,
                                                "",
-                                               context).unwrap();
+                                               context)
+                                .unwrap();
 
         return add(provider.provision(spec)
                            .await()
                            .onFailure(EmberAddNodeRoleLabelTest::fail)
-                           .map(info -> info.nodeId()
-                                            .or(""))
+                           .map(info -> info.nodeId().or(""))
                            .or(""));
     }
 
@@ -278,23 +275,22 @@ class EmberAddNodeRoleLabelTest {
     private boolean classifiedCoreByPeer(String nodeIdStr) {
         var id = NodeId.nodeId(nodeIdStr).unwrap();
 
-        await().atMost(OBSERVE_TIMEOUT).pollInterval(POLL).until(() -> peerDescriptorOf(nodeIdStr, id).isPresent());
+        await().atMost(OBSERVE_TIMEOUT)
+               .pollInterval(POLL)
+               .until(() -> peerDescriptorOf(nodeIdStr, id).isPresent());
 
         return peerDescriptorOf(nodeIdStr, id).map(MemberDescriptor::isCore)
-                               .or(() -> {
-                                   throw new AssertionError("no peer holds a descriptor for " + nodeIdStr);
-                               });
+                                              .or(() -> {
+                                                  throw new AssertionError("no peer holds a descriptor for "
+                                                                           + nodeIdStr);
+                                              });
     }
 
     /// First descriptor for `id` held by any node OTHER than the subject itself.
     private Option<MemberDescriptor> peerDescriptorOf(String nodeIdStr, NodeId id) {
         return cluster.allNodes()
                       .stream()
-                      .filter(node -> !node.topologyManager()
-                                           .self()
-                                           .id()
-                                           .id()
-                                           .equals(nodeIdStr))
+                      .filter(node -> !node.topologyManager().self().id().id().equals(nodeIdStr))
                       .map(node -> descriptorFrom(node, id))
                       .flatMap(Option::stream)
                       .findFirst()
@@ -303,8 +299,7 @@ class EmberAddNodeRoleLabelTest {
     }
 
     private static Option<MemberDescriptor> descriptorFrom(AetherNode node, NodeId id) {
-        return node.membershipFsm()
-                   .memberDescriptor(id);
+        return node.membershipFsm().memberDescriptor(id);
     }
 
     /// Reads the node's OWN advertised `NodeInfo` — the field peers and its own `MemberDescriptor`

--- a/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/EmberInstanceTagRoundTripTest.java
+++ b/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/EmberInstanceTagRoundTripTest.java
@@ -27,9 +27,10 @@ import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
 
+import static org.pragmatica.aether.ember.EmberCluster.emberCluster;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
-import static org.pragmatica.aether.ember.EmberCluster.emberCluster;
+
 
 /// The #694 guard: an instance provisioned through `EmberComputeProvider.createFrom` must
 /// round-trip the CTM's worker-reconcile selector (`aether-cluster`/`aether-source`/`aether-role`),
@@ -51,7 +52,6 @@ class EmberInstanceTagRoundTripTest {
     private static final int BASE_APP_HTTP_PORT = 22550;
     private static final Duration WAIT_TIMEOUT = Duration.ofSeconds(240);
     private static final Duration POLL_INTERVAL = Duration.ofMillis(500);
-
     private static final String CLUSTER = "tag-cluster";
     private static final String SOURCE = "src-1";
     private static final String ROLE = "worker";
@@ -74,14 +74,9 @@ class EmberInstanceTagRoundTripTest {
 
             return base;
         });
-        cluster.start()
-               .await()
-               .onFailure(cause -> {
-                   throw new AssertionError("Cluster start failed: " + cause.message());
-               });
-        await().atMost(WAIT_TIMEOUT)
-               .pollInterval(POLL_INTERVAL)
-               .until(() -> cluster.currentLeader().isPresent());
+        LifecycleAwait.settled("cluster start in setUp()", cluster, cluster.start());
+        await().atMost(WAIT_TIMEOUT).pollInterval(POLL_INTERVAL).until(() -> cluster.currentLeader()
+                                                                                    .isPresent());
         provider = captured.get();
         assertThat(provider).as("decorator must have captured the base provider during start").isNotNull();
         workerInstanceId = provision(ROLE);
@@ -91,8 +86,7 @@ class EmberInstanceTagRoundTripTest {
     @AfterAll
     void tearDown() {
         if (cluster != null) {
-            cluster.stop()
-                   .await();
+            LifecycleAwait.settled("cluster stop in tearDown()", cluster, cluster.stop());
         }
     }
 
@@ -103,12 +97,16 @@ class EmberInstanceTagRoundTripTest {
     void provisionedInstance_isFoundByTheSelectorBuiltFromItsOwnContext() {
         var found = listBy(ctmSelector(CLUSTER, SOURCE, ROLE));
 
-        assertThat(found).extracting(info -> info.id().value())
-                         .contains(workerInstanceId);
-        assertThat(tagsOf(workerInstanceId)).isEqualTo(Map.of("aether-cluster", CLUSTER,
-                                                              "aether-role", ROLE,
-                                                              "aether-source", SOURCE,
-                                                              "aether.node-id", workerInstanceId));
+        assertThat(found).extracting(info -> info.id()
+                                                 .value()).contains(workerInstanceId);
+        assertThat(tagsOf(workerInstanceId)).isEqualTo(Map.of("aether-cluster",
+                                                              CLUSTER,
+                                                              "aether-role",
+                                                              ROLE,
+                                                              "aether-source",
+                                                              SOURCE,
+                                                              "aether.node-id",
+                                                              workerInstanceId));
     }
 
     /// The one-field-off guard, all three fields: a selector wrong in ANY single field must not find
@@ -116,15 +114,15 @@ class EmberInstanceTagRoundTripTest {
     /// everything would pass it while corrupting every other source's count.
     @Test
     void provisionedInstance_isNotFoundBySelectorsDifferingInAnyOneField() {
-        assertThat(listBy(ctmSelector("other-cluster", SOURCE, ROLE)))
-            .extracting(info -> info.id().value())
-            .doesNotContain(workerInstanceId);
-        assertThat(listBy(ctmSelector(CLUSTER, "other-source", ROLE)))
-            .extracting(info -> info.id().value())
-            .doesNotContain(workerInstanceId);
-        assertThat(listBy(ctmSelector(CLUSTER, SOURCE, "core")))
-            .extracting(info -> info.id().value())
-            .doesNotContain(workerInstanceId);
+        assertThat(listBy(ctmSelector("other-cluster", SOURCE, ROLE))).extracting(info -> info.id()
+                                                                                              .value())
+                  .doesNotContain(workerInstanceId);
+        assertThat(listBy(ctmSelector(CLUSTER, "other-source", ROLE))).extracting(info -> info.id()
+                                                                                              .value())
+                  .doesNotContain(workerInstanceId);
+        assertThat(listBy(ctmSelector(CLUSTER, SOURCE, "core"))).extracting(info -> info.id()
+                                                                                        .value())
+                  .doesNotContain(workerInstanceId);
     }
 
     /// A blank context role stamps `aether-role=core`, mirroring `HetznerComputeProvider.labelsFor` —
@@ -133,9 +131,9 @@ class EmberInstanceTagRoundTripTest {
     @Test
     void blankRole_stampsTheProductionCoreDefault() {
         assertThat(tagsOf(defaultRoleInstanceId)).containsEntry("aether-role", "core");
-        assertThat(listBy(ctmSelector(CLUSTER, SOURCE, "core")))
-            .extracting(info -> info.id().value())
-            .contains(defaultRoleInstanceId);
+        assertThat(listBy(ctmSelector(CLUSTER, SOURCE, "core"))).extracting(info -> info.id()
+                                                                                        .value())
+                  .contains(defaultRoleInstanceId);
     }
 
     /// The untagged-instance guard: nodes created OUTSIDE the provider (the initial cluster) keep
@@ -152,16 +150,15 @@ class EmberInstanceTagRoundTripTest {
                                        },
                                        instances -> instances);
 
-        assertThat(unfiltered).extracting(info -> info.id().value())
-                              .contains(initialId);
+        assertThat(unfiltered).extracting(info -> info.id()
+                                                      .value()).contains(initialId);
         assertThat(tagsOf(initialId)).isEmpty();
-        assertThat(listBy(ctmSelector(CLUSTER, SOURCE, ROLE)))
-            .extracting(info -> info.id().value())
-            .doesNotContain(initialId);
+        assertThat(listBy(ctmSelector(CLUSTER, SOURCE, ROLE))).extracting(info -> info.id()
+                                                                                      .value())
+                  .doesNotContain(initialId);
     }
 
     // ---- helpers -------------------------------------------------------------------------------
-
     private String provision(String role) {
         var context = new ProvisionContext(Option.some(new ClusterName(CLUSTER)),
                                            role,
@@ -184,7 +181,8 @@ class EmberInstanceTagRoundTripTest {
                        .fold(cause -> {
                                  throw new AssertionError("provision failed: " + cause.message());
                              },
-                             info -> info.id().value());
+                             info -> info.id()
+                                         .value());
     }
 
     private static Map<String, String> ctmSelector(String clusterName, String source, String role) {
@@ -207,7 +205,9 @@ class EmberInstanceTagRoundTripTest {
                                  throw new AssertionError("listInstances failed: " + cause.message());
                              },
                              instances -> instances.stream()
-                                                   .filter(info -> info.id().value().equals(instanceId))
+                                                   .filter(info -> info.id()
+                                                                       .value()
+                                                                       .equals(instanceId))
                                                    .findFirst()
                                                    .map(InstanceInfo::tags)
                                                    .orElseThrow(() -> new AssertionError("instance not listed: " + instanceId)));

--- a/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/EmberInstanceTagRoundTripTest.java
+++ b/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/EmberInstanceTagRoundTripTest.java
@@ -27,10 +27,9 @@ import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
 
-import static org.pragmatica.aether.ember.EmberCluster.emberCluster;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
-
+import static org.pragmatica.aether.ember.EmberCluster.emberCluster;
 
 /// The #694 guard: an instance provisioned through `EmberComputeProvider.createFrom` must
 /// round-trip the CTM's worker-reconcile selector (`aether-cluster`/`aether-source`/`aether-role`),
@@ -52,6 +51,7 @@ class EmberInstanceTagRoundTripTest {
     private static final int BASE_APP_HTTP_PORT = 22550;
     private static final Duration WAIT_TIMEOUT = Duration.ofSeconds(240);
     private static final Duration POLL_INTERVAL = Duration.ofMillis(500);
+
     private static final String CLUSTER = "tag-cluster";
     private static final String SOURCE = "src-1";
     private static final String ROLE = "worker";
@@ -75,8 +75,9 @@ class EmberInstanceTagRoundTripTest {
             return base;
         });
         LifecycleAwait.settled("cluster start in setUp()", cluster, cluster.start());
-        await().atMost(WAIT_TIMEOUT).pollInterval(POLL_INTERVAL).until(() -> cluster.currentLeader()
-                                                                                    .isPresent());
+        await().atMost(WAIT_TIMEOUT)
+               .pollInterval(POLL_INTERVAL)
+               .until(() -> cluster.currentLeader().isPresent());
         provider = captured.get();
         assertThat(provider).as("decorator must have captured the base provider during start").isNotNull();
         workerInstanceId = provision(ROLE);
@@ -86,7 +87,7 @@ class EmberInstanceTagRoundTripTest {
     @AfterAll
     void tearDown() {
         if (cluster != null) {
-            LifecycleAwait.settled("cluster stop in tearDown()", cluster, cluster.stop());
+            LifecycleAwait.bestEffort("cluster stop in tearDown()", cluster, cluster.stop());
         }
     }
 
@@ -97,16 +98,12 @@ class EmberInstanceTagRoundTripTest {
     void provisionedInstance_isFoundByTheSelectorBuiltFromItsOwnContext() {
         var found = listBy(ctmSelector(CLUSTER, SOURCE, ROLE));
 
-        assertThat(found).extracting(info -> info.id()
-                                                 .value()).contains(workerInstanceId);
-        assertThat(tagsOf(workerInstanceId)).isEqualTo(Map.of("aether-cluster",
-                                                              CLUSTER,
-                                                              "aether-role",
-                                                              ROLE,
-                                                              "aether-source",
-                                                              SOURCE,
-                                                              "aether.node-id",
-                                                              workerInstanceId));
+        assertThat(found).extracting(info -> info.id().value())
+                         .contains(workerInstanceId);
+        assertThat(tagsOf(workerInstanceId)).isEqualTo(Map.of("aether-cluster", CLUSTER,
+                                                              "aether-role", ROLE,
+                                                              "aether-source", SOURCE,
+                                                              "aether.node-id", workerInstanceId));
     }
 
     /// The one-field-off guard, all three fields: a selector wrong in ANY single field must not find
@@ -114,15 +111,15 @@ class EmberInstanceTagRoundTripTest {
     /// everything would pass it while corrupting every other source's count.
     @Test
     void provisionedInstance_isNotFoundBySelectorsDifferingInAnyOneField() {
-        assertThat(listBy(ctmSelector("other-cluster", SOURCE, ROLE))).extracting(info -> info.id()
-                                                                                              .value())
-                  .doesNotContain(workerInstanceId);
-        assertThat(listBy(ctmSelector(CLUSTER, "other-source", ROLE))).extracting(info -> info.id()
-                                                                                              .value())
-                  .doesNotContain(workerInstanceId);
-        assertThat(listBy(ctmSelector(CLUSTER, SOURCE, "core"))).extracting(info -> info.id()
-                                                                                        .value())
-                  .doesNotContain(workerInstanceId);
+        assertThat(listBy(ctmSelector("other-cluster", SOURCE, ROLE)))
+            .extracting(info -> info.id().value())
+            .doesNotContain(workerInstanceId);
+        assertThat(listBy(ctmSelector(CLUSTER, "other-source", ROLE)))
+            .extracting(info -> info.id().value())
+            .doesNotContain(workerInstanceId);
+        assertThat(listBy(ctmSelector(CLUSTER, SOURCE, "core")))
+            .extracting(info -> info.id().value())
+            .doesNotContain(workerInstanceId);
     }
 
     /// A blank context role stamps `aether-role=core`, mirroring `HetznerComputeProvider.labelsFor` —
@@ -131,9 +128,9 @@ class EmberInstanceTagRoundTripTest {
     @Test
     void blankRole_stampsTheProductionCoreDefault() {
         assertThat(tagsOf(defaultRoleInstanceId)).containsEntry("aether-role", "core");
-        assertThat(listBy(ctmSelector(CLUSTER, SOURCE, "core"))).extracting(info -> info.id()
-                                                                                        .value())
-                  .contains(defaultRoleInstanceId);
+        assertThat(listBy(ctmSelector(CLUSTER, SOURCE, "core")))
+            .extracting(info -> info.id().value())
+            .contains(defaultRoleInstanceId);
     }
 
     /// The untagged-instance guard: nodes created OUTSIDE the provider (the initial cluster) keep
@@ -150,15 +147,16 @@ class EmberInstanceTagRoundTripTest {
                                        },
                                        instances -> instances);
 
-        assertThat(unfiltered).extracting(info -> info.id()
-                                                      .value()).contains(initialId);
+        assertThat(unfiltered).extracting(info -> info.id().value())
+                              .contains(initialId);
         assertThat(tagsOf(initialId)).isEmpty();
-        assertThat(listBy(ctmSelector(CLUSTER, SOURCE, ROLE))).extracting(info -> info.id()
-                                                                                      .value())
-                  .doesNotContain(initialId);
+        assertThat(listBy(ctmSelector(CLUSTER, SOURCE, ROLE)))
+            .extracting(info -> info.id().value())
+            .doesNotContain(initialId);
     }
 
     // ---- helpers -------------------------------------------------------------------------------
+
     private String provision(String role) {
         var context = new ProvisionContext(Option.some(new ClusterName(CLUSTER)),
                                            role,
@@ -181,8 +179,7 @@ class EmberInstanceTagRoundTripTest {
                        .fold(cause -> {
                                  throw new AssertionError("provision failed: " + cause.message());
                              },
-                             info -> info.id()
-                                         .value());
+                             info -> info.id().value());
     }
 
     private static Map<String, String> ctmSelector(String clusterName, String source, String role) {
@@ -205,9 +202,7 @@ class EmberInstanceTagRoundTripTest {
                                  throw new AssertionError("listInstances failed: " + cause.message());
                              },
                              instances -> instances.stream()
-                                                   .filter(info -> info.id()
-                                                                       .value()
-                                                                       .equals(instanceId))
+                                                   .filter(info -> info.id().value().equals(instanceId))
                                                    .findFirst()
                                                    .map(InstanceInfo::tags)
                                                    .orElseThrow(() -> new AssertionError("instance not listed: " + instanceId)));

--- a/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/GeneratedSliceForgeE2ETest.java
+++ b/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/GeneratedSliceForgeE2ETest.java
@@ -87,7 +87,7 @@ class GeneratedSliceForgeE2ETest {
     @AfterAll
     void tearDown() {
         if (cluster != null) {
-            LifecycleAwait.settled("cluster stop in tearDown()", cluster, cluster.stop());
+            LifecycleAwait.bestEffort("cluster stop in tearDown()", cluster, cluster.stop());
         }
     }
 

--- a/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/GeneratedSliceForgeE2ETest.java
+++ b/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/GeneratedSliceForgeE2ETest.java
@@ -77,11 +77,7 @@ class GeneratedSliceForgeE2ETest {
         var scaffold = generateAndBuildScaffold();
 
         cluster = emberCluster(3, BASE_PORT, BASE_MGMT_PORT, BASE_APP_HTTP_PORT, "ge");
-        cluster.start()
-               .await()
-               .onFailure(cause -> {
-                   throw new AssertionError("Cluster start failed: " + cause.message());
-               });
+        LifecycleAwait.settled("cluster start in setUp()", cluster, cluster.start());
         await().atMost(WAIT_TIMEOUT).pollInterval(POLL_INTERVAL).until(() -> cluster.currentLeader()
                                                                                     .isPresent());
         await().atMost(WAIT_TIMEOUT).pollInterval(POLL_INTERVAL).until(this::allNodesHealthy);
@@ -91,7 +87,7 @@ class GeneratedSliceForgeE2ETest {
     @AfterAll
     void tearDown() {
         if (cluster != null) {
-            cluster.stop().await();
+            LifecycleAwait.settled("cluster stop in tearDown()", cluster, cluster.stop());
         }
     }
 

--- a/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/LifecycleAwait.java
+++ b/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/LifecycleAwait.java
@@ -11,6 +11,7 @@ import org.pragmatica.aether.node.AetherNode;
 import org.pragmatica.lang.Promise;
 import org.pragmatica.lang.io.TimeSpan;
 
+
 /// #915 — every lifecycle await in this module is bounded, and every expiry NAMES its step.
 ///
 /// ## The defect this closes
@@ -54,14 +55,18 @@ import org.pragmatica.lang.io.TimeSpan;
 /// lifecycle backstop is double the longest internal guard, so the test's own await is the mechanism
 /// that fires and the backstop stays the outer net it was designed to be.
 ///
-/// [#NODE_BOUND] is 60 s — ~55x the measured 1.1 s. A single node join or kill is a far smaller step
-/// than standing a cluster up, and giving it the full 240 s would spend four minutes to report a
-/// one-second operation that stalled.
+/// [#NODE_BOUND] is 120 s — ~110x the measured 1.1 s, and half [#LIFECYCLE_BOUND]. A single node join
+/// or kill is a far smaller step than standing a cluster up, so a stalled one should be reported
+/// sooner; but the measurement behind it comes from a 5-node cluster, and the scale-up and churn
+/// probes drive joins into larger ones under deliberate stress. Half the cluster bound keeps the
+/// faster diagnosis while staying far outside any healthy time this module has been observed to take
+/// — the failure mode of guessing too LOW here is a red run on a healthy cluster, which is the exact
+/// flakiness this ticket exists to remove.
 final class LifecycleAwait {
     /// Cluster-wide start and stop.
     static final TimeSpan LIFECYCLE_BOUND = TimeSpan.timeSpan(240).seconds();
     /// Single-node join, kill and blackhole.
-    static final TimeSpan NODE_BOUND = TimeSpan.timeSpan(60).seconds();
+    static final TimeSpan NODE_BOUND = TimeSpan.timeSpan(120).seconds();
 
     private LifecycleAwait() {}
 
@@ -74,10 +79,10 @@ final class LifecycleAwait {
     static <T> T settled(String step, EmberCluster cluster, TimeSpan bound, Promise<T> promise) {
         return promise.await(bound)
                       .fold(cause -> {
-                                throw new AssertionError(step + " did not settle within " + bound
-                                                         + ": " + cause.message()
-                                                         + "\nCluster state when the wait ended:\n"
-                                                         + snapshot(cluster));
+                                throw new AssertionError(step
+                                                        + " did not settle within " + bound
+                                                        + ": " + cause.message()
+                                                        + "\nCluster state when the wait ended:\n" + snapshot(cluster));
                             },
                             value -> value);
     }
@@ -106,11 +111,12 @@ final class LifecycleAwait {
             return "  no node is registered with this cluster (nodeCount=" + cluster.nodeCount() + ")";
         }
 
-        return "  leader=" + status.leaderId() + " nodeCount=" + cluster.nodeCount() + "\n"
-               + status.nodes()
-                       .stream()
-                       .map(node -> nodeLine(cluster, node))
-                       .collect(Collectors.joining("\n"));
+        return "  leader=" + status.leaderId()
+             + " nodeCount=" + cluster.nodeCount()
+             + "\n" + status.nodes()
+                            .stream()
+                            .map(node -> nodeLine(cluster, node))
+                            .collect(Collectors.joining("\n"));
     }
 
     /// `ready` is [AetherNode#isReady] read from the node, or the named absence `unregistered` when
@@ -118,12 +124,12 @@ final class LifecycleAwait {
     /// blank to fill with `false`.
     private static String nodeLine(EmberCluster cluster, EmberCluster.NodeStatus node) {
         return "  " + node.id()
-               + " port=" + node.port()
-               + " mgmt=" + node.mgmtPort()
-               + " leader=" + node.isLeader()
-               + " ready=" + cluster.getNode(node.id())
-                                    .map(AetherNode::isReady)
-                                    .map(String::valueOf)
-                                    .or("unregistered");
+             + " port=" + node.port()
+             + " mgmt=" + node.mgmtPort()
+             + " leader=" + node.isLeader()
+             + " ready=" + cluster.getNode(node.id())
+                                  .map(AetherNode::isReady)
+                                  .map(String::valueOf)
+                                  .or("unregistered");
     }
 }

--- a/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/LifecycleAwait.java
+++ b/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/LifecycleAwait.java
@@ -4,13 +4,13 @@
 // See LICENSE in the repository root for full terms.
 package org.pragmatica.aether.forge;
 
-import java.util.stream.Collectors;
-
 import org.pragmatica.aether.ember.EmberCluster;
-import org.pragmatica.aether.node.AetherNode;
+import org.pragmatica.lang.Option;
 import org.pragmatica.lang.Promise;
 import org.pragmatica.lang.io.TimeSpan;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /// #915 — every lifecycle await in this module is bounded, and every expiry NAMES its step.
 ///
@@ -33,14 +33,31 @@ import org.pragmatica.lang.io.TimeSpan;
 /// silent one. So every expiry here carries the step's own name, the bound it exceeded, and a
 /// snapshot of what the cluster was doing when it gave up.
 ///
-/// ## What the snapshot deliberately omits
+/// ## Two failure policies, because the base had two
 ///
-/// [EmberCluster.NodeStatus#state] is not rendered. On this branch `toNodeStatus` passes the string
-/// literal `"healthy"` for every node, so the field is a constant wearing the costume of an
-/// observation — a broken node and a formed one report it identically. Printing it into a failure
-/// dump would point the next reader away from the fault. `ready` below is read from the node itself
-/// ([AetherNode#isReady], the consensus-active sample), which is a real observation. #913 fixes the
-/// literal at its source in `EmberCluster`; this class does not wait on that and does not touch it.
+/// [#settled] throws; [#bestEffort] logs. Which one a call site gets is decided by what the site did
+/// BEFORE this ticket, not by preference: a site that already threw on failure keeps throwing, and a
+/// site whose `await()` read no `Result` at all keeps not failing the test. Promoting ~40 discarded
+/// teardown results to test failures is a real improvement and a SEPARATE change — it is a new
+/// failure mode in 30+ classes this branch only compiles, and a cleanup hiccup that reddens an
+/// otherwise passing test is the same flakiness this ticket exists to remove. The bound is the fix
+/// for #915; the error policy is not this ticket's to change.
+///
+/// ## The snapshot
+///
+/// Rendering is [ClusterSnapshot]'s, not this class's. #913 landed that renderer for the same need on
+/// the same package, and it already handles the case that matters most here: since #913,
+/// `EmberCluster.start` settles on the FIRST node failure and its abort clears `nodes`/`nodeInfos`
+/// before the caller sees the failure, so a start-failure dump read off `status()` alone is empty on
+/// exactly the failure it exists for. [EmberCluster#lastStartFailure] retains it, and
+/// [ClusterSnapshot] reads it. A second renderer here would diverge from that one on the common path.
+///
+/// Note for readers of the first revision of this file: it omitted [EmberCluster.NodeStatus#state] on
+/// the grounds that `toNodeStatus` passed the string literal `"healthy"` for every node. #913 removed
+/// that literal — the field is now [EmberCluster#observedState], read from [AetherNode#isReady] — so
+/// the omission is obsolete and the field is rendered. The `ready` field this class used to derive
+/// itself was the SAME sample read a second time, and the weaker of the two: it re-read the live
+/// registry, which a start-failure abort has already cleared.
 ///
 /// ## Bounds
 ///
@@ -63,6 +80,12 @@ import org.pragmatica.lang.io.TimeSpan;
 /// — the failure mode of guessing too LOW here is a red run on a healthy cluster, which is the exact
 /// flakiness this ticket exists to remove.
 final class LifecycleAwait {
+    private static final Logger log = LoggerFactory.getLogger(LifecycleAwait.class);
+
+    /// The named absence for a field that was never assigned — a `@BeforeAll` that threw before the
+    /// constructor ran leaves `cluster` null, and `null` printed into a dump reads as a value.
+    static final String NO_CLUSTER = "  no cluster: the field was never assigned";
+
     /// Cluster-wide start and stop.
     static final TimeSpan LIFECYCLE_BOUND = TimeSpan.timeSpan(240).seconds();
     /// Single-node join, kill and blackhole.
@@ -79,10 +102,7 @@ final class LifecycleAwait {
     static <T> T settled(String step, EmberCluster cluster, TimeSpan bound, Promise<T> promise) {
         return promise.await(bound)
                       .fold(cause -> {
-                                throw new AssertionError(step
-                                                        + " did not settle within " + bound
-                                                        + ": " + cause.message()
-                                                        + "\nCluster state when the wait ended:\n" + snapshot(cluster));
+                                throw new AssertionError(report(step, bound, cause.message(), cluster));
                             },
                             value -> value);
     }
@@ -97,39 +117,49 @@ final class LifecycleAwait {
         return settled(step, cluster, NODE_BOUND, promise);
     }
 
-    /// Every value here is read at call time; nothing is defaulted. A cluster with no registered node
-    /// says so in words rather than rendering an empty block, because an empty dump and an absent dump
-    /// read identically in a CI log.
-    static String snapshot(EmberCluster cluster) {
-        if (cluster == null) {
-            return "  no cluster: the field was never assigned";
-        }
-
-        var status = cluster.status();
-
-        if (status.nodes().isEmpty()) {
-            return "  no node is registered with this cluster (nodeCount=" + cluster.nodeCount() + ")";
-        }
-
-        return "  leader=" + status.leaderId()
-             + " nodeCount=" + cluster.nodeCount()
-             + "\n" + status.nodes()
-                            .stream()
-                            .map(node -> nodeLine(cluster, node))
-                            .collect(Collectors.joining("\n"));
+    /// Bounded exactly as [#settled] is, but an expiry or failure is LOGGED rather than thrown.
+    ///
+    /// This is what a call site gets when its `await()` read no `Result` before this ticket. The
+    /// stall is closed either way — the wait now ends at the bound instead of parking to the
+    /// backstop — while the test's own verdict stays the test's. Reporting is strictly more than the
+    /// bare `await()` did, which was nothing at all.
+    static void bestEffort(String step, EmberCluster cluster, TimeSpan bound, Promise<?> promise) {
+        promise.await(bound)
+               .onFailure(cause -> log.error("#915 lifecycle step did not settle (not failing the test — "
+                                             + "this step's result was discarded before #915):\n{}",
+                                             report(step, bound, cause.message(), cluster)));
     }
 
-    /// `ready` is [AetherNode#isReady] read from the node, or the named absence `unregistered` when
-    /// the id in the status answer no longer resolves to a node — which is itself a finding, not a
-    /// blank to fill with `false`.
-    private static String nodeLine(EmberCluster cluster, EmberCluster.NodeStatus node) {
-        return "  " + node.id()
-             + " port=" + node.port()
-             + " mgmt=" + node.mgmtPort()
-             + " leader=" + node.isLeader()
-             + " ready=" + cluster.getNode(node.id())
-                                  .map(AetherNode::isReady)
-                                  .map(String::valueOf)
-                                  .or("unregistered");
+    /// The cluster-wide bound, for a `stop` whose result was previously discarded.
+    static void bestEffort(String step, EmberCluster cluster, Promise<?> promise) {
+        bestEffort(step, cluster, LIFECYCLE_BOUND, promise);
+    }
+
+    /// The single-node bound, for a `killNode` or `blackhole` whose result was previously discarded.
+    static void nodeBestEffort(String step, EmberCluster cluster, Promise<?> promise) {
+        bestEffort(step, cluster, NODE_BOUND, promise);
+    }
+
+    static String report(String step, TimeSpan bound, String cause, EmberCluster cluster) {
+        return step + " did not settle within " + bound
+               + ": " + cause
+               + "\nCluster state when the wait ended:\n" + snapshot(cluster);
+    }
+
+    /// Delegates to [ClusterSnapshot], which is the module's one renderer. The only thing decided
+    /// here is the case that renderer cannot be asked about: a cluster reference that is null.
+    static String snapshot(EmberCluster cluster) {
+        if (cluster == null) {
+            return NO_CLUSTER;
+        }
+
+        return snapshot(cluster.status(), cluster.lastStartFailure());
+    }
+
+    /// Split from the accessor above for the reason #913 split [ClusterSnapshot#render]: the branches
+    /// that matter — a populated registry, and a registry a failed start has already cleared — are
+    /// drivable from a test only if the inputs can be supplied directly.
+    static String snapshot(EmberCluster.ClusterStatus live, Option<EmberCluster.StartFailure> startFailure) {
+        return ClusterSnapshot.render(live, startFailure);
     }
 }

--- a/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/LifecycleAwait.java
+++ b/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/LifecycleAwait.java
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2025 Pragmatica Labs - Sergiy Yevtushenko
+// Licensed under Business Source License 1.1. Change Date: 2030-01-01. Change License: Apache-2.0.
+// See LICENSE in the repository root for full terms.
+package org.pragmatica.aether.forge;
+
+import java.util.stream.Collectors;
+
+import org.pragmatica.aether.ember.EmberCluster;
+import org.pragmatica.aether.node.AetherNode;
+import org.pragmatica.lang.Promise;
+import org.pragmatica.lang.io.TimeSpan;
+
+/// #915 — every lifecycle await in this module is bounded, and every expiry NAMES its step.
+///
+/// ## The defect this closes
+///
+/// `cluster.start().await()`, `cluster.stop().await()` and `cluster.addNode(..).await()` were untimed
+/// across this module. An untimed [Promise#await] parks until the promise resolves and consults
+/// nothing else — so a lifecycle step that never settles is not merely slow, it is unreachable by any
+/// caller-side deadline. #914 records why the framework cannot rescue it either: `await()` never
+/// checks the interrupt flag, so JUnit's lifecycle backstop interrupts a thread that simply re-parks.
+/// The observable result on CI was a class-level ERROR at ~515 s (the 8-minute lifecycle backstop
+/// plus a ~35 s constant prefix) whose entire text was the backstop's own timeout — naming the class,
+/// but never the step that stalled nor the state it stalled in.
+///
+/// ## Why a bound alone is not the fix
+///
+/// [Promise#await(TimeSpan)] expires into `CoreError.Timeout("Promise is not resolved within
+/// specified timeout")`. That string is identical for a cluster that never elected a leader and a
+/// node that never bound its port. Bounding without naming converts a slow silent failure into a fast
+/// silent one. So every expiry here carries the step's own name, the bound it exceeded, and a
+/// snapshot of what the cluster was doing when it gave up.
+///
+/// ## What the snapshot deliberately omits
+///
+/// [EmberCluster.NodeStatus#state] is not rendered. On this branch `toNodeStatus` passes the string
+/// literal `"healthy"` for every node, so the field is a constant wearing the costume of an
+/// observation — a broken node and a formed one report it identically. Printing it into a failure
+/// dump would point the next reader away from the fault. `ready` below is read from the node itself
+/// ([AetherNode#isReady], the consensus-active sample), which is a real observation. #913 fixes the
+/// literal at its source in `EmberCluster`; this class does not wait on that and does not touch it.
+///
+/// ## Bounds
+///
+/// Measured on 2026-09-07 in `pragmatica-stream-h` (16-core box, load average ~10 — two sibling trees
+/// building, so these are LOADED-box numbers, deliberately: a quiet-box baseline would understate
+/// what a CI runner does). `MultiSourceCommunitySmokeTest` green in 42.09 s: cluster start resolved
+/// in ~3-8 s, whole formation 18.5 s, `addNode` 1.1 s, `stop` 16.6 s.
+///
+/// [#LIFECYCLE_BOUND] is 240 s — ~30x the measured start and ~14x the measured stop. It matches the
+/// 240 s guard #913 gives `SliceInvocationTest` and the longest existing internal guard in the
+/// non-Heavy set, which is what keeps `junit-platform.properties`' stated invariant true: the 8 m
+/// lifecycle backstop is double the longest internal guard, so the test's own await is the mechanism
+/// that fires and the backstop stays the outer net it was designed to be.
+///
+/// [#NODE_BOUND] is 60 s — ~55x the measured 1.1 s. A single node join or kill is a far smaller step
+/// than standing a cluster up, and giving it the full 240 s would spend four minutes to report a
+/// one-second operation that stalled.
+final class LifecycleAwait {
+    /// Cluster-wide start and stop.
+    static final TimeSpan LIFECYCLE_BOUND = TimeSpan.timeSpan(240).seconds();
+    /// Single-node join, kill and blackhole.
+    static final TimeSpan NODE_BOUND = TimeSpan.timeSpan(60).seconds();
+
+    private LifecycleAwait() {}
+
+    /// Await `promise` under `bound`, returning its value, or fail with a named [AssertionError].
+    ///
+    /// The failure path covers BOTH a promise that expired and a promise that resolved to a failure:
+    /// each one leaves the lifecycle step undone, and each one is worth the same dump. The step name
+    /// is supplied by the caller because only the caller knows which of several awaits in the same
+    /// method this is.
+    static <T> T settled(String step, EmberCluster cluster, TimeSpan bound, Promise<T> promise) {
+        return promise.await(bound)
+                      .fold(cause -> {
+                                throw new AssertionError(step + " did not settle within " + bound
+                                                         + ": " + cause.message()
+                                                         + "\nCluster state when the wait ended:\n"
+                                                         + snapshot(cluster));
+                            },
+                            value -> value);
+    }
+
+    /// The cluster-wide bound, for `start` and `stop`.
+    static <T> T settled(String step, EmberCluster cluster, Promise<T> promise) {
+        return settled(step, cluster, LIFECYCLE_BOUND, promise);
+    }
+
+    /// The single-node bound, for `addNode`, `killNode` and `blackhole`.
+    static <T> T nodeSettled(String step, EmberCluster cluster, Promise<T> promise) {
+        return settled(step, cluster, NODE_BOUND, promise);
+    }
+
+    /// Every value here is read at call time; nothing is defaulted. A cluster with no registered node
+    /// says so in words rather than rendering an empty block, because an empty dump and an absent dump
+    /// read identically in a CI log.
+    static String snapshot(EmberCluster cluster) {
+        if (cluster == null) {
+            return "  no cluster: the field was never assigned";
+        }
+
+        var status = cluster.status();
+
+        if (status.nodes().isEmpty()) {
+            return "  no node is registered with this cluster (nodeCount=" + cluster.nodeCount() + ")";
+        }
+
+        return "  leader=" + status.leaderId() + " nodeCount=" + cluster.nodeCount() + "\n"
+               + status.nodes()
+                       .stream()
+                       .map(node -> nodeLine(cluster, node))
+                       .collect(Collectors.joining("\n"));
+    }
+
+    /// `ready` is [AetherNode#isReady] read from the node, or the named absence `unregistered` when
+    /// the id in the status answer no longer resolves to a node — which is itself a finding, not a
+    /// blank to fill with `false`.
+    private static String nodeLine(EmberCluster cluster, EmberCluster.NodeStatus node) {
+        return "  " + node.id()
+               + " port=" + node.port()
+               + " mgmt=" + node.mgmtPort()
+               + " leader=" + node.isLeader()
+               + " ready=" + cluster.getNode(node.id())
+                                    .map(AetherNode::isReady)
+                                    .map(String::valueOf)
+                                    .or("unregistered");
+    }
+}

--- a/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/LifecycleAwait.java
+++ b/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/LifecycleAwait.java
@@ -7,10 +7,14 @@ package org.pragmatica.aether.forge;
 import org.pragmatica.aether.ember.EmberCluster;
 import org.pragmatica.lang.Option;
 import org.pragmatica.lang.Promise;
+import org.pragmatica.lang.Result;
+import org.pragmatica.lang.Unit;
 import org.pragmatica.lang.io.TimeSpan;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static org.assertj.core.api.Assertions.fail;
 
 /// #915 — every lifecycle await in this module is bounded, and every expiry NAMES its step.
 ///
@@ -101,9 +105,7 @@ final class LifecycleAwait {
     /// method this is.
     static <T> T settled(String step, EmberCluster cluster, TimeSpan bound, Promise<T> promise) {
         return promise.await(bound)
-                      .fold(cause -> {
-                                throw new AssertionError(report(step, bound, cause.message(), cluster));
-                            },
+                      .fold(cause -> fail(report(step, bound, cause.message(), cluster)),
                             value -> value);
     }
 
@@ -123,21 +125,22 @@ final class LifecycleAwait {
     /// stall is closed either way — the wait now ends at the bound instead of parking to the
     /// backstop — while the test's own verdict stays the test's. Reporting is strictly more than the
     /// bare `await()` did, which was nothing at all.
-    static void bestEffort(String step, EmberCluster cluster, TimeSpan bound, Promise<?> promise) {
-        promise.await(bound)
-               .onFailure(cause -> log.error("#915 lifecycle step did not settle (not failing the test — "
-                                             + "this step's result was discarded before #915):\n{}",
-                                             report(step, bound, cause.message(), cluster)));
+    static Result<Unit> bestEffort(String step, EmberCluster cluster, TimeSpan bound, Promise<?> promise) {
+        return promise.await(bound)
+                      .onFailure(cause -> log.error("#915 lifecycle step did not settle (not failing the test — "
+                                                    + "this step's result was discarded before #915):\n{}",
+                                                    report(step, bound, cause.message(), cluster)))
+                      .mapToUnit();
     }
 
     /// The cluster-wide bound, for a `stop` whose result was previously discarded.
-    static void bestEffort(String step, EmberCluster cluster, Promise<?> promise) {
-        bestEffort(step, cluster, LIFECYCLE_BOUND, promise);
+    static Result<Unit> bestEffort(String step, EmberCluster cluster, Promise<?> promise) {
+        return bestEffort(step, cluster, LIFECYCLE_BOUND, promise);
     }
 
     /// The single-node bound, for a `killNode` or `blackhole` whose result was previously discarded.
-    static void nodeBestEffort(String step, EmberCluster cluster, Promise<?> promise) {
-        bestEffort(step, cluster, NODE_BOUND, promise);
+    static Result<Unit> nodeBestEffort(String step, EmberCluster cluster, Promise<?> promise) {
+        return bestEffort(step, cluster, NODE_BOUND, promise);
     }
 
     static String report(String step, TimeSpan bound, String cause, EmberCluster cluster) {
@@ -149,11 +152,9 @@ final class LifecycleAwait {
     /// Delegates to [ClusterSnapshot], which is the module's one renderer. The only thing decided
     /// here is the case that renderer cannot be asked about: a cluster reference that is null.
     static String snapshot(EmberCluster cluster) {
-        if (cluster == null) {
-            return NO_CLUSTER;
-        }
-
-        return snapshot(cluster.status(), cluster.lastStartFailure());
+        return Option.option(cluster)
+                     .map(present -> snapshot(present.status(), present.lastStartFailure()))
+                     .or(NO_CLUSTER);
     }
 
     /// Split from the accessor above for the reason #913 split [ClusterSnapshot#render]: the branches

--- a/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/LifecycleAwaitStartFailureTest.java
+++ b/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/LifecycleAwaitStartFailureTest.java
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2025 Pragmatica Labs - Sergiy Yevtushenko
+// Licensed under Business Source License 1.1. Change Date: 2030-01-01. Change License: Apache-2.0.
+// See LICENSE in the repository root for full terms.
+package org.pragmatica.aether.forge;
+
+import java.net.ServerSocket;
+
+import org.pragmatica.lang.io.TimeSpan;
+
+import org.junit.jupiter.api.Test;
+
+import static org.pragmatica.aether.ember.EmberCluster.emberCluster;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/// #915 review round 2 — the pin for the ONE-ARGUMENT [LifecycleAwait#snapshot(EmberCluster)].
+///
+/// `LifecycleAwaitTest` supplies its inputs directly and therefore only ever drives the two-argument
+/// overload. That left the accessor's own wiring unpinned: swapping `present.lastStartFailure()` for
+/// [Option#none] there kept all 14 tests green, because nothing reached it with a start failure
+/// actually retained. The accessor is what all 92 call sites in this module use, so the branch it
+/// selects is worth a test of its own.
+///
+/// This is the one case in the #915 set that CANNOT be supplied directly: [EmberCluster] captures the
+/// failure into a private field during `start()`, and there is no seam to set it. So the start really
+/// is made to fail — one management port is bound before the cluster is built — and the assertions
+/// below are about what the accessor renders afterwards.
+///
+/// Kept out of `LifecycleAwaitTest` deliberately: that class states that no cluster is started in it,
+/// and that statement should stay true.
+class LifecycleAwaitStartFailureTest {
+    private static final int BASE_PORT = 27800;
+    private static final int BASE_MGMT_PORT = 27840;
+    private static final int BASE_APP_HTTP_PORT = 27880;
+    /// The start is expected to FAIL, not to expire; this only stops a wedge from hanging the class.
+    private static final TimeSpan START_BOUND = TimeSpan.timeSpan(120).seconds();
+    /// `toNodeStatus` derives mgmt as `baseMgmtPort + (clusterPort - basePort)`, so holding this port
+    /// is what fails the second node.
+    private static final int HELD_MGMT_PORT = BASE_MGMT_PORT + 1;
+
+    @Test
+    void aFailedStart_isRenderedByTheOneArgAccessor_fromTheRetainedCapture() throws Exception {
+        try (var heldByAnotherProcess = new ServerSocket(HELD_MGMT_PORT)) {
+            assertThat(heldByAnotherProcess.isBound()).describedAs("the whole test rests on this port being taken before the "
+                                                                  + "cluster asks for it")
+                      .isTrue();
+
+            var cluster = emberCluster(3, BASE_PORT, BASE_MGMT_PORT, BASE_APP_HTTP_PORT, "la-sf");
+
+            try {
+                var outcome = cluster.start().await(START_BOUND);
+
+                assertThat(outcome.isFailure()).describedAs("a management port that cannot be bound must fail the start — "
+                                                           + "if it succeeded this test would pin nothing")
+                          .isTrue();
+                assertThat(cluster.status().nodes()).describedAs("#913's abort clears the live registry BEFORE the caller sees "
+                                                                + "the failure; that emptiness is why the capture exists")
+                          .isEmpty();
+
+                var snapshot = LifecycleAwait.snapshot(cluster);
+
+                assertThat(snapshot).describedAs("the accessor must read the retained capture — rendering NO_STATE here is "
+                                                + "exactly the un-named empty dump #913 added it to prevent")
+                          .isNotEqualTo(ClusterSnapshot.NO_STATE);
+                assertThat(snapshot).contains("captured when the start failed");
+                assertThat(snapshot).describedAs("the node that could not bind must be identifiable by its port")
+                          .contains("mgmt=" + HELD_MGMT_PORT);
+                assertThat(snapshot).describedAs("and the reason must be named, not left to the reader")
+                          .contains("Address already in use");
+            } finally {
+                LifecycleAwait.bestEffort("cluster stop after the failed start", cluster, cluster.stop());
+            }
+        }
+    }
+}

--- a/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/LifecycleAwaitTest.java
+++ b/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/LifecycleAwaitTest.java
@@ -4,16 +4,18 @@
 // See LICENSE in the repository root for full terms.
 package org.pragmatica.aether.forge;
 
-import org.junit.jupiter.api.Test;
 import org.pragmatica.aether.ember.EmberCluster;
 import org.pragmatica.lang.Cause;
 import org.pragmatica.lang.Promise;
 import org.pragmatica.lang.Unit;
 import org.pragmatica.lang.io.TimeSpan;
 
+import org.junit.jupiter.api.Test;
+
+import static org.pragmatica.aether.ember.EmberCluster.emberCluster;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.pragmatica.aether.ember.EmberCluster.emberCluster;
+
 
 /// #915 — the pin for [LifecycleAwait]. No cluster is started here.
 ///
@@ -37,33 +39,29 @@ class LifecycleAwaitTest {
 
     @Test
     void aPromiseThatNeverSettles_expiresAtTheBound_andNamesTheStep() {
-        var neverSettles = Promise.<Unit>promise();
+        var neverSettles = Promise.<Unit> promise();
         var cluster = unstartedCluster();
         var startedAtMs = System.currentTimeMillis();
 
-        assertThatThrownBy(() -> LifecycleAwait.settled("5-core cluster start", cluster, SHORT_BOUND, neverSettles))
-            .isInstanceOf(AssertionError.class)
-            .describedAs("the expiry must name the step, which is the whole defect: the 8m backstop "
-                         + "named only the class")
-            .hasMessageContaining("5-core cluster start")
-            .hasMessageContaining("did not settle within")
-            .describedAs("and must carry the cluster state, so the next reader does not need a rerun")
-            .hasMessageContaining("Cluster state when the wait ended:");
-
+        assertThatThrownBy(() -> LifecycleAwait.settled("5-core cluster start", cluster, SHORT_BOUND, neverSettles)).isInstanceOf(AssertionError.class)
+                          .describedAs("the expiry must name the step, which is the whole defect: the 8m backstop "
+                                      + "named only the class")
+                          .hasMessageContaining("5-core cluster start")
+                          .hasMessageContaining("did not settle within")
+                          .describedAs("and must carry the cluster state, so the next reader does not need a rerun")
+                          .hasMessageContaining("Cluster state when the wait ended:");
         var elapsedMs = System.currentTimeMillis() - startedAtMs;
 
-        assertThat(elapsedMs)
-            .describedAs("the BOUND must be what ended the wait — an unbounded await would still be "
-                         + "parked here, which is exactly how ~515s class-level ERRORs were produced")
-            .isGreaterThanOrEqualTo(SHORT_BOUND.duration().toMillis())
-            .isLessThan(SHORT_BOUND.duration().toMillis() + SLACK_MS);
+        assertThat(elapsedMs).describedAs("the BOUND must be what ended the wait — an unbounded await would still be "
+                                         + "parked here, which is exactly how ~515s class-level ERRORs were produced")
+                  .isGreaterThanOrEqualTo(SHORT_BOUND.duration().toMillis())
+                  .isLessThan(SHORT_BOUND.duration().toMillis() + SLACK_MS);
     }
 
     /// The positive control. A `settled` that always threw would pass the test above.
     @Test
     void aPromiseThatSettles_returnsItsValue() {
-        var settled = Promise.<String>promise().resolve(org.pragmatica.lang.Result.success("msrc-6"));
-
+        var settled = Promise.<String> promise().resolve(org.pragmatica.lang.Result.success("msrc-6"));
         var value = LifecycleAwait.settled("worker join", unstartedCluster(), SHORT_BOUND, settled);
 
         assertThat(value).isEqualTo("msrc-6");
@@ -74,12 +72,14 @@ class LifecycleAwaitTest {
     /// Result at all, so a stop that failed outright was silently a success.
     @Test
     void aPromiseThatFails_isReportedWithTheSameNamedShape() {
-        var failed = Promise.<Unit>failure(new TestCause("Address already in use"));
+        var failed = Promise.<Unit> failure(new TestCause("Address already in use"));
 
-        assertThatThrownBy(() -> LifecycleAwait.settled("cluster stop", unstartedCluster(), SHORT_BOUND, failed))
-            .isInstanceOf(AssertionError.class)
-            .hasMessageContaining("cluster stop")
-            .hasMessageContaining("Address already in use");
+        assertThatThrownBy(() -> LifecycleAwait.settled("cluster stop",
+                                                        unstartedCluster(),
+                                                        SHORT_BOUND,
+                                                        failed)).isInstanceOf(AssertionError.class)
+                          .hasMessageContaining("cluster stop")
+                          .hasMessageContaining("Address already in use");
     }
 
     @Test
@@ -105,9 +105,8 @@ class LifecycleAwaitTest {
     /// the field, this goes red rather than the fabrication reaching a CI log unnoticed.
     @Test
     void theSnapshotNeverRendersTheFabricatedHealthyLiteral() {
-        assertThat(LifecycleAwait.snapshot(unstartedCluster()))
-            .describedAs("NodeStatus.state is a hardcoded literal on this branch, not an observation")
-            .doesNotContain("healthy");
+        assertThat(LifecycleAwait.snapshot(unstartedCluster())).describedAs("NodeStatus.state is a hardcoded literal on this branch, not an observation")
+                  .doesNotContain("healthy");
     }
 
     /// Constructed, never started: [EmberCluster]'s constructor only assigns fields, so this binds no

--- a/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/LifecycleAwaitTest.java
+++ b/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/LifecycleAwaitTest.java
@@ -4,8 +4,12 @@
 // See LICENSE in the repository root for full terms.
 package org.pragmatica.aether.forge;
 
+import java.util.List;
+import java.util.Map;
+
 import org.pragmatica.aether.ember.EmberCluster;
 import org.pragmatica.lang.Cause;
+import org.pragmatica.lang.Option;
 import org.pragmatica.lang.Promise;
 import org.pragmatica.lang.Unit;
 import org.pragmatica.lang.io.TimeSpan;
@@ -14,21 +18,27 @@ import org.junit.jupiter.api.Test;
 
 import static org.pragmatica.aether.ember.EmberCluster.emberCluster;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-
 
 /// #915 — the pin for [LifecycleAwait]. No cluster is started here.
 ///
 /// The defect being closed is a DIAGNOSTIC one, and a diagnostic cannot be pinned by a test that only
 /// ever runs against a healthy system: the whole point is what the message says on the path that does
 /// not happen in a green run. So every input here is supplied directly — an unresolved promise, a
-/// failed promise, a cluster that was constructed and never started — which makes the failure text
-/// itself the assertion subject and keeps the class down in the milliseconds.
+/// failed promise, a cluster status carrying nodes, the state a failed start retained — which makes
+/// the failure text itself the assertion subject and keeps the class down in the milliseconds.
 ///
 /// The pair that matters is [#aPromiseThatNeverSettles_expiresAtTheBound_andNamesTheStep] and
 /// [#aPromiseThatSettles_returnsItsValue]. Without the second, a `settled` rewritten to throw
 /// unconditionally would satisfy the first — the failure test alone cannot tell "expires correctly"
 /// from "never works".
+///
+/// Review round 1 recorded that the first revision of this class asserted only on the EARLY-RETURN
+/// branch of the snapshot: every case passed an unstarted cluster, whose registry is empty, so no
+/// test ever reached a node line and a mutation that fabricated one stayed green. The populated and
+/// captured-failure cases below exist to close that, and they are the two a healthy cluster never
+/// produces.
 class LifecycleAwaitTest {
     private static final TimeSpan SHORT_BOUND = TimeSpan.timeSpan(2).seconds();
     /// Generous: the assertion below only needs to separate "the bound ended it" from "something
@@ -68,8 +78,7 @@ class LifecycleAwaitTest {
     }
 
     /// A lifecycle step that FAILED and one that never settled both leave the step undone, and both
-    /// used to be discarded here: the bare `c.stop().await()` in several @AfterAll methods read no
-    /// Result at all, so a stop that failed outright was silently a success.
+    /// get the same named report.
     @Test
     void aPromiseThatFails_isReportedWithTheSameNamedShape() {
         var failed = Promise.<Unit> failure(new TestCause("Address already in use"));
@@ -82,12 +91,35 @@ class LifecycleAwaitTest {
                           .hasMessageContaining("Address already in use");
     }
 
+    /// #915 review round 1 — the ~40 sites whose `await()` read no `Result` before this ticket keep
+    /// not failing the test. Only the bound is new there; promoting a discarded cleanup result to a
+    /// test failure is a separate change, and this pins that this branch did not make it.
     @Test
-    void aClusterWithNoRegisteredNode_saysSo_ratherThanRenderingAnEmptyBlock() {
-        var snapshot = LifecycleAwait.snapshot(unstartedCluster());
+    void bestEffort_boundsTheWaitButDoesNotFailTheTest() {
+        var failed = Promise.<Unit> failure(new TestCause("stop rejected"));
+        var neverSettles = Promise.<Unit> promise();
+        var startedAtMs = System.currentTimeMillis();
 
-        assertThat(snapshot).contains("no node is registered with this cluster");
-        assertThat(snapshot).contains("nodeCount=0");
+        assertThatCode(() -> LifecycleAwait.bestEffort("cluster stop in tearDown()",
+                                                       unstartedCluster(),
+                                                       SHORT_BOUND,
+                                                       failed)).doesNotThrowAnyException();
+        assertThatCode(() -> LifecycleAwait.bestEffort("cluster stop in tearDown()",
+                                                       unstartedCluster(),
+                                                       SHORT_BOUND,
+                                                       neverSettles)).doesNotThrowAnyException();
+
+        assertThat(System.currentTimeMillis() - startedAtMs).describedAs("the never-settling arm must have been ended by the BOUND — "
+                                                                       + "not throwing must not mean not returning")
+                  .isGreaterThanOrEqualTo(SHORT_BOUND.duration().toMillis())
+                  .isLessThan(SHORT_BOUND.duration().toMillis() + SLACK_MS);
+    }
+
+    /// Pins the delegation itself: [ClusterSnapshot#NO_STATE] is the OTHER class's constant, so a
+    /// `LifecycleAwait` that went back to rendering its own empty-registry sentence fails here.
+    @Test
+    void aClusterWithNothingToReport_isRenderedByTheModulesOneRenderer() {
+        assertThat(LifecycleAwait.snapshot(unstartedCluster())).isEqualTo(ClusterSnapshot.NO_STATE);
     }
 
     @Test
@@ -98,15 +130,52 @@ class LifecycleAwaitTest {
         assertThat(snapshot).doesNotContain("null");
     }
 
-    /// The honesty pin. On this branch `EmberCluster.toNodeStatus` passes the string literal
-    /// `"healthy"` for every node, so `NodeStatus.state()` is a constant that cannot distinguish a
-    /// formed cluster from a wedged one. Rendering it would put a fabricated observation into the one
-    /// artifact a reader consults when things are already wrong. If a later change starts rendering
-    /// the field, this goes red rather than the fabrication reaching a CI log unnoticed.
+    /// Review round 1, BLOCKING 1 — the node line, which nothing in the first revision reached.
+    ///
+    /// Asserted as a whole rendered block rather than by `contains`, so anything ADDED to the line is
+    /// a failure too: the mutation the reviewer used to prove the old pin vacuous was an addition.
+    /// The two nodes differ in state, leader and both ports, which makes each rendered field evidence
+    /// about its own node rather than a constant that happens to read correctly.
     @Test
-    void theSnapshotNeverRendersTheFabricatedHealthyLiteral() {
-        assertThat(LifecycleAwait.snapshot(unstartedCluster())).describedAs("NodeStatus.state is a hardcoded literal on this branch, not an observation")
-                  .doesNotContain("healthy");
+    void aPopulatedRegistry_rendersEveryNodeLine_withObservedStateAndPorts() {
+        var live = new EmberCluster.ClusterStatus(List.of(node("p921-1", 27700, 27740, EmberCluster.STATE_ACTIVE, true),
+                                                          node("p921-2", 27701, 27741, EmberCluster.STATE_INACTIVE, false)),
+                                                  "p921-1");
+
+        assertThat(LifecycleAwait.snapshot(live, Option.none()))
+                  .isEqualTo("  leader=p921-1\n"
+                            + "  p921-1 state=active leader=true port=27700 mgmt=27740\n"
+                            + "  p921-2 state=inactive leader=false port=27701 mgmt=27741");
+    }
+
+    /// Review round 1, BLOCKING 2 — the branch #913 made the COMMON one.
+    ///
+    /// Since #913, `EmberCluster.start` settles on the first node failure and the abort clears
+    /// `nodes`/`nodeInfos` before the caller sees the failure. A dump read off `status()` alone is
+    /// therefore empty on exactly the failure it exists for, which is why this must not render
+    /// [ClusterSnapshot#NO_STATE].
+    @Test
+    void aClearedRegistryAfterAFailedStart_rendersWhatTheStartFailureRetained() {
+        var captured = new EmberCluster.StartFailure(
+            new EmberCluster.ClusterStatus(List.of(node("p921-1", 27700, 27740, EmberCluster.STATE_INACTIVE, false)),
+                                           "none"),
+            Map.of("p921-1", "Address already in use"));
+
+        var rendered = LifecycleAwait.snapshot(emptyStatus(), Option.some(captured));
+
+        assertThat(rendered).describedAs("an empty dump on a failed start is the defect #913's NO_STATE exists to name")
+                            .isNotEqualTo(ClusterSnapshot.NO_STATE);
+        assertThat(rendered).contains("p921-1 state=inactive leader=false port=27700 mgmt=27740");
+        assertThat(rendered).contains("start failures: {p921-1=Address already in use}");
+        assertThat(rendered).contains("captured when the start failed");
+    }
+
+    private static EmberCluster.NodeStatus node(String id, int port, int mgmtPort, String state, boolean isLeader) {
+        return new EmberCluster.NodeStatus(id, port, mgmtPort, state, isLeader);
+    }
+
+    private static EmberCluster.ClusterStatus emptyStatus() {
+        return new EmberCluster.ClusterStatus(List.of(), "none");
     }
 
     /// Constructed, never started: [EmberCluster]'s constructor only assigns fields, so this binds no

--- a/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/LifecycleAwaitTest.java
+++ b/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/LifecycleAwaitTest.java
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2025 Pragmatica Labs - Sergiy Yevtushenko
+// Licensed under Business Source License 1.1. Change Date: 2030-01-01. Change License: Apache-2.0.
+// See LICENSE in the repository root for full terms.
+package org.pragmatica.aether.forge;
+
+import org.junit.jupiter.api.Test;
+import org.pragmatica.aether.ember.EmberCluster;
+import org.pragmatica.lang.Cause;
+import org.pragmatica.lang.Promise;
+import org.pragmatica.lang.Unit;
+import org.pragmatica.lang.io.TimeSpan;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.pragmatica.aether.ember.EmberCluster.emberCluster;
+
+/// #915 — the pin for [LifecycleAwait]. No cluster is started here.
+///
+/// The defect being closed is a DIAGNOSTIC one, and a diagnostic cannot be pinned by a test that only
+/// ever runs against a healthy system: the whole point is what the message says on the path that does
+/// not happen in a green run. So every input here is supplied directly — an unresolved promise, a
+/// failed promise, a cluster that was constructed and never started — which makes the failure text
+/// itself the assertion subject and keeps the class down in the milliseconds.
+///
+/// The pair that matters is [#aPromiseThatNeverSettles_expiresAtTheBound_andNamesTheStep] and
+/// [#aPromiseThatSettles_returnsItsValue]. Without the second, a `settled` rewritten to throw
+/// unconditionally would satisfy the first — the failure test alone cannot tell "expires correctly"
+/// from "never works".
+class LifecycleAwaitTest {
+    private static final TimeSpan SHORT_BOUND = TimeSpan.timeSpan(2).seconds();
+    /// Generous: the assertion below only needs to separate "the bound ended it" from "something
+    /// else did", not to measure scheduling precision on a loaded box.
+    private static final long SLACK_MS = 20_000;
+
+    private record TestCause(String message) implements Cause {}
+
+    @Test
+    void aPromiseThatNeverSettles_expiresAtTheBound_andNamesTheStep() {
+        var neverSettles = Promise.<Unit>promise();
+        var cluster = unstartedCluster();
+        var startedAtMs = System.currentTimeMillis();
+
+        assertThatThrownBy(() -> LifecycleAwait.settled("5-core cluster start", cluster, SHORT_BOUND, neverSettles))
+            .isInstanceOf(AssertionError.class)
+            .describedAs("the expiry must name the step, which is the whole defect: the 8m backstop "
+                         + "named only the class")
+            .hasMessageContaining("5-core cluster start")
+            .hasMessageContaining("did not settle within")
+            .describedAs("and must carry the cluster state, so the next reader does not need a rerun")
+            .hasMessageContaining("Cluster state when the wait ended:");
+
+        var elapsedMs = System.currentTimeMillis() - startedAtMs;
+
+        assertThat(elapsedMs)
+            .describedAs("the BOUND must be what ended the wait — an unbounded await would still be "
+                         + "parked here, which is exactly how ~515s class-level ERRORs were produced")
+            .isGreaterThanOrEqualTo(SHORT_BOUND.duration().toMillis())
+            .isLessThan(SHORT_BOUND.duration().toMillis() + SLACK_MS);
+    }
+
+    /// The positive control. A `settled` that always threw would pass the test above.
+    @Test
+    void aPromiseThatSettles_returnsItsValue() {
+        var settled = Promise.<String>promise().resolve(org.pragmatica.lang.Result.success("msrc-6"));
+
+        var value = LifecycleAwait.settled("worker join", unstartedCluster(), SHORT_BOUND, settled);
+
+        assertThat(value).isEqualTo("msrc-6");
+    }
+
+    /// A lifecycle step that FAILED and one that never settled both leave the step undone, and both
+    /// used to be discarded here: the bare `c.stop().await()` in several @AfterAll methods read no
+    /// Result at all, so a stop that failed outright was silently a success.
+    @Test
+    void aPromiseThatFails_isReportedWithTheSameNamedShape() {
+        var failed = Promise.<Unit>failure(new TestCause("Address already in use"));
+
+        assertThatThrownBy(() -> LifecycleAwait.settled("cluster stop", unstartedCluster(), SHORT_BOUND, failed))
+            .isInstanceOf(AssertionError.class)
+            .hasMessageContaining("cluster stop")
+            .hasMessageContaining("Address already in use");
+    }
+
+    @Test
+    void aClusterWithNoRegisteredNode_saysSo_ratherThanRenderingAnEmptyBlock() {
+        var snapshot = LifecycleAwait.snapshot(unstartedCluster());
+
+        assertThat(snapshot).contains("no node is registered with this cluster");
+        assertThat(snapshot).contains("nodeCount=0");
+    }
+
+    @Test
+    void anAbsentCluster_isNamedRatherThanNullPrinted() {
+        var snapshot = LifecycleAwait.snapshot(null);
+
+        assertThat(snapshot).contains("no cluster: the field was never assigned");
+        assertThat(snapshot).doesNotContain("null");
+    }
+
+    /// The honesty pin. On this branch `EmberCluster.toNodeStatus` passes the string literal
+    /// `"healthy"` for every node, so `NodeStatus.state()` is a constant that cannot distinguish a
+    /// formed cluster from a wedged one. Rendering it would put a fabricated observation into the one
+    /// artifact a reader consults when things are already wrong. If a later change starts rendering
+    /// the field, this goes red rather than the fabrication reaching a CI log unnoticed.
+    @Test
+    void theSnapshotNeverRendersTheFabricatedHealthyLiteral() {
+        assertThat(LifecycleAwait.snapshot(unstartedCluster()))
+            .describedAs("NodeStatus.state is a hardcoded literal on this branch, not an observation")
+            .doesNotContain("healthy");
+    }
+
+    /// Constructed, never started: [EmberCluster]'s constructor only assigns fields, so this binds no
+    /// port and starts no thread.
+    private static EmberCluster unstartedCluster() {
+        return emberCluster(3, 29900, 29940, 29980, "la-probe");
+    }
+}

--- a/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/LinearizableReadForgeTest.java
+++ b/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/LinearizableReadForgeTest.java
@@ -2,16 +2,11 @@
 // Copyright (c) 2025 Pragmatica Labs - Sergiy Yevtushenko
 // Licensed under Business Source License 1.1. Change Date: 2030-01-01. Change License: Apache-2.0.
 // See LICENSE in the repository root for full terms.
-
 package org.pragmatica.aether.forge;
 
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
+import java.time.Duration;
+import java.util.List;
+
 import org.pragmatica.aether.ember.EmberCluster;
 import org.pragmatica.aether.node.AetherNode;
 import org.pragmatica.aether.slice.ReadPreference;
@@ -27,16 +22,22 @@ import org.pragmatica.hlc.HlcClock;
 import org.pragmatica.lang.Cause;
 import org.pragmatica.lang.Option;
 import org.pragmatica.lang.TerminalOperation;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.time.Duration;
-import java.util.List;
-
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.pragmatica.aether.ember.EmberCluster.emberCluster;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
-import static org.pragmatica.aether.ember.EmberCluster.emberCluster;
+
 
 /// #345 item 1e end-to-end gate: a `LINEARIZABLE` stream read routes to the COMMITTED owner of the
 /// `(stream, partition)` arc and returns the authoritative data, both when issued ON the committed owner
@@ -64,17 +65,14 @@ import static org.pragmatica.aether.ember.EmberCluster.emberCluster;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class LinearizableReadForgeTest {
     private static final Logger log = LoggerFactory.getLogger(LinearizableReadForgeTest.class);
-
     private static final int SIZE = 5;
     private static final int BASE_PORT = 5980;
     private static final int BASE_MGMT_PORT = 6080;
     private static final int BASE_APP_HTTP_PORT = 6180;
     private static final String PREFIX = "linr";
-
     private static final Duration FORM_TIMEOUT = Duration.ofSeconds(180);
     private static final Duration OBSERVE_TIMEOUT = Duration.ofSeconds(150);
     private static final Duration POLL = Duration.ofMillis(500);
-
     private static final String STREAM = "linr:events";
     private static final int PARTITION = 0;
     private static final int REQUESTED_RF = 1;
@@ -85,72 +83,83 @@ class LinearizableReadForgeTest {
     @TerminalOperation
     void setUp() {
         cluster = emberCluster(SIZE, BASE_PORT, BASE_MGMT_PORT, BASE_APP_HTTP_PORT, PREFIX);
-        cluster.start().await().onFailure(LinearizableReadForgeTest::failStart);
-        await().atMost(FORM_TIMEOUT).pollInterval(POLL).until(() -> cluster.currentLeader().isPresent());
+        LifecycleAwait.settled("cluster start in setUp()", cluster, cluster.start());
+        await().atMost(FORM_TIMEOUT).pollInterval(POLL).until(() -> cluster.currentLeader()
+                                                                           .isPresent());
         await().atMost(FORM_TIMEOUT).pollInterval(POLL).until(this::allNodesReady);
-        log.info("LINEARIZABLE-READ: {}-node cluster formed, leader={}", SIZE, cluster.currentLeader().or("none"));
+        log.info("LINEARIZABLE-READ: {}-node cluster formed, leader={}",
+                 SIZE,
+                 cluster.currentLeader().or("none"));
     }
 
     @AfterAll
     @TerminalOperation
     void tearDown() {
-        Option.option(cluster).onPresent(c -> c.stop().await());
+        Option.option(cluster).onPresent(c -> LifecycleAwait.settled("cluster stop in tearDown()", c, c.stop()));
     }
 
     @Test
     @TerminalOperation
     void linearizableRead_servedByCommittedOwner_returnsWrittenData_onOwnerAndForwardedFromNonOwner() {
         cluster.allNodes().forEach(node -> materialize(node, STREAM));
-
         var owner = hrwOwner(STREAM, PARTITION);
         var ownerNode = resolveNode(owner);
         var term = leaderNode().currentGenerationEpoch().rabiaTerm();
-        log.info("LINEARIZABLE-READ: committed owner={} term={}", owner.id(), term);
 
+        log.info("LINEARIZABLE-READ: committed owner={} term={}", owner.id(), term);
         // Commit ownership through the production writer + REAL consensus, so the LINEARIZABLE arm has a
         // committed StreamPartitionOwnershipValue.owner to route to.
         var writer = liveWriter(term, owner);
-        commitOwnershipVia(writer, STREAM, PARTITION);
-        await().atMost(OBSERVE_TIMEOUT).pollInterval(POLL)
-               .until(() -> committedOwner(PARTITION).map(v -> v.owner().equals(owner)).or(false));
-        log.info("LINEARIZABLE-READ: committed ownership for {}[{}] owner={}", STREAM, PARTITION, owner.id());
 
+        commitOwnershipVia(writer, STREAM, PARTITION);
+        await().atMost(OBSERVE_TIMEOUT)
+             .pollInterval(POLL)
+             .until(() -> committedOwner(PARTITION).map(v -> v.owner()
+                                                              .equals(owner))
+                                        .or(false));
+        log.info("LINEARIZABLE-READ: committed ownership for {}[{}] owner={}", STREAM, PARTITION, owner.id());
         // The committed owner publishes the authoritative events locally.
         ownerNode.streamPartitionManager()
-                 .publishLocal(STREAM, PARTITION, "lin-0".getBytes(UTF_8), System.currentTimeMillis())
+                 .publishLocal(STREAM,
+                               PARTITION,
+                               "lin-0".getBytes(UTF_8),
+                               System.currentTimeMillis())
                  .onFailure(LinearizableReadForgeTest::failScenario);
         ownerNode.streamPartitionManager()
-                 .publishLocal(STREAM, PARTITION, "lin-1".getBytes(UTF_8), System.currentTimeMillis())
+                 .publishLocal(STREAM,
+                               PARTITION,
+                               "lin-1".getBytes(UTF_8),
+                               System.currentTimeMillis())
                  .onFailure(LinearizableReadForgeTest::failScenario);
-
         // 1. LINEARIZABLE read issued ON the committed owner returns the written events.
-        await().atMost(OBSERVE_TIMEOUT).pollInterval(POLL)
-               .until(() -> linearizableRead(ownerNode).size() == 2);
-        assertThat(linearizableRead(ownerNode))
-            .as("LINEARIZABLE read on the committed owner returns the authoritative events")
-            .hasSize(2);
+        await().atMost(OBSERVE_TIMEOUT).pollInterval(POLL).until(() -> linearizableRead(ownerNode).size() == 2);
+        assertThat(linearizableRead(ownerNode)).as("LINEARIZABLE read on the committed owner returns the authoritative events")
+                  .hasSize(2);
         log.info("LINEARIZABLE-READ: owner-served read returned {} events", linearizableRead(ownerNode).size());
-
         // 2. LINEARIZABLE read issued from a NON-owner node forwards to the committed owner and returns
         //    the same events.
-        var nonOwnerNode = cluster.allNodes().stream()
-                                  .filter(node -> !node.self().equals(owner))
+        var nonOwnerNode = cluster.allNodes()
+                                  .stream()
+                                  .filter(node -> !node.self()
+                                                       .equals(owner))
                                   .findFirst()
                                   .orElseThrow();
-        await().atMost(OBSERVE_TIMEOUT).pollInterval(POLL)
-               .until(() -> linearizableRead(nonOwnerNode).size() == 2);
-        assertThat(linearizableRead(nonOwnerNode))
-            .as("LINEARIZABLE read from a non-owner forwards to the committed owner and returns the same events")
-            .hasSize(2);
+
+        await().atMost(OBSERVE_TIMEOUT).pollInterval(POLL).until(() -> linearizableRead(nonOwnerNode).size() == 2);
+        assertThat(linearizableRead(nonOwnerNode)).as("LINEARIZABLE read from a non-owner forwards to the committed owner and returns the same events")
+                  .hasSize(2);
         log.info("LINEARIZABLE-READ: non-owner {} forwarded read returned {} events",
-                 nonOwnerNode.self().id(), linearizableRead(nonOwnerNode).size());
+                 nonOwnerNode.self().id(),
+                 linearizableRead(nonOwnerNode).size());
     }
 
     private List<OffHeapRingEvent> linearizableRead(AetherNode node) {
         return node.streamReadRouter()
                    .read(STREAM, PARTITION, 0, 10, ReadPreference.LINEARIZABLE)
                    .await()
-                   .map(events -> events.stream().map(e -> new OffHeapRingEvent(e.offset())).toList())
+                   .map(events -> events.stream()
+                                        .map(e -> new OffHeapRingEvent(e.offset()))
+                                        .toList())
                    .or(List.of());
     }
 
@@ -172,13 +181,13 @@ class LinearizableReadForgeTest {
 
     @TerminalOperation
     private void applyOnLeader(KVCommand<org.pragmatica.aether.slice.kvstore.AetherKey> command) {
-        leaderNode().<Object>apply(List.of(command)).await().onFailure(LinearizableReadForgeTest::failScenario);
+        leaderNode().<Object> apply(List.of(command)).await().onFailure(LinearizableReadForgeTest::failScenario);
     }
 
     private Option<StreamPartitionOwnershipValue> committedOwner(int partition) {
         return leaderNode().kvStore()
-                           .getTyped(StreamPartitionOwnershipKey.streamPartitionOwnershipKey(STREAM, partition),
-                                     StreamPartitionOwnershipValue.class);
+                         .getTyped(StreamPartitionOwnershipKey.streamPartitionOwnershipKey(STREAM, partition),
+                                   StreamPartitionOwnershipValue.class);
     }
 
     private NodeId hrwOwner(String stream, int partition) {
@@ -200,11 +209,16 @@ class LinearizableReadForgeTest {
     }
 
     private List<NodeId> coreMembers(AetherNode node) {
-        return node.clusterTopologyManager().map(ctm -> List.copyOf(ctm.observer().coreNodes())).or(List.of());
+        return node.clusterTopologyManager()
+                   .map(ctm -> List.copyOf(ctm.observer().coreNodes()))
+                   .or(List.of());
     }
 
     private int clusterSize(AetherNode node) {
-        return node.clusterTopologyManager().map(ctm -> ctm.observer().clusterSize()).or(SIZE);
+        return node.clusterTopologyManager()
+                   .map(ctm -> ctm.observer()
+                                  .clusterSize())
+                   .or(SIZE);
     }
 
     private AetherNode resolveNode(NodeId nodeId) {
@@ -215,11 +229,15 @@ class LinearizableReadForgeTest {
     }
 
     private AetherNode leaderNode() {
-        return cluster.currentLeader().flatMap(cluster::getNode).or(cluster.allNodes().getFirst());
+        return cluster.currentLeader()
+                      .flatMap(cluster::getNode)
+                      .or(cluster.allNodes().getFirst());
     }
 
     private boolean allNodesReady() {
-        return cluster.allNodes().stream().allMatch(AetherNode::isReady);
+        return cluster.allNodes()
+                      .stream()
+                      .allMatch(AetherNode::isReady);
     }
 
     private static void failStart(Cause cause) {
@@ -237,13 +255,10 @@ class LinearizableReadForgeTest {
     private enum ForgeError implements Cause {
         NO_PLACEMENT("ReplicaPlacement returned no owner for the partition"),
         NODE_UNRESOLVED("Computed owner NodeId could not be resolved to a cluster node");
-
         private final String message;
-
         ForgeError(String message) {
             this.message = message;
         }
-
         @Override
         public String message() {
             return message;

--- a/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/LinearizableReadForgeTest.java
+++ b/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/LinearizableReadForgeTest.java
@@ -2,11 +2,16 @@
 // Copyright (c) 2025 Pragmatica Labs - Sergiy Yevtushenko
 // Licensed under Business Source License 1.1. Change Date: 2030-01-01. Change License: Apache-2.0.
 // See LICENSE in the repository root for full terms.
+
 package org.pragmatica.aether.forge;
 
-import java.time.Duration;
-import java.util.List;
-
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.pragmatica.aether.ember.EmberCluster;
 import org.pragmatica.aether.node.AetherNode;
 import org.pragmatica.aether.slice.ReadPreference;
@@ -22,22 +27,16 @@ import org.pragmatica.hlc.HlcClock;
 import org.pragmatica.lang.Cause;
 import org.pragmatica.lang.Option;
 import org.pragmatica.lang.TerminalOperation;
-
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.time.Duration;
+import java.util.List;
+
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.pragmatica.aether.ember.EmberCluster.emberCluster;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
-
+import static org.pragmatica.aether.ember.EmberCluster.emberCluster;
 
 /// #345 item 1e end-to-end gate: a `LINEARIZABLE` stream read routes to the COMMITTED owner of the
 /// `(stream, partition)` arc and returns the authoritative data, both when issued ON the committed owner
@@ -65,14 +64,17 @@ import static org.awaitility.Awaitility.await;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class LinearizableReadForgeTest {
     private static final Logger log = LoggerFactory.getLogger(LinearizableReadForgeTest.class);
+
     private static final int SIZE = 5;
     private static final int BASE_PORT = 5980;
     private static final int BASE_MGMT_PORT = 6080;
     private static final int BASE_APP_HTTP_PORT = 6180;
     private static final String PREFIX = "linr";
+
     private static final Duration FORM_TIMEOUT = Duration.ofSeconds(180);
     private static final Duration OBSERVE_TIMEOUT = Duration.ofSeconds(150);
     private static final Duration POLL = Duration.ofMillis(500);
+
     private static final String STREAM = "linr:events";
     private static final int PARTITION = 0;
     private static final int REQUESTED_RF = 1;
@@ -84,82 +86,71 @@ class LinearizableReadForgeTest {
     void setUp() {
         cluster = emberCluster(SIZE, BASE_PORT, BASE_MGMT_PORT, BASE_APP_HTTP_PORT, PREFIX);
         LifecycleAwait.settled("cluster start in setUp()", cluster, cluster.start());
-        await().atMost(FORM_TIMEOUT).pollInterval(POLL).until(() -> cluster.currentLeader()
-                                                                           .isPresent());
+        await().atMost(FORM_TIMEOUT).pollInterval(POLL).until(() -> cluster.currentLeader().isPresent());
         await().atMost(FORM_TIMEOUT).pollInterval(POLL).until(this::allNodesReady);
-        log.info("LINEARIZABLE-READ: {}-node cluster formed, leader={}",
-                 SIZE,
-                 cluster.currentLeader().or("none"));
+        log.info("LINEARIZABLE-READ: {}-node cluster formed, leader={}", SIZE, cluster.currentLeader().or("none"));
     }
 
     @AfterAll
     @TerminalOperation
     void tearDown() {
-        Option.option(cluster).onPresent(c -> LifecycleAwait.settled("cluster stop in tearDown()", c, c.stop()));
+        Option.option(cluster).onPresent(c -> LifecycleAwait.bestEffort("cluster stop in tearDown()", c, c.stop()));
     }
 
     @Test
     @TerminalOperation
     void linearizableRead_servedByCommittedOwner_returnsWrittenData_onOwnerAndForwardedFromNonOwner() {
         cluster.allNodes().forEach(node -> materialize(node, STREAM));
+
         var owner = hrwOwner(STREAM, PARTITION);
         var ownerNode = resolveNode(owner);
         var term = leaderNode().currentGenerationEpoch().rabiaTerm();
-
         log.info("LINEARIZABLE-READ: committed owner={} term={}", owner.id(), term);
+
         // Commit ownership through the production writer + REAL consensus, so the LINEARIZABLE arm has a
         // committed StreamPartitionOwnershipValue.owner to route to.
         var writer = liveWriter(term, owner);
-
         commitOwnershipVia(writer, STREAM, PARTITION);
-        await().atMost(OBSERVE_TIMEOUT)
-             .pollInterval(POLL)
-             .until(() -> committedOwner(PARTITION).map(v -> v.owner()
-                                                              .equals(owner))
-                                        .or(false));
+        await().atMost(OBSERVE_TIMEOUT).pollInterval(POLL)
+               .until(() -> committedOwner(PARTITION).map(v -> v.owner().equals(owner)).or(false));
         log.info("LINEARIZABLE-READ: committed ownership for {}[{}] owner={}", STREAM, PARTITION, owner.id());
+
         // The committed owner publishes the authoritative events locally.
         ownerNode.streamPartitionManager()
-                 .publishLocal(STREAM,
-                               PARTITION,
-                               "lin-0".getBytes(UTF_8),
-                               System.currentTimeMillis())
+                 .publishLocal(STREAM, PARTITION, "lin-0".getBytes(UTF_8), System.currentTimeMillis())
                  .onFailure(LinearizableReadForgeTest::failScenario);
         ownerNode.streamPartitionManager()
-                 .publishLocal(STREAM,
-                               PARTITION,
-                               "lin-1".getBytes(UTF_8),
-                               System.currentTimeMillis())
+                 .publishLocal(STREAM, PARTITION, "lin-1".getBytes(UTF_8), System.currentTimeMillis())
                  .onFailure(LinearizableReadForgeTest::failScenario);
+
         // 1. LINEARIZABLE read issued ON the committed owner returns the written events.
-        await().atMost(OBSERVE_TIMEOUT).pollInterval(POLL).until(() -> linearizableRead(ownerNode).size() == 2);
-        assertThat(linearizableRead(ownerNode)).as("LINEARIZABLE read on the committed owner returns the authoritative events")
-                  .hasSize(2);
+        await().atMost(OBSERVE_TIMEOUT).pollInterval(POLL)
+               .until(() -> linearizableRead(ownerNode).size() == 2);
+        assertThat(linearizableRead(ownerNode))
+            .as("LINEARIZABLE read on the committed owner returns the authoritative events")
+            .hasSize(2);
         log.info("LINEARIZABLE-READ: owner-served read returned {} events", linearizableRead(ownerNode).size());
+
         // 2. LINEARIZABLE read issued from a NON-owner node forwards to the committed owner and returns
         //    the same events.
-        var nonOwnerNode = cluster.allNodes()
-                                  .stream()
-                                  .filter(node -> !node.self()
-                                                       .equals(owner))
+        var nonOwnerNode = cluster.allNodes().stream()
+                                  .filter(node -> !node.self().equals(owner))
                                   .findFirst()
                                   .orElseThrow();
-
-        await().atMost(OBSERVE_TIMEOUT).pollInterval(POLL).until(() -> linearizableRead(nonOwnerNode).size() == 2);
-        assertThat(linearizableRead(nonOwnerNode)).as("LINEARIZABLE read from a non-owner forwards to the committed owner and returns the same events")
-                  .hasSize(2);
+        await().atMost(OBSERVE_TIMEOUT).pollInterval(POLL)
+               .until(() -> linearizableRead(nonOwnerNode).size() == 2);
+        assertThat(linearizableRead(nonOwnerNode))
+            .as("LINEARIZABLE read from a non-owner forwards to the committed owner and returns the same events")
+            .hasSize(2);
         log.info("LINEARIZABLE-READ: non-owner {} forwarded read returned {} events",
-                 nonOwnerNode.self().id(),
-                 linearizableRead(nonOwnerNode).size());
+                 nonOwnerNode.self().id(), linearizableRead(nonOwnerNode).size());
     }
 
     private List<OffHeapRingEvent> linearizableRead(AetherNode node) {
         return node.streamReadRouter()
                    .read(STREAM, PARTITION, 0, 10, ReadPreference.LINEARIZABLE)
                    .await()
-                   .map(events -> events.stream()
-                                        .map(e -> new OffHeapRingEvent(e.offset()))
-                                        .toList())
+                   .map(events -> events.stream().map(e -> new OffHeapRingEvent(e.offset())).toList())
                    .or(List.of());
     }
 
@@ -181,13 +172,13 @@ class LinearizableReadForgeTest {
 
     @TerminalOperation
     private void applyOnLeader(KVCommand<org.pragmatica.aether.slice.kvstore.AetherKey> command) {
-        leaderNode().<Object> apply(List.of(command)).await().onFailure(LinearizableReadForgeTest::failScenario);
+        leaderNode().<Object>apply(List.of(command)).await().onFailure(LinearizableReadForgeTest::failScenario);
     }
 
     private Option<StreamPartitionOwnershipValue> committedOwner(int partition) {
         return leaderNode().kvStore()
-                         .getTyped(StreamPartitionOwnershipKey.streamPartitionOwnershipKey(STREAM, partition),
-                                   StreamPartitionOwnershipValue.class);
+                           .getTyped(StreamPartitionOwnershipKey.streamPartitionOwnershipKey(STREAM, partition),
+                                     StreamPartitionOwnershipValue.class);
     }
 
     private NodeId hrwOwner(String stream, int partition) {
@@ -209,16 +200,11 @@ class LinearizableReadForgeTest {
     }
 
     private List<NodeId> coreMembers(AetherNode node) {
-        return node.clusterTopologyManager()
-                   .map(ctm -> List.copyOf(ctm.observer().coreNodes()))
-                   .or(List.of());
+        return node.clusterTopologyManager().map(ctm -> List.copyOf(ctm.observer().coreNodes())).or(List.of());
     }
 
     private int clusterSize(AetherNode node) {
-        return node.clusterTopologyManager()
-                   .map(ctm -> ctm.observer()
-                                  .clusterSize())
-                   .or(SIZE);
+        return node.clusterTopologyManager().map(ctm -> ctm.observer().clusterSize()).or(SIZE);
     }
 
     private AetherNode resolveNode(NodeId nodeId) {
@@ -229,20 +215,13 @@ class LinearizableReadForgeTest {
     }
 
     private AetherNode leaderNode() {
-        return cluster.currentLeader()
-                      .flatMap(cluster::getNode)
-                      .or(cluster.allNodes().getFirst());
+        return cluster.currentLeader().flatMap(cluster::getNode).or(cluster.allNodes().getFirst());
     }
 
     private boolean allNodesReady() {
-        return cluster.allNodes()
-                      .stream()
-                      .allMatch(AetherNode::isReady);
+        return cluster.allNodes().stream().allMatch(AetherNode::isReady);
     }
 
-    private static void failStart(Cause cause) {
-        throw new AssertionError("Cluster start failed: " + cause.message());
-    }
 
     private static void failScenario(Cause cause) {
         throw new AssertionError("Scenario setup failed: " + cause.message());
@@ -255,10 +234,13 @@ class LinearizableReadForgeTest {
     private enum ForgeError implements Cause {
         NO_PLACEMENT("ReplicaPlacement returned no owner for the partition"),
         NODE_UNRESOLVED("Computed owner NodeId could not be resolved to a cluster node");
+
         private final String message;
+
         ForgeError(String message) {
             this.message = message;
         }
+
         @Override
         public String message() {
             return message;

--- a/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/MembershipBlackHoleSpikeTest.java
+++ b/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/MembershipBlackHoleSpikeTest.java
@@ -2,22 +2,7 @@
 // Copyright (c) 2025 Pragmatica Labs - Sergiy Yevtushenko
 // Licensed under Business Source License 1.1. Change Date: 2030-01-01. Change License: Apache-2.0.
 // See LICENSE in the repository root for full terms.
-
 package org.pragmatica.aether.forge;
-
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
-import org.pragmatica.http.HttpOperations;
-import org.pragmatica.http.HttpResult;
-import org.pragmatica.lang.Cause;
-import org.pragmatica.lang.Option;
-import org.pragmatica.lang.TerminalOperation;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.net.URI;
 import java.net.http.HttpRequest;
@@ -26,13 +11,28 @@ import java.util.List;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
 
+import org.pragmatica.http.HttpOperations;
+import org.pragmatica.http.HttpResult;
+import org.pragmatica.lang.Cause;
+import org.pragmatica.lang.Option;
+import org.pragmatica.lang.TerminalOperation;
 import org.pragmatica.aether.ember.EmberCluster;
 import org.pragmatica.aether.ember.EmberCluster.NodeStatus;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.awaitility.Awaitility.await;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import static org.pragmatica.aether.ember.EmberCluster.emberCluster;
 import static org.pragmatica.http.JdkHttpOperations.jdkHttpOperations;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
 
 /// Spike — in-process (Ember/single-JVM) reproduction of the Docker-only SILENT-DEATH
 /// failure-detection bug (issues #230/#231/#232).
@@ -57,14 +57,13 @@ import static org.pragmatica.http.JdkHttpOperations.jdkHttpOperations;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class MembershipBlackHoleSpikeTest {
     private static final Logger log = LoggerFactory.getLogger(MembershipBlackHoleSpikeTest.class);
-
     private static final int SIZE = 5;
     private static final int BASE_PORT = 5360;
     private static final int BASE_MGMT_PORT = 5460;
     private static final int BASE_APP_HTTP_PORT = 5560;
     private static final Duration FORM_TIMEOUT = Duration.ofSeconds(240);
     private static final Duration POLL = Duration.ofMillis(500);
-    private static final Duration SETTLE = Duration.ofSeconds(20);     // clear 15s auto-heal cooldown
+    private static final Duration SETTLE = Duration.ofSeconds(20);  // clear 15s auto-heal cooldown
     private static final Duration DETECT_BUDGET = Duration.ofSeconds(60);
     private static final Duration OBSERVE_POLL = Duration.ofMillis(500);
     private static final Duration LOG_EVERY = Duration.ofMillis(2000);
@@ -79,19 +78,19 @@ class MembershipBlackHoleSpikeTest {
     @TerminalOperation
     void setUp() {
         cluster = emberCluster(SIZE, BASE_PORT, BASE_MGMT_PORT, BASE_APP_HTTP_PORT, "bh");
-        cluster.start()
-               .await()
-               .onFailure(MembershipBlackHoleSpikeTest::failStart);
-
-        await().atMost(FORM_TIMEOUT).pollInterval(POLL).until(() -> cluster.currentLeader().isPresent());
+        LifecycleAwait.settled("cluster start in setUp()", cluster, cluster.start());
+        await().atMost(FORM_TIMEOUT).pollInterval(POLL).until(() -> cluster.currentLeader()
+                                                                           .isPresent());
         await().atMost(FORM_TIMEOUT).pollInterval(POLL).until(this::allNodesHealthy);
-        log.info("BLACKHOLE-SPIKE: {}-node cluster formed, leader={}", SIZE, cluster.currentLeader().or("none"));
+        log.info("BLACKHOLE-SPIKE: {}-node cluster formed, leader={}",
+                 SIZE,
+                 cluster.currentLeader().or("none"));
     }
 
     @AfterAll
     @TerminalOperation
     void tearDown() {
-        Option.option(cluster).onPresent(c -> c.stop().await());
+        Option.option(cluster).onPresent(c -> LifecycleAwait.settled("cluster stop in tearDown()", c, c.stop()));
     }
 
     @Test
@@ -99,7 +98,8 @@ class MembershipBlackHoleSpikeTest {
     void blackHoleNonLeader_shouldStillBeDetectedDeadAndTerminallyRemoved() {
         var nodes = cluster.status().nodes();
 
-        Option.all(firstMatching(nodes, n -> !n.isLeader()),
+        Option.all(firstMatching(nodes,
+                                 n -> !n.isLeader()),
                    firstMatching(nodes, NodeStatus::isLeader))
               .map(Selection::new)
               .toResult(SpikeError.LEADER_OR_VICTIM_UNAVAILABLE)
@@ -111,61 +111,71 @@ class MembershipBlackHoleSpikeTest {
     private void runSpike(Selection selection) {
         var victim = selection.victim();
         var survivorPort = selection.survivor().mgmtPort();
-        log.info("BLACKHOLE-SPIKE: leader/survivor={} victim={} (will go silent, channels stay open)",
-                 selection.survivor().id(), victim.id());
 
+        log.info("BLACKHOLE-SPIKE: leader/survivor={} victim={} (will go silent, channels stay open)",
+                 selection.survivor().id(),
+                 victim.id());
         log.info("BLACKHOLE-SPIKE: settling {}s (auto-heal cooldown)", SETTLE.toSeconds());
         await().pollDelay(SETTLE).timeout(SETTLE.plusSeconds(5)).until(() -> true);
         log.info("BLACKHOLE-SPIKE: pre-kill survivor connectedPeers={} terminallyRemoved={}",
                  connectedPeers(survivorPort).map(Object::toString).or("?"),
                  terminallyRemoved(survivorPort, victim.id()));
-
         var t0 = System.nanoTime();
-        cluster.blackhole(victim.id()).await();
-        log.info("BLACKHOLE-SPIKE: black-holed {} at t0 — node is now silent but NOT disconnected", victim.id());
 
+        LifecycleAwait.nodeSettled("blackhole node " + victim.id() + " in runSpike()",
+                                   cluster,
+                                   cluster.blackhole(victim.id()));
+        log.info("BLACKHOLE-SPIKE: black-holed {} at t0 — node is now silent but NOT disconnected", victim.id());
         var detectedMs = observeUntilRemoved(survivorPort, victim.id(), t0);
+
         log.info("BLACKHOLE-SPIKE RESULT: victim={} terminal-removal={}ms (-1=NOT within {}s)  "
-                 + "survivor connectedPeers={}",
-                 victim.id(), detectedMs, DETECT_BUDGET.toSeconds(),
+                + "survivor connectedPeers={}",
+                 victim.id(),
+                 detectedMs,
+                 DETECT_BUDGET.toSeconds(),
                  connectedPeers(survivorPort).map(Object::toString).or("?"));
         log.info("BLACKHOLE-SPIKE FINAL /api/v1/nodes/status: {}", status(survivorPort));
         log.info("BLACKHOLE-SPIKE FINAL /api/v1/events: {}", events(survivorPort));
-
-        assertThat(detectedMs)
-            .as("EXPECTED: silently-dead %s is terminally removed within %ds — ABSENT from the "
-                + "leader's active membership AND a NODE_FAILED/NODE_LEFT event emitted for it "
-                + "(-1 = lingering in membership — reproduces the Docker silent-death bug)",
-                victim.id(), DETECT_BUDGET.toSeconds())
-            .isGreaterThanOrEqualTo(0L);
+        assertThat(detectedMs).as("EXPECTED: silently-dead %s is terminally removed within %ds — ABSENT from the "
+                                 + "leader's active membership AND a NODE_FAILED/NODE_LEFT event emitted for it "
+                                 + "(-1 = lingering in membership — reproduces the Docker silent-death bug)",
+                                  victim.id(),
+                                  DETECT_BUDGET.toSeconds())
+                  .isGreaterThanOrEqualTo(0L);
     }
 
     /// Polls the survivor's membership + cluster-event view until the victim is terminally
     /// removed (absent from active membership AND a NODE_FAILED/NODE_LEFT event present) or the
     /// budget expires. Returns the first-observed terminal latency in ms, or -1 if never observed.
     private long observeUntilRemoved(int survivorPort, String victimId, long t0) {
-        var latch = new long[]{-1L};
+        var latch = new long[]{ - 1L};
         var lastLog = new long[]{0L};
+
         await().pollInterval(OBSERVE_POLL)
-               .pollDelay(Duration.ZERO)
-               .timeout(DETECT_BUDGET.plusSeconds(5))
-               .until(() -> recordTick(survivorPort, victimId, t0, latch, lastLog));
+             .pollDelay(Duration.ZERO)
+             .timeout(DETECT_BUDGET.plusSeconds(5))
+             .until(() -> recordTick(survivorPort, victimId, t0, latch, lastLog));
+
         return latch[0];
     }
 
     private boolean recordTick(int survivorPort, String victimId, long t0, long[] latch, long[] lastLog) {
         var elapsed = (System.nanoTime() - t0) / 1_000_000L;
-        if (terminallyRemoved(survivorPort, victimId) && latch[0] < 0) {
+
+        if (terminallyRemoved(survivorPort, victimId) && latch[0]< 0) {
             latch[0] = elapsed;
         }
+
         maybeLog(survivorPort, victimId, elapsed, lastLog);
-        return latch[0] >= 0 || elapsed >= DETECT_BUDGET.toMillis();
+
+        return latch[0]>= 0 || elapsed >= DETECT_BUDGET.toMillis();
     }
 
     private void maybeLog(int survivorPort, String victimId, long elapsedMs, long[] lastLog) {
-        if (elapsedMs - lastLog[0] < LOG_EVERY.toMillis()) {
+        if (elapsedMs - lastLog[0]< LOG_EVERY.toMillis()) {
             return;
         }
+
         lastLog[0] = elapsedMs;
         log.info("BLACKHOLE-SPIKE: t+{}ms survivor connectedPeers={} victimAbsent={} failedEvent={}",
                  elapsedMs,
@@ -175,12 +185,16 @@ class MembershipBlackHoleSpikeTest {
     }
 
     private boolean allNodesHealthy() {
-        return cluster.status().nodes().stream()
-                      .allMatch(node -> httpGet(node.mgmtPort(), "/api/v1/health").contains("\"quorum\":true"));
+        return cluster.status()
+                      .nodes()
+                      .stream()
+                      .allMatch(node -> httpGet(node.mgmtPort(),
+                                                "/api/v1/health").contains("\"quorum\":true"));
     }
 
     private Option<Integer> connectedPeers(int port) {
         var matcher = CONNECTED_PEERS.matcher(httpGet(port, "/api/v1/health"));
+
         return matcher.find()
                ? Option.some(Integer.parseInt(matcher.group(1)))
                : Option.none();
@@ -196,7 +210,7 @@ class MembershipBlackHoleSpikeTest {
     /// Victim is gone from the leader's active node list (`/api/v1/nodes/status` no longer carries
     /// its id). Matched on the JSON `"id":"<victimId>"` field present per NodeInfo entry.
     private boolean victimAbsentFromMembership(int port, String victimId) {
-        return !status(port).contains("\"id\":\"" + victimId + "\"");
+        return ! status(port).contains("\"id\":\"" + victimId + "\"");
     }
 
     /// A terminal departure event (NODE_FAILED or NODE_LEFT) for the victim appears in the
@@ -204,6 +218,7 @@ class MembershipBlackHoleSpikeTest {
     /// `type` enum name; require both the type marker and the victim id in the event payload.
     private boolean victimHasDepartureEvent(int port, String victimId) {
         var body = events(port);
+
         return body.contains(victimId) && (body.contains(NODE_FAILED) || body.contains(NODE_LEFT));
     }
 
@@ -222,6 +237,7 @@ class MembershipBlackHoleSpikeTest {
                                  .GET()
                                  .timeout(Duration.ofSeconds(5))
                                  .build();
+
         return http.sendString(request)
                    .await()
                    .map(HttpResult::body)
@@ -246,13 +262,10 @@ class MembershipBlackHoleSpikeTest {
 
     private enum SpikeError implements Cause {
         LEADER_OR_VICTIM_UNAVAILABLE("No leader, or no non-leader victim / leader survivor available");
-
         private final String message;
-
         SpikeError(String message) {
             this.message = message;
         }
-
         @Override
         public String message() {
             return message;

--- a/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/MembershipBlackHoleSpikeTest.java
+++ b/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/MembershipBlackHoleSpikeTest.java
@@ -2,7 +2,22 @@
 // Copyright (c) 2025 Pragmatica Labs - Sergiy Yevtushenko
 // Licensed under Business Source License 1.1. Change Date: 2030-01-01. Change License: Apache-2.0.
 // See LICENSE in the repository root for full terms.
+
 package org.pragmatica.aether.forge;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.pragmatica.http.HttpOperations;
+import org.pragmatica.http.HttpResult;
+import org.pragmatica.lang.Cause;
+import org.pragmatica.lang.Option;
+import org.pragmatica.lang.TerminalOperation;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.net.URI;
 import java.net.http.HttpRequest;
@@ -11,28 +26,13 @@ import java.util.List;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
 
-import org.pragmatica.http.HttpOperations;
-import org.pragmatica.http.HttpResult;
-import org.pragmatica.lang.Cause;
-import org.pragmatica.lang.Option;
-import org.pragmatica.lang.TerminalOperation;
 import org.pragmatica.aether.ember.EmberCluster;
 import org.pragmatica.aether.ember.EmberCluster.NodeStatus;
 
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import static org.pragmatica.aether.ember.EmberCluster.emberCluster;
-import static org.pragmatica.http.JdkHttpOperations.jdkHttpOperations;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
-
+import static org.pragmatica.aether.ember.EmberCluster.emberCluster;
+import static org.pragmatica.http.JdkHttpOperations.jdkHttpOperations;
 
 /// Spike — in-process (Ember/single-JVM) reproduction of the Docker-only SILENT-DEATH
 /// failure-detection bug (issues #230/#231/#232).
@@ -57,13 +57,14 @@ import static org.awaitility.Awaitility.await;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class MembershipBlackHoleSpikeTest {
     private static final Logger log = LoggerFactory.getLogger(MembershipBlackHoleSpikeTest.class);
+
     private static final int SIZE = 5;
     private static final int BASE_PORT = 5360;
     private static final int BASE_MGMT_PORT = 5460;
     private static final int BASE_APP_HTTP_PORT = 5560;
     private static final Duration FORM_TIMEOUT = Duration.ofSeconds(240);
     private static final Duration POLL = Duration.ofMillis(500);
-    private static final Duration SETTLE = Duration.ofSeconds(20);  // clear 15s auto-heal cooldown
+    private static final Duration SETTLE = Duration.ofSeconds(20);     // clear 15s auto-heal cooldown
     private static final Duration DETECT_BUDGET = Duration.ofSeconds(60);
     private static final Duration OBSERVE_POLL = Duration.ofMillis(500);
     private static final Duration LOG_EVERY = Duration.ofMillis(2000);
@@ -79,18 +80,16 @@ class MembershipBlackHoleSpikeTest {
     void setUp() {
         cluster = emberCluster(SIZE, BASE_PORT, BASE_MGMT_PORT, BASE_APP_HTTP_PORT, "bh");
         LifecycleAwait.settled("cluster start in setUp()", cluster, cluster.start());
-        await().atMost(FORM_TIMEOUT).pollInterval(POLL).until(() -> cluster.currentLeader()
-                                                                           .isPresent());
+
+        await().atMost(FORM_TIMEOUT).pollInterval(POLL).until(() -> cluster.currentLeader().isPresent());
         await().atMost(FORM_TIMEOUT).pollInterval(POLL).until(this::allNodesHealthy);
-        log.info("BLACKHOLE-SPIKE: {}-node cluster formed, leader={}",
-                 SIZE,
-                 cluster.currentLeader().or("none"));
+        log.info("BLACKHOLE-SPIKE: {}-node cluster formed, leader={}", SIZE, cluster.currentLeader().or("none"));
     }
 
     @AfterAll
     @TerminalOperation
     void tearDown() {
-        Option.option(cluster).onPresent(c -> LifecycleAwait.settled("cluster stop in tearDown()", c, c.stop()));
+        Option.option(cluster).onPresent(c -> LifecycleAwait.bestEffort("cluster stop in tearDown()", c, c.stop()));
     }
 
     @Test
@@ -98,8 +97,7 @@ class MembershipBlackHoleSpikeTest {
     void blackHoleNonLeader_shouldStillBeDetectedDeadAndTerminallyRemoved() {
         var nodes = cluster.status().nodes();
 
-        Option.all(firstMatching(nodes,
-                                 n -> !n.isLeader()),
+        Option.all(firstMatching(nodes, n -> !n.isLeader()),
                    firstMatching(nodes, NodeStatus::isLeader))
               .map(Selection::new)
               .toResult(SpikeError.LEADER_OR_VICTIM_UNAVAILABLE)
@@ -111,71 +109,63 @@ class MembershipBlackHoleSpikeTest {
     private void runSpike(Selection selection) {
         var victim = selection.victim();
         var survivorPort = selection.survivor().mgmtPort();
-
         log.info("BLACKHOLE-SPIKE: leader/survivor={} victim={} (will go silent, channels stay open)",
-                 selection.survivor().id(),
-                 victim.id());
+                 selection.survivor().id(), victim.id());
+
         log.info("BLACKHOLE-SPIKE: settling {}s (auto-heal cooldown)", SETTLE.toSeconds());
         await().pollDelay(SETTLE).timeout(SETTLE.plusSeconds(5)).until(() -> true);
         log.info("BLACKHOLE-SPIKE: pre-kill survivor connectedPeers={} terminallyRemoved={}",
                  connectedPeers(survivorPort).map(Object::toString).or("?"),
                  terminallyRemoved(survivorPort, victim.id()));
-        var t0 = System.nanoTime();
 
-        LifecycleAwait.nodeSettled("blackhole node " + victim.id() + " in runSpike()",
+        var t0 = System.nanoTime();
+        LifecycleAwait.nodeBestEffort("blackhole node " + victim.id() + " in runSpike()",
                                    cluster,
                                    cluster.blackhole(victim.id()));
         log.info("BLACKHOLE-SPIKE: black-holed {} at t0 — node is now silent but NOT disconnected", victim.id());
-        var detectedMs = observeUntilRemoved(survivorPort, victim.id(), t0);
 
+        var detectedMs = observeUntilRemoved(survivorPort, victim.id(), t0);
         log.info("BLACKHOLE-SPIKE RESULT: victim={} terminal-removal={}ms (-1=NOT within {}s)  "
-                + "survivor connectedPeers={}",
-                 victim.id(),
-                 detectedMs,
-                 DETECT_BUDGET.toSeconds(),
+                 + "survivor connectedPeers={}",
+                 victim.id(), detectedMs, DETECT_BUDGET.toSeconds(),
                  connectedPeers(survivorPort).map(Object::toString).or("?"));
         log.info("BLACKHOLE-SPIKE FINAL /api/v1/nodes/status: {}", status(survivorPort));
         log.info("BLACKHOLE-SPIKE FINAL /api/v1/events: {}", events(survivorPort));
-        assertThat(detectedMs).as("EXPECTED: silently-dead %s is terminally removed within %ds — ABSENT from the "
-                                 + "leader's active membership AND a NODE_FAILED/NODE_LEFT event emitted for it "
-                                 + "(-1 = lingering in membership — reproduces the Docker silent-death bug)",
-                                  victim.id(),
-                                  DETECT_BUDGET.toSeconds())
-                  .isGreaterThanOrEqualTo(0L);
+
+        assertThat(detectedMs)
+            .as("EXPECTED: silently-dead %s is terminally removed within %ds — ABSENT from the "
+                + "leader's active membership AND a NODE_FAILED/NODE_LEFT event emitted for it "
+                + "(-1 = lingering in membership — reproduces the Docker silent-death bug)",
+                victim.id(), DETECT_BUDGET.toSeconds())
+            .isGreaterThanOrEqualTo(0L);
     }
 
     /// Polls the survivor's membership + cluster-event view until the victim is terminally
     /// removed (absent from active membership AND a NODE_FAILED/NODE_LEFT event present) or the
     /// budget expires. Returns the first-observed terminal latency in ms, or -1 if never observed.
     private long observeUntilRemoved(int survivorPort, String victimId, long t0) {
-        var latch = new long[]{ - 1L};
+        var latch = new long[]{-1L};
         var lastLog = new long[]{0L};
-
         await().pollInterval(OBSERVE_POLL)
-             .pollDelay(Duration.ZERO)
-             .timeout(DETECT_BUDGET.plusSeconds(5))
-             .until(() -> recordTick(survivorPort, victimId, t0, latch, lastLog));
-
+               .pollDelay(Duration.ZERO)
+               .timeout(DETECT_BUDGET.plusSeconds(5))
+               .until(() -> recordTick(survivorPort, victimId, t0, latch, lastLog));
         return latch[0];
     }
 
     private boolean recordTick(int survivorPort, String victimId, long t0, long[] latch, long[] lastLog) {
         var elapsed = (System.nanoTime() - t0) / 1_000_000L;
-
-        if (terminallyRemoved(survivorPort, victimId) && latch[0]< 0) {
+        if (terminallyRemoved(survivorPort, victimId) && latch[0] < 0) {
             latch[0] = elapsed;
         }
-
         maybeLog(survivorPort, victimId, elapsed, lastLog);
-
-        return latch[0]>= 0 || elapsed >= DETECT_BUDGET.toMillis();
+        return latch[0] >= 0 || elapsed >= DETECT_BUDGET.toMillis();
     }
 
     private void maybeLog(int survivorPort, String victimId, long elapsedMs, long[] lastLog) {
-        if (elapsedMs - lastLog[0]< LOG_EVERY.toMillis()) {
+        if (elapsedMs - lastLog[0] < LOG_EVERY.toMillis()) {
             return;
         }
-
         lastLog[0] = elapsedMs;
         log.info("BLACKHOLE-SPIKE: t+{}ms survivor connectedPeers={} victimAbsent={} failedEvent={}",
                  elapsedMs,
@@ -185,16 +175,12 @@ class MembershipBlackHoleSpikeTest {
     }
 
     private boolean allNodesHealthy() {
-        return cluster.status()
-                      .nodes()
-                      .stream()
-                      .allMatch(node -> httpGet(node.mgmtPort(),
-                                                "/api/v1/health").contains("\"quorum\":true"));
+        return cluster.status().nodes().stream()
+                      .allMatch(node -> httpGet(node.mgmtPort(), "/api/v1/health").contains("\"quorum\":true"));
     }
 
     private Option<Integer> connectedPeers(int port) {
         var matcher = CONNECTED_PEERS.matcher(httpGet(port, "/api/v1/health"));
-
         return matcher.find()
                ? Option.some(Integer.parseInt(matcher.group(1)))
                : Option.none();
@@ -210,7 +196,7 @@ class MembershipBlackHoleSpikeTest {
     /// Victim is gone from the leader's active node list (`/api/v1/nodes/status` no longer carries
     /// its id). Matched on the JSON `"id":"<victimId>"` field present per NodeInfo entry.
     private boolean victimAbsentFromMembership(int port, String victimId) {
-        return ! status(port).contains("\"id\":\"" + victimId + "\"");
+        return !status(port).contains("\"id\":\"" + victimId + "\"");
     }
 
     /// A terminal departure event (NODE_FAILED or NODE_LEFT) for the victim appears in the
@@ -218,7 +204,6 @@ class MembershipBlackHoleSpikeTest {
     /// `type` enum name; require both the type marker and the victim id in the event payload.
     private boolean victimHasDepartureEvent(int port, String victimId) {
         var body = events(port);
-
         return body.contains(victimId) && (body.contains(NODE_FAILED) || body.contains(NODE_LEFT));
     }
 
@@ -237,7 +222,6 @@ class MembershipBlackHoleSpikeTest {
                                  .GET()
                                  .timeout(Duration.ofSeconds(5))
                                  .build();
-
         return http.sendString(request)
                    .await()
                    .map(HttpResult::body)
@@ -248,9 +232,6 @@ class MembershipBlackHoleSpikeTest {
         return Option.from(items.stream().filter(predicate).findFirst());
     }
 
-    private static void failStart(Cause cause) {
-        throw new AssertionError("Cluster start failed: " + cause.message());
-    }
 
     private static void failScenario(Cause cause) {
         throw new AssertionError("Scenario setup failed: " + cause.message());
@@ -262,10 +243,13 @@ class MembershipBlackHoleSpikeTest {
 
     private enum SpikeError implements Cause {
         LEADER_OR_VICTIM_UNAVAILABLE("No leader, or no non-leader victim / leader survivor available");
+
         private final String message;
+
         SpikeError(String message) {
             this.message = message;
         }
+
         @Override
         public String message() {
             return message;

--- a/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/MembershipChaosCycleTest.java
+++ b/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/MembershipChaosCycleTest.java
@@ -2,27 +2,8 @@
 // Copyright (c) 2025 Pragmatica Labs - Sergiy Yevtushenko
 // Licensed under Business Source License 1.1. Change Date: 2030-01-01. Change License: Apache-2.0.
 // See LICENSE in the repository root for full terms.
+
 package org.pragmatica.aether.forge;
-
-import java.time.Duration;
-import java.util.List;
-import java.util.Set;
-import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.concurrent.atomic.AtomicLong;
-
-import org.pragmatica.aether.ember.EmberCluster;
-import org.pragmatica.aether.environment.ComputeProvider;
-import org.pragmatica.aether.environment.InstanceId;
-import org.pragmatica.aether.environment.InstanceInfo;
-import org.pragmatica.aether.environment.ProviderDefaults;
-import org.pragmatica.aether.environment.ProvisionRequest;
-import org.pragmatica.aether.node.AetherNode;
-import org.pragmatica.consensus.NodeId;
-import org.pragmatica.lang.Cause;
-import org.pragmatica.lang.Option;
-import org.pragmatica.lang.Promise;
-import org.pragmatica.lang.TerminalOperation;
-import org.pragmatica.lang.Unit;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -31,13 +12,30 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.pragmatica.aether.ember.EmberCluster;
+import org.pragmatica.aether.environment.ComputeProvider;
+import org.pragmatica.aether.environment.InstanceId;
+import org.pragmatica.aether.environment.InstanceInfo;
+import org.pragmatica.aether.environment.ProviderDefaults;
+import org.pragmatica.aether.environment.ProvisionRequest;
+import org.pragmatica.aether.node.AetherNode;
+import org.pragmatica.consensus.NodeId;
+import org.pragmatica.lang.Option;
+import org.pragmatica.lang.Promise;
+import org.pragmatica.lang.TerminalOperation;
+import org.pragmatica.lang.Unit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.pragmatica.aether.ember.EmberCluster.emberCluster;
+import java.time.Duration;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicLong;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
-
+import static org.pragmatica.aether.ember.EmberCluster.emberCluster;
 
 /// #232 — the in-process membership chaos cycle: kill → detect → decommission → heal.
 ///
@@ -105,27 +103,32 @@ import static org.awaitility.Awaitility.await;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class MembershipChaosCycleTest {
     private static final Logger log = LoggerFactory.getLogger(MembershipChaosCycleTest.class);
+
     private static final int SIZE = 5;
     private static final int BASE_PORT = 20500;
     private static final int BASE_MGMT_PORT = 20600;
     private static final int BASE_APP_HTTP_PORT = 20700;
+
     /// `AutoHealConfig.DEFAULT` startupCooldown is 15s: the reconciler will not fill a deficit until a
     /// node has been up that long. Killing inside that window would measure the cooldown, not
     /// detection, so the run settles past it before the kill.
     private static final Duration AUTO_HEAL_STARTUP_COOLDOWN = Duration.ofSeconds(15);
     private static final Duration SETTLE = AUTO_HEAL_STARTUP_COOLDOWN.plusSeconds(5);
+
     /// SWIM suspicion (`SwimConfig.suspectTimeout`, 10s) plus NTT departure
     /// (`MembershipConfig.nttDepartureTimeout`, 15s) — the detection window `AutoHealSpec` names when
     /// it sizes its own hint TTL. 25s is the mechanism; the budget triples it so a loaded CI box does
     /// not turn a slow detection into a red build.
     private static final Duration DETECTION_WINDOW = Duration.ofSeconds(25);
     private static final Duration DECOMMISSION_BUDGET = DETECTION_WINDOW.multipliedBy(3);
+
     /// After the deficit is visible: `autoHealRetry` (10s) to re-arm, `provisioningTimeout` (60s) as
     /// the provider ceiling, then the replacement has to boot, join via SWIM and be counted. Doubled
     /// for the same CI-load reason.
     private static final Duration AUTO_HEAL_RETRY = Duration.ofSeconds(10);
     private static final Duration PROVISIONING_TIMEOUT = Duration.ofSeconds(60);
     private static final Duration HEAL_BUDGET = AUTO_HEAL_RETRY.plus(PROVISIONING_TIMEOUT).multipliedBy(2);
+
     private static final Duration FORM_TIMEOUT = Duration.ofSeconds(240);
     private static final Duration POLL = Duration.ofMillis(500);
 
@@ -138,42 +141,44 @@ class MembershipChaosCycleTest {
         cluster = emberCluster(SIZE, BASE_PORT, BASE_MGMT_PORT, BASE_APP_HTTP_PORT, "chaos");
         cluster.withComputeProviderDecorator(recorder::wrap);
         LifecycleAwait.settled("cluster start in setUp()", cluster, cluster.start());
-        await().atMost(FORM_TIMEOUT).pollInterval(POLL).until(() -> cluster.currentLeader()
-                                                                           .isPresent());
+
+        await().atMost(FORM_TIMEOUT).pollInterval(POLL).until(() -> cluster.currentLeader().isPresent());
         await().atMost(FORM_TIMEOUT).pollInterval(POLL).until(() -> countedCores() == SIZE);
         log.info("CHAOS-CYCLE: {}-node cluster formed, leader={} countedCores={}",
-                 SIZE,
-                 cluster.currentLeader().or("none"),
-                 countedCores());
+                 SIZE, cluster.currentLeader().or("none"), countedCores());
     }
 
     @AfterAll
     @TerminalOperation
     void tearDown() {
-        Option.option(cluster).onPresent(c -> LifecycleAwait.settled("cluster stop in tearDown()", c, c.stop()));
+        Option.option(cluster).onPresent(c -> LifecycleAwait.bestEffort("cluster stop in tearDown()", c, c.stop()));
     }
 
     @Test
     void killedCoreNode_isDecommissioned_andTheClusterHealsItselfBackToFullMembership() {
         settlePastAutoHealCooldown();
+
         var victim = nonLeaderNode();
         var provisionsBeforeKill = recorder.provisionCalls();
 
         log.info("CHAOS-CYCLE: leader={} victim={} (hard kill, connections close) provisionsBefore={}",
-                 cluster.currentLeader().or("none"),
-                 victim,
-                 provisionsBeforeKill);
+                 cluster.currentLeader().or("none"), victim, provisionsBeforeKill);
+
         var t0 = System.nanoTime();
 
         LifecycleAwait.nodeSettled("kill node " + victim
                                   + " in killedCoreNode_isDecommissioned_andTheClusterHealsItselfBackToFullMembership()",
                                    cluster,
                                    cluster.killNode(victim, false));
+
         var decommissionMs = awaitMillis("DECOMMISSION",
                                          t0,
                                          DECOMMISSION_BUDGET,
                                          () -> !countedCoreIds().contains(victim));
-        var healMs = awaitMillis("HEAL", t0, DECOMMISSION_BUDGET.plus(HEAL_BUDGET), () -> countedCores() >= SIZE);
+        var healMs = awaitMillis("HEAL",
+                                 t0,
+                                 DECOMMISSION_BUDGET.plus(HEAL_BUDGET),
+                                 () -> countedCores() >= SIZE);
         // Leadership is a CONVERGENCE property, not an instant one. The first run of this class read
         // `currentLeader()` at the moment heal completed and saw `none` — a re-election was in flight
         // as the replacement joined and changed the topology. Asserting on that instant would have
@@ -183,45 +188,44 @@ class MembershipChaosCycleTest {
         var leaderMs = awaitMillis("LEADER-RECOVERY",
                                    t0,
                                    DECOMMISSION_BUDGET.plus(HEAL_BUDGET),
-                                   () -> cluster.currentLeader()
-                                                .isPresent());
+                                   () -> cluster.currentLeader().isPresent());
         var provisionsAfter = recorder.provisionCalls();
+
         // Logged BEFORE the assertions: a failing assertion is exactly when this timeline is the
         // evidence the ticket asked for, and an AssertionError would skip anything logged after it.
         log.info("CHAOS-CYCLE RESULT (measured, not carried over from the phi-accrual era): "
-                + "decommission={}ms heal={}ms leaderRecovery={}ms provisions={} countedCores={} leader={} ids={}",
-                 decommissionMs,
-                 healMs,
-                 leaderMs,
-                 provisionsAfter - provisionsBeforeKill,
-                 countedCores(),
-                 cluster.currentLeader().or("none"),
-                 countedCoreIds());
-        assertThat(decommissionMs).as("a hard-killed core must leave counted membership within %ds "
-                                     + "(SWIM suspicion 10s + NTT departure 15s, tripled for CI load); -1 means it never did",
-                                      DECOMMISSION_BUDGET.toSeconds())
-                  .isBetween(0L,
-                             DECOMMISSION_BUDGET.toMillis());
-        assertThat(provisionsAfter).as("auto-heal must reach the real ComputeProvider.provision path — counted membership "
-                                      + "returning to %d without a provision would mean something rejoined rather than the "
-                                      + "cluster healing itself, and the heal leg would be unproven",
-                                       SIZE)
-                  .isGreaterThan(provisionsBeforeKill);
-        assertThat(healMs).as("the replacement must boot, join and be COUNTED within %ds; a provision that never "
-                             + "joins leaves the cycle half-proven",
-                              DECOMMISSION_BUDGET.plus(HEAL_BUDGET).toSeconds())
-                  .isBetween(0L,
-                             DECOMMISSION_BUDGET.plus(HEAL_BUDGET).toMillis());
-        assertThat(leaderMs).as("the cluster must settle back to having a leader within %ds — healing to %d nodes is "
-                               + "not a success if leadership never recovers. Awaited, not sampled: a re-election is "
-                               + "legitimately in flight while the replacement joins",
-                                DECOMMISSION_BUDGET.plus(HEAL_BUDGET).toSeconds(),
-                                SIZE)
-                  .isBetween(0L,
-                             DECOMMISSION_BUDGET.plus(HEAL_BUDGET).toMillis());
-        assertThat(countedCoreIds()).as("the dead node must NOT reappear in counted membership — the cluster heals by "
-                                       + "replacing it, not by resurrecting the id that was decommissioned")
-                  .doesNotContain(victim);
+                 + "decommission={}ms heal={}ms leaderRecovery={}ms provisions={} countedCores={} leader={} ids={}",
+                 decommissionMs, healMs, leaderMs, provisionsAfter - provisionsBeforeKill,
+                 countedCores(), cluster.currentLeader().or("none"), countedCoreIds());
+
+        assertThat(decommissionMs)
+            .as("a hard-killed core must leave counted membership within %ds "
+                + "(SWIM suspicion 10s + NTT departure 15s, tripled for CI load); -1 means it never did",
+                DECOMMISSION_BUDGET.toSeconds())
+            .isBetween(0L, DECOMMISSION_BUDGET.toMillis());
+
+        assertThat(provisionsAfter)
+            .as("auto-heal must reach the real ComputeProvider.provision path — counted membership "
+                + "returning to %d without a provision would mean something rejoined rather than the "
+                + "cluster healing itself, and the heal leg would be unproven", SIZE)
+            .isGreaterThan(provisionsBeforeKill);
+
+        assertThat(healMs)
+            .as("the replacement must boot, join and be COUNTED within %ds; a provision that never "
+                + "joins leaves the cycle half-proven", DECOMMISSION_BUDGET.plus(HEAL_BUDGET).toSeconds())
+            .isBetween(0L, DECOMMISSION_BUDGET.plus(HEAL_BUDGET).toMillis());
+
+        assertThat(leaderMs)
+            .as("the cluster must settle back to having a leader within %ds — healing to %d nodes is "
+                + "not a success if leadership never recovers. Awaited, not sampled: a re-election is "
+                + "legitimately in flight while the replacement joins",
+                DECOMMISSION_BUDGET.plus(HEAL_BUDGET).toSeconds(), SIZE)
+            .isBetween(0L, DECOMMISSION_BUDGET.plus(HEAL_BUDGET).toMillis());
+
+        assertThat(countedCoreIds())
+            .as("the dead node must NOT reappear in counted membership — the cluster heals by "
+                + "replacing it, not by resurrecting the id that was decommissioned")
+            .doesNotContain(victim);
     }
 
     /// Polls until `condition`, returning elapsed millis from `t0`, or -1 on timeout. Returning a
@@ -232,23 +236,18 @@ class MembershipChaosCycleTest {
 
         try {
             await().atMost(budget.plusSeconds(10))
-                 .pollInterval(POLL)
-                 .until(() -> {
-                            if (condition.getAsBoolean()) {
-                            latch.compareAndSet(-1,
-                                                (System.nanoTime() - t0) / 1_000_000);
+                   .pollInterval(POLL)
+                   .until(() -> {
+                       if (condition.getAsBoolean()) {
+                           latch.compareAndSet(-1, (System.nanoTime() - t0) / 1_000_000);
 
-                            return true;
-                        }
+                           return true;
+                       }
+                       log.info("CHAOS-CYCLE: {} pending at t+{}ms countedCores={} ids={}",
+                                label, (System.nanoTime() - t0) / 1_000_000, countedCores(), countedCoreIds());
 
-                            log.info("CHAOS-CYCLE: {} pending at t+{}ms countedCores={} ids={}",
-                                     label,
-                                     (System.nanoTime() - t0) / 1_000_000,
-                                     countedCores(),
-                                     countedCoreIds());
-
-                            return false;
-                        });
+                       return false;
+                   });
         } catch (Exception e) {
             log.warn("CHAOS-CYCLE: {} NOT reached within {}s", label, budget.toSeconds());
         }
@@ -258,9 +257,8 @@ class MembershipChaosCycleTest {
 
     private void settlePastAutoHealCooldown() {
         log.info("CHAOS-CYCLE: settling {}s past the {}s auto-heal startup cooldown so the kill "
-                + "measures detection rather than the cooldown",
-                 SETTLE.toSeconds(),
-                 AUTO_HEAL_STARTUP_COOLDOWN.toSeconds());
+                 + "measures detection rather than the cooldown",
+                 SETTLE.toSeconds(), AUTO_HEAL_STARTUP_COOLDOWN.toSeconds());
         await().pollDelay(SETTLE).timeout(SETTLE.plusSeconds(10)).until(() -> true);
     }
 
@@ -284,12 +282,12 @@ class MembershipChaosCycleTest {
         return leaderOrAnyNode().map(node -> node.membershipFsm()
                                                  .coreCountedMembers()
                                                  .size())
-                              .or(0);
+                                .or(0);
     }
 
     private String countedCoreIds() {
         return leaderOrAnyNode().map(node -> idStrings(node.membershipFsm().coreCountedMembers()))
-                              .or("");
+                                .or("");
     }
 
     private Option<AetherNode> leaderOrAnyNode() {
@@ -306,13 +304,7 @@ class MembershipChaosCycleTest {
                   .toString();
     }
 
-    private static void failStart(Cause cause) {
-        throw new AssertionError("Cluster start failed: " + cause.message());
-    }
 
-    private static void failScenario(Cause cause) {
-        throw new AssertionError("Scenario step failed: " + cause.message());
-    }
 
     /// Counts every provision and ALWAYS delegates — this class must not inject provider faults, it
     /// is measuring the healthy heal path.

--- a/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/MembershipChaosCycleTest.java
+++ b/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/MembershipChaosCycleTest.java
@@ -2,16 +2,14 @@
 // Copyright (c) 2025 Pragmatica Labs - Sergiy Yevtushenko
 // Licensed under Business Source License 1.1. Change Date: 2030-01-01. Change License: Apache-2.0.
 // See LICENSE in the repository root for full terms.
-
 package org.pragmatica.aether.forge;
 
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
+import java.time.Duration;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicLong;
+
 import org.pragmatica.aether.ember.EmberCluster;
 import org.pragmatica.aether.environment.ComputeProvider;
 import org.pragmatica.aether.environment.InstanceId;
@@ -25,18 +23,21 @@ import org.pragmatica.lang.Option;
 import org.pragmatica.lang.Promise;
 import org.pragmatica.lang.TerminalOperation;
 import org.pragmatica.lang.Unit;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.time.Duration;
-import java.util.List;
-import java.util.Set;
-import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.concurrent.atomic.AtomicLong;
-
+import static org.pragmatica.aether.ember.EmberCluster.emberCluster;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
-import static org.pragmatica.aether.ember.EmberCluster.emberCluster;
+
 
 /// #232 — the in-process membership chaos cycle: kill → detect → decommission → heal.
 ///
@@ -104,32 +105,27 @@ import static org.pragmatica.aether.ember.EmberCluster.emberCluster;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class MembershipChaosCycleTest {
     private static final Logger log = LoggerFactory.getLogger(MembershipChaosCycleTest.class);
-
     private static final int SIZE = 5;
     private static final int BASE_PORT = 20500;
     private static final int BASE_MGMT_PORT = 20600;
     private static final int BASE_APP_HTTP_PORT = 20700;
-
     /// `AutoHealConfig.DEFAULT` startupCooldown is 15s: the reconciler will not fill a deficit until a
     /// node has been up that long. Killing inside that window would measure the cooldown, not
     /// detection, so the run settles past it before the kill.
     private static final Duration AUTO_HEAL_STARTUP_COOLDOWN = Duration.ofSeconds(15);
     private static final Duration SETTLE = AUTO_HEAL_STARTUP_COOLDOWN.plusSeconds(5);
-
     /// SWIM suspicion (`SwimConfig.suspectTimeout`, 10s) plus NTT departure
     /// (`MembershipConfig.nttDepartureTimeout`, 15s) — the detection window `AutoHealSpec` names when
     /// it sizes its own hint TTL. 25s is the mechanism; the budget triples it so a loaded CI box does
     /// not turn a slow detection into a red build.
     private static final Duration DETECTION_WINDOW = Duration.ofSeconds(25);
     private static final Duration DECOMMISSION_BUDGET = DETECTION_WINDOW.multipliedBy(3);
-
     /// After the deficit is visible: `autoHealRetry` (10s) to re-arm, `provisioningTimeout` (60s) as
     /// the provider ceiling, then the replacement has to boot, join via SWIM and be counted. Doubled
     /// for the same CI-load reason.
     private static final Duration AUTO_HEAL_RETRY = Duration.ofSeconds(10);
     private static final Duration PROVISIONING_TIMEOUT = Duration.ofSeconds(60);
     private static final Duration HEAL_BUDGET = AUTO_HEAL_RETRY.plus(PROVISIONING_TIMEOUT).multipliedBy(2);
-
     private static final Duration FORM_TIMEOUT = Duration.ofSeconds(240);
     private static final Duration POLL = Duration.ofMillis(500);
 
@@ -141,42 +137,43 @@ class MembershipChaosCycleTest {
     void setUp() {
         cluster = emberCluster(SIZE, BASE_PORT, BASE_MGMT_PORT, BASE_APP_HTTP_PORT, "chaos");
         cluster.withComputeProviderDecorator(recorder::wrap);
-        cluster.start().await().onFailure(MembershipChaosCycleTest::failStart);
-
-        await().atMost(FORM_TIMEOUT).pollInterval(POLL).until(() -> cluster.currentLeader().isPresent());
+        LifecycleAwait.settled("cluster start in setUp()", cluster, cluster.start());
+        await().atMost(FORM_TIMEOUT).pollInterval(POLL).until(() -> cluster.currentLeader()
+                                                                           .isPresent());
         await().atMost(FORM_TIMEOUT).pollInterval(POLL).until(() -> countedCores() == SIZE);
         log.info("CHAOS-CYCLE: {}-node cluster formed, leader={} countedCores={}",
-                 SIZE, cluster.currentLeader().or("none"), countedCores());
+                 SIZE,
+                 cluster.currentLeader().or("none"),
+                 countedCores());
     }
 
     @AfterAll
     @TerminalOperation
     void tearDown() {
-        Option.option(cluster).onPresent(c -> c.stop().await());
+        Option.option(cluster).onPresent(c -> LifecycleAwait.settled("cluster stop in tearDown()", c, c.stop()));
     }
 
     @Test
     void killedCoreNode_isDecommissioned_andTheClusterHealsItselfBackToFullMembership() {
         settlePastAutoHealCooldown();
-
         var victim = nonLeaderNode();
         var provisionsBeforeKill = recorder.provisionCalls();
 
         log.info("CHAOS-CYCLE: leader={} victim={} (hard kill, connections close) provisionsBefore={}",
-                 cluster.currentLeader().or("none"), victim, provisionsBeforeKill);
-
+                 cluster.currentLeader().or("none"),
+                 victim,
+                 provisionsBeforeKill);
         var t0 = System.nanoTime();
 
-        cluster.killNode(victim, false).await().onFailure(MembershipChaosCycleTest::failScenario);
-
+        LifecycleAwait.nodeSettled("kill node " + victim
+                                  + " in killedCoreNode_isDecommissioned_andTheClusterHealsItselfBackToFullMembership()",
+                                   cluster,
+                                   cluster.killNode(victim, false));
         var decommissionMs = awaitMillis("DECOMMISSION",
                                          t0,
                                          DECOMMISSION_BUDGET,
                                          () -> !countedCoreIds().contains(victim));
-        var healMs = awaitMillis("HEAL",
-                                 t0,
-                                 DECOMMISSION_BUDGET.plus(HEAL_BUDGET),
-                                 () -> countedCores() >= SIZE);
+        var healMs = awaitMillis("HEAL", t0, DECOMMISSION_BUDGET.plus(HEAL_BUDGET), () -> countedCores() >= SIZE);
         // Leadership is a CONVERGENCE property, not an instant one. The first run of this class read
         // `currentLeader()` at the moment heal completed and saw `none` — a re-election was in flight
         // as the replacement joined and changed the topology. Asserting on that instant would have
@@ -186,44 +183,45 @@ class MembershipChaosCycleTest {
         var leaderMs = awaitMillis("LEADER-RECOVERY",
                                    t0,
                                    DECOMMISSION_BUDGET.plus(HEAL_BUDGET),
-                                   () -> cluster.currentLeader().isPresent());
+                                   () -> cluster.currentLeader()
+                                                .isPresent());
         var provisionsAfter = recorder.provisionCalls();
-
         // Logged BEFORE the assertions: a failing assertion is exactly when this timeline is the
         // evidence the ticket asked for, and an AssertionError would skip anything logged after it.
         log.info("CHAOS-CYCLE RESULT (measured, not carried over from the phi-accrual era): "
-                 + "decommission={}ms heal={}ms leaderRecovery={}ms provisions={} countedCores={} leader={} ids={}",
-                 decommissionMs, healMs, leaderMs, provisionsAfter - provisionsBeforeKill,
-                 countedCores(), cluster.currentLeader().or("none"), countedCoreIds());
-
-        assertThat(decommissionMs)
-            .as("a hard-killed core must leave counted membership within %ds "
-                + "(SWIM suspicion 10s + NTT departure 15s, tripled for CI load); -1 means it never did",
-                DECOMMISSION_BUDGET.toSeconds())
-            .isBetween(0L, DECOMMISSION_BUDGET.toMillis());
-
-        assertThat(provisionsAfter)
-            .as("auto-heal must reach the real ComputeProvider.provision path — counted membership "
-                + "returning to %d without a provision would mean something rejoined rather than the "
-                + "cluster healing itself, and the heal leg would be unproven", SIZE)
-            .isGreaterThan(provisionsBeforeKill);
-
-        assertThat(healMs)
-            .as("the replacement must boot, join and be COUNTED within %ds; a provision that never "
-                + "joins leaves the cycle half-proven", DECOMMISSION_BUDGET.plus(HEAL_BUDGET).toSeconds())
-            .isBetween(0L, DECOMMISSION_BUDGET.plus(HEAL_BUDGET).toMillis());
-
-        assertThat(leaderMs)
-            .as("the cluster must settle back to having a leader within %ds — healing to %d nodes is "
-                + "not a success if leadership never recovers. Awaited, not sampled: a re-election is "
-                + "legitimately in flight while the replacement joins",
-                DECOMMISSION_BUDGET.plus(HEAL_BUDGET).toSeconds(), SIZE)
-            .isBetween(0L, DECOMMISSION_BUDGET.plus(HEAL_BUDGET).toMillis());
-
-        assertThat(countedCoreIds())
-            .as("the dead node must NOT reappear in counted membership — the cluster heals by "
-                + "replacing it, not by resurrecting the id that was decommissioned")
-            .doesNotContain(victim);
+                + "decommission={}ms heal={}ms leaderRecovery={}ms provisions={} countedCores={} leader={} ids={}",
+                 decommissionMs,
+                 healMs,
+                 leaderMs,
+                 provisionsAfter - provisionsBeforeKill,
+                 countedCores(),
+                 cluster.currentLeader().or("none"),
+                 countedCoreIds());
+        assertThat(decommissionMs).as("a hard-killed core must leave counted membership within %ds "
+                                     + "(SWIM suspicion 10s + NTT departure 15s, tripled for CI load); -1 means it never did",
+                                      DECOMMISSION_BUDGET.toSeconds())
+                  .isBetween(0L,
+                             DECOMMISSION_BUDGET.toMillis());
+        assertThat(provisionsAfter).as("auto-heal must reach the real ComputeProvider.provision path — counted membership "
+                                      + "returning to %d without a provision would mean something rejoined rather than the "
+                                      + "cluster healing itself, and the heal leg would be unproven",
+                                       SIZE)
+                  .isGreaterThan(provisionsBeforeKill);
+        assertThat(healMs).as("the replacement must boot, join and be COUNTED within %ds; a provision that never "
+                             + "joins leaves the cycle half-proven",
+                              DECOMMISSION_BUDGET.plus(HEAL_BUDGET).toSeconds())
+                  .isBetween(0L,
+                             DECOMMISSION_BUDGET.plus(HEAL_BUDGET).toMillis());
+        assertThat(leaderMs).as("the cluster must settle back to having a leader within %ds — healing to %d nodes is "
+                               + "not a success if leadership never recovers. Awaited, not sampled: a re-election is "
+                               + "legitimately in flight while the replacement joins",
+                                DECOMMISSION_BUDGET.plus(HEAL_BUDGET).toSeconds(),
+                                SIZE)
+                  .isBetween(0L,
+                             DECOMMISSION_BUDGET.plus(HEAL_BUDGET).toMillis());
+        assertThat(countedCoreIds()).as("the dead node must NOT reappear in counted membership — the cluster heals by "
+                                       + "replacing it, not by resurrecting the id that was decommissioned")
+                  .doesNotContain(victim);
     }
 
     /// Polls until `condition`, returning elapsed millis from `t0`, or -1 on timeout. Returning a
@@ -234,18 +232,23 @@ class MembershipChaosCycleTest {
 
         try {
             await().atMost(budget.plusSeconds(10))
-                   .pollInterval(POLL)
-                   .until(() -> {
-                       if (condition.getAsBoolean()) {
-                           latch.compareAndSet(-1, (System.nanoTime() - t0) / 1_000_000);
+                 .pollInterval(POLL)
+                 .until(() -> {
+                            if (condition.getAsBoolean()) {
+                            latch.compareAndSet(-1,
+                                                (System.nanoTime() - t0) / 1_000_000);
 
-                           return true;
-                       }
-                       log.info("CHAOS-CYCLE: {} pending at t+{}ms countedCores={} ids={}",
-                                label, (System.nanoTime() - t0) / 1_000_000, countedCores(), countedCoreIds());
+                            return true;
+                        }
 
-                       return false;
-                   });
+                            log.info("CHAOS-CYCLE: {} pending at t+{}ms countedCores={} ids={}",
+                                     label,
+                                     (System.nanoTime() - t0) / 1_000_000,
+                                     countedCores(),
+                                     countedCoreIds());
+
+                            return false;
+                        });
         } catch (Exception e) {
             log.warn("CHAOS-CYCLE: {} NOT reached within {}s", label, budget.toSeconds());
         }
@@ -255,8 +258,9 @@ class MembershipChaosCycleTest {
 
     private void settlePastAutoHealCooldown() {
         log.info("CHAOS-CYCLE: settling {}s past the {}s auto-heal startup cooldown so the kill "
-                 + "measures detection rather than the cooldown",
-                 SETTLE.toSeconds(), AUTO_HEAL_STARTUP_COOLDOWN.toSeconds());
+                + "measures detection rather than the cooldown",
+                 SETTLE.toSeconds(),
+                 AUTO_HEAL_STARTUP_COOLDOWN.toSeconds());
         await().pollDelay(SETTLE).timeout(SETTLE.plusSeconds(10)).until(() -> true);
     }
 
@@ -280,12 +284,12 @@ class MembershipChaosCycleTest {
         return leaderOrAnyNode().map(node -> node.membershipFsm()
                                                  .coreCountedMembers()
                                                  .size())
-                                .or(0);
+                              .or(0);
     }
 
     private String countedCoreIds() {
         return leaderOrAnyNode().map(node -> idStrings(node.membershipFsm().coreCountedMembers()))
-                                .or("");
+                              .or("");
     }
 
     private Option<AetherNode> leaderOrAnyNode() {

--- a/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/MultiPartitionCrashDurabilityTest.java
+++ b/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/MultiPartitionCrashDurabilityTest.java
@@ -2,22 +2,7 @@
 // Copyright (c) 2025 Pragmatica Labs - Sergiy Yevtushenko
 // Licensed under Business Source License 1.1. Change Date: 2030-01-01. Change License: Apache-2.0.
 // See LICENSE in the repository root for full terms.
-
 package org.pragmatica.aether.forge;
-
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
-import org.junit.jupiter.api.io.TempDir;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
-import org.pragmatica.aether.stream.StreamReadRouter.ReplicaSetView;
-import org.pragmatica.http.HttpOperations;
-import org.pragmatica.http.HttpResult;
-import org.pragmatica.config.ConfigurationProvider;
-import org.pragmatica.lang.Option;
 
 import java.io.IOException;
 import java.net.URI;
@@ -31,12 +16,27 @@ import java.util.concurrent.locks.LockSupport;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.awaitility.Awaitility.await;
+import org.pragmatica.aether.stream.StreamReadRouter.ReplicaSetView;
+import org.pragmatica.http.HttpOperations;
+import org.pragmatica.http.HttpResult;
+import org.pragmatica.config.ConfigurationProvider;
+import org.pragmatica.lang.Option;
+import org.pragmatica.aether.ember.EmberCluster;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+
 import static org.pragmatica.aether.ember.EmberCluster.emberCluster;
 import static org.pragmatica.http.JdkHttpOperations.jdkHttpOperations;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
 
-import org.pragmatica.aether.ember.EmberCluster;
 
 /// Streaming-persistence — MULTI-PARTITION full-cluster restart crash-durability proof for the
 /// per-partition WAL. The single-partition sibling [StreamCrashDurabilityTest] proves ONE partition's
@@ -80,6 +80,7 @@ import org.pragmatica.aether.ember.EmberCluster;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class MultiPartitionCrashDurabilityTest {
     private static final System.Logger LOG = System.getLogger(MultiPartitionCrashDurabilityTest.class.getName());
+
     private static final int BASE_PORT = 17500;
     private static final int BASE_MGMT_PORT = 17600;
     private static final int BASE_APP_HTTP_PORT = 17700;
@@ -87,25 +88,21 @@ class MultiPartitionCrashDurabilityTest {
     private static final int INSTANCES = 5;
     private static final int PARTITIONS = 4;
     private static final int EVENT_COUNT = 40;
-
     private static final Duration WAIT_TIMEOUT = Duration.ofSeconds(240);
     private static final Duration POLL_INTERVAL = Duration.ofMillis(500);
     private static final Duration PLACEMENT_TIMEOUT = Duration.ofSeconds(120);
     private static final Duration RECOVERY_TIMEOUT = Duration.ofSeconds(240);
     private static final long POLL_GAP_NANOS = Duration.ofMillis(20).toNanos();
-
     private static final String STREAM_SLICE = TestArtifacts.STREAM_MULTIPART_SLICE;
     private static final String STREAM_NAME = "multipart-events";
     private static final String BLUEPRINT_ID = "forge.test:multipart-crash-durability:1.0.0";
     private static final String ERROR_FALLBACK = "{\"error\":\"request failed\"}";
-
     private static final Pattern EVENT_OBJECT = Pattern.compile("\\{[^{}]*\"offset\"[^{}]*}");
     private static final Pattern OFFSET_FIELD = Pattern.compile("\"offset\"\\s*:\\s*(\\d+)");
     private static final Pattern PAYLOAD_FIELD = Pattern.compile("\"payload\"\\s*:\\s*\"([^\"]*)\"");
     private static final Pattern NODE_COUNT_FIELD = Pattern.compile("\"nodeCount\"\\s*:\\s*(\\d+)");
 
     Path baseDir;
-
     private EmberCluster cluster;
     private final HttpOperations http = jdkHttpOperations();
 
@@ -116,7 +113,6 @@ class MultiPartitionCrashDurabilityTest {
     @BeforeAll
     void setUp(@TempDir Path tempDir) {
         this.baseDir = tempDir;
-
         // A ConfigurationProvider must be present for the node to enable resource provisioning
         // (StreamPublisher / StreamAccess); without it AetherNode installs a no-op facade that fails
         // every resource-backed slice (mirrors StreamFanoutConsumerTest / AbstractMultiPartitionStream).
@@ -124,10 +120,10 @@ class MultiPartitionCrashDurabilityTest {
                                                   .withSystemProperties("aether.")
                                                   .withEnvironment("AETHER_")
                                                   .build();
+
         cluster = emberCluster(NODES, BASE_PORT, BASE_MGMT_PORT, BASE_APP_HTTP_PORT, "mpcd", Option.some(configProvider));
         // Opt in to a writable, restart-stable per-node data dir -> disk tier + per-partition WALs ON.
         cluster.withDataBaseDir(baseDir);
-
         startAndAwaitReady();
     }
 
@@ -135,9 +131,9 @@ class MultiPartitionCrashDurabilityTest {
     void tearDown() {
         if (cluster != null) {
             var leaderPort = cluster.getLeaderManagementPort().or(anyMgmtPort());
+
             httpDelete(leaderPort, "/api/v1/blueprints/" + BLUEPRINT_ID);
-            cluster.stop()
-                   .await();
+            LifecycleAwait.settled("cluster stop in tearDown()", cluster, cluster.stop());
         }
     }
 
@@ -148,27 +144,20 @@ class MultiPartitionCrashDurabilityTest {
     @Test
     void multiPartitionRestart_recoversEveryPartition_viaWalReplay() throws IOException {
         var port = appPort();
-
         // All 4 partitions must have owner + in-sync replica PLACED before the min-sync-2 publishes, else a
         // publish to a not-yet-replicated partition cannot ack; placement also confirms HRW spread owners
         // across the cluster so the keyless round-robin populates every partition.
-        await().atMost(PLACEMENT_TIMEOUT)
-               .pollInterval(POLL_INTERVAL)
-               .until(this::allPartitionsPlaced);
-
+        await().atMost(PLACEMENT_TIMEOUT).pollInterval(POLL_INTERVAL).until(this::allPartitionsPlaced);
         publishBatch(port, EVENT_COUNT);
-
         var preByPartition = drainAllPartitions(port);
+
         assertEveryPartitionPopulated(preByPartition);
         assertAllSeqsPresent(preByPartition, EVENT_COUNT);
         assertPerPartitionOrdered(preByPartition);
-
         // A NON-EMPTY 'multipart-events' WAL must exist on disk, proving the owners appended + fsync'd the
         // acked events before ack — the only medium that survives the restart (nothing is ever sealed).
         assertWalActiveForMultipart();
-
         restartCluster();
-
         var recoveredPort = appPort();
         var postByPartition = drainAllPartitionsUntil(recoveredPort, preByPartition);
 
@@ -179,53 +168,32 @@ class MultiPartitionCrashDurabilityTest {
     }
 
     // --- restart ------------------------------------------------------------
-
     private void restartCluster() {
-        cluster.stop()
-               .await()
-               .onFailure(cause -> {
-                   throw new AssertionError("Cluster stop failed: " + cause.message());
-               });
-
+        LifecycleAwait.settled("cluster stop in restartCluster()", cluster, cluster.stop());
         startAndAwaitReady();
     }
 
     private void startAndAwaitReady() {
-        cluster.start()
-               .await()
-               .onFailure(cause -> {
-                   throw new AssertionError("Cluster start failed: " + cause.message());
-               });
-
-        await().atMost(WAIT_TIMEOUT)
-               .pollInterval(POLL_INTERVAL)
-               .until(() -> cluster.currentLeader().isPresent());
-
-        await().atMost(WAIT_TIMEOUT)
-               .pollInterval(POLL_INTERVAL)
-               .until(this::allNodesHealthy);
-
+        LifecycleAwait.settled("cluster start in startAndAwaitReady()", cluster, cluster.start());
+        await().atMost(WAIT_TIMEOUT).pollInterval(POLL_INTERVAL).until(() -> cluster.currentLeader()
+                                                                                    .isPresent());
+        await().atMost(WAIT_TIMEOUT).pollInterval(POLL_INTERVAL).until(this::allNodesHealthy);
         // Gate on FULL membership before publish (pre-restart) or read (post-restart): after a full-cluster
         // restart the cold-boot convergence window must let ALL NODES re-form so every partition's HRW owner
         // is a rejoined node holding its WAL, not an empty-WAL replacement picked because a straggler was
         // prematurely evicted.
-        await().atMost(WAIT_TIMEOUT)
-               .pollInterval(POLL_INTERVAL)
-               .until(() -> allNodesAreMembers(NODES));
-
+        await().atMost(WAIT_TIMEOUT).pollInterval(POLL_INTERVAL).until(() -> allNodesAreMembers(NODES));
         // Re-deploy: Forge KV is in-memory, so a full-cluster restart wiped the stream config. This re-puts
         // the deterministic `multipart-events` config -> each partition's owner re-materializes and its
         // partition build opens-or-recovers the WAL and replays the un-sealed tail. Carries NO events.
         deployStreamSlice();
-
         await().atMost(WAIT_TIMEOUT)
-               .pollInterval(POLL_INTERVAL)
-               .failFast(this::failIfSliceFailed)
-               .until(this::appHttpReady);
+             .pollInterval(POLL_INTERVAL)
+             .failFast(this::failIfSliceFailed)
+             .until(this::appHttpReady);
     }
 
     // --- placement (in-JVM, owner-authoritative) ---------------------------
-
     /// The owner-authoritative replica-set view for `(STREAM_NAME, partition)`: the registry is
     /// authoritative only on the partition's HRW owner (`servedByOwner()` true), so scan every live node's
     /// in-JVM `replicaSnapshot` and return the owner's (the HTTP sensor is delegate-routed, #490).
@@ -252,72 +220,70 @@ class MultiPartitionCrashDurabilityTest {
     }
 
     private boolean partitionPlaced(int partition) {
-        return ownerView(partition).map(view -> view.replicas().size() >= 2
-                                                 && view.replicas().stream().anyMatch(r -> !r.hrwOwner()))
-                                   .or(false);
+        return ownerView(partition).map(view -> view.replicas()
+                                                    .size() >= 2 && view.replicas()
+                                                                        .stream()
+                                                                        .anyMatch(r -> !r.hrwOwner()))
+                        .or(false);
     }
 
     // --- WAL on-disk assertion ---------------------------------------------
-
     private void assertWalActiveForMultipart() throws IOException {
         var multipartWals = walFiles(baseDir).stream()
-                                             .filter(MultiPartitionCrashDurabilityTest::isMultipartWal)
-                                             .toList();
+                                    .filter(MultiPartitionCrashDurabilityTest::isMultipartWal)
+                                    .toList();
 
-        assertThat(multipartWals)
-            .describedAs("stream WAL must be ACTIVE: a 'multipart-events' WAL file must exist under %s "
-                         + "(WAL OFF -> none; acked events would not survive restart)", baseDir)
-            .isNotEmpty();
-
+        assertThat(multipartWals).describedAs("stream WAL must be ACTIVE: a 'multipart-events' WAL file must exist under %s "
+                                             + "(WAL OFF -> none; acked events would not survive restart)",
+                                              baseDir)
+                  .isNotEmpty();
         long totalBytes = 0;
 
         for (var wal : multipartWals) {
             totalBytes += Files.size(wal);
         }
 
-        assertThat(totalBytes)
-            .describedAs("the owners' 'multipart-events' WALs must hold the acked events (non-empty) — proof "
-                         + "they were appended + fsync'd before ack, not just that the WAL dir was writable")
-            .isPositive();
+        assertThat(totalBytes).describedAs("the owners' 'multipart-events' WALs must hold the acked events (non-empty) — proof "
+                                          + "they were appended + fsync'd before ack, not just that the WAL dir was writable")
+                  .isPositive();
     }
 
     private static boolean isMultipartWal(Path walFile) {
         var parent = walFile.getParent();
 
-        return parent != null && parent.getFileName().toString().equals("multipart-events");
+        return parent != null && parent.getFileName()
+                                       .toString()
+                                       .equals("multipart-events");
     }
 
     private static List<Path> walFiles(Path base) throws IOException {
         try (var paths = Files.walk(base)) {
             return paths.filter(Files::isRegularFile)
-                        .filter(p -> p.getFileName().toString().endsWith(".wal"))
+                        .filter(p -> p.getFileName()
+                                      .toString()
+                                      .endsWith(".wal"))
                         .toList();
         }
     }
 
     // --- assertions ---------------------------------------------------------
-
     private void assertEveryPartitionPopulated(List<List<Event>> byPartition) {
         for (int partition = 0; partition < PARTITIONS; partition++) {
-            assertThat(byPartition.get(partition))
-                .describedAs("partition %d must be populated (keyless round-robin spreads over all %d partitions)",
-                             partition, PARTITIONS)
-                .isNotEmpty();
+            assertThat(byPartition.get(partition)).describedAs("partition %d must be populated (keyless round-robin spreads over all %d partitions)",
+                                                               partition,
+                                                               PARTITIONS)
+                      .isNotEmpty();
         }
     }
 
     /// The union of every partition's seqs is exactly {0..count-1} — no acked event lost, none duplicated,
     /// none stranded on the wrong partition.
     private void assertAllSeqsPresent(List<List<Event>> byPartition, int count) {
-        var seqs = byPartition.stream()
-                              .flatMap(List::stream)
-                              .map(Event::seq)
-                              .sorted()
-                              .toList();
+        var seqs = byPartition.stream().flatMap(List::stream).map(Event::seq).sorted().toList();
 
-        assertThat(seqs)
-            .describedAs("every published seq 0..%d must be present across the partitions exactly once", count - 1)
-            .containsExactlyElementsOf(contiguousSeqs(count));
+        assertThat(seqs).describedAs("every published seq 0..%d must be present across the partitions exactly once",
+                                     count - 1)
+                  .containsExactlyElementsOf(contiguousSeqs(count));
     }
 
     private static List<Long> contiguousSeqs(int count) {
@@ -338,15 +304,16 @@ class MultiPartitionCrashDurabilityTest {
             var events = byPartition.get(partition);
 
             for (int i = 0; i < events.size(); i++) {
-                assertThat(events.get(i).offset())
-                    .describedAs("partition %d offset at index %d is contiguous from 0 (no dup/gap)", partition, i)
-                    .isEqualTo((long) i);
+                assertThat(events.get(i).offset()).describedAs("partition %d offset at index %d is contiguous from 0 (no dup/gap)",
+                                                               partition,
+                                                               i)
+                          .isEqualTo((long) i);
             }
 
             for (int i = 1; i < events.size(); i++) {
-                assertThat(events.get(i).seq())
-                    .describedAs("partition %d seq strictly increases with offset (publish order preserved)", partition)
-                    .isGreaterThan(events.get(i - 1).seq());
+                assertThat(events.get(i).seq()).describedAs("partition %d seq strictly increases with offset (publish order preserved)",
+                                                            partition)
+                          .isGreaterThan(events.get(i - 1).seq());
             }
         }
     }
@@ -358,15 +325,14 @@ class MultiPartitionCrashDurabilityTest {
             var preSeqs = pre.get(partition).stream().map(Event::seq).toList();
             var postSeqs = post.get(partition).stream().map(Event::seq).toList();
 
-            assertThat(postSeqs)
-                .describedAs("partition %d: every event durably readable before the restart must be readable "
-                             + "after, in order (independent per-partition WAL replay)", partition)
-                .containsExactlyElementsOf(preSeqs);
+            assertThat(postSeqs).describedAs("partition %d: every event durably readable before the restart must be readable "
+                                            + "after, in order (independent per-partition WAL replay)",
+                                             partition)
+                      .containsExactlyElementsOf(preSeqs);
         }
     }
 
     // --- failure-path observability ----------------------------------------
-
     private void dumpIfPartitionsShort(List<List<Event>> post, List<List<Event>> pre) {
         for (int partition = 0; partition < PARTITIONS; partition++) {
             if (post.get(partition).size() < pre.get(partition).size()) {
@@ -394,7 +360,6 @@ class MultiPartitionCrashDurabilityTest {
     }
 
     // --- consumers ----------------------------------------------------------
-
     /// Drain every partition (0..PARTITIONS-1) fully; index i = partition i's events in offset order.
     private List<List<Event>> drainAllPartitions(int port) {
         var byPartition = new ArrayList<List<Event>>();
@@ -413,7 +378,10 @@ class MultiPartitionCrashDurabilityTest {
         var byPartition = new ArrayList<List<Event>>();
 
         for (int partition = 0; partition < PARTITIONS; partition++) {
-            byPartition.add(drainPartitionUntil(port, partition, pre.get(partition).size(), recoveryDeadlineNanos()));
+            byPartition.add(drainPartitionUntil(port,
+                                                partition,
+                                                pre.get(partition).size(),
+                                                recoveryDeadlineNanos()));
         }
 
         return byPartition;
@@ -486,7 +454,6 @@ class MultiPartitionCrashDurabilityTest {
     }
 
     // --- publishing ---------------------------------------------------------
-
     private void publishBatch(int port, int count) {
         for (int seq = 0; seq < count; seq++) {
             publish(port, seq);
@@ -497,14 +464,13 @@ class MultiPartitionCrashDurabilityTest {
         var body = "{\"payload\":\"" + seq + "\"}";
         var response = httpPost(port, "/api/stream-mp/publish", body);
 
-        assertThat(response)
-            .describedAs("publish seq %d must ack (min-sync-2: durable on >=2 nodes' WALs before ack)", seq)
-            .doesNotContain("\"error\"")
-            .contains("published");
+        assertThat(response).describedAs("publish seq %d must ack (min-sync-2: durable on >=2 nodes' WALs before ack)",
+                                         seq)
+                  .doesNotContain("\"error\"")
+                  .contains("published");
     }
 
     // --- deployment + readiness --------------------------------------------
-
     private void deployStreamSlice() {
         var blueprint = """
             id = "%s"
@@ -516,10 +482,9 @@ class MultiPartitionCrashDurabilityTest {
         var leaderPort = cluster.getLeaderManagementPort().or(anyMgmtPort());
         var response = postBlueprintWithRetry(leaderPort, blueprint);
 
-        assertThat(response)
-            .describedAs("multi-partition (partitions=4, RF=2) stream-slice deployment")
-            .doesNotContain("\"error\"")
-            .contains("\"status\":\"applied\"");
+        assertThat(response).describedAs("multi-partition (partitions=4, RF=2) stream-slice deployment")
+                  .doesNotContain("\"error\"")
+                  .contains("\"status\":\"applied\"");
     }
 
     private boolean appHttpReady() {
@@ -529,15 +494,19 @@ class MultiPartitionCrashDurabilityTest {
             return false;
         }
 
-        var body = httpPost(ports.getFirst(), "/api/stream-mp/read", "{\"partition\":0,\"fromOffset\":0,\"maxEvents\":1}");
+        var body = httpPost(ports.getFirst(),
+                            "/api/stream-mp/read",
+                            "{\"partition\":0,\"fromOffset\":0,\"maxEvents\":1}");
 
-        return !body.contains("\"error\"") && body.contains("events");
+        return ! body.contains("\"error\"") && body.contains("events");
     }
 
     private void failIfSliceFailed() {
         var failed = cluster.slicesStatus()
                             .stream()
-                            .anyMatch(s -> s.artifact().equals(STREAM_SLICE) && s.state().equals("FAILED"));
+                            .anyMatch(s -> s.artifact()
+                                            .equals(STREAM_SLICE) && s.state()
+                                                                      .equals("FAILED"));
 
         if (failed) {
             throw new AssertionError("multi-partition stream slice deployment FAILED: " + STREAM_SLICE);
@@ -552,7 +521,10 @@ class MultiPartitionCrashDurabilityTest {
     }
 
     private int anyMgmtPort() {
-        return cluster.status().nodes().getFirst().mgmtPort();
+        return cluster.status()
+                      .nodes()
+                      .getFirst()
+                      .mgmtPort();
     }
 
     private long recoveryDeadlineNanos() {
@@ -572,9 +544,11 @@ class MultiPartitionCrashDurabilityTest {
                                  .GET()
                                  .timeout(Duration.ofSeconds(5))
                                  .build();
+
         return http.sendString(request)
                    .await()
-                   .map(r -> r.statusCode() == 200 && r.body().contains("\"quorum\":true"))
+                   .map(r -> r.statusCode() == 200 && r.body()
+                                                       .contains("\"quorum\":true"))
                    .or(false);
     }
 
@@ -585,9 +559,11 @@ class MultiPartitionCrashDurabilityTest {
                                  .GET()
                                  .timeout(Duration.ofSeconds(5))
                                  .build();
+
         return http.sendString(request)
                    .await()
-                   .map(r -> r.statusCode() == 200 && healthHasFullMembership(r.body(), expected))
+                   .map(r -> r.statusCode() == 200 && healthHasFullMembership(r.body(),
+                                                                              expected))
                    .or(false);
     }
 
@@ -602,13 +578,11 @@ class MultiPartitionCrashDurabilityTest {
     }
 
     // --- HTTP ---------------------------------------------------------------
-
     private String postBlueprintWithRetry(int port, String body) {
         var lastResponse = ERROR_FALLBACK;
 
         for (int attempt = 1; attempt <= 3; attempt++) {
             lastResponse = httpPostToml(port, "/api/v1/blueprints", body);
-
             if (!lastResponse.contains("\"error\"")) {
                 return lastResponse;
             }
@@ -628,6 +602,7 @@ class MultiPartitionCrashDurabilityTest {
                                  .POST(HttpRequest.BodyPublishers.ofString(body))
                                  .timeout(Duration.ofSeconds(10))
                                  .build();
+
         return http.sendString(request)
                    .await()
                    .map(HttpResult::body)
@@ -641,6 +616,7 @@ class MultiPartitionCrashDurabilityTest {
                                  .POST(HttpRequest.BodyPublishers.ofString(body))
                                  .timeout(Duration.ofSeconds(15))
                                  .build();
+
         return http.sendString(request)
                    .await()
                    .map(HttpResult::body)
@@ -653,6 +629,7 @@ class MultiPartitionCrashDurabilityTest {
                                  .DELETE()
                                  .timeout(Duration.ofSeconds(10))
                                  .build();
+
         return http.sendString(request)
                    .await()
                    .map(HttpResult::body)

--- a/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/MultiPartitionCrashDurabilityTest.java
+++ b/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/MultiPartitionCrashDurabilityTest.java
@@ -2,7 +2,22 @@
 // Copyright (c) 2025 Pragmatica Labs - Sergiy Yevtushenko
 // Licensed under Business Source License 1.1. Change Date: 2030-01-01. Change License: Apache-2.0.
 // See LICENSE in the repository root for full terms.
+
 package org.pragmatica.aether.forge;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.pragmatica.aether.stream.StreamReadRouter.ReplicaSetView;
+import org.pragmatica.http.HttpOperations;
+import org.pragmatica.http.HttpResult;
+import org.pragmatica.config.ConfigurationProvider;
+import org.pragmatica.lang.Option;
 
 import java.io.IOException;
 import java.net.URI;
@@ -16,27 +31,12 @@ import java.util.concurrent.locks.LockSupport;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.pragmatica.aether.stream.StreamReadRouter.ReplicaSetView;
-import org.pragmatica.http.HttpOperations;
-import org.pragmatica.http.HttpResult;
-import org.pragmatica.config.ConfigurationProvider;
-import org.pragmatica.lang.Option;
-import org.pragmatica.aether.ember.EmberCluster;
-
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
-import org.junit.jupiter.api.io.TempDir;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
-
-import static org.pragmatica.aether.ember.EmberCluster.emberCluster;
-import static org.pragmatica.http.JdkHttpOperations.jdkHttpOperations;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
+import static org.pragmatica.aether.ember.EmberCluster.emberCluster;
+import static org.pragmatica.http.JdkHttpOperations.jdkHttpOperations;
 
+import org.pragmatica.aether.ember.EmberCluster;
 
 /// Streaming-persistence — MULTI-PARTITION full-cluster restart crash-durability proof for the
 /// per-partition WAL. The single-partition sibling [StreamCrashDurabilityTest] proves ONE partition's
@@ -80,7 +80,6 @@ import static org.awaitility.Awaitility.await;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class MultiPartitionCrashDurabilityTest {
     private static final System.Logger LOG = System.getLogger(MultiPartitionCrashDurabilityTest.class.getName());
-
     private static final int BASE_PORT = 17500;
     private static final int BASE_MGMT_PORT = 17600;
     private static final int BASE_APP_HTTP_PORT = 17700;
@@ -88,21 +87,25 @@ class MultiPartitionCrashDurabilityTest {
     private static final int INSTANCES = 5;
     private static final int PARTITIONS = 4;
     private static final int EVENT_COUNT = 40;
+
     private static final Duration WAIT_TIMEOUT = Duration.ofSeconds(240);
     private static final Duration POLL_INTERVAL = Duration.ofMillis(500);
     private static final Duration PLACEMENT_TIMEOUT = Duration.ofSeconds(120);
     private static final Duration RECOVERY_TIMEOUT = Duration.ofSeconds(240);
     private static final long POLL_GAP_NANOS = Duration.ofMillis(20).toNanos();
+
     private static final String STREAM_SLICE = TestArtifacts.STREAM_MULTIPART_SLICE;
     private static final String STREAM_NAME = "multipart-events";
     private static final String BLUEPRINT_ID = "forge.test:multipart-crash-durability:1.0.0";
     private static final String ERROR_FALLBACK = "{\"error\":\"request failed\"}";
+
     private static final Pattern EVENT_OBJECT = Pattern.compile("\\{[^{}]*\"offset\"[^{}]*}");
     private static final Pattern OFFSET_FIELD = Pattern.compile("\"offset\"\\s*:\\s*(\\d+)");
     private static final Pattern PAYLOAD_FIELD = Pattern.compile("\"payload\"\\s*:\\s*\"([^\"]*)\"");
     private static final Pattern NODE_COUNT_FIELD = Pattern.compile("\"nodeCount\"\\s*:\\s*(\\d+)");
 
     Path baseDir;
+
     private EmberCluster cluster;
     private final HttpOperations http = jdkHttpOperations();
 
@@ -113,6 +116,7 @@ class MultiPartitionCrashDurabilityTest {
     @BeforeAll
     void setUp(@TempDir Path tempDir) {
         this.baseDir = tempDir;
+
         // A ConfigurationProvider must be present for the node to enable resource provisioning
         // (StreamPublisher / StreamAccess); without it AetherNode installs a no-op facade that fails
         // every resource-backed slice (mirrors StreamFanoutConsumerTest / AbstractMultiPartitionStream).
@@ -120,10 +124,10 @@ class MultiPartitionCrashDurabilityTest {
                                                   .withSystemProperties("aether.")
                                                   .withEnvironment("AETHER_")
                                                   .build();
-
         cluster = emberCluster(NODES, BASE_PORT, BASE_MGMT_PORT, BASE_APP_HTTP_PORT, "mpcd", Option.some(configProvider));
         // Opt in to a writable, restart-stable per-node data dir -> disk tier + per-partition WALs ON.
         cluster.withDataBaseDir(baseDir);
+
         startAndAwaitReady();
     }
 
@@ -131,9 +135,8 @@ class MultiPartitionCrashDurabilityTest {
     void tearDown() {
         if (cluster != null) {
             var leaderPort = cluster.getLeaderManagementPort().or(anyMgmtPort());
-
             httpDelete(leaderPort, "/api/v1/blueprints/" + BLUEPRINT_ID);
-            LifecycleAwait.settled("cluster stop in tearDown()", cluster, cluster.stop());
+            LifecycleAwait.bestEffort("cluster stop in tearDown()", cluster, cluster.stop());
         }
     }
 
@@ -144,20 +147,27 @@ class MultiPartitionCrashDurabilityTest {
     @Test
     void multiPartitionRestart_recoversEveryPartition_viaWalReplay() throws IOException {
         var port = appPort();
+
         // All 4 partitions must have owner + in-sync replica PLACED before the min-sync-2 publishes, else a
         // publish to a not-yet-replicated partition cannot ack; placement also confirms HRW spread owners
         // across the cluster so the keyless round-robin populates every partition.
-        await().atMost(PLACEMENT_TIMEOUT).pollInterval(POLL_INTERVAL).until(this::allPartitionsPlaced);
-        publishBatch(port, EVENT_COUNT);
-        var preByPartition = drainAllPartitions(port);
+        await().atMost(PLACEMENT_TIMEOUT)
+               .pollInterval(POLL_INTERVAL)
+               .until(this::allPartitionsPlaced);
 
+        publishBatch(port, EVENT_COUNT);
+
+        var preByPartition = drainAllPartitions(port);
         assertEveryPartitionPopulated(preByPartition);
         assertAllSeqsPresent(preByPartition, EVENT_COUNT);
         assertPerPartitionOrdered(preByPartition);
+
         // A NON-EMPTY 'multipart-events' WAL must exist on disk, proving the owners appended + fsync'd the
         // acked events before ack — the only medium that survives the restart (nothing is ever sealed).
         assertWalActiveForMultipart();
+
         restartCluster();
+
         var recoveredPort = appPort();
         var postByPartition = drainAllPartitionsUntil(recoveredPort, preByPartition);
 
@@ -168,32 +178,45 @@ class MultiPartitionCrashDurabilityTest {
     }
 
     // --- restart ------------------------------------------------------------
+
     private void restartCluster() {
         LifecycleAwait.settled("cluster stop in restartCluster()", cluster, cluster.stop());
+
         startAndAwaitReady();
     }
 
     private void startAndAwaitReady() {
         LifecycleAwait.settled("cluster start in startAndAwaitReady()", cluster, cluster.start());
-        await().atMost(WAIT_TIMEOUT).pollInterval(POLL_INTERVAL).until(() -> cluster.currentLeader()
-                                                                                    .isPresent());
-        await().atMost(WAIT_TIMEOUT).pollInterval(POLL_INTERVAL).until(this::allNodesHealthy);
+
+        await().atMost(WAIT_TIMEOUT)
+               .pollInterval(POLL_INTERVAL)
+               .until(() -> cluster.currentLeader().isPresent());
+
+        await().atMost(WAIT_TIMEOUT)
+               .pollInterval(POLL_INTERVAL)
+               .until(this::allNodesHealthy);
+
         // Gate on FULL membership before publish (pre-restart) or read (post-restart): after a full-cluster
         // restart the cold-boot convergence window must let ALL NODES re-form so every partition's HRW owner
         // is a rejoined node holding its WAL, not an empty-WAL replacement picked because a straggler was
         // prematurely evicted.
-        await().atMost(WAIT_TIMEOUT).pollInterval(POLL_INTERVAL).until(() -> allNodesAreMembers(NODES));
+        await().atMost(WAIT_TIMEOUT)
+               .pollInterval(POLL_INTERVAL)
+               .until(() -> allNodesAreMembers(NODES));
+
         // Re-deploy: Forge KV is in-memory, so a full-cluster restart wiped the stream config. This re-puts
         // the deterministic `multipart-events` config -> each partition's owner re-materializes and its
         // partition build opens-or-recovers the WAL and replays the un-sealed tail. Carries NO events.
         deployStreamSlice();
+
         await().atMost(WAIT_TIMEOUT)
-             .pollInterval(POLL_INTERVAL)
-             .failFast(this::failIfSliceFailed)
-             .until(this::appHttpReady);
+               .pollInterval(POLL_INTERVAL)
+               .failFast(this::failIfSliceFailed)
+               .until(this::appHttpReady);
     }
 
     // --- placement (in-JVM, owner-authoritative) ---------------------------
+
     /// The owner-authoritative replica-set view for `(STREAM_NAME, partition)`: the registry is
     /// authoritative only on the partition's HRW owner (`servedByOwner()` true), so scan every live node's
     /// in-JVM `replicaSnapshot` and return the owner's (the HTTP sensor is delegate-routed, #490).
@@ -220,70 +243,72 @@ class MultiPartitionCrashDurabilityTest {
     }
 
     private boolean partitionPlaced(int partition) {
-        return ownerView(partition).map(view -> view.replicas()
-                                                    .size() >= 2 && view.replicas()
-                                                                        .stream()
-                                                                        .anyMatch(r -> !r.hrwOwner()))
-                        .or(false);
+        return ownerView(partition).map(view -> view.replicas().size() >= 2
+                                                 && view.replicas().stream().anyMatch(r -> !r.hrwOwner()))
+                                   .or(false);
     }
 
     // --- WAL on-disk assertion ---------------------------------------------
+
     private void assertWalActiveForMultipart() throws IOException {
         var multipartWals = walFiles(baseDir).stream()
-                                    .filter(MultiPartitionCrashDurabilityTest::isMultipartWal)
-                                    .toList();
+                                             .filter(MultiPartitionCrashDurabilityTest::isMultipartWal)
+                                             .toList();
 
-        assertThat(multipartWals).describedAs("stream WAL must be ACTIVE: a 'multipart-events' WAL file must exist under %s "
-                                             + "(WAL OFF -> none; acked events would not survive restart)",
-                                              baseDir)
-                  .isNotEmpty();
+        assertThat(multipartWals)
+            .describedAs("stream WAL must be ACTIVE: a 'multipart-events' WAL file must exist under %s "
+                         + "(WAL OFF -> none; acked events would not survive restart)", baseDir)
+            .isNotEmpty();
+
         long totalBytes = 0;
 
         for (var wal : multipartWals) {
             totalBytes += Files.size(wal);
         }
 
-        assertThat(totalBytes).describedAs("the owners' 'multipart-events' WALs must hold the acked events (non-empty) — proof "
-                                          + "they were appended + fsync'd before ack, not just that the WAL dir was writable")
-                  .isPositive();
+        assertThat(totalBytes)
+            .describedAs("the owners' 'multipart-events' WALs must hold the acked events (non-empty) — proof "
+                         + "they were appended + fsync'd before ack, not just that the WAL dir was writable")
+            .isPositive();
     }
 
     private static boolean isMultipartWal(Path walFile) {
         var parent = walFile.getParent();
 
-        return parent != null && parent.getFileName()
-                                       .toString()
-                                       .equals("multipart-events");
+        return parent != null && parent.getFileName().toString().equals("multipart-events");
     }
 
     private static List<Path> walFiles(Path base) throws IOException {
         try (var paths = Files.walk(base)) {
             return paths.filter(Files::isRegularFile)
-                        .filter(p -> p.getFileName()
-                                      .toString()
-                                      .endsWith(".wal"))
+                        .filter(p -> p.getFileName().toString().endsWith(".wal"))
                         .toList();
         }
     }
 
     // --- assertions ---------------------------------------------------------
+
     private void assertEveryPartitionPopulated(List<List<Event>> byPartition) {
         for (int partition = 0; partition < PARTITIONS; partition++) {
-            assertThat(byPartition.get(partition)).describedAs("partition %d must be populated (keyless round-robin spreads over all %d partitions)",
-                                                               partition,
-                                                               PARTITIONS)
-                      .isNotEmpty();
+            assertThat(byPartition.get(partition))
+                .describedAs("partition %d must be populated (keyless round-robin spreads over all %d partitions)",
+                             partition, PARTITIONS)
+                .isNotEmpty();
         }
     }
 
     /// The union of every partition's seqs is exactly {0..count-1} — no acked event lost, none duplicated,
     /// none stranded on the wrong partition.
     private void assertAllSeqsPresent(List<List<Event>> byPartition, int count) {
-        var seqs = byPartition.stream().flatMap(List::stream).map(Event::seq).sorted().toList();
+        var seqs = byPartition.stream()
+                              .flatMap(List::stream)
+                              .map(Event::seq)
+                              .sorted()
+                              .toList();
 
-        assertThat(seqs).describedAs("every published seq 0..%d must be present across the partitions exactly once",
-                                     count - 1)
-                  .containsExactlyElementsOf(contiguousSeqs(count));
+        assertThat(seqs)
+            .describedAs("every published seq 0..%d must be present across the partitions exactly once", count - 1)
+            .containsExactlyElementsOf(contiguousSeqs(count));
     }
 
     private static List<Long> contiguousSeqs(int count) {
@@ -304,16 +329,15 @@ class MultiPartitionCrashDurabilityTest {
             var events = byPartition.get(partition);
 
             for (int i = 0; i < events.size(); i++) {
-                assertThat(events.get(i).offset()).describedAs("partition %d offset at index %d is contiguous from 0 (no dup/gap)",
-                                                               partition,
-                                                               i)
-                          .isEqualTo((long) i);
+                assertThat(events.get(i).offset())
+                    .describedAs("partition %d offset at index %d is contiguous from 0 (no dup/gap)", partition, i)
+                    .isEqualTo((long) i);
             }
 
             for (int i = 1; i < events.size(); i++) {
-                assertThat(events.get(i).seq()).describedAs("partition %d seq strictly increases with offset (publish order preserved)",
-                                                            partition)
-                          .isGreaterThan(events.get(i - 1).seq());
+                assertThat(events.get(i).seq())
+                    .describedAs("partition %d seq strictly increases with offset (publish order preserved)", partition)
+                    .isGreaterThan(events.get(i - 1).seq());
             }
         }
     }
@@ -325,14 +349,15 @@ class MultiPartitionCrashDurabilityTest {
             var preSeqs = pre.get(partition).stream().map(Event::seq).toList();
             var postSeqs = post.get(partition).stream().map(Event::seq).toList();
 
-            assertThat(postSeqs).describedAs("partition %d: every event durably readable before the restart must be readable "
-                                            + "after, in order (independent per-partition WAL replay)",
-                                             partition)
-                      .containsExactlyElementsOf(preSeqs);
+            assertThat(postSeqs)
+                .describedAs("partition %d: every event durably readable before the restart must be readable "
+                             + "after, in order (independent per-partition WAL replay)", partition)
+                .containsExactlyElementsOf(preSeqs);
         }
     }
 
     // --- failure-path observability ----------------------------------------
+
     private void dumpIfPartitionsShort(List<List<Event>> post, List<List<Event>> pre) {
         for (int partition = 0; partition < PARTITIONS; partition++) {
             if (post.get(partition).size() < pre.get(partition).size()) {
@@ -360,6 +385,7 @@ class MultiPartitionCrashDurabilityTest {
     }
 
     // --- consumers ----------------------------------------------------------
+
     /// Drain every partition (0..PARTITIONS-1) fully; index i = partition i's events in offset order.
     private List<List<Event>> drainAllPartitions(int port) {
         var byPartition = new ArrayList<List<Event>>();
@@ -378,10 +404,7 @@ class MultiPartitionCrashDurabilityTest {
         var byPartition = new ArrayList<List<Event>>();
 
         for (int partition = 0; partition < PARTITIONS; partition++) {
-            byPartition.add(drainPartitionUntil(port,
-                                                partition,
-                                                pre.get(partition).size(),
-                                                recoveryDeadlineNanos()));
+            byPartition.add(drainPartitionUntil(port, partition, pre.get(partition).size(), recoveryDeadlineNanos()));
         }
 
         return byPartition;
@@ -454,6 +477,7 @@ class MultiPartitionCrashDurabilityTest {
     }
 
     // --- publishing ---------------------------------------------------------
+
     private void publishBatch(int port, int count) {
         for (int seq = 0; seq < count; seq++) {
             publish(port, seq);
@@ -464,13 +488,14 @@ class MultiPartitionCrashDurabilityTest {
         var body = "{\"payload\":\"" + seq + "\"}";
         var response = httpPost(port, "/api/stream-mp/publish", body);
 
-        assertThat(response).describedAs("publish seq %d must ack (min-sync-2: durable on >=2 nodes' WALs before ack)",
-                                         seq)
-                  .doesNotContain("\"error\"")
-                  .contains("published");
+        assertThat(response)
+            .describedAs("publish seq %d must ack (min-sync-2: durable on >=2 nodes' WALs before ack)", seq)
+            .doesNotContain("\"error\"")
+            .contains("published");
     }
 
     // --- deployment + readiness --------------------------------------------
+
     private void deployStreamSlice() {
         var blueprint = """
             id = "%s"
@@ -482,9 +507,10 @@ class MultiPartitionCrashDurabilityTest {
         var leaderPort = cluster.getLeaderManagementPort().or(anyMgmtPort());
         var response = postBlueprintWithRetry(leaderPort, blueprint);
 
-        assertThat(response).describedAs("multi-partition (partitions=4, RF=2) stream-slice deployment")
-                  .doesNotContain("\"error\"")
-                  .contains("\"status\":\"applied\"");
+        assertThat(response)
+            .describedAs("multi-partition (partitions=4, RF=2) stream-slice deployment")
+            .doesNotContain("\"error\"")
+            .contains("\"status\":\"applied\"");
     }
 
     private boolean appHttpReady() {
@@ -494,19 +520,15 @@ class MultiPartitionCrashDurabilityTest {
             return false;
         }
 
-        var body = httpPost(ports.getFirst(),
-                            "/api/stream-mp/read",
-                            "{\"partition\":0,\"fromOffset\":0,\"maxEvents\":1}");
+        var body = httpPost(ports.getFirst(), "/api/stream-mp/read", "{\"partition\":0,\"fromOffset\":0,\"maxEvents\":1}");
 
-        return ! body.contains("\"error\"") && body.contains("events");
+        return !body.contains("\"error\"") && body.contains("events");
     }
 
     private void failIfSliceFailed() {
         var failed = cluster.slicesStatus()
                             .stream()
-                            .anyMatch(s -> s.artifact()
-                                            .equals(STREAM_SLICE) && s.state()
-                                                                      .equals("FAILED"));
+                            .anyMatch(s -> s.artifact().equals(STREAM_SLICE) && s.state().equals("FAILED"));
 
         if (failed) {
             throw new AssertionError("multi-partition stream slice deployment FAILED: " + STREAM_SLICE);
@@ -521,10 +543,7 @@ class MultiPartitionCrashDurabilityTest {
     }
 
     private int anyMgmtPort() {
-        return cluster.status()
-                      .nodes()
-                      .getFirst()
-                      .mgmtPort();
+        return cluster.status().nodes().getFirst().mgmtPort();
     }
 
     private long recoveryDeadlineNanos() {
@@ -544,11 +563,9 @@ class MultiPartitionCrashDurabilityTest {
                                  .GET()
                                  .timeout(Duration.ofSeconds(5))
                                  .build();
-
         return http.sendString(request)
                    .await()
-                   .map(r -> r.statusCode() == 200 && r.body()
-                                                       .contains("\"quorum\":true"))
+                   .map(r -> r.statusCode() == 200 && r.body().contains("\"quorum\":true"))
                    .or(false);
     }
 
@@ -559,11 +576,9 @@ class MultiPartitionCrashDurabilityTest {
                                  .GET()
                                  .timeout(Duration.ofSeconds(5))
                                  .build();
-
         return http.sendString(request)
                    .await()
-                   .map(r -> r.statusCode() == 200 && healthHasFullMembership(r.body(),
-                                                                              expected))
+                   .map(r -> r.statusCode() == 200 && healthHasFullMembership(r.body(), expected))
                    .or(false);
     }
 
@@ -578,11 +593,13 @@ class MultiPartitionCrashDurabilityTest {
     }
 
     // --- HTTP ---------------------------------------------------------------
+
     private String postBlueprintWithRetry(int port, String body) {
         var lastResponse = ERROR_FALLBACK;
 
         for (int attempt = 1; attempt <= 3; attempt++) {
             lastResponse = httpPostToml(port, "/api/v1/blueprints", body);
+
             if (!lastResponse.contains("\"error\"")) {
                 return lastResponse;
             }
@@ -602,7 +619,6 @@ class MultiPartitionCrashDurabilityTest {
                                  .POST(HttpRequest.BodyPublishers.ofString(body))
                                  .timeout(Duration.ofSeconds(10))
                                  .build();
-
         return http.sendString(request)
                    .await()
                    .map(HttpResult::body)
@@ -616,7 +632,6 @@ class MultiPartitionCrashDurabilityTest {
                                  .POST(HttpRequest.BodyPublishers.ofString(body))
                                  .timeout(Duration.ofSeconds(15))
                                  .build();
-
         return http.sendString(request)
                    .await()
                    .map(HttpResult::body)
@@ -629,7 +644,6 @@ class MultiPartitionCrashDurabilityTest {
                                  .DELETE()
                                  .timeout(Duration.ofSeconds(10))
                                  .build();
-
         return http.sendString(request)
                    .await()
                    .map(HttpResult::body)

--- a/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/MultiSourceCommunitySmokeTest.java
+++ b/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/MultiSourceCommunitySmokeTest.java
@@ -17,19 +17,20 @@ import org.pragmatica.aether.slice.kvstore.AetherValue.CommunityValue;
 import org.pragmatica.consensus.net.NodeInfo;
 import org.pragmatica.lang.Option;
 
+import org.awaitility.core.ConditionTimeoutException;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
-import org.awaitility.core.ConditionTimeoutException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static org.pragmatica.aether.ember.EmberCluster.emberCluster;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
+
 
 /// The REQUIRED #367 pre-flight smoke (CTO ruling 2026-08-29, the pole-gate redefinition):
 /// multi-source worker topology is the SHIPPED mechanism the GA ladder's 3×3 topology rides —
@@ -81,18 +82,15 @@ import static org.awaitility.Awaitility.await;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class MultiSourceCommunitySmokeTest {
     private static final Logger log = LoggerFactory.getLogger(MultiSourceCommunitySmokeTest.class);
-
     private static final int INITIAL_CORES = 5;
     private static final String SOURCE_A = "src-a";
     private static final String SOURCE_B = "src-b";
     private static final String COMMUNITY_A = SOURCE_A + "-w-0";
     private static final String COMMUNITY_B = SOURCE_B + "-w-0";
     private static final String DEFAULT_COMMUNITY = "default-w-0";
-
     private static final int BASE_PORT = 22650;
     private static final int BASE_MGMT_PORT = 22750;
     private static final int BASE_APP_HTTP_PORT = 22850;
-
     private static final Duration FORM_TIMEOUT = Duration.ofSeconds(90);
     private static final Duration SETTLE_TIMEOUT = Duration.ofSeconds(30);
     private static final Duration MINT_TIMEOUT = Duration.ofSeconds(120);
@@ -112,14 +110,14 @@ class MultiSourceCommunitySmokeTest {
         LifecycleAwait.settled(INITIAL_CORES + "-core cluster start (ports " + BASE_PORT + "+)",
                                cluster,
                                cluster.start());
-
         awaitFormation("leader elected among " + INITIAL_CORES + " cores",
-                       () -> cluster.currentLeader().isPresent());
+                       () -> cluster.currentLeader()
+                                    .isPresent());
         // The leader's BootstrapModule auto-seeds committed ClusterConfig.coreCount = 5; until it
         // lands, joiners would be promoted to core instead of assigned WORKER.
-        awaitFormation("committed ClusterConfig.coreCount == " + INITIAL_CORES
-                       + " (BootstrapModule auto-seed)",
-                       () -> committedCoreCount().filter(count -> count == INITIAL_CORES).isPresent());
+        awaitFormation("committed ClusterConfig.coreCount == " + INITIAL_CORES + " (BootstrapModule auto-seed)",
+                       () -> committedCoreCount().filter(count -> count == INITIAL_CORES)
+                                               .isPresent());
         log.info("MSRC-SMOKE: {}-core cluster formed, committed cap={}", INITIAL_CORES, committedCoreCount().or(-1));
     }
 
@@ -137,49 +135,49 @@ class MultiSourceCommunitySmokeTest {
         addWorkerAndSettle(2, SOURCE_A);
         addWorkerAndSettle(3, SOURCE_B);
         addWorkerAndSettle(4, SOURCE_B);
-
         awaitBounded("communities " + COMMUNITY_A + " and " + COMMUNITY_B + " both minted",
                      MINT_TIMEOUT,
                      () -> communityValue(COMMUNITY_A).isPresent() && communityValue(COMMUNITY_B).isPresent());
-
-        assertThat(communityValue(COMMUNITY_A).map(CommunityValue::sourceName).or(""))
-            .as("community %s must record its minting source", COMMUNITY_A)
-            .isEqualTo(SOURCE_A);
-        assertThat(communityValue(COMMUNITY_B).map(CommunityValue::sourceName).or(""))
-            .as("community %s must record its minting source", COMMUNITY_B)
-            .isEqualTo(SOURCE_B);
+        assertThat(communityValue(COMMUNITY_A).map(CommunityValue::sourceName).or("")).as("community %s must record its minting source",
+                                                                                          COMMUNITY_A)
+                  .isEqualTo(SOURCE_A);
+        assertThat(communityValue(COMMUNITY_B).map(CommunityValue::sourceName).or("")).as("community %s must record its minting source",
+                                                                                          COMMUNITY_B)
+                  .isEqualTo(SOURCE_B);
         // The label round-trip proof: unlabeled joins mint default-w-0 (CommunityFormationProbeTest
         // demonstrates exactly that), so an existing default community here would mean the source
         // label was dropped somewhere and the two named communities above were minted by luck.
-        assertThat(communityValue(DEFAULT_COMMUNITY).isPresent())
-            .as("no worker may fall back to the default source — the label must round-trip")
-            .isFalse();
-        assertThat(countedCores())
-            .as("the core count must stay at the cap — no worker was promoted to core")
-            .isEqualTo(INITIAL_CORES);
+        assertThat(communityValue(DEFAULT_COMMUNITY).isPresent()).as("no worker may fall back to the default source — the label must round-trip")
+                  .isFalse();
+        assertThat(countedCores()).as("the core count must stay at the cap — no worker was promoted to core")
+                  .isEqualTo(INITIAL_CORES);
     }
 
     // ----- worker join, mirroring CommunityFormationProbeTest's sequential settle -----
-
     private void addWorkerAndSettle(int index, String source) {
         var expectedNodeCount = INITIAL_CORES + index;
-
         // #915: the third untimed lifecycle await in this class, and not named in the ticket —
         // found by the module-wide sweep. A worker join that never settles wedges the @Test body
         // exactly as a start wedges @BeforeAll.
         var nodeId = LifecycleAwait.nodeSettled("worker " + index + "/4 (source " + source + ") join",
                                                 cluster,
-                                                cluster.addNode(Map.of(NodeInfo.LABEL_ROLE, "worker",
-                                                                       NodeInfo.LABEL_SOURCE, source)));
-        log.info("MSRC-SMOKE: worker {}/4 (source={}) joined as {}", index, source, nodeId.id());
+                                                cluster.addNode(Map.of(NodeInfo.LABEL_ROLE,
+                                                                       "worker",
+                                                                       NodeInfo.LABEL_SOURCE,
+                                                                       source)));
 
-        awaitSettle("worker " + index + "/4 settled: leader present, countedCores==" + INITIAL_CORES
-                    + ", nodeCount==" + expectedNodeCount,
-                    () -> cluster.currentLeader().isPresent()
+        log.info("MSRC-SMOKE: worker {}/4 (source={}) joined as {}", index, source, nodeId.id());
+        awaitSettle("worker " + index
+                   + "/4 settled: leader present, countedCores==" + INITIAL_CORES
+                   + ", nodeCount==" + expectedNodeCount,
+                    () -> cluster.currentLeader()
+                                 .isPresent()
                           && countedCores() == INITIAL_CORES
                           && cluster.nodeCount() == expectedNodeCount);
         log.info("MSRC-SMOKE: after worker {}/4 countedCores={} nodeCount={}",
-                 index, countedCores(), cluster.nodeCount());
+                 index,
+                 countedCores(),
+                 cluster.nodeCount());
     }
 
     // ----- named waits (#915) -----
@@ -188,7 +186,6 @@ class MultiSourceCommunitySmokeTest {
     // MultiSourceCommunitySmokeTest was not fulfilled within N seconds" — it names the CLASS and
     // nothing else, so a stalled formation and a stalled mint are indistinguishable in a CI log.
     // These three wrappers give every wait an alias and attach the cluster state at expiry.
-
     private void awaitFormation(String what, Callable<Boolean> condition) {
         awaitBounded(what, FORM_TIMEOUT, condition);
     }
@@ -199,35 +196,35 @@ class MultiSourceCommunitySmokeTest {
 
     private void awaitBounded(String what, Duration bound, Callable<Boolean> condition) {
         try {
-            await().alias(what)
-                   .atMost(bound)
-                   .pollInterval(POLL)
-                   .until(condition);
+            await().alias(what).atMost(bound).pollInterval(POLL).until(condition);
         } catch (ConditionTimeoutException timeout) {
             throw new AssertionError(timeout.getMessage()
-                                     + "\nCluster state when the wait ended:\n"
-                                     + LifecycleAwait.snapshot(cluster),
+                                    + "\nCluster state when the wait ended:\n" + LifecycleAwait.snapshot(cluster),
                                      timeout);
         }
     }
 
     // ----- committed-state reads off the leader KV store (the probe's accessors) -----
-
     private Option<Integer> committedCoreCount() {
-        return leaderOrAnyNode().flatMap(node -> node.kvStore().get(ClusterConfigKey.CURRENT))
-                                .filter(ClusterConfigValue.class::isInstance)
-                                .map(ClusterConfigValue.class::cast)
-                                .map(ClusterConfigValue::coreCount);
+        return leaderOrAnyNode().flatMap(node -> node.kvStore()
+                                                     .get(ClusterConfigKey.CURRENT))
+                              .filter(ClusterConfigValue.class::isInstance)
+                              .map(ClusterConfigValue.class::cast)
+                              .map(ClusterConfigValue::coreCount);
     }
 
     private Option<CommunityValue> communityValue(String communityId) {
-        return leaderOrAnyNode().flatMap(node -> node.kvStore().get(CommunityKey.communityKey(communityId)))
-                                .filter(CommunityValue.class::isInstance)
-                                .map(CommunityValue.class::cast);
+        return leaderOrAnyNode().flatMap(node -> node.kvStore()
+                                                     .get(CommunityKey.communityKey(communityId)))
+                              .filter(CommunityValue.class::isInstance)
+                              .map(CommunityValue.class::cast);
     }
 
     private int countedCores() {
-        return leaderOrAnyNode().map(node -> node.membershipFsm().coreCountedMembers().size()).or(0);
+        return leaderOrAnyNode().map(node -> node.membershipFsm()
+                                                 .coreCountedMembers()
+                                                 .size())
+                              .or(0);
     }
 
     private Option<AetherNode> leaderOrAnyNode() {

--- a/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/MultiSourceCommunitySmokeTest.java
+++ b/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/MultiSourceCommunitySmokeTest.java
@@ -31,7 +31,6 @@ import static org.pragmatica.aether.ember.EmberCluster.emberCluster;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
-
 /// The REQUIRED #367 pre-flight smoke (CTO ruling 2026-08-29, the pole-gate redefinition):
 /// multi-source worker topology is the SHIPPED mechanism the GA ladder's 3×3 topology rides —
 /// communities are minted one-per-source (`ClusterDeploymentState`, `source + "-w-0"`), so three
@@ -82,15 +81,18 @@ import static org.awaitility.Awaitility.await;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class MultiSourceCommunitySmokeTest {
     private static final Logger log = LoggerFactory.getLogger(MultiSourceCommunitySmokeTest.class);
+
     private static final int INITIAL_CORES = 5;
     private static final String SOURCE_A = "src-a";
     private static final String SOURCE_B = "src-b";
     private static final String COMMUNITY_A = SOURCE_A + "-w-0";
     private static final String COMMUNITY_B = SOURCE_B + "-w-0";
     private static final String DEFAULT_COMMUNITY = "default-w-0";
+
     private static final int BASE_PORT = 22650;
     private static final int BASE_MGMT_PORT = 22750;
     private static final int BASE_APP_HTTP_PORT = 22850;
+
     private static final Duration FORM_TIMEOUT = Duration.ofSeconds(90);
     private static final Duration SETTLE_TIMEOUT = Duration.ofSeconds(30);
     private static final Duration MINT_TIMEOUT = Duration.ofSeconds(120);
@@ -110,14 +112,13 @@ class MultiSourceCommunitySmokeTest {
         LifecycleAwait.settled(INITIAL_CORES + "-core cluster start (ports " + BASE_PORT + "+)",
                                cluster,
                                cluster.start());
+
         awaitFormation("leader elected among " + INITIAL_CORES + " cores",
-                       () -> cluster.currentLeader()
-                                    .isPresent());
+                       () -> cluster.currentLeader().isPresent());
         // The leader's BootstrapModule auto-seeds committed ClusterConfig.coreCount = 5; until it
         // lands, joiners would be promoted to core instead of assigned WORKER.
         awaitFormation("committed ClusterConfig.coreCount == " + INITIAL_CORES + " (BootstrapModule auto-seed)",
-                       () -> committedCoreCount().filter(count -> count == INITIAL_CORES)
-                                               .isPresent());
+                       () -> committedCoreCount().filter(count -> count == INITIAL_CORES).isPresent());
         log.info("MSRC-SMOKE: {}-core cluster formed, committed cap={}", INITIAL_CORES, committedCoreCount().or(-1));
     }
 
@@ -126,7 +127,7 @@ class MultiSourceCommunitySmokeTest {
         // #915: bounded and checked. The bare await() here could neither expire nor report:
         // a stop that never settled hung @AfterAll to the backstop, and a stop that FAILED was
         // discarded because nothing read the Result.
-        Option.option(cluster).onPresent(c -> LifecycleAwait.settled("cluster stop", c, c.stop()));
+        Option.option(cluster).onPresent(c -> LifecycleAwait.bestEffort("cluster stop", c, c.stop()));
     }
 
     @Test
@@ -135,49 +136,50 @@ class MultiSourceCommunitySmokeTest {
         addWorkerAndSettle(2, SOURCE_A);
         addWorkerAndSettle(3, SOURCE_B);
         addWorkerAndSettle(4, SOURCE_B);
+
         awaitBounded("communities " + COMMUNITY_A + " and " + COMMUNITY_B + " both minted",
                      MINT_TIMEOUT,
                      () -> communityValue(COMMUNITY_A).isPresent() && communityValue(COMMUNITY_B).isPresent());
-        assertThat(communityValue(COMMUNITY_A).map(CommunityValue::sourceName).or("")).as("community %s must record its minting source",
-                                                                                          COMMUNITY_A)
-                  .isEqualTo(SOURCE_A);
-        assertThat(communityValue(COMMUNITY_B).map(CommunityValue::sourceName).or("")).as("community %s must record its minting source",
-                                                                                          COMMUNITY_B)
-                  .isEqualTo(SOURCE_B);
+
+        assertThat(communityValue(COMMUNITY_A).map(CommunityValue::sourceName).or(""))
+            .as("community %s must record its minting source", COMMUNITY_A)
+            .isEqualTo(SOURCE_A);
+        assertThat(communityValue(COMMUNITY_B).map(CommunityValue::sourceName).or(""))
+            .as("community %s must record its minting source", COMMUNITY_B)
+            .isEqualTo(SOURCE_B);
         // The label round-trip proof: unlabeled joins mint default-w-0 (CommunityFormationProbeTest
         // demonstrates exactly that), so an existing default community here would mean the source
         // label was dropped somewhere and the two named communities above were minted by luck.
-        assertThat(communityValue(DEFAULT_COMMUNITY).isPresent()).as("no worker may fall back to the default source — the label must round-trip")
-                  .isFalse();
-        assertThat(countedCores()).as("the core count must stay at the cap — no worker was promoted to core")
-                  .isEqualTo(INITIAL_CORES);
+        assertThat(communityValue(DEFAULT_COMMUNITY).isPresent())
+            .as("no worker may fall back to the default source — the label must round-trip")
+            .isFalse();
+        assertThat(countedCores())
+            .as("the core count must stay at the cap — no worker was promoted to core")
+            .isEqualTo(INITIAL_CORES);
     }
 
     // ----- worker join, mirroring CommunityFormationProbeTest's sequential settle -----
+
     private void addWorkerAndSettle(int index, String source) {
         var expectedNodeCount = INITIAL_CORES + index;
+
         // #915: the third untimed lifecycle await in this class, and not named in the ticket —
         // found by the module-wide sweep. A worker join that never settles wedges the @Test body
         // exactly as a start wedges @BeforeAll.
         var nodeId = LifecycleAwait.nodeSettled("worker " + index + "/4 (source " + source + ") join",
                                                 cluster,
-                                                cluster.addNode(Map.of(NodeInfo.LABEL_ROLE,
-                                                                       "worker",
-                                                                       NodeInfo.LABEL_SOURCE,
-                                                                       source)));
+                                                cluster.addNode(Map.of(NodeInfo.LABEL_ROLE, "worker",
+                                                                       NodeInfo.LABEL_SOURCE, source)));
 
         log.info("MSRC-SMOKE: worker {}/4 (source={}) joined as {}", index, source, nodeId.id());
-        awaitSettle("worker " + index
-                   + "/4 settled: leader present, countedCores==" + INITIAL_CORES
-                   + ", nodeCount==" + expectedNodeCount,
-                    () -> cluster.currentLeader()
-                                 .isPresent()
+
+        awaitSettle("worker " + index + "/4 settled: leader present, countedCores==" + INITIAL_CORES
+                    + ", nodeCount==" + expectedNodeCount,
+                    () -> cluster.currentLeader().isPresent()
                           && countedCores() == INITIAL_CORES
                           && cluster.nodeCount() == expectedNodeCount);
         log.info("MSRC-SMOKE: after worker {}/4 countedCores={} nodeCount={}",
-                 index,
-                 countedCores(),
-                 cluster.nodeCount());
+                 index, countedCores(), cluster.nodeCount());
     }
 
     // ----- named waits (#915) -----
@@ -186,6 +188,7 @@ class MultiSourceCommunitySmokeTest {
     // MultiSourceCommunitySmokeTest was not fulfilled within N seconds" — it names the CLASS and
     // nothing else, so a stalled formation and a stalled mint are indistinguishable in a CI log.
     // These three wrappers give every wait an alias and attach the cluster state at expiry.
+
     private void awaitFormation(String what, Callable<Boolean> condition) {
         awaitBounded(what, FORM_TIMEOUT, condition);
     }
@@ -199,32 +202,28 @@ class MultiSourceCommunitySmokeTest {
             await().alias(what).atMost(bound).pollInterval(POLL).until(condition);
         } catch (ConditionTimeoutException timeout) {
             throw new AssertionError(timeout.getMessage()
-                                    + "\nCluster state when the wait ended:\n" + LifecycleAwait.snapshot(cluster),
+                                     + "\nCluster state when the wait ended:\n" + LifecycleAwait.snapshot(cluster),
                                      timeout);
         }
     }
 
     // ----- committed-state reads off the leader KV store (the probe's accessors) -----
+
     private Option<Integer> committedCoreCount() {
-        return leaderOrAnyNode().flatMap(node -> node.kvStore()
-                                                     .get(ClusterConfigKey.CURRENT))
-                              .filter(ClusterConfigValue.class::isInstance)
-                              .map(ClusterConfigValue.class::cast)
-                              .map(ClusterConfigValue::coreCount);
+        return leaderOrAnyNode().flatMap(node -> node.kvStore().get(ClusterConfigKey.CURRENT))
+                                .filter(ClusterConfigValue.class::isInstance)
+                                .map(ClusterConfigValue.class::cast)
+                                .map(ClusterConfigValue::coreCount);
     }
 
     private Option<CommunityValue> communityValue(String communityId) {
-        return leaderOrAnyNode().flatMap(node -> node.kvStore()
-                                                     .get(CommunityKey.communityKey(communityId)))
-                              .filter(CommunityValue.class::isInstance)
-                              .map(CommunityValue.class::cast);
+        return leaderOrAnyNode().flatMap(node -> node.kvStore().get(CommunityKey.communityKey(communityId)))
+                                .filter(CommunityValue.class::isInstance)
+                                .map(CommunityValue.class::cast);
     }
 
     private int countedCores() {
-        return leaderOrAnyNode().map(node -> node.membershipFsm()
-                                                 .coreCountedMembers()
-                                                 .size())
-                              .or(0);
+        return leaderOrAnyNode().map(node -> node.membershipFsm().coreCountedMembers().size()).or(0);
     }
 
     private Option<AetherNode> leaderOrAnyNode() {

--- a/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/MultiSourceCommunitySmokeTest.java
+++ b/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/MultiSourceCommunitySmokeTest.java
@@ -6,6 +6,7 @@ package org.pragmatica.aether.forge;
 
 import java.time.Duration;
 import java.util.Map;
+import java.util.concurrent.Callable;
 
 import org.pragmatica.aether.ember.EmberCluster;
 import org.pragmatica.aether.node.AetherNode;
@@ -22,6 +23,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.awaitility.core.ConditionTimeoutException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -104,24 +106,29 @@ class MultiSourceCommunitySmokeTest {
         // #491 raised SWIM/membership timeouts: nine in-JVM nodes contend for the same machine's
         // cores, and the default windows read scheduling stalls as SUSPECT churn.
         cluster.withRaisedSwimTimeouts();
-        cluster.start()
-               .await()
-               .onFailure(cause -> {
-                   throw new AssertionError("Cluster start failed: " + cause.message());
-               });
+        // #915: bounded, and named on expiry. Untimed, this await() parks until the start resolves
+        // and ignores JUnit's lifecycle interrupt (#914), so a start that never settles reached the
+        // 8-minute backstop and reported a class-level ERROR at ~515s naming no step at all.
+        LifecycleAwait.settled(INITIAL_CORES + "-core cluster start (ports " + BASE_PORT + "+)",
+                               cluster,
+                               cluster.start());
 
-        await().atMost(FORM_TIMEOUT).pollInterval(POLL).until(() -> cluster.currentLeader().isPresent());
+        awaitFormation("leader elected among " + INITIAL_CORES + " cores",
+                       () -> cluster.currentLeader().isPresent());
         // The leader's BootstrapModule auto-seeds committed ClusterConfig.coreCount = 5; until it
         // lands, joiners would be promoted to core instead of assigned WORKER.
-        await().atMost(FORM_TIMEOUT)
-               .pollInterval(POLL)
-               .until(() -> committedCoreCount().filter(count -> count == INITIAL_CORES).isPresent());
+        awaitFormation("committed ClusterConfig.coreCount == " + INITIAL_CORES
+                       + " (BootstrapModule auto-seed)",
+                       () -> committedCoreCount().filter(count -> count == INITIAL_CORES).isPresent());
         log.info("MSRC-SMOKE: {}-core cluster formed, committed cap={}", INITIAL_CORES, committedCoreCount().or(-1));
     }
 
     @AfterAll
     void tearDown() {
-        Option.option(cluster).onPresent(c -> c.stop().await());
+        // #915: bounded and checked. The bare await() here could neither expire nor report:
+        // a stop that never settled hung @AfterAll to the backstop, and a stop that FAILED was
+        // discarded because nothing read the Result.
+        Option.option(cluster).onPresent(c -> LifecycleAwait.settled("cluster stop", c, c.stop()));
     }
 
     @Test
@@ -131,9 +138,9 @@ class MultiSourceCommunitySmokeTest {
         addWorkerAndSettle(3, SOURCE_B);
         addWorkerAndSettle(4, SOURCE_B);
 
-        await().atMost(MINT_TIMEOUT)
-               .pollInterval(POLL)
-               .until(() -> communityValue(COMMUNITY_A).isPresent() && communityValue(COMMUNITY_B).isPresent());
+        awaitBounded("communities " + COMMUNITY_A + " and " + COMMUNITY_B + " both minted",
+                     MINT_TIMEOUT,
+                     () -> communityValue(COMMUNITY_A).isPresent() && communityValue(COMMUNITY_B).isPresent());
 
         assertThat(communityValue(COMMUNITY_A).map(CommunityValue::sourceName).or(""))
             .as("community %s must record its minting source", COMMUNITY_A)
@@ -157,21 +164,51 @@ class MultiSourceCommunitySmokeTest {
     private void addWorkerAndSettle(int index, String source) {
         var expectedNodeCount = INITIAL_CORES + index;
 
-        cluster.addNode(Map.of(NodeInfo.LABEL_ROLE, "worker", NodeInfo.LABEL_SOURCE, source))
-               .await()
-               .onSuccess(nodeId -> log.info("MSRC-SMOKE: worker {}/4 (source={}) joined as {}",
-                                             index, source, nodeId.id()))
-               .onFailure(cause -> {
-                   throw new AssertionError("worker " + index + " (source " + source + ") failed to join: "
-                                            + cause.message());
-               });
-        await().atMost(SETTLE_TIMEOUT)
-               .pollInterval(POLL)
-               .until(() -> cluster.currentLeader().isPresent()
-                            && countedCores() == INITIAL_CORES
-                            && cluster.nodeCount() == expectedNodeCount);
+        // #915: the third untimed lifecycle await in this class, and not named in the ticket —
+        // found by the module-wide sweep. A worker join that never settles wedges the @Test body
+        // exactly as a start wedges @BeforeAll.
+        var nodeId = LifecycleAwait.nodeSettled("worker " + index + "/4 (source " + source + ") join",
+                                                cluster,
+                                                cluster.addNode(Map.of(NodeInfo.LABEL_ROLE, "worker",
+                                                                       NodeInfo.LABEL_SOURCE, source)));
+        log.info("MSRC-SMOKE: worker {}/4 (source={}) joined as {}", index, source, nodeId.id());
+
+        awaitSettle("worker " + index + "/4 settled: leader present, countedCores==" + INITIAL_CORES
+                    + ", nodeCount==" + expectedNodeCount,
+                    () -> cluster.currentLeader().isPresent()
+                          && countedCores() == INITIAL_CORES
+                          && cluster.nodeCount() == expectedNodeCount);
         log.info("MSRC-SMOKE: after worker {}/4 countedCores={} nodeCount={}",
                  index, countedCores(), cluster.nodeCount());
+    }
+
+    // ----- named waits (#915) -----
+    //
+    // Awaitility's own expiry message is "Condition with Lambda expression in
+    // MultiSourceCommunitySmokeTest was not fulfilled within N seconds" — it names the CLASS and
+    // nothing else, so a stalled formation and a stalled mint are indistinguishable in a CI log.
+    // These three wrappers give every wait an alias and attach the cluster state at expiry.
+
+    private void awaitFormation(String what, Callable<Boolean> condition) {
+        awaitBounded(what, FORM_TIMEOUT, condition);
+    }
+
+    private void awaitSettle(String what, Callable<Boolean> condition) {
+        awaitBounded(what, SETTLE_TIMEOUT, condition);
+    }
+
+    private void awaitBounded(String what, Duration bound, Callable<Boolean> condition) {
+        try {
+            await().alias(what)
+                   .atMost(bound)
+                   .pollInterval(POLL)
+                   .until(condition);
+        } catch (ConditionTimeoutException timeout) {
+            throw new AssertionError(timeout.getMessage()
+                                     + "\nCluster state when the wait ended:\n"
+                                     + LifecycleAwait.snapshot(cluster),
+                                     timeout);
+        }
     }
 
     // ----- committed-state reads off the leader KV store (the probe's accessors) -----

--- a/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/NodeLifecyclePeriodicArmingForgeTest.java
+++ b/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/NodeLifecyclePeriodicArmingForgeTest.java
@@ -5,7 +5,6 @@
 package org.pragmatica.aether.forge;
 
 import java.time.Duration;
-import java.util.Set;
 
 import org.pragmatica.aether.ember.EmberCluster;
 import org.pragmatica.aether.node.AetherNode;
@@ -21,11 +20,12 @@ import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
 
+import java.util.Set;
+
 import static org.pragmatica.aether.ember.EmberCluster.emberCluster;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.awaitility.Awaitility.await;
-
 
 /// The #644 WIRING pin — the one assertion no unit test can make: that `AetherNode.start()` actually
 /// arms the deferred periodic tasks, and that a CREATED-but-never-started node holds none.
@@ -63,18 +63,21 @@ class NodeLifecyclePeriodicArmingForgeTest {
     @BeforeAll
     void setUp() {
         cluster = emberCluster(3, BASE_PORT, BASE_MGMT_PORT, BASE_APP_HTTP_PORT, NODE_PREFIX);
+
         // 2 of 3 started is a Rabia quorum, so the cluster genuinely forms around the held-back node.
         LifecycleAwait.settled("cluster start in setUp()",
                                cluster,
                                cluster.start(Set.of(HELD_BACK_ID)));
-        await().atMost(WAIT_TIMEOUT).pollInterval(POLL_INTERVAL).until(() -> cluster.currentLeader()
-                                                                                    .isPresent());
+
+        await().atMost(WAIT_TIMEOUT)
+               .pollInterval(POLL_INTERVAL)
+               .until(() -> cluster.currentLeader().isPresent());
     }
 
     @AfterAll
     void tearDown() {
         if (cluster != null) {
-            LifecycleAwait.settled("cluster stop in tearDown()", cluster, cluster.stop());
+            LifecycleAwait.bestEffort("cluster stop in tearDown()", cluster, cluster.stop());
         }
     }
 
@@ -86,12 +89,14 @@ class NodeLifecyclePeriodicArmingForgeTest {
     void heldBackNode_holdsDeferredWork_andArmsNothingWhileUnstarted() {
         var held = periodicTasksOf(heldBackInstance());
 
-        assertThat(held.deferredCount()).as("assembly must have deferred the periodic-task family").isPositive();
+        assertThat(held.deferredCount()).as("assembly must have deferred the periodic-task family")
+                                        .isPositive();
         deferredWhileHeld = held.deferredCount();
+
         await().during(HOLD_OBSERVATION)
-             .atMost(HOLD_OBSERVATION.plusSeconds(2))
-             .pollInterval(POLL_INTERVAL)
-             .until(() -> held.armedCount() == 0);
+               .atMost(HOLD_OBSERVATION.plusSeconds(2))
+               .pollInterval(POLL_INTERVAL)
+               .until(() -> held.armedCount() == 0);
     }
 
     /// The wiring pin for every STARTED node: start() armed the full deferred set. This is the
@@ -102,13 +107,13 @@ class NodeLifecyclePeriodicArmingForgeTest {
         assertThat(cluster.allNodes()).isNotEmpty();
         cluster.allNodes()
                .forEach(node -> {
-                            var tasks = periodicTasksOf(node);
+                   var tasks = periodicTasksOf(node);
 
-                            assertThat(tasks.armedCount()).as("a started node must have armed its periodic work")
-                                      .isPositive();
-                            assertThat(tasks.deferredCount()).as("start() must arm the WHOLE deferred set, leaving nothing behind")
-                                      .isZero();
-                        });
+                   assertThat(tasks.armedCount()).as("a started node must have armed its periodic work")
+                                                 .isPositive();
+                   assertThat(tasks.deferredCount()).as("start() must arm the WHOLE deferred set, leaving nothing behind")
+                                                    .isZero();
+               });
     }
 
     /// Releasing the hold arms exactly the set that was deferred while held — late start is ordinary
@@ -121,6 +126,7 @@ class NodeLifecyclePeriodicArmingForgeTest {
         LifecycleAwait.settled("held-back node start in startingTheHeldBackNode_armsExactlyTheDeferredSet()",
                                cluster,
                                cluster.startHeldBackNodes());
+
         assertThat(held.armedCount()).isEqualTo(deferredWhileHeld);
         assertThat(held.deferredCount()).isZero();
     }
@@ -130,16 +136,21 @@ class NodeLifecyclePeriodicArmingForgeTest {
     @Test
     @Order(4)
     void stop_disarmsEveryNode() {
-        var observed = cluster.allNodes().stream().map(NodeLifecyclePeriodicArmingForgeTest::periodicTasksOf).toList();
+        var observed = cluster.allNodes()
+                              .stream()
+                              .map(NodeLifecyclePeriodicArmingForgeTest::periodicTasksOf)
+                              .toList();
 
-        LifecycleAwait.settled("cluster stop in stop_disarmsEveryNode()", cluster, cluster.stop());
+        LifecycleAwait.bestEffort("cluster stop in stop_disarmsEveryNode()", cluster, cluster.stop());
         cluster = null;
+
         assertThat(observed).isNotEmpty();
         observed.forEach(tasks -> assertThat(tasks.armedCount()).as("stop() must cancel every armed periodic task")
-                                            .isZero());
+                                                                .isZero());
     }
 
     // ---- helpers -------------------------------------------------------------------------------
+
     private AetherNode heldBackInstance() {
         return cluster.heldBackNode(HELD_BACK_ID)
                       .fold(() -> fail("held-back node " + HELD_BACK_ID + " not found — was it already started?"),

--- a/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/NodeLifecyclePeriodicArmingForgeTest.java
+++ b/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/NodeLifecyclePeriodicArmingForgeTest.java
@@ -5,6 +5,7 @@
 package org.pragmatica.aether.forge;
 
 import java.time.Duration;
+import java.util.Set;
 
 import org.pragmatica.aether.ember.EmberCluster;
 import org.pragmatica.aether.node.AetherNode;
@@ -20,12 +21,11 @@ import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
 
-import java.util.Set;
-
 import static org.pragmatica.aether.ember.EmberCluster.emberCluster;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.awaitility.Awaitility.await;
+
 
 /// The #644 WIRING pin — the one assertion no unit test can make: that `AetherNode.start()` actually
 /// arms the deferred periodic tasks, and that a CREATED-but-never-started node holds none.
@@ -63,24 +63,18 @@ class NodeLifecyclePeriodicArmingForgeTest {
     @BeforeAll
     void setUp() {
         cluster = emberCluster(3, BASE_PORT, BASE_MGMT_PORT, BASE_APP_HTTP_PORT, NODE_PREFIX);
-
         // 2 of 3 started is a Rabia quorum, so the cluster genuinely forms around the held-back node.
-        cluster.start(Set.of(HELD_BACK_ID))
-               .await()
-               .onFailure(cause -> {
-                   throw new AssertionError("Cluster start failed: " + cause.message());
-               });
-
-        await().atMost(WAIT_TIMEOUT)
-               .pollInterval(POLL_INTERVAL)
-               .until(() -> cluster.currentLeader().isPresent());
+        LifecycleAwait.settled("cluster start in setUp()",
+                               cluster,
+                               cluster.start(Set.of(HELD_BACK_ID)));
+        await().atMost(WAIT_TIMEOUT).pollInterval(POLL_INTERVAL).until(() -> cluster.currentLeader()
+                                                                                    .isPresent());
     }
 
     @AfterAll
     void tearDown() {
         if (cluster != null) {
-            cluster.stop()
-                   .await();
+            LifecycleAwait.settled("cluster stop in tearDown()", cluster, cluster.stop());
         }
     }
 
@@ -92,14 +86,12 @@ class NodeLifecyclePeriodicArmingForgeTest {
     void heldBackNode_holdsDeferredWork_andArmsNothingWhileUnstarted() {
         var held = periodicTasksOf(heldBackInstance());
 
-        assertThat(held.deferredCount()).as("assembly must have deferred the periodic-task family")
-                                        .isPositive();
+        assertThat(held.deferredCount()).as("assembly must have deferred the periodic-task family").isPositive();
         deferredWhileHeld = held.deferredCount();
-
         await().during(HOLD_OBSERVATION)
-               .atMost(HOLD_OBSERVATION.plusSeconds(2))
-               .pollInterval(POLL_INTERVAL)
-               .until(() -> held.armedCount() == 0);
+             .atMost(HOLD_OBSERVATION.plusSeconds(2))
+             .pollInterval(POLL_INTERVAL)
+             .until(() -> held.armedCount() == 0);
     }
 
     /// The wiring pin for every STARTED node: start() armed the full deferred set. This is the
@@ -110,13 +102,13 @@ class NodeLifecyclePeriodicArmingForgeTest {
         assertThat(cluster.allNodes()).isNotEmpty();
         cluster.allNodes()
                .forEach(node -> {
-                   var tasks = periodicTasksOf(node);
+                            var tasks = periodicTasksOf(node);
 
-                   assertThat(tasks.armedCount()).as("a started node must have armed its periodic work")
-                                                 .isPositive();
-                   assertThat(tasks.deferredCount()).as("start() must arm the WHOLE deferred set, leaving nothing behind")
-                                                    .isZero();
-               });
+                            assertThat(tasks.armedCount()).as("a started node must have armed its periodic work")
+                                      .isPositive();
+                            assertThat(tasks.deferredCount()).as("start() must arm the WHOLE deferred set, leaving nothing behind")
+                                      .isZero();
+                        });
     }
 
     /// Releasing the hold arms exactly the set that was deferred while held — late start is ordinary
@@ -126,12 +118,9 @@ class NodeLifecyclePeriodicArmingForgeTest {
     void startingTheHeldBackNode_armsExactlyTheDeferredSet() {
         var held = periodicTasksOf(heldBackInstance());
 
-        cluster.startHeldBackNodes()
-               .await()
-               .onFailure(cause -> {
-                   throw new AssertionError("Held-back start failed: " + cause.message());
-               });
-
+        LifecycleAwait.settled("held-back node start in startingTheHeldBackNode_armsExactlyTheDeferredSet()",
+                               cluster,
+                               cluster.startHeldBackNodes());
         assertThat(held.armedCount()).isEqualTo(deferredWhileHeld);
         assertThat(held.deferredCount()).isZero();
     }
@@ -141,22 +130,16 @@ class NodeLifecyclePeriodicArmingForgeTest {
     @Test
     @Order(4)
     void stop_disarmsEveryNode() {
-        var observed = cluster.allNodes()
-                              .stream()
-                              .map(NodeLifecyclePeriodicArmingForgeTest::periodicTasksOf)
-                              .toList();
+        var observed = cluster.allNodes().stream().map(NodeLifecyclePeriodicArmingForgeTest::periodicTasksOf).toList();
 
-        cluster.stop()
-               .await();
+        LifecycleAwait.settled("cluster stop in stop_disarmsEveryNode()", cluster, cluster.stop());
         cluster = null;
-
         assertThat(observed).isNotEmpty();
         observed.forEach(tasks -> assertThat(tasks.armedCount()).as("stop() must cancel every armed periodic task")
-                                                                .isZero());
+                                            .isZero());
     }
 
     // ---- helpers -------------------------------------------------------------------------------
-
     private AetherNode heldBackInstance() {
         return cluster.heldBackNode(HELD_BACK_ID)
                       .fold(() -> fail("held-back node " + HELD_BACK_ID + " not found — was it already started?"),

--- a/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/OwnershipFenceBaselineTest.java
+++ b/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/OwnershipFenceBaselineTest.java
@@ -2,11 +2,17 @@
 // Copyright (c) 2025 Pragmatica Labs - Sergiy Yevtushenko
 // Licensed under Business Source License 1.1. Change Date: 2030-01-01. Change License: Apache-2.0.
 // See LICENSE in the repository root for full terms.
+
 package org.pragmatica.aether.forge;
 
-import java.time.Duration;
-import java.util.List;
-
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.api.Assertions;
 import org.pragmatica.aether.ember.EmberCluster;
 import org.pragmatica.aether.node.AetherNode;
 import org.pragmatica.aether.slice.StreamConfig;
@@ -26,23 +32,16 @@ import org.pragmatica.lang.Cause;
 import org.pragmatica.lang.Option;
 import org.pragmatica.lang.Result;
 import org.pragmatica.lang.TerminalOperation;
-
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.time.Duration;
+import java.util.List;
+
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.pragmatica.aether.ember.EmberCluster.emberCluster;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
-
+import static org.pragmatica.aether.ember.EmberCluster.emberCluster;
 
 /// STEP-0 → 1d-ii regression gate for the #345 stream ownership fence.
 ///
@@ -83,17 +82,21 @@ import static org.awaitility.Awaitility.await;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class OwnershipFenceBaselineTest {
     private static final Logger log = LoggerFactory.getLogger(OwnershipFenceBaselineTest.class);
+
     private static final int SIZE = 5;
     private static final int BASE_PORT = 5760;
     private static final int BASE_MGMT_PORT = 5860;
     private static final int BASE_APP_HTTP_PORT = 5960;
     private static final String PREFIX = "ofb";
+
     private static final Duration WAIT_TIMEOUT = Duration.ofSeconds(240);
     private static final Duration POLL_INTERVAL = Duration.ofMillis(500);
+
     private static final String FENCE_STREAM = "ofb:fence-baseline";
     private static final String THROUGHPUT_STREAM = "ofb:throughput";
     private static final int PARTITION = 0;
     private static final int REQUESTED_RF = 1;
+
     private static final int THROUGHPUT_APPENDS = 2000;
     private static final int THROUGHPUT_PAYLOAD_BYTES = 32;
 
@@ -104,18 +107,16 @@ class OwnershipFenceBaselineTest {
     void setUp() {
         cluster = emberCluster(SIZE, BASE_PORT, BASE_MGMT_PORT, BASE_APP_HTTP_PORT, PREFIX);
         LifecycleAwait.settled("cluster start in setUp()", cluster, cluster.start());
-        await().atMost(WAIT_TIMEOUT).pollInterval(POLL_INTERVAL).until(() -> cluster.currentLeader()
-                                                                                    .isPresent());
+
+        await().atMost(WAIT_TIMEOUT).pollInterval(POLL_INTERVAL).until(() -> cluster.currentLeader().isPresent());
         await().atMost(WAIT_TIMEOUT).pollInterval(POLL_INTERVAL).until(this::allNodesReady);
-        log.info("OWNERSHIP-FENCE-BASELINE: {}-node cluster formed, leader={}",
-                 SIZE,
-                 cluster.currentLeader().or("none"));
+        log.info("OWNERSHIP-FENCE-BASELINE: {}-node cluster formed, leader={}", SIZE, cluster.currentLeader().or("none"));
     }
 
     @AfterAll
     @TerminalOperation
     void tearDown() {
-        Option.option(cluster).onPresent(c -> LifecycleAwait.settled("cluster stop in tearDown()", c, c.stop()));
+        Option.option(cluster).onPresent(c -> LifecycleAwait.bestEffort("cluster stop in tearDown()", c, c.stop()));
     }
 
     /// 1d-ii fence: a deposed/stale owner's data-plane append, stamped with its now-stale owner epoch,
@@ -128,44 +129,43 @@ class OwnershipFenceBaselineTest {
     @TerminalOperation
     void staleOwnerAppend_afterOwnershipAndEpochAdvance_isRejected() {
         var members = cluster.allNodes().stream().map(AetherNode::self).toList();
-
         assertThat(members).hasSize(SIZE);
+
         var rf = ReplicaPlacement.replicationFactor(REQUESTED_RF, members.size());
         var owner0 = ownerOf(FENCE_STREAM, members, rf);
+
         var epoch0 = Epoch.epoch(7L, 0L);
         var epoch1 = Epoch.epoch(8L, 0L);
+        assertThat(epoch1.isStrictlyAfter(epoch0))
+            .as("new owner's generation (term 8) must strictly dominate the deposed owner's (term 7)")
+            .isTrue();
 
-        assertThat(epoch1.isStrictlyAfter(epoch0)).as("new owner's generation (term 8) must strictly dominate the deposed owner's (term 7)")
-                  .isTrue();
         var membersAfter = members.stream().filter(n -> !n.equals(owner0)).toList();
-        var owner1 = ownerOf(FENCE_STREAM,
-                             membersAfter,
-                             ReplicaPlacement.replicationFactor(REQUESTED_RF, membersAfter.size()));
+        var owner1 = ownerOf(FENCE_STREAM, membersAfter, ReplicaPlacement.replicationFactor(REQUESTED_RF, membersAfter.size()));
+        assertThat(owner1)
+            .as("removing owner0 must RELOCATE ownership (HRW) so owner0 is now a STALE owner under epoch1")
+            .isNotEqualTo(owner0);
 
-        assertThat(owner1).as("removing owner0 must RELOCATE ownership (HRW) so owner0 is now a STALE owner under epoch1")
-                  .isNotEqualTo(owner0);
         var staleOwnerNode = resolveNode(owner0);
-
         materialize(staleOwnerNode, FENCE_STREAM);
+
         // Advance the partition high-water to epoch1 through the REAL committed-ownership observe chain
         // (1d-i): commit a genuine StreamPartitionOwnershipValue(owner1, epoch1) so every node's
         // OwnershipEpochHighWater observes the ValuePut and advances StreamPartition(FENCE_STREAM, 0).
         commitOwnership(owner1, epoch1);
         await().atMost(WAIT_TIMEOUT)
-             .pollInterval(POLL_INTERVAL)
-             .until(() -> staleAppend(staleOwnerNode, epoch0).isFailure());
+               .pollInterval(POLL_INTERVAL)
+               .until(() -> staleAppend(staleOwnerNode, epoch0).isFailure());
+
         // The deposed owner (owner0) appends stamped with its now-stale epoch0 → rejected everywhere.
-        staleAppend(staleOwnerNode, epoch0).onSuccess(offset -> Assertions.fail("fence: deposed owner's stale-epoch append must be REJECTED, but was accepted at offset " + offset))
-                   .onFailure(OwnershipFenceBaselineTest::assertStaleEpochAppend);
+        staleAppend(staleOwnerNode, epoch0)
+            .onSuccess(offset -> Assertions.fail("fence: deposed owner's stale-epoch append must be REJECTED, but was accepted at offset " + offset))
+            .onFailure(OwnershipFenceBaselineTest::assertStaleEpochAppend);
     }
 
     private Result<Long> staleAppend(AetherNode staleOwnerNode, Epoch staleEpoch) {
         return staleOwnerNode.streamPartitionManager()
-                             .publishLocal(FENCE_STREAM,
-                                           PARTITION,
-                                           "stale-write".getBytes(UTF_8),
-                                           System.currentTimeMillis(),
-                                           staleEpoch);
+                             .publishLocal(FENCE_STREAM, PARTITION, "stale-write".getBytes(UTF_8), System.currentTimeMillis(), staleEpoch);
     }
 
     /// Commit a real `StreamPartitionOwnershipValue` for `(FENCE_STREAM, PARTITION)` through cluster KV
@@ -176,7 +176,9 @@ class OwnershipFenceBaselineTest {
         var value = StreamPartitionOwnershipValue.streamPartitionOwnershipValue(owner, epoch, 1L, HlcTimestamp.ZERO);
         KVCommand<AetherKey> put = new KVCommand.Put<AetherKey, AetherValue>(key, value);
 
-        leaderNode().<Object> apply(List.of(put)).await().onFailure(OwnershipFenceBaselineTest::failScenario);
+        leaderNode().<Object>apply(List.of(put))
+                    .await()
+                    .onFailure(OwnershipFenceBaselineTest::failScenario);
     }
 
     private AetherNode leaderNode() {
@@ -194,32 +196,30 @@ class OwnershipFenceBaselineTest {
     @TerminalOperation
     void withinEpochAppendThroughput_onOwnedPartition_recordsBaseline() {
         var members = cluster.allNodes().stream().map(AetherNode::self).toList();
-
         assertThat(members).hasSize(SIZE);
+
         var rf = ReplicaPlacement.replicationFactor(REQUESTED_RF, members.size());
         var owner = ownerOf(THROUGHPUT_STREAM, members, rf);
         var ownerNode = resolveNode(owner);
-
         materialize(ownerNode, THROUGHPUT_STREAM);
+
         var spm = ownerNode.streamPartitionManager();
         var payload = new byte[THROUGHPUT_PAYLOAD_BYTES];
         var successes = new int[]{0};
-        var startNanos = System.nanoTime();
 
+        var startNanos = System.nanoTime();
         for (var i = 0; i < THROUGHPUT_APPENDS; i++) {
             appendOnce(spm, THROUGHPUT_STREAM, payload).onSuccess(offset -> successes[0]++);
         }
-
         var elapsedMs = (System.nanoTime() - startNanos) / 1_000_000L;
         var writesPerSec = THROUGHPUT_APPENDS * 1000.0 / Math.max(1L, elapsedMs);
 
         log.info("OWNERSHIP-FENCE-BASELINE throughput: {} appends in {} ms = {} writes/sec",
-                 THROUGHPUT_APPENDS,
-                 elapsedMs,
-                 writesPerSec);
-        assertThat(successes[0]).as("all %d within-epoch appends on the owned partition must succeed",
-                                    THROUGHPUT_APPENDS)
-                  .isEqualTo(THROUGHPUT_APPENDS);
+                 THROUGHPUT_APPENDS, elapsedMs, writesPerSec);
+
+        assertThat(successes[0])
+            .as("all %d within-epoch appends on the owned partition must succeed", THROUGHPUT_APPENDS)
+            .isEqualTo(THROUGHPUT_APPENDS);
     }
 
     private NodeId ownerOf(String stream, List<NodeId> members, int rf) {
@@ -248,14 +248,9 @@ class OwnershipFenceBaselineTest {
     }
 
     private boolean allNodesReady() {
-        return cluster.allNodes()
-                      .stream()
-                      .allMatch(AetherNode::isReady);
+        return cluster.allNodes().stream().allMatch(AetherNode::isReady);
     }
 
-    private static void failStart(Cause cause) {
-        throw new AssertionError("Cluster start failed: " + cause.message());
-    }
 
     private static void failScenario(Cause cause) {
         throw new AssertionError("Scenario setup failed: " + cause.message());
@@ -266,18 +261,21 @@ class OwnershipFenceBaselineTest {
     }
 
     private static void assertStaleEpochAppend(Cause cause) {
-        assertThat(cause).as("deposed owner's append must be rejected with a StaleEpochAppend cause, but got: %s",
-                             cause.message())
-                  .isInstanceOf(StreamError.StaleEpochAppend.class);
+        assertThat(cause)
+            .as("deposed owner's append must be rejected with a StaleEpochAppend cause, but got: %s", cause.message())
+            .isInstanceOf(StreamError.StaleEpochAppend.class);
     }
 
     private enum BaselineError implements Cause {
         NO_PLACEMENT("ReplicaPlacement returned no owner for the partition"),
         NODE_UNRESOLVED("Computed owner NodeId could not be resolved to a cluster node");
+
         private final String message;
+
         BaselineError(String message) {
             this.message = message;
         }
+
         @Override
         public String message() {
             return message;

--- a/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/OwnershipFenceBaselineTest.java
+++ b/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/OwnershipFenceBaselineTest.java
@@ -2,17 +2,11 @@
 // Copyright (c) 2025 Pragmatica Labs - Sergiy Yevtushenko
 // Licensed under Business Source License 1.1. Change Date: 2030-01-01. Change License: Apache-2.0.
 // See LICENSE in the repository root for full terms.
-
 package org.pragmatica.aether.forge;
 
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
-import org.junit.jupiter.api.Assertions;
+import java.time.Duration;
+import java.util.List;
+
 import org.pragmatica.aether.ember.EmberCluster;
 import org.pragmatica.aether.node.AetherNode;
 import org.pragmatica.aether.slice.StreamConfig;
@@ -32,16 +26,23 @@ import org.pragmatica.lang.Cause;
 import org.pragmatica.lang.Option;
 import org.pragmatica.lang.Result;
 import org.pragmatica.lang.TerminalOperation;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.time.Duration;
-import java.util.List;
-
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.pragmatica.aether.ember.EmberCluster.emberCluster;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
-import static org.pragmatica.aether.ember.EmberCluster.emberCluster;
+
 
 /// STEP-0 → 1d-ii regression gate for the #345 stream ownership fence.
 ///
@@ -82,21 +83,17 @@ import static org.pragmatica.aether.ember.EmberCluster.emberCluster;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class OwnershipFenceBaselineTest {
     private static final Logger log = LoggerFactory.getLogger(OwnershipFenceBaselineTest.class);
-
     private static final int SIZE = 5;
     private static final int BASE_PORT = 5760;
     private static final int BASE_MGMT_PORT = 5860;
     private static final int BASE_APP_HTTP_PORT = 5960;
     private static final String PREFIX = "ofb";
-
     private static final Duration WAIT_TIMEOUT = Duration.ofSeconds(240);
     private static final Duration POLL_INTERVAL = Duration.ofMillis(500);
-
     private static final String FENCE_STREAM = "ofb:fence-baseline";
     private static final String THROUGHPUT_STREAM = "ofb:throughput";
     private static final int PARTITION = 0;
     private static final int REQUESTED_RF = 1;
-
     private static final int THROUGHPUT_APPENDS = 2000;
     private static final int THROUGHPUT_PAYLOAD_BYTES = 32;
 
@@ -106,19 +103,19 @@ class OwnershipFenceBaselineTest {
     @TerminalOperation
     void setUp() {
         cluster = emberCluster(SIZE, BASE_PORT, BASE_MGMT_PORT, BASE_APP_HTTP_PORT, PREFIX);
-        cluster.start()
-               .await()
-               .onFailure(OwnershipFenceBaselineTest::failStart);
-
-        await().atMost(WAIT_TIMEOUT).pollInterval(POLL_INTERVAL).until(() -> cluster.currentLeader().isPresent());
+        LifecycleAwait.settled("cluster start in setUp()", cluster, cluster.start());
+        await().atMost(WAIT_TIMEOUT).pollInterval(POLL_INTERVAL).until(() -> cluster.currentLeader()
+                                                                                    .isPresent());
         await().atMost(WAIT_TIMEOUT).pollInterval(POLL_INTERVAL).until(this::allNodesReady);
-        log.info("OWNERSHIP-FENCE-BASELINE: {}-node cluster formed, leader={}", SIZE, cluster.currentLeader().or("none"));
+        log.info("OWNERSHIP-FENCE-BASELINE: {}-node cluster formed, leader={}",
+                 SIZE,
+                 cluster.currentLeader().or("none"));
     }
 
     @AfterAll
     @TerminalOperation
     void tearDown() {
-        Option.option(cluster).onPresent(c -> c.stop().await());
+        Option.option(cluster).onPresent(c -> LifecycleAwait.settled("cluster stop in tearDown()", c, c.stop()));
     }
 
     /// 1d-ii fence: a deposed/stale owner's data-plane append, stamped with its now-stale owner epoch,
@@ -131,43 +128,44 @@ class OwnershipFenceBaselineTest {
     @TerminalOperation
     void staleOwnerAppend_afterOwnershipAndEpochAdvance_isRejected() {
         var members = cluster.allNodes().stream().map(AetherNode::self).toList();
-        assertThat(members).hasSize(SIZE);
 
+        assertThat(members).hasSize(SIZE);
         var rf = ReplicaPlacement.replicationFactor(REQUESTED_RF, members.size());
         var owner0 = ownerOf(FENCE_STREAM, members, rf);
-
         var epoch0 = Epoch.epoch(7L, 0L);
         var epoch1 = Epoch.epoch(8L, 0L);
-        assertThat(epoch1.isStrictlyAfter(epoch0))
-            .as("new owner's generation (term 8) must strictly dominate the deposed owner's (term 7)")
-            .isTrue();
 
+        assertThat(epoch1.isStrictlyAfter(epoch0)).as("new owner's generation (term 8) must strictly dominate the deposed owner's (term 7)")
+                  .isTrue();
         var membersAfter = members.stream().filter(n -> !n.equals(owner0)).toList();
-        var owner1 = ownerOf(FENCE_STREAM, membersAfter, ReplicaPlacement.replicationFactor(REQUESTED_RF, membersAfter.size()));
-        assertThat(owner1)
-            .as("removing owner0 must RELOCATE ownership (HRW) so owner0 is now a STALE owner under epoch1")
-            .isNotEqualTo(owner0);
+        var owner1 = ownerOf(FENCE_STREAM,
+                             membersAfter,
+                             ReplicaPlacement.replicationFactor(REQUESTED_RF, membersAfter.size()));
 
+        assertThat(owner1).as("removing owner0 must RELOCATE ownership (HRW) so owner0 is now a STALE owner under epoch1")
+                  .isNotEqualTo(owner0);
         var staleOwnerNode = resolveNode(owner0);
-        materialize(staleOwnerNode, FENCE_STREAM);
 
+        materialize(staleOwnerNode, FENCE_STREAM);
         // Advance the partition high-water to epoch1 through the REAL committed-ownership observe chain
         // (1d-i): commit a genuine StreamPartitionOwnershipValue(owner1, epoch1) so every node's
         // OwnershipEpochHighWater observes the ValuePut and advances StreamPartition(FENCE_STREAM, 0).
         commitOwnership(owner1, epoch1);
         await().atMost(WAIT_TIMEOUT)
-               .pollInterval(POLL_INTERVAL)
-               .until(() -> staleAppend(staleOwnerNode, epoch0).isFailure());
-
+             .pollInterval(POLL_INTERVAL)
+             .until(() -> staleAppend(staleOwnerNode, epoch0).isFailure());
         // The deposed owner (owner0) appends stamped with its now-stale epoch0 → rejected everywhere.
-        staleAppend(staleOwnerNode, epoch0)
-            .onSuccess(offset -> Assertions.fail("fence: deposed owner's stale-epoch append must be REJECTED, but was accepted at offset " + offset))
-            .onFailure(OwnershipFenceBaselineTest::assertStaleEpochAppend);
+        staleAppend(staleOwnerNode, epoch0).onSuccess(offset -> Assertions.fail("fence: deposed owner's stale-epoch append must be REJECTED, but was accepted at offset " + offset))
+                   .onFailure(OwnershipFenceBaselineTest::assertStaleEpochAppend);
     }
 
     private Result<Long> staleAppend(AetherNode staleOwnerNode, Epoch staleEpoch) {
         return staleOwnerNode.streamPartitionManager()
-                             .publishLocal(FENCE_STREAM, PARTITION, "stale-write".getBytes(UTF_8), System.currentTimeMillis(), staleEpoch);
+                             .publishLocal(FENCE_STREAM,
+                                           PARTITION,
+                                           "stale-write".getBytes(UTF_8),
+                                           System.currentTimeMillis(),
+                                           staleEpoch);
     }
 
     /// Commit a real `StreamPartitionOwnershipValue` for `(FENCE_STREAM, PARTITION)` through cluster KV
@@ -178,9 +176,7 @@ class OwnershipFenceBaselineTest {
         var value = StreamPartitionOwnershipValue.streamPartitionOwnershipValue(owner, epoch, 1L, HlcTimestamp.ZERO);
         KVCommand<AetherKey> put = new KVCommand.Put<AetherKey, AetherValue>(key, value);
 
-        leaderNode().<Object>apply(List.of(put))
-                    .await()
-                    .onFailure(OwnershipFenceBaselineTest::failScenario);
+        leaderNode().<Object> apply(List.of(put)).await().onFailure(OwnershipFenceBaselineTest::failScenario);
     }
 
     private AetherNode leaderNode() {
@@ -198,30 +194,32 @@ class OwnershipFenceBaselineTest {
     @TerminalOperation
     void withinEpochAppendThroughput_onOwnedPartition_recordsBaseline() {
         var members = cluster.allNodes().stream().map(AetherNode::self).toList();
-        assertThat(members).hasSize(SIZE);
 
+        assertThat(members).hasSize(SIZE);
         var rf = ReplicaPlacement.replicationFactor(REQUESTED_RF, members.size());
         var owner = ownerOf(THROUGHPUT_STREAM, members, rf);
         var ownerNode = resolveNode(owner);
-        materialize(ownerNode, THROUGHPUT_STREAM);
 
+        materialize(ownerNode, THROUGHPUT_STREAM);
         var spm = ownerNode.streamPartitionManager();
         var payload = new byte[THROUGHPUT_PAYLOAD_BYTES];
         var successes = new int[]{0};
-
         var startNanos = System.nanoTime();
+
         for (var i = 0; i < THROUGHPUT_APPENDS; i++) {
             appendOnce(spm, THROUGHPUT_STREAM, payload).onSuccess(offset -> successes[0]++);
         }
+
         var elapsedMs = (System.nanoTime() - startNanos) / 1_000_000L;
         var writesPerSec = THROUGHPUT_APPENDS * 1000.0 / Math.max(1L, elapsedMs);
 
         log.info("OWNERSHIP-FENCE-BASELINE throughput: {} appends in {} ms = {} writes/sec",
-                 THROUGHPUT_APPENDS, elapsedMs, writesPerSec);
-
-        assertThat(successes[0])
-            .as("all %d within-epoch appends on the owned partition must succeed", THROUGHPUT_APPENDS)
-            .isEqualTo(THROUGHPUT_APPENDS);
+                 THROUGHPUT_APPENDS,
+                 elapsedMs,
+                 writesPerSec);
+        assertThat(successes[0]).as("all %d within-epoch appends on the owned partition must succeed",
+                                    THROUGHPUT_APPENDS)
+                  .isEqualTo(THROUGHPUT_APPENDS);
     }
 
     private NodeId ownerOf(String stream, List<NodeId> members, int rf) {
@@ -250,7 +248,9 @@ class OwnershipFenceBaselineTest {
     }
 
     private boolean allNodesReady() {
-        return cluster.allNodes().stream().allMatch(AetherNode::isReady);
+        return cluster.allNodes()
+                      .stream()
+                      .allMatch(AetherNode::isReady);
     }
 
     private static void failStart(Cause cause) {
@@ -266,21 +266,18 @@ class OwnershipFenceBaselineTest {
     }
 
     private static void assertStaleEpochAppend(Cause cause) {
-        assertThat(cause)
-            .as("deposed owner's append must be rejected with a StaleEpochAppend cause, but got: %s", cause.message())
-            .isInstanceOf(StreamError.StaleEpochAppend.class);
+        assertThat(cause).as("deposed owner's append must be rejected with a StaleEpochAppend cause, but got: %s",
+                             cause.message())
+                  .isInstanceOf(StreamError.StaleEpochAppend.class);
     }
 
     private enum BaselineError implements Cause {
         NO_PLACEMENT("ReplicaPlacement returned no owner for the partition"),
         NODE_UNRESOLVED("Computed owner NodeId could not be resolved to a cluster node");
-
         private final String message;
-
         BaselineError(String message) {
             this.message = message;
         }
-
         @Override
         public String message() {
             return message;

--- a/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/PerSliceDecisionSnapshotProbeTest.java
+++ b/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/PerSliceDecisionSnapshotProbeTest.java
@@ -2,15 +2,8 @@
 // Copyright (c) 2025 Pragmatica Labs - Sergiy Yevtushenko
 // Licensed under Business Source License 1.1. Change Date: 2030-01-01. Change License: Apache-2.0.
 // See LICENSE in the repository root for full terms.
+
 package org.pragmatica.aether.forge;
-
-import java.net.URI;
-import java.net.http.HttpRequest;
-import java.time.Duration;
-
-import org.pragmatica.http.HttpOperations;
-import org.pragmatica.http.HttpResult;
-import org.pragmatica.aether.ember.EmberCluster;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -18,12 +11,19 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.pragmatica.http.HttpOperations;
+import org.pragmatica.http.HttpResult;
 
-import static org.pragmatica.aether.ember.EmberCluster.emberCluster;
-import static org.pragmatica.http.JdkHttpOperations.jdkHttpOperations;
+import java.net.URI;
+import java.net.http.HttpRequest;
+import java.time.Duration;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
+import static org.pragmatica.aether.ember.EmberCluster.emberCluster;
+import static org.pragmatica.http.JdkHttpOperations.jdkHttpOperations;
 
+import org.pragmatica.aether.ember.EmberCluster;
 
 /// #422/#423/#425 full-stack proof that per-slice metric attribution is LIVE end-to-end. Two
 /// distinct slices are deployed and the leader's `GET /api/v1/controller/decisions` snapshot is read:
@@ -56,15 +56,15 @@ class PerSliceDecisionSnapshotProbeTest {
     void setUp() {
         cluster = emberCluster(3, BASE_PORT, BASE_MGMT_PORT, BASE_APP_HTTP_PORT, "psa");
         LifecycleAwait.settled("cluster start in setUp()", cluster, cluster.start());
-        await().atMost(WAIT_TIMEOUT).pollInterval(POLL_INTERVAL).until(() -> cluster.currentLeader()
-                                                                                    .isPresent());
+
+        await().atMost(WAIT_TIMEOUT).pollInterval(POLL_INTERVAL).until(() -> cluster.currentLeader().isPresent());
         await().atMost(WAIT_TIMEOUT).pollInterval(POLL_INTERVAL).until(this::allNodesHealthy);
     }
 
     @AfterAll
     void tearDown() {
         if (cluster != null) {
-            LifecycleAwait.settled("cluster stop in tearDown()", cluster, cluster.stop());
+            LifecycleAwait.bestEffort("cluster stop in tearDown()", cluster, cluster.stop());
         }
     }
 
@@ -73,14 +73,15 @@ class PerSliceDecisionSnapshotProbeTest {
         deployTwoSlices();
         awaitBothSlicesActive();
         awaitBothArtifactsInDecisionSnapshot();
+
         var decisions = getDecisions();
 
         assertThat(decisions).describedAs("per-slice attribution: slice A tracked separately")
-                  .contains(SLICE_A_FRAGMENT);
+                             .contains(SLICE_A_FRAGMENT);
         assertThat(decisions).describedAs("per-slice attribution: slice B tracked separately")
-                  .contains(SLICE_B_FRAGMENT);
+                             .contains(SLICE_B_FRAGMENT);
         assertThat(decisions).describedAs("idle slices must not be scaled up (no mis-attribution)")
-                  .doesNotContain("\"outcome\":\"SCALED_UP\"");
+                             .doesNotContain("\"outcome\":\"SCALED_UP\"");
     }
 
     private void deployTwoSlices() {
@@ -97,29 +98,23 @@ class PerSliceDecisionSnapshotProbeTest {
             """.formatted(BLUEPRINT_ID, SLICE_A, SLICE_B);
         var response = postBlueprint(leaderPort(), blueprint);
 
-        assertThat(response).describedAs("Deployment response")
-                  .doesNotContain("\"error\"")
-                  .contains("\"status\":\"applied\"");
+        assertThat(response).describedAs("Deployment response").doesNotContain("\"error\"").contains("\"status\":\"applied\"");
     }
 
     private void awaitBothSlicesActive() {
-        await().atMost(WAIT_TIMEOUT)
-             .pollInterval(POLL_INTERVAL)
-             .until(() -> {
-                        var slices = getSlices();
+        await().atMost(WAIT_TIMEOUT).pollInterval(POLL_INTERVAL).until(() -> {
+            var slices = getSlices();
 
-                        return slices.contains(SLICE_A_FRAGMENT) && slices.contains(SLICE_B_FRAGMENT);
-                    });
+            return slices.contains(SLICE_A_FRAGMENT) && slices.contains(SLICE_B_FRAGMENT);
+        });
     }
 
     private void awaitBothArtifactsInDecisionSnapshot() {
-        await().atMost(WAIT_TIMEOUT)
-             .pollInterval(POLL_INTERVAL)
-             .until(() -> {
-                        var decisions = getDecisions();
+        await().atMost(WAIT_TIMEOUT).pollInterval(POLL_INTERVAL).until(() -> {
+            var decisions = getDecisions();
 
-                        return decisions.contains(SLICE_A_FRAGMENT) && decisions.contains(SLICE_B_FRAGMENT);
-                    });
+            return decisions.contains(SLICE_A_FRAGMENT) && decisions.contains(SLICE_B_FRAGMENT);
+        });
     }
 
     private String getDecisions() {
@@ -131,8 +126,7 @@ class PerSliceDecisionSnapshotProbeTest {
     }
 
     private int leaderPort() {
-        return cluster.getLeaderManagementPort()
-                      .or(cluster.status().nodes().getFirst().mgmtPort());
+        return cluster.getLeaderManagementPort().or(cluster.status().nodes().getFirst().mgmtPort());
     }
 
     private String postBlueprint(int port, String body) {
@@ -143,10 +137,7 @@ class PerSliceDecisionSnapshotProbeTest {
                                  .timeout(Duration.ofSeconds(10))
                                  .build();
 
-        return http.sendString(request)
-                   .await()
-                   .map(HttpResult::body)
-                   .or(ERROR_FALLBACK);
+        return http.sendString(request).await().map(HttpResult::body).or(ERROR_FALLBACK);
     }
 
     private String httpGet(int port, String path) {
@@ -156,17 +147,11 @@ class PerSliceDecisionSnapshotProbeTest {
                                  .timeout(Duration.ofSeconds(10))
                                  .build();
 
-        return http.sendString(request)
-                   .await()
-                   .map(HttpResult::body)
-                   .or(ERROR_FALLBACK);
+        return http.sendString(request).await().map(HttpResult::body).or(ERROR_FALLBACK);
     }
 
     private boolean allNodesHealthy() {
-        return cluster.status()
-                      .nodes()
-                      .stream()
-                      .allMatch(node -> checkNodeHealth(node.mgmtPort()));
+        return cluster.status().nodes().stream().allMatch(node -> checkNodeHealth(node.mgmtPort()));
     }
 
     private boolean checkNodeHealth(int port) {
@@ -178,8 +163,7 @@ class PerSliceDecisionSnapshotProbeTest {
 
         return http.sendString(request)
                    .await()
-                   .map(r -> r.statusCode() == 200 && r.body()
-                                                       .contains("\"quorum\":true"))
+                   .map(r -> r.statusCode() == 200 && r.body().contains("\"quorum\":true"))
                    .or(false);
     }
 }

--- a/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/PerSliceDecisionSnapshotProbeTest.java
+++ b/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/PerSliceDecisionSnapshotProbeTest.java
@@ -2,8 +2,15 @@
 // Copyright (c) 2025 Pragmatica Labs - Sergiy Yevtushenko
 // Licensed under Business Source License 1.1. Change Date: 2030-01-01. Change License: Apache-2.0.
 // See LICENSE in the repository root for full terms.
-
 package org.pragmatica.aether.forge;
+
+import java.net.URI;
+import java.net.http.HttpRequest;
+import java.time.Duration;
+
+import org.pragmatica.http.HttpOperations;
+import org.pragmatica.http.HttpResult;
+import org.pragmatica.aether.ember.EmberCluster;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -11,19 +18,12 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
-import org.pragmatica.http.HttpOperations;
-import org.pragmatica.http.HttpResult;
 
-import java.net.URI;
-import java.net.http.HttpRequest;
-import java.time.Duration;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.awaitility.Awaitility.await;
 import static org.pragmatica.aether.ember.EmberCluster.emberCluster;
 import static org.pragmatica.http.JdkHttpOperations.jdkHttpOperations;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
 
-import org.pragmatica.aether.ember.EmberCluster;
 
 /// #422/#423/#425 full-stack proof that per-slice metric attribution is LIVE end-to-end. Two
 /// distinct slices are deployed and the leader's `GET /api/v1/controller/decisions` snapshot is read:
@@ -55,20 +55,16 @@ class PerSliceDecisionSnapshotProbeTest {
     @BeforeAll
     void setUp() {
         cluster = emberCluster(3, BASE_PORT, BASE_MGMT_PORT, BASE_APP_HTTP_PORT, "psa");
-        cluster.start()
-               .await()
-               .onFailure(cause -> {
-                   throw new AssertionError("Cluster start failed: " + cause.message());
-               });
-
-        await().atMost(WAIT_TIMEOUT).pollInterval(POLL_INTERVAL).until(() -> cluster.currentLeader().isPresent());
+        LifecycleAwait.settled("cluster start in setUp()", cluster, cluster.start());
+        await().atMost(WAIT_TIMEOUT).pollInterval(POLL_INTERVAL).until(() -> cluster.currentLeader()
+                                                                                    .isPresent());
         await().atMost(WAIT_TIMEOUT).pollInterval(POLL_INTERVAL).until(this::allNodesHealthy);
     }
 
     @AfterAll
     void tearDown() {
         if (cluster != null) {
-            cluster.stop().await();
+            LifecycleAwait.settled("cluster stop in tearDown()", cluster, cluster.stop());
         }
     }
 
@@ -77,15 +73,14 @@ class PerSliceDecisionSnapshotProbeTest {
         deployTwoSlices();
         awaitBothSlicesActive();
         awaitBothArtifactsInDecisionSnapshot();
-
         var decisions = getDecisions();
 
         assertThat(decisions).describedAs("per-slice attribution: slice A tracked separately")
-                             .contains(SLICE_A_FRAGMENT);
+                  .contains(SLICE_A_FRAGMENT);
         assertThat(decisions).describedAs("per-slice attribution: slice B tracked separately")
-                             .contains(SLICE_B_FRAGMENT);
+                  .contains(SLICE_B_FRAGMENT);
         assertThat(decisions).describedAs("idle slices must not be scaled up (no mis-attribution)")
-                             .doesNotContain("\"outcome\":\"SCALED_UP\"");
+                  .doesNotContain("\"outcome\":\"SCALED_UP\"");
     }
 
     private void deployTwoSlices() {
@@ -102,23 +97,29 @@ class PerSliceDecisionSnapshotProbeTest {
             """.formatted(BLUEPRINT_ID, SLICE_A, SLICE_B);
         var response = postBlueprint(leaderPort(), blueprint);
 
-        assertThat(response).describedAs("Deployment response").doesNotContain("\"error\"").contains("\"status\":\"applied\"");
+        assertThat(response).describedAs("Deployment response")
+                  .doesNotContain("\"error\"")
+                  .contains("\"status\":\"applied\"");
     }
 
     private void awaitBothSlicesActive() {
-        await().atMost(WAIT_TIMEOUT).pollInterval(POLL_INTERVAL).until(() -> {
-            var slices = getSlices();
+        await().atMost(WAIT_TIMEOUT)
+             .pollInterval(POLL_INTERVAL)
+             .until(() -> {
+                        var slices = getSlices();
 
-            return slices.contains(SLICE_A_FRAGMENT) && slices.contains(SLICE_B_FRAGMENT);
-        });
+                        return slices.contains(SLICE_A_FRAGMENT) && slices.contains(SLICE_B_FRAGMENT);
+                    });
     }
 
     private void awaitBothArtifactsInDecisionSnapshot() {
-        await().atMost(WAIT_TIMEOUT).pollInterval(POLL_INTERVAL).until(() -> {
-            var decisions = getDecisions();
+        await().atMost(WAIT_TIMEOUT)
+             .pollInterval(POLL_INTERVAL)
+             .until(() -> {
+                        var decisions = getDecisions();
 
-            return decisions.contains(SLICE_A_FRAGMENT) && decisions.contains(SLICE_B_FRAGMENT);
-        });
+                        return decisions.contains(SLICE_A_FRAGMENT) && decisions.contains(SLICE_B_FRAGMENT);
+                    });
     }
 
     private String getDecisions() {
@@ -130,7 +131,8 @@ class PerSliceDecisionSnapshotProbeTest {
     }
 
     private int leaderPort() {
-        return cluster.getLeaderManagementPort().or(cluster.status().nodes().getFirst().mgmtPort());
+        return cluster.getLeaderManagementPort()
+                      .or(cluster.status().nodes().getFirst().mgmtPort());
     }
 
     private String postBlueprint(int port, String body) {
@@ -141,7 +143,10 @@ class PerSliceDecisionSnapshotProbeTest {
                                  .timeout(Duration.ofSeconds(10))
                                  .build();
 
-        return http.sendString(request).await().map(HttpResult::body).or(ERROR_FALLBACK);
+        return http.sendString(request)
+                   .await()
+                   .map(HttpResult::body)
+                   .or(ERROR_FALLBACK);
     }
 
     private String httpGet(int port, String path) {
@@ -151,11 +156,17 @@ class PerSliceDecisionSnapshotProbeTest {
                                  .timeout(Duration.ofSeconds(10))
                                  .build();
 
-        return http.sendString(request).await().map(HttpResult::body).or(ERROR_FALLBACK);
+        return http.sendString(request)
+                   .await()
+                   .map(HttpResult::body)
+                   .or(ERROR_FALLBACK);
     }
 
     private boolean allNodesHealthy() {
-        return cluster.status().nodes().stream().allMatch(node -> checkNodeHealth(node.mgmtPort()));
+        return cluster.status()
+                      .nodes()
+                      .stream()
+                      .allMatch(node -> checkNodeHealth(node.mgmtPort()));
     }
 
     private boolean checkNodeHealth(int port) {
@@ -167,7 +178,8 @@ class PerSliceDecisionSnapshotProbeTest {
 
         return http.sendString(request)
                    .await()
-                   .map(r -> r.statusCode() == 200 && r.body().contains("\"quorum\":true"))
+                   .map(r -> r.statusCode() == 200 && r.body()
+                                                       .contains("\"quorum\":true"))
                    .or(false);
     }
 }

--- a/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/PostRestartSlowRejoinDeficitFillProbeTest.java
+++ b/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/PostRestartSlowRejoinDeficitFillProbeTest.java
@@ -204,15 +204,24 @@ class PostRestartSlowRejoinDeficitFillProbeTest {
     void setUp() {
         cluster = emberCluster(INITIAL_CORES, BASE_PORT, BASE_MGMT_PORT, BASE_APP_HTTP_PORT, NODE_PREFIX);
         cluster.withComputeProviderDecorator(recorder::wrap);
-        cluster.start().await().onFailure(PostRestartSlowRejoinDeficitFillProbeTest::failStart);
+        LifecycleAwait.settled("cluster start in setUp()", cluster, cluster.start());
         expectStarted(allConfiguredIds(), "FORMATION-1 start");
-        await().atMost(FORM_TIMEOUT).pollInterval(POLL).failFast(this::failIfClusterUnhealthy).until(() -> cluster.currentLeader()
-                                                                           .isPresent());
-        await().atMost(FORM_TIMEOUT).pollInterval(POLL).failFast(this::failIfClusterUnhealthy).until(() -> countedCores() == INITIAL_CORES);
+        await().atMost(FORM_TIMEOUT)
+             .pollInterval(POLL)
+             .failFast(this::failIfClusterUnhealthy)
+             .until(() -> cluster.currentLeader()
+                                 .isPresent());
+        await().atMost(FORM_TIMEOUT)
+             .pollInterval(POLL)
+             .failFast(this::failIfClusterUnhealthy)
+             .until(() -> countedCores() == INITIAL_CORES);
         // Formation 1 must reach FULL observed membership before the restart: the sampler PEAK is what
         // the reconciler's `reachedFullMembership` cold-start latch reads, and gating here means the
         // pre-restart cluster is genuinely formed rather than merely quorate.
-        await().atMost(FORM_TIMEOUT).pollInterval(POLL).failFast(this::failIfClusterUnhealthy).until(() -> observedPeak() >= INITIAL_CORES);
+        await().atMost(FORM_TIMEOUT)
+             .pollInterval(POLL)
+             .failFast(this::failIfClusterUnhealthy)
+             .until(() -> observedPeak() >= INITIAL_CORES);
         recordMilestone("FORMATION-1 complete: leader=" + cluster.currentLeader().or("none")
                        + " countedCores=" + countedCores()
                        + " observedPeak=" + observedPeak());
@@ -227,8 +236,7 @@ class PostRestartSlowRejoinDeficitFillProbeTest {
     @AfterAll
     @TerminalOperation
     void tearDown() {
-        option(cluster).onPresent(c -> c.stop()
-                                        .await());
+        option(cluster).onPresent(c -> LifecycleAwait.settled("cluster stop in tearDown()", c, c.stop()));
     }
 
     /// THE #509 INVARIANT. Restart the cluster with 2 configured members held back, hold past every
@@ -320,14 +328,20 @@ class PostRestartSlowRejoinDeficitFillProbeTest {
     @Order(1)
     @TerminalOperation
     void reconcile_configuredCoreCountRaised_provisionsReplacement() {
-        await().atMost(REJOIN_TIMEOUT).pollInterval(POLL).failFast(this::failIfStartedNodeDied).until(() -> observedPeak() >= INITIAL_CORES);
+        await().atMost(REJOIN_TIMEOUT)
+             .pollInterval(POLL)
+             .failFast(this::failIfStartedNodeDied)
+             .until(() -> observedPeak() >= INITIAL_CORES);
         recordMilestone("CONTROL armed: observedPeak=" + observedPeak() + " (reachedFullMembership latch can now open)");
         var leaderPort = cluster.getLeaderManagementPort()
                                 .toResult(ProbeError.NO_LEADER)
                                 .onFailure(PostRestartSlowRejoinDeficitFillProbeTest::failScenario)
                                 .or(-1);
 
-        await().atMost(FORM_TIMEOUT).pollInterval(POLL).failFast(this::failIfStartedNodeDied).until(() -> readConfigVersion(leaderPort) >= 1);
+        await().atMost(FORM_TIMEOUT)
+             .pollInterval(POLL)
+             .failFast(this::failIfStartedNodeDied)
+             .until(() -> readConfigVersion(leaderPort) >= 1);
         var version = readConfigVersion(leaderPort);
         var response = postScale(leaderPort, RAISED_CORES, version);
 
@@ -371,11 +385,11 @@ class PostRestartSlowRejoinDeficitFillProbeTest {
     /// this probe has none of: membership, not durability, is the question here.
     @TerminalOperation
     private void restartWithHeldBackMembers() {
-        cluster.stop().await().onFailure(PostRestartSlowRejoinDeficitFillProbeTest::failScenario);
+        LifecycleAwait.settled("cluster stop in restartWithHeldBackMembers()", cluster, cluster.stop());
         recordMilestone("RESTART: cluster stopped");
         // Nothing is expected alive between stop() and the restart completing.
         expectStarted(Set.of(), "RESTART stop");
-        cluster.start(HELD_BACK).await().onFailure(PostRestartSlowRejoinDeficitFillProbeTest::failStart);
+        LifecycleAwait.settled("cluster start in restartWithHeldBackMembers()", cluster, cluster.start(HELD_BACK));
         expectStarted(startedAfterHoldBack(), "RESTART start (held back " + HELD_BACK + ")");
         recordMilestone("RESTART: started " + (INITIAL_CORES - HELD_BACK.size())
                        + " of " + INITIAL_CORES
@@ -396,11 +410,17 @@ class PostRestartSlowRejoinDeficitFillProbeTest {
     @TerminalOperation
     private void releaseHeldBackMembers() {
         log.info("SLOWJOIN-PROBE: releasing held-back members {}", HELD_BACK);
-        cluster.startHeldBackNodes().await().onFailure(PostRestartSlowRejoinDeficitFillProbeTest::failScenario);
+        LifecycleAwait.settled("held-back node start in releaseHeldBackMembers()", cluster, cluster.startHeldBackNodes());
         expectStarted(allConfiguredIds(), "REJOIN (held-back released)");
-        await().atMost(REJOIN_TIMEOUT).pollInterval(POLL).failFast(this::failIfClusterUnhealthy).until(() -> countedCores() >= INITIAL_CORES);
-        await().atMost(REJOIN_TIMEOUT).pollInterval(POLL).failFast(this::failIfClusterUnhealthy).until(() -> cluster.currentLeader()
-                                                                             .isPresent());
+        await().atMost(REJOIN_TIMEOUT)
+             .pollInterval(POLL)
+             .failFast(this::failIfClusterUnhealthy)
+             .until(() -> countedCores() >= INITIAL_CORES);
+        await().atMost(REJOIN_TIMEOUT)
+             .pollInterval(POLL)
+             .failFast(this::failIfClusterUnhealthy)
+             .until(() -> cluster.currentLeader()
+                                 .isPresent());
     }
 
     // ----- observation -----
@@ -553,7 +573,8 @@ class PostRestartSlowRejoinDeficitFillProbeTest {
     /// [#releaseHeldBackMembers] adds them.
     private void failIfStartedNodeDied() {
         var dead = startedNodeIds.stream()
-                                 .filter(id -> cluster.getNode(id).isEmpty())
+                                 .filter(id -> cluster.getNode(id)
+                                                      .isEmpty())
                                  .sorted()
                                  .collect(Collectors.joining(","));
 
@@ -569,7 +590,8 @@ class PostRestartSlowRejoinDeficitFillProbeTest {
                                 + "). A node leaves EmberCluster's running registry only via handleSelfDrain, "
                                 + "so this is a self-fence/drain, not a crash. Every subsequent observation "
                                 + "this probe could make is invalid. Live now: " + cluster.nodeCount()
-                                + " node(s), leader=" + cluster.currentLeader().or("none")
+                                + " node(s), leader=" + cluster.currentLeader()
+                                                               .or("none")
                                 + " countedCores=" + countedCores()
                                 + " countedIds=" + countedCoreIds()
                                 + " provisions=" + recorder.render()
@@ -594,8 +616,8 @@ class PostRestartSlowRejoinDeficitFillProbeTest {
 
     private static Set<String> startedAfterHoldBack() {
         return allConfiguredIds().stream()
-                                 .filter(id -> !HELD_BACK.contains(id))
-                                 .collect(Collectors.toCollection(LinkedHashSet::new));
+                               .filter(id -> !HELD_BACK.contains(id))
+                               .collect(Collectors.toCollection(LinkedHashSet::new));
     }
 
     private static long elapsedMs(long t0) {
@@ -696,7 +718,8 @@ class PostRestartSlowRejoinDeficitFillProbeTest {
     @TerminalOperation
     private String postScale(int port, int coreCount, int expectedVersion) {
         var body = "{\"source\":\"\",\"role\":\"core\",\"count\":" + coreCount
-                   + ",\"expectedVersion\":" + expectedVersion + "}";
+                 + ",\"expectedVersion\":" + expectedVersion
+                 + "}";
         var request = HttpRequest.newBuilder()
                                  .uri(URI.create("http://localhost:" + port + "/api/v1/cluster/scale"))
                                  .header("Content-Type", "application/json")
@@ -714,11 +737,10 @@ class PostRestartSlowRejoinDeficitFillProbeTest {
     /// can never be mistaken for an inert provisioning path.
     private static String requireScaleAccepted(HttpResult result) {
         if (result.statusCode() / 100 != 2) {
-            throw new AssertionError("CONTROL TRIGGER REJECTED: POST /api/v1/cluster/scale returned HTTP "
-                                     + result.statusCode()
-                                     + " — the configured core count was never raised, so any subsequent "
-                                     + "zero-provision observation says nothing about the deficit-fill path. "
-                                     + "Body: " + result.body());
+            throw new AssertionError("CONTROL TRIGGER REJECTED: POST /api/v1/cluster/scale returned HTTP " + result.statusCode()
+                                    + " — the configured core count was never raised, so any subsequent "
+                                    + "zero-provision observation says nothing about the deficit-fill path. "
+                                    + "Body: " + result.body());
         }
 
         return renderResponse(result);

--- a/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/PostRestartSlowRejoinDeficitFillProbeTest.java
+++ b/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/PostRestartSlowRejoinDeficitFillProbeTest.java
@@ -206,22 +206,13 @@ class PostRestartSlowRejoinDeficitFillProbeTest {
         cluster.withComputeProviderDecorator(recorder::wrap);
         LifecycleAwait.settled("cluster start in setUp()", cluster, cluster.start());
         expectStarted(allConfiguredIds(), "FORMATION-1 start");
-        await().atMost(FORM_TIMEOUT)
-             .pollInterval(POLL)
-             .failFast(this::failIfClusterUnhealthy)
-             .until(() -> cluster.currentLeader()
-                                 .isPresent());
-        await().atMost(FORM_TIMEOUT)
-             .pollInterval(POLL)
-             .failFast(this::failIfClusterUnhealthy)
-             .until(() -> countedCores() == INITIAL_CORES);
+        await().atMost(FORM_TIMEOUT).pollInterval(POLL).failFast(this::failIfClusterUnhealthy).until(() -> cluster.currentLeader()
+                                                                           .isPresent());
+        await().atMost(FORM_TIMEOUT).pollInterval(POLL).failFast(this::failIfClusterUnhealthy).until(() -> countedCores() == INITIAL_CORES);
         // Formation 1 must reach FULL observed membership before the restart: the sampler PEAK is what
         // the reconciler's `reachedFullMembership` cold-start latch reads, and gating here means the
         // pre-restart cluster is genuinely formed rather than merely quorate.
-        await().atMost(FORM_TIMEOUT)
-             .pollInterval(POLL)
-             .failFast(this::failIfClusterUnhealthy)
-             .until(() -> observedPeak() >= INITIAL_CORES);
+        await().atMost(FORM_TIMEOUT).pollInterval(POLL).failFast(this::failIfClusterUnhealthy).until(() -> observedPeak() >= INITIAL_CORES);
         recordMilestone("FORMATION-1 complete: leader=" + cluster.currentLeader().or("none")
                        + " countedCores=" + countedCores()
                        + " observedPeak=" + observedPeak());
@@ -236,7 +227,7 @@ class PostRestartSlowRejoinDeficitFillProbeTest {
     @AfterAll
     @TerminalOperation
     void tearDown() {
-        option(cluster).onPresent(c -> LifecycleAwait.settled("cluster stop in tearDown()", c, c.stop()));
+        option(cluster).onPresent(c -> LifecycleAwait.bestEffort("cluster stop in tearDown()", c, c.stop()));
     }
 
     /// THE #509 INVARIANT. Restart the cluster with 2 configured members held back, hold past every
@@ -328,20 +319,14 @@ class PostRestartSlowRejoinDeficitFillProbeTest {
     @Order(1)
     @TerminalOperation
     void reconcile_configuredCoreCountRaised_provisionsReplacement() {
-        await().atMost(REJOIN_TIMEOUT)
-             .pollInterval(POLL)
-             .failFast(this::failIfStartedNodeDied)
-             .until(() -> observedPeak() >= INITIAL_CORES);
+        await().atMost(REJOIN_TIMEOUT).pollInterval(POLL).failFast(this::failIfStartedNodeDied).until(() -> observedPeak() >= INITIAL_CORES);
         recordMilestone("CONTROL armed: observedPeak=" + observedPeak() + " (reachedFullMembership latch can now open)");
         var leaderPort = cluster.getLeaderManagementPort()
                                 .toResult(ProbeError.NO_LEADER)
                                 .onFailure(PostRestartSlowRejoinDeficitFillProbeTest::failScenario)
                                 .or(-1);
 
-        await().atMost(FORM_TIMEOUT)
-             .pollInterval(POLL)
-             .failFast(this::failIfStartedNodeDied)
-             .until(() -> readConfigVersion(leaderPort) >= 1);
+        await().atMost(FORM_TIMEOUT).pollInterval(POLL).failFast(this::failIfStartedNodeDied).until(() -> readConfigVersion(leaderPort) >= 1);
         var version = readConfigVersion(leaderPort);
         var response = postScale(leaderPort, RAISED_CORES, version);
 
@@ -412,15 +397,9 @@ class PostRestartSlowRejoinDeficitFillProbeTest {
         log.info("SLOWJOIN-PROBE: releasing held-back members {}", HELD_BACK);
         LifecycleAwait.settled("held-back node start in releaseHeldBackMembers()", cluster, cluster.startHeldBackNodes());
         expectStarted(allConfiguredIds(), "REJOIN (held-back released)");
-        await().atMost(REJOIN_TIMEOUT)
-             .pollInterval(POLL)
-             .failFast(this::failIfClusterUnhealthy)
-             .until(() -> countedCores() >= INITIAL_CORES);
-        await().atMost(REJOIN_TIMEOUT)
-             .pollInterval(POLL)
-             .failFast(this::failIfClusterUnhealthy)
-             .until(() -> cluster.currentLeader()
-                                 .isPresent());
+        await().atMost(REJOIN_TIMEOUT).pollInterval(POLL).failFast(this::failIfClusterUnhealthy).until(() -> countedCores() >= INITIAL_CORES);
+        await().atMost(REJOIN_TIMEOUT).pollInterval(POLL).failFast(this::failIfClusterUnhealthy).until(() -> cluster.currentLeader()
+                                                                             .isPresent());
     }
 
     // ----- observation -----
@@ -573,8 +552,7 @@ class PostRestartSlowRejoinDeficitFillProbeTest {
     /// [#releaseHeldBackMembers] adds them.
     private void failIfStartedNodeDied() {
         var dead = startedNodeIds.stream()
-                                 .filter(id -> cluster.getNode(id)
-                                                      .isEmpty())
+                                 .filter(id -> cluster.getNode(id).isEmpty())
                                  .sorted()
                                  .collect(Collectors.joining(","));
 
@@ -590,8 +568,7 @@ class PostRestartSlowRejoinDeficitFillProbeTest {
                                 + "). A node leaves EmberCluster's running registry only via handleSelfDrain, "
                                 + "so this is a self-fence/drain, not a crash. Every subsequent observation "
                                 + "this probe could make is invalid. Live now: " + cluster.nodeCount()
-                                + " node(s), leader=" + cluster.currentLeader()
-                                                               .or("none")
+                                + " node(s), leader=" + cluster.currentLeader().or("none")
                                 + " countedCores=" + countedCores()
                                 + " countedIds=" + countedCoreIds()
                                 + " provisions=" + recorder.render()
@@ -616,8 +593,8 @@ class PostRestartSlowRejoinDeficitFillProbeTest {
 
     private static Set<String> startedAfterHoldBack() {
         return allConfiguredIds().stream()
-                               .filter(id -> !HELD_BACK.contains(id))
-                               .collect(Collectors.toCollection(LinkedHashSet::new));
+                                 .filter(id -> !HELD_BACK.contains(id))
+                                 .collect(Collectors.toCollection(LinkedHashSet::new));
     }
 
     private static long elapsedMs(long t0) {
@@ -686,9 +663,6 @@ class PostRestartSlowRejoinDeficitFillProbeTest {
         recorder.recorded().forEach(call -> log.info("SLOWJOIN-PROBE {}", call.describe()));
     }
 
-    private static void failStart(Cause cause) {
-        throw new AssertionError("Cluster start failed: " + cause.message());
-    }
 
     private static void failScenario(Cause cause) {
         throw new AssertionError("Scenario setup failed: " + cause.message());
@@ -718,8 +692,7 @@ class PostRestartSlowRejoinDeficitFillProbeTest {
     @TerminalOperation
     private String postScale(int port, int coreCount, int expectedVersion) {
         var body = "{\"source\":\"\",\"role\":\"core\",\"count\":" + coreCount
-                 + ",\"expectedVersion\":" + expectedVersion
-                 + "}";
+                   + ",\"expectedVersion\":" + expectedVersion + "}";
         var request = HttpRequest.newBuilder()
                                  .uri(URI.create("http://localhost:" + port + "/api/v1/cluster/scale"))
                                  .header("Content-Type", "application/json")
@@ -737,10 +710,11 @@ class PostRestartSlowRejoinDeficitFillProbeTest {
     /// can never be mistaken for an inert provisioning path.
     private static String requireScaleAccepted(HttpResult result) {
         if (result.statusCode() / 100 != 2) {
-            throw new AssertionError("CONTROL TRIGGER REJECTED: POST /api/v1/cluster/scale returned HTTP " + result.statusCode()
-                                    + " — the configured core count was never raised, so any subsequent "
-                                    + "zero-provision observation says nothing about the deficit-fill path. "
-                                    + "Body: " + result.body());
+            throw new AssertionError("CONTROL TRIGGER REJECTED: POST /api/v1/cluster/scale returned HTTP "
+                                     + result.statusCode()
+                                     + " — the configured core count was never raised, so any subsequent "
+                                     + "zero-provision observation says nothing about the deficit-fill path. "
+                                     + "Body: " + result.body());
         }
 
         return renderResponse(result);

--- a/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/ProvisioningRecoveryAfterFailureBurstProbeTest.java
+++ b/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/ProvisioningRecoveryAfterFailureBurstProbeTest.java
@@ -2,16 +2,14 @@
 // Copyright (c) 2025 Pragmatica Labs - Sergiy Yevtushenko
 // Licensed under Business Source License 1.1. Change Date: 2030-01-01. Change License: Apache-2.0.
 // See LICENSE in the repository root for full terms.
-
 package org.pragmatica.aether.forge;
 
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
 import org.pragmatica.aether.deployment.cluster.ClusterTopologyManager.CircuitBreakerState;
 import org.pragmatica.aether.ember.EmberCluster;
 import org.pragmatica.aether.environment.ComputeProvider;
@@ -27,18 +25,21 @@ import org.pragmatica.lang.Option;
 import org.pragmatica.lang.Promise;
 import org.pragmatica.lang.TerminalOperation;
 import org.pragmatica.lang.Unit;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.time.Duration;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicLong;
-
+import static org.pragmatica.aether.ember.EmberCluster.emberCluster;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
-import static org.pragmatica.aether.ember.EmberCluster.emberCluster;
+
 
 /// Diagnostic probe (GH #336 suspected root) — when core-provisioning fails in a transient BURST
 /// that trips the #148 provisioning circuit breaker, and conditions then clear, does provisioning
@@ -105,6 +106,7 @@ class ProvisioningRecoveryAfterFailureBurstProbeTest {
     private static final int BASE_APP_HTTP_PORT = 6160;
 
     private static final Duration FORM_TIMEOUT = Duration.ofSeconds(60);
+
     // Budget sized from the OBSERVED cadence: DEFICIT_FOLLOW_UP re-attempts ~every 30s pre-trip, and
     // the #148 breaker backoff is provisioningTimeout=60s. With K=4 the success attempt lands ~205s
     // after the kill (fail@~24/54/84[trip]/145[re-trip] → success@~205s), so 240s gives margin.
@@ -120,25 +122,26 @@ class ProvisioningRecoveryAfterFailureBurstProbeTest {
     void setUp() {
         cluster = emberCluster(INITIAL_CORES, BASE_PORT, BASE_MGMT_PORT, BASE_APP_HTTP_PORT, "recover");
         cluster.withComputeProviderDecorator(faultFactory::wrap);
-        cluster.start()
-               .await()
-               .onFailure(ProvisioningRecoveryAfterFailureBurstProbeTest::failStart);
-
-        await().atMost(FORM_TIMEOUT).pollInterval(POLL).until(() -> cluster.currentLeader().isPresent());
+        LifecycleAwait.settled("cluster start in setUp()", cluster, cluster.start());
+        await().atMost(FORM_TIMEOUT).pollInterval(POLL).until(() -> cluster.currentLeader()
+                                                                           .isPresent());
         await().atMost(FORM_TIMEOUT).pollInterval(POLL).until(() -> countedCores() == INITIAL_CORES);
         // The reconciler's `reachedFullMembership` cold-start latch reads the leader PresenceSampler
         // PEAK (peak >= configuredCoreCount), NOT coreCountedMembers(). Both must reach 5 before a
         // kill, or the deficit pass logs reason=COLD_START_NOT_FULL and never provisions.
         await().atMost(FORM_TIMEOUT).pollInterval(POLL).until(() -> observedPeak() >= INITIAL_CORES);
         log.info("RECOVERY-PROBE: {}-core cluster formed, leader={}, countedCores={} observedPeak={} "
-                 + "(full membership observed — reachedFullMembership armed)",
-                 INITIAL_CORES, cluster.currentLeader().or("none"), countedCores(), observedPeak());
+                + "(full membership observed — reachedFullMembership armed)",
+                 INITIAL_CORES,
+                 cluster.currentLeader().or("none"),
+                 countedCores(),
+                 observedPeak());
     }
 
     @AfterAll
     @TerminalOperation
     void tearDown() {
-        Option.option(cluster).onPresent(c -> c.stop().await());
+        Option.option(cluster).onPresent(c -> LifecycleAwait.settled("cluster stop in tearDown()", c, c.stop()));
     }
 
     @Test
@@ -146,17 +149,18 @@ class ProvisioningRecoveryAfterFailureBurstProbeTest {
     void provisioningRecoversAfterTransientFailureBurst_breakerTripsThenDeficitRefills() {
         var leaderId = cluster.currentLeader().or("none");
         var victim = pickNonLeaderCore();
+
         log.info("RECOVERY-PROBE: leader={} FORCE-killing NON-LEADER core victim={} to open a 1-core deficit (auto-heal path)",
-                 leaderId, victim);
-
-        cluster.killNode(victim, false)
-               .await()
-               .onFailure(ProvisioningRecoveryAfterFailureBurstProbeTest::failScenario);
-
+                 leaderId,
+                 victim);
+        LifecycleAwait.nodeSettled("kill node " + victim
+                                  + " in provisioningRecoversAfterTransientFailureBurst_breakerTripsThenDeficitRefills()",
+                                   cluster,
+                                   cluster.killNode(victim, false));
         var t0 = System.nanoTime();
         var probe = new ProbeState();
-        observeUntilRecoveredOrBudget(t0, probe);
 
+        observeUntilRecoveredOrBudget(t0, probe);
         var finalCounted = countedCores();
         var deficitObserved = probe.deficitObservedAt.get() >= 0;
         var breakerTripped = probe.breakerTrippedAt.get() >= 0;
@@ -166,41 +170,48 @@ class ProvisioningRecoveryAfterFailureBurstProbeTest {
         probe.timeline.forEach(line -> log.info("RECOVERY-PROBE {}", line));
         log.info("RECOVERY-PROBE ----------------------------------------------------------------");
         log.info("RECOVERY-PROBE RESULT: deficitObservedAtMs={} breakerTrippedAtMs={} recoveredAtMs={} "
-                 + "finalCountedCores={} injectedFailures={} provisionCalls={} provisionFailuresServed={} finalBreaker={}",
-                 probe.deficitObservedAt.get(), probe.breakerTrippedAt.get(), probe.recoveredAt.get(), finalCounted,
-                 INJECTED_FAILURES, faultFactory.provisionCalls(), faultFactory.failuresServed(),
+                + "finalCountedCores={} injectedFailures={} provisionCalls={} provisionFailuresServed={} finalBreaker={}",
+                 probe.deficitObservedAt.get(),
+                 probe.breakerTrippedAt.get(),
+                 probe.recoveredAt.get(),
+                 finalCounted,
+                 INJECTED_FAILURES,
+                 faultFactory.provisionCalls(),
+                 faultFactory.failuresServed(),
                  breakerSummary());
         dumpDiagnostics();
-
-        assertThat(deficitObserved)
-            .as("PRECONDITION-1: killing core %s must register a deficit (coreCountedMembers drops "
-                + "below %d, a provision is attempted, or the breaker activates) within the budget. "
-                + "If false, the auto-heal path never engaged — provisionCalls=%d. Nothing about "
-                + "recovery can be concluded.",
-                victim, INITIAL_CORES, faultFactory.provisionCalls())
-            .isTrue();
-
-        assertThat(breakerTripped)
-            .as("PRECONDITION-2: the injected burst of %d provision failures must TRIP the #148 "
-                + "circuit breaker (tripped=true observed at least once). If false, the burst never "
-                + "reached the breaker — provisionCalls=%d failuresServed=%d. The recovery question "
-                + "is only meaningful once the breaker actually trips.",
-                INJECTED_FAILURES, faultFactory.provisionCalls(), faultFactory.failuresServed())
-            .isTrue();
-
-        assertThat(recovered)
-            .as("RECOVERY: after the deficit appeared AND the %d-failure burst cleared (wrapper now "
-                + "delegates to the real provider, which SUCCEEDS) AND the breaker backoff window "
-                + "elapsed, coreCountedMembers() must return to %d within %ds. recoveredAtMs=%d "
-                + "finalCounted=%d finalBreaker=%s. FALSE = WEDGE: the provider would now succeed but "
-                + "the deficit stayed open / no further provision was attempted — this is #336 "
-                + "reproducing IN-JVM (provider-independent logic bug). The stuck breaker state and "
-                + "the provisionCalls vs failuresServed counters above pinpoint whether the "
-                + "reconciler stopped re-attempting (provisionCalls frozen) or kept attempting but the "
-                + "join never counted.",
-                INJECTED_FAILURES, INITIAL_CORES, RECOVERY_BUDGET.toSeconds(),
-                probe.recoveredAt.get(), finalCounted, breakerSummary())
-            .isTrue();
+        assertThat(deficitObserved).as("PRECONDITION-1: killing core %s must register a deficit (coreCountedMembers drops "
+                                      + "below %d, a provision is attempted, or the breaker activates) within the budget. "
+                                      + "If false, the auto-heal path never engaged — provisionCalls=%d. Nothing about "
+                                      + "recovery can be concluded.",
+                                       victim,
+                                       INITIAL_CORES,
+                                       faultFactory.provisionCalls())
+                  .isTrue();
+        assertThat(breakerTripped).as("PRECONDITION-2: the injected burst of %d provision failures must TRIP the #148 "
+                                     + "circuit breaker (tripped=true observed at least once). If false, the burst never "
+                                     + "reached the breaker — provisionCalls=%d failuresServed=%d. The recovery question "
+                                     + "is only meaningful once the breaker actually trips.",
+                                      INJECTED_FAILURES,
+                                      faultFactory.provisionCalls(),
+                                      faultFactory.failuresServed())
+                  .isTrue();
+        assertThat(recovered).as("RECOVERY: after the deficit appeared AND the %d-failure burst cleared (wrapper now "
+                                + "delegates to the real provider, which SUCCEEDS) AND the breaker backoff window "
+                                + "elapsed, coreCountedMembers() must return to %d within %ds. recoveredAtMs=%d "
+                                + "finalCounted=%d finalBreaker=%s. FALSE = WEDGE: the provider would now succeed but "
+                                + "the deficit stayed open / no further provision was attempted — this is #336 "
+                                + "reproducing IN-JVM (provider-independent logic bug). The stuck breaker state and "
+                                + "the provisionCalls vs failuresServed counters above pinpoint whether the "
+                                + "reconciler stopped re-attempting (provisionCalls frozen) or kept attempting but the "
+                                + "join never counted.",
+                                 INJECTED_FAILURES,
+                                 INITIAL_CORES,
+                                 RECOVERY_BUDGET.toSeconds(),
+                                 probe.recoveredAt.get(),
+                                 finalCounted,
+                                 breakerSummary())
+                  .isTrue();
     }
 
     /// Mutable, thread-confined (single observer thread) probe latches. `deficitObservedAt` MUST
@@ -217,9 +228,9 @@ class ProvisioningRecoveryAfterFailureBurstProbeTest {
 
     private void observeUntilRecoveredOrBudget(long t0, ProbeState probe) {
         await().pollInterval(POLL)
-               .pollDelay(Duration.ZERO)
-               .timeout(RECOVERY_BUDGET.plusSeconds(10))
-               .until(() -> recordTick(t0, probe));
+             .pollDelay(Duration.ZERO)
+             .timeout(RECOVERY_BUDGET.plusSeconds(10))
+             .until(() -> recordTick(t0, probe));
     }
 
     private boolean recordTick(long t0, ProbeState probe) {
@@ -230,12 +241,15 @@ class ProvisioningRecoveryAfterFailureBurstProbeTest {
         if (state.tripped() && probe.breakerTrippedAt.get() < 0) {
             probe.breakerTrippedAt.set(elapsed);
         }
+
         if (deficitReacted(counted, state) && probe.deficitObservedAt.get() < 0) {
             probe.deficitObservedAt.set(elapsed);
         }
+
         if (probe.deficitObservedAt.get() >= 0 && counted >= INITIAL_CORES && probe.recoveredAt.get() < 0) {
             probe.recoveredAt.set(elapsed);
         }
+
         maybeRecord(elapsed, counted, state, probe);
 
         return probe.recoveredAt.get() >= 0 || elapsed >= RECOVERY_BUDGET.toMillis();
@@ -245,16 +259,14 @@ class ProvisioningRecoveryAfterFailureBurstProbeTest {
     /// below target (victim left the MEMBER+SUSPECT set), or a provision was attempted, or the
     /// breaker activated. Any one is sufficient evidence a deficit was registered.
     private boolean deficitReacted(int counted, CircuitBreakerState state) {
-        return counted < INITIAL_CORES
-               || faultFactory.provisionCalls() > 0
-               || state.consecutiveFailures() > 0
-               || state.tripped();
+        return counted < INITIAL_CORES || faultFactory.provisionCalls() > 0 || state.consecutiveFailures() > 0 || state.tripped();
     }
 
     private void maybeRecord(long elapsed, int counted, CircuitBreakerState state, ProbeState probe) {
         if (elapsed - probe.lastLogMs < LOG_EVERY.toMillis()) {
             return;
         }
+
         probe.lastLogMs = elapsed;
         probe.timeline.add(formatTick(elapsed, counted, state));
     }
@@ -264,44 +276,55 @@ class ProvisioningRecoveryAfterFailureBurstProbeTest {
     /// the breaker state and the counted-core denominator the reconciler itself uses for deficit
     /// math, so it tracks the same decision the reconciler is making.
     private String formatTick(long elapsedMs, int counted, CircuitBreakerState state) {
-        return "t+" + elapsedMs + "ms coreCount=" + counted + "/" + INITIAL_CORES
-               + " breaker[" + formatBreaker(state) + "]"
-               + " provisionCalls=" + faultFactory.provisionCalls()
-               + " failuresServed=" + faultFactory.failuresServed()
-               + " phase=" + derivePhase(counted, state);
+        return "t+" + elapsedMs
+             + "ms coreCount=" + counted
+             + "/" + INITIAL_CORES
+             + " breaker[" + formatBreaker(state)
+             + "]"
+             + " provisionCalls=" + faultFactory.provisionCalls()
+             + " failuresServed=" + faultFactory.failuresServed()
+             + " phase=" + derivePhase(counted, state);
     }
 
     private String derivePhase(int counted, CircuitBreakerState state) {
         if (counted >= INITIAL_CORES) {
             return "RECOVERED_NO_DEFICIT";
         }
+
         if (state.tripped()) {
             return "DEFICIT_CIRCUIT_OPEN";
         }
+
         if (faultFactory.failuresServed() < INJECTED_FAILURES) {
             return "DEFICIT_PROVISIONING_FAILING";
         }
+
         return "DEFICIT_PROVISIONING_PERMITTED";
     }
 
     // ----- in-process membership reads -----
-
     private int countedCores() {
-        return leaderOrAnyNode().map(node -> node.membershipFsm().coreCountedMembers().size()).or(0);
+        return leaderOrAnyNode().map(node -> node.membershipFsm()
+                                                 .coreCountedMembers()
+                                                 .size())
+                              .or(0);
     }
 
     /// Leader PresenceSampler peak (high-water mark) — the value the reconciler's
     /// `reachedFullMembership` cold-start latch reads. Must reach the cluster size before a kill,
     /// or the deficit pass never arms provisioning.
     private int observedPeak() {
-        return leaderOrAnyNode().map(AetherNode::observedPeakMembership).or(0);
+        return leaderOrAnyNode().map(AetherNode::observedPeakMembership)
+                              .or(0);
     }
 
     private String pickNonLeaderCore() {
         var leader = cluster.currentLeader().or("none");
 
-        return cluster.allNodes().stream()
-                      .map(node -> node.self().id())
+        return cluster.allNodes()
+                      .stream()
+                      .map(node -> node.self()
+                                       .id())
                       .filter(id -> !id.equals(leader))
                       .findFirst()
                       .orElse(leader);
@@ -315,8 +338,8 @@ class ProvisioningRecoveryAfterFailureBurstProbeTest {
 
     private CircuitBreakerState breakerState() {
         return leaderOrAnyNode().flatMap(AetherNode::clusterTopologyManager)
-                                .map(ctm -> ctm.circuitBreakerState())
-                                .or(EMPTY_BREAKER);
+                              .map(ctm -> ctm.circuitBreakerState())
+                              .or(EMPTY_BREAKER);
     }
 
     private static final CircuitBreakerState EMPTY_BREAKER = new CircuitBreakerState(0, 3, 0L, false);
@@ -327,21 +350,29 @@ class ProvisioningRecoveryAfterFailureBurstProbeTest {
 
     private static String formatBreaker(CircuitBreakerState state) {
         return "consecutiveFailures=" + state.consecutiveFailures()
-               + " tripped=" + state.tripped()
-               + " trippedAt(cap)=" + state.trippedAt()
-               + " nextAllowedMs=" + state.nextAllowedMs();
+             + " tripped=" + state.tripped()
+             + " trippedAt(cap)=" + state.trippedAt()
+             + " nextAllowedMs=" + state.nextAllowedMs();
     }
 
     @TerminalOperation
     private void dumpDiagnostics() {
         var counted = countedCores();
+
         log.info("RECOVERY-PROBE DUMP: leader={} countedCores={}/{} ember.nodeCount={}",
-                 cluster.currentLeader().or("none"), counted, INITIAL_CORES, cluster.nodeCount());
+                 cluster.currentLeader().or("none"),
+                 counted,
+                 INITIAL_CORES,
+                 cluster.nodeCount());
         log.info("RECOVERY-PROBE DUMP: provisioning circuit-breaker = {}", breakerSummary());
         log.info("RECOVERY-PROBE DUMP: wrapper provisionCalls={} failuresServed={} (injected={})",
-                 faultFactory.provisionCalls(), faultFactory.failuresServed(), INJECTED_FAILURES);
-        cluster.allNodes().forEach(node -> log.info("RECOVERY-PROBE DUMP: node={} leader={}",
-                                                    node.self().id(), node.isLeader()));
+                 faultFactory.provisionCalls(),
+                 faultFactory.failuresServed(),
+                 INJECTED_FAILURES);
+        cluster.allNodes()
+               .forEach(node -> log.info("RECOVERY-PROBE DUMP: node={} leader={}",
+                                         node.self().id(),
+                                         node.isLeader()));
     }
 
     private static void failStart(Cause cause) {
@@ -403,6 +434,7 @@ class ProvisioningRecoveryAfterFailureBurstProbeTest {
 
             private Promise<InstanceInfo> injectFailure() {
                 var n = served.incrementAndGet();
+
                 log.info("RECOVERY-PROBE INJECT: provision FAILURE {}/{} (CapacityUnavailable)", n, injectedFailures);
 
                 return TRANSIENT_CAPACITY.promise();
@@ -425,6 +457,6 @@ class ProvisioningRecoveryAfterFailureBurstProbeTest {
         }
     }
 
-    private static final Cause TRANSIENT_CAPACITY =
-        EnvironmentError.capacityUnavailable("", new RuntimeException("injected transient capacity exhaustion (#336 probe)"));
+    private static final Cause TRANSIENT_CAPACITY = EnvironmentError.capacityUnavailable("",
+                                                                                         new RuntimeException("injected transient capacity exhaustion (#336 probe)"));
 }

--- a/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/ProvisioningRecoveryAfterFailureBurstProbeTest.java
+++ b/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/ProvisioningRecoveryAfterFailureBurstProbeTest.java
@@ -2,14 +2,16 @@
 // Copyright (c) 2025 Pragmatica Labs - Sergiy Yevtushenko
 // Licensed under Business Source License 1.1. Change Date: 2030-01-01. Change License: Apache-2.0.
 // See LICENSE in the repository root for full terms.
+
 package org.pragmatica.aether.forge;
 
-import java.time.Duration;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicLong;
-
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.pragmatica.aether.deployment.cluster.ClusterTopologyManager.CircuitBreakerState;
 import org.pragmatica.aether.ember.EmberCluster;
 import org.pragmatica.aether.environment.ComputeProvider;
@@ -25,21 +27,18 @@ import org.pragmatica.lang.Option;
 import org.pragmatica.lang.Promise;
 import org.pragmatica.lang.TerminalOperation;
 import org.pragmatica.lang.Unit;
-
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.pragmatica.aether.ember.EmberCluster.emberCluster;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
-
+import static org.pragmatica.aether.ember.EmberCluster.emberCluster;
 
 /// Diagnostic probe (GH #336 suspected root) — when core-provisioning fails in a transient BURST
 /// that trips the #148 provisioning circuit breaker, and conditions then clear, does provisioning
@@ -106,7 +105,6 @@ class ProvisioningRecoveryAfterFailureBurstProbeTest {
     private static final int BASE_APP_HTTP_PORT = 6160;
 
     private static final Duration FORM_TIMEOUT = Duration.ofSeconds(60);
-
     // Budget sized from the OBSERVED cadence: DEFICIT_FOLLOW_UP re-attempts ~every 30s pre-trip, and
     // the #148 breaker backoff is provisioningTimeout=60s. With K=4 the success attempt lands ~205s
     // after the kill (fail@~24/54/84[trip]/145[re-trip] → success@~205s), so 240s gives margin.
@@ -123,25 +121,22 @@ class ProvisioningRecoveryAfterFailureBurstProbeTest {
         cluster = emberCluster(INITIAL_CORES, BASE_PORT, BASE_MGMT_PORT, BASE_APP_HTTP_PORT, "recover");
         cluster.withComputeProviderDecorator(faultFactory::wrap);
         LifecycleAwait.settled("cluster start in setUp()", cluster, cluster.start());
-        await().atMost(FORM_TIMEOUT).pollInterval(POLL).until(() -> cluster.currentLeader()
-                                                                           .isPresent());
+
+        await().atMost(FORM_TIMEOUT).pollInterval(POLL).until(() -> cluster.currentLeader().isPresent());
         await().atMost(FORM_TIMEOUT).pollInterval(POLL).until(() -> countedCores() == INITIAL_CORES);
         // The reconciler's `reachedFullMembership` cold-start latch reads the leader PresenceSampler
         // PEAK (peak >= configuredCoreCount), NOT coreCountedMembers(). Both must reach 5 before a
         // kill, or the deficit pass logs reason=COLD_START_NOT_FULL and never provisions.
         await().atMost(FORM_TIMEOUT).pollInterval(POLL).until(() -> observedPeak() >= INITIAL_CORES);
         log.info("RECOVERY-PROBE: {}-core cluster formed, leader={}, countedCores={} observedPeak={} "
-                + "(full membership observed — reachedFullMembership armed)",
-                 INITIAL_CORES,
-                 cluster.currentLeader().or("none"),
-                 countedCores(),
-                 observedPeak());
+                 + "(full membership observed — reachedFullMembership armed)",
+                 INITIAL_CORES, cluster.currentLeader().or("none"), countedCores(), observedPeak());
     }
 
     @AfterAll
     @TerminalOperation
     void tearDown() {
-        Option.option(cluster).onPresent(c -> LifecycleAwait.settled("cluster stop in tearDown()", c, c.stop()));
+        Option.option(cluster).onPresent(c -> LifecycleAwait.bestEffort("cluster stop in tearDown()", c, c.stop()));
     }
 
     @Test
@@ -149,18 +144,18 @@ class ProvisioningRecoveryAfterFailureBurstProbeTest {
     void provisioningRecoversAfterTransientFailureBurst_breakerTripsThenDeficitRefills() {
         var leaderId = cluster.currentLeader().or("none");
         var victim = pickNonLeaderCore();
-
         log.info("RECOVERY-PROBE: leader={} FORCE-killing NON-LEADER core victim={} to open a 1-core deficit (auto-heal path)",
-                 leaderId,
-                 victim);
+                 leaderId, victim);
+
         LifecycleAwait.nodeSettled("kill node " + victim
                                   + " in provisioningRecoversAfterTransientFailureBurst_breakerTripsThenDeficitRefills()",
                                    cluster,
                                    cluster.killNode(victim, false));
+
         var t0 = System.nanoTime();
         var probe = new ProbeState();
-
         observeUntilRecoveredOrBudget(t0, probe);
+
         var finalCounted = countedCores();
         var deficitObserved = probe.deficitObservedAt.get() >= 0;
         var breakerTripped = probe.breakerTrippedAt.get() >= 0;
@@ -170,48 +165,41 @@ class ProvisioningRecoveryAfterFailureBurstProbeTest {
         probe.timeline.forEach(line -> log.info("RECOVERY-PROBE {}", line));
         log.info("RECOVERY-PROBE ----------------------------------------------------------------");
         log.info("RECOVERY-PROBE RESULT: deficitObservedAtMs={} breakerTrippedAtMs={} recoveredAtMs={} "
-                + "finalCountedCores={} injectedFailures={} provisionCalls={} provisionFailuresServed={} finalBreaker={}",
-                 probe.deficitObservedAt.get(),
-                 probe.breakerTrippedAt.get(),
-                 probe.recoveredAt.get(),
-                 finalCounted,
-                 INJECTED_FAILURES,
-                 faultFactory.provisionCalls(),
-                 faultFactory.failuresServed(),
+                 + "finalCountedCores={} injectedFailures={} provisionCalls={} provisionFailuresServed={} finalBreaker={}",
+                 probe.deficitObservedAt.get(), probe.breakerTrippedAt.get(), probe.recoveredAt.get(), finalCounted,
+                 INJECTED_FAILURES, faultFactory.provisionCalls(), faultFactory.failuresServed(),
                  breakerSummary());
         dumpDiagnostics();
-        assertThat(deficitObserved).as("PRECONDITION-1: killing core %s must register a deficit (coreCountedMembers drops "
-                                      + "below %d, a provision is attempted, or the breaker activates) within the budget. "
-                                      + "If false, the auto-heal path never engaged — provisionCalls=%d. Nothing about "
-                                      + "recovery can be concluded.",
-                                       victim,
-                                       INITIAL_CORES,
-                                       faultFactory.provisionCalls())
-                  .isTrue();
-        assertThat(breakerTripped).as("PRECONDITION-2: the injected burst of %d provision failures must TRIP the #148 "
-                                     + "circuit breaker (tripped=true observed at least once). If false, the burst never "
-                                     + "reached the breaker — provisionCalls=%d failuresServed=%d. The recovery question "
-                                     + "is only meaningful once the breaker actually trips.",
-                                      INJECTED_FAILURES,
-                                      faultFactory.provisionCalls(),
-                                      faultFactory.failuresServed())
-                  .isTrue();
-        assertThat(recovered).as("RECOVERY: after the deficit appeared AND the %d-failure burst cleared (wrapper now "
-                                + "delegates to the real provider, which SUCCEEDS) AND the breaker backoff window "
-                                + "elapsed, coreCountedMembers() must return to %d within %ds. recoveredAtMs=%d "
-                                + "finalCounted=%d finalBreaker=%s. FALSE = WEDGE: the provider would now succeed but "
-                                + "the deficit stayed open / no further provision was attempted — this is #336 "
-                                + "reproducing IN-JVM (provider-independent logic bug). The stuck breaker state and "
-                                + "the provisionCalls vs failuresServed counters above pinpoint whether the "
-                                + "reconciler stopped re-attempting (provisionCalls frozen) or kept attempting but the "
-                                + "join never counted.",
-                                 INJECTED_FAILURES,
-                                 INITIAL_CORES,
-                                 RECOVERY_BUDGET.toSeconds(),
-                                 probe.recoveredAt.get(),
-                                 finalCounted,
-                                 breakerSummary())
-                  .isTrue();
+
+        assertThat(deficitObserved)
+            .as("PRECONDITION-1: killing core %s must register a deficit (coreCountedMembers drops "
+                + "below %d, a provision is attempted, or the breaker activates) within the budget. "
+                + "If false, the auto-heal path never engaged — provisionCalls=%d. Nothing about "
+                + "recovery can be concluded.",
+                victim, INITIAL_CORES, faultFactory.provisionCalls())
+            .isTrue();
+
+        assertThat(breakerTripped)
+            .as("PRECONDITION-2: the injected burst of %d provision failures must TRIP the #148 "
+                + "circuit breaker (tripped=true observed at least once). If false, the burst never "
+                + "reached the breaker — provisionCalls=%d failuresServed=%d. The recovery question "
+                + "is only meaningful once the breaker actually trips.",
+                INJECTED_FAILURES, faultFactory.provisionCalls(), faultFactory.failuresServed())
+            .isTrue();
+
+        assertThat(recovered)
+            .as("RECOVERY: after the deficit appeared AND the %d-failure burst cleared (wrapper now "
+                + "delegates to the real provider, which SUCCEEDS) AND the breaker backoff window "
+                + "elapsed, coreCountedMembers() must return to %d within %ds. recoveredAtMs=%d "
+                + "finalCounted=%d finalBreaker=%s. FALSE = WEDGE: the provider would now succeed but "
+                + "the deficit stayed open / no further provision was attempted — this is #336 "
+                + "reproducing IN-JVM (provider-independent logic bug). The stuck breaker state and "
+                + "the provisionCalls vs failuresServed counters above pinpoint whether the "
+                + "reconciler stopped re-attempting (provisionCalls frozen) or kept attempting but the "
+                + "join never counted.",
+                INJECTED_FAILURES, INITIAL_CORES, RECOVERY_BUDGET.toSeconds(),
+                probe.recoveredAt.get(), finalCounted, breakerSummary())
+            .isTrue();
     }
 
     /// Mutable, thread-confined (single observer thread) probe latches. `deficitObservedAt` MUST
@@ -228,9 +216,9 @@ class ProvisioningRecoveryAfterFailureBurstProbeTest {
 
     private void observeUntilRecoveredOrBudget(long t0, ProbeState probe) {
         await().pollInterval(POLL)
-             .pollDelay(Duration.ZERO)
-             .timeout(RECOVERY_BUDGET.plusSeconds(10))
-             .until(() -> recordTick(t0, probe));
+               .pollDelay(Duration.ZERO)
+               .timeout(RECOVERY_BUDGET.plusSeconds(10))
+               .until(() -> recordTick(t0, probe));
     }
 
     private boolean recordTick(long t0, ProbeState probe) {
@@ -241,15 +229,12 @@ class ProvisioningRecoveryAfterFailureBurstProbeTest {
         if (state.tripped() && probe.breakerTrippedAt.get() < 0) {
             probe.breakerTrippedAt.set(elapsed);
         }
-
         if (deficitReacted(counted, state) && probe.deficitObservedAt.get() < 0) {
             probe.deficitObservedAt.set(elapsed);
         }
-
         if (probe.deficitObservedAt.get() >= 0 && counted >= INITIAL_CORES && probe.recoveredAt.get() < 0) {
             probe.recoveredAt.set(elapsed);
         }
-
         maybeRecord(elapsed, counted, state, probe);
 
         return probe.recoveredAt.get() >= 0 || elapsed >= RECOVERY_BUDGET.toMillis();
@@ -259,14 +244,16 @@ class ProvisioningRecoveryAfterFailureBurstProbeTest {
     /// below target (victim left the MEMBER+SUSPECT set), or a provision was attempted, or the
     /// breaker activated. Any one is sufficient evidence a deficit was registered.
     private boolean deficitReacted(int counted, CircuitBreakerState state) {
-        return counted < INITIAL_CORES || faultFactory.provisionCalls() > 0 || state.consecutiveFailures() > 0 || state.tripped();
+        return counted < INITIAL_CORES
+               || faultFactory.provisionCalls() > 0
+               || state.consecutiveFailures() > 0
+               || state.tripped();
     }
 
     private void maybeRecord(long elapsed, int counted, CircuitBreakerState state, ProbeState probe) {
         if (elapsed - probe.lastLogMs < LOG_EVERY.toMillis()) {
             return;
         }
-
         probe.lastLogMs = elapsed;
         probe.timeline.add(formatTick(elapsed, counted, state));
     }
@@ -276,55 +263,44 @@ class ProvisioningRecoveryAfterFailureBurstProbeTest {
     /// the breaker state and the counted-core denominator the reconciler itself uses for deficit
     /// math, so it tracks the same decision the reconciler is making.
     private String formatTick(long elapsedMs, int counted, CircuitBreakerState state) {
-        return "t+" + elapsedMs
-             + "ms coreCount=" + counted
-             + "/" + INITIAL_CORES
-             + " breaker[" + formatBreaker(state)
-             + "]"
-             + " provisionCalls=" + faultFactory.provisionCalls()
-             + " failuresServed=" + faultFactory.failuresServed()
-             + " phase=" + derivePhase(counted, state);
+        return "t+" + elapsedMs + "ms coreCount=" + counted + "/" + INITIAL_CORES
+               + " breaker[" + formatBreaker(state) + "]"
+               + " provisionCalls=" + faultFactory.provisionCalls()
+               + " failuresServed=" + faultFactory.failuresServed()
+               + " phase=" + derivePhase(counted, state);
     }
 
     private String derivePhase(int counted, CircuitBreakerState state) {
         if (counted >= INITIAL_CORES) {
             return "RECOVERED_NO_DEFICIT";
         }
-
         if (state.tripped()) {
             return "DEFICIT_CIRCUIT_OPEN";
         }
-
         if (faultFactory.failuresServed() < INJECTED_FAILURES) {
             return "DEFICIT_PROVISIONING_FAILING";
         }
-
         return "DEFICIT_PROVISIONING_PERMITTED";
     }
 
     // ----- in-process membership reads -----
+
     private int countedCores() {
-        return leaderOrAnyNode().map(node -> node.membershipFsm()
-                                                 .coreCountedMembers()
-                                                 .size())
-                              .or(0);
+        return leaderOrAnyNode().map(node -> node.membershipFsm().coreCountedMembers().size()).or(0);
     }
 
     /// Leader PresenceSampler peak (high-water mark) — the value the reconciler's
     /// `reachedFullMembership` cold-start latch reads. Must reach the cluster size before a kill,
     /// or the deficit pass never arms provisioning.
     private int observedPeak() {
-        return leaderOrAnyNode().map(AetherNode::observedPeakMembership)
-                              .or(0);
+        return leaderOrAnyNode().map(AetherNode::observedPeakMembership).or(0);
     }
 
     private String pickNonLeaderCore() {
         var leader = cluster.currentLeader().or("none");
 
-        return cluster.allNodes()
-                      .stream()
-                      .map(node -> node.self()
-                                       .id())
+        return cluster.allNodes().stream()
+                      .map(node -> node.self().id())
                       .filter(id -> !id.equals(leader))
                       .findFirst()
                       .orElse(leader);
@@ -338,8 +314,8 @@ class ProvisioningRecoveryAfterFailureBurstProbeTest {
 
     private CircuitBreakerState breakerState() {
         return leaderOrAnyNode().flatMap(AetherNode::clusterTopologyManager)
-                              .map(ctm -> ctm.circuitBreakerState())
-                              .or(EMPTY_BREAKER);
+                                .map(ctm -> ctm.circuitBreakerState())
+                                .or(EMPTY_BREAKER);
     }
 
     private static final CircuitBreakerState EMPTY_BREAKER = new CircuitBreakerState(0, 3, 0L, false);
@@ -350,38 +326,24 @@ class ProvisioningRecoveryAfterFailureBurstProbeTest {
 
     private static String formatBreaker(CircuitBreakerState state) {
         return "consecutiveFailures=" + state.consecutiveFailures()
-             + " tripped=" + state.tripped()
-             + " trippedAt(cap)=" + state.trippedAt()
-             + " nextAllowedMs=" + state.nextAllowedMs();
+               + " tripped=" + state.tripped()
+               + " trippedAt(cap)=" + state.trippedAt()
+               + " nextAllowedMs=" + state.nextAllowedMs();
     }
 
     @TerminalOperation
     private void dumpDiagnostics() {
         var counted = countedCores();
-
         log.info("RECOVERY-PROBE DUMP: leader={} countedCores={}/{} ember.nodeCount={}",
-                 cluster.currentLeader().or("none"),
-                 counted,
-                 INITIAL_CORES,
-                 cluster.nodeCount());
+                 cluster.currentLeader().or("none"), counted, INITIAL_CORES, cluster.nodeCount());
         log.info("RECOVERY-PROBE DUMP: provisioning circuit-breaker = {}", breakerSummary());
         log.info("RECOVERY-PROBE DUMP: wrapper provisionCalls={} failuresServed={} (injected={})",
-                 faultFactory.provisionCalls(),
-                 faultFactory.failuresServed(),
-                 INJECTED_FAILURES);
-        cluster.allNodes()
-               .forEach(node -> log.info("RECOVERY-PROBE DUMP: node={} leader={}",
-                                         node.self().id(),
-                                         node.isLeader()));
+                 faultFactory.provisionCalls(), faultFactory.failuresServed(), INJECTED_FAILURES);
+        cluster.allNodes().forEach(node -> log.info("RECOVERY-PROBE DUMP: node={} leader={}",
+                                                    node.self().id(), node.isLeader()));
     }
 
-    private static void failStart(Cause cause) {
-        throw new AssertionError("Cluster start failed: " + cause.message());
-    }
 
-    private static void failScenario(Cause cause) {
-        throw new AssertionError("Scenario setup failed: " + cause.message());
-    }
 
     /// Fault-injecting [ComputeProvider] decorator factory (authorized test seam consumer). Fails the
     /// first `injectedFailures` `provision()` calls with a transient `CapacityUnavailable` cause, then
@@ -434,7 +396,6 @@ class ProvisioningRecoveryAfterFailureBurstProbeTest {
 
             private Promise<InstanceInfo> injectFailure() {
                 var n = served.incrementAndGet();
-
                 log.info("RECOVERY-PROBE INJECT: provision FAILURE {}/{} (CapacityUnavailable)", n, injectedFailures);
 
                 return TRANSIENT_CAPACITY.promise();
@@ -457,6 +418,6 @@ class ProvisioningRecoveryAfterFailureBurstProbeTest {
         }
     }
 
-    private static final Cause TRANSIENT_CAPACITY = EnvironmentError.capacityUnavailable("",
-                                                                                         new RuntimeException("injected transient capacity exhaustion (#336 probe)"));
+    private static final Cause TRANSIENT_CAPACITY =
+        EnvironmentError.capacityUnavailable("", new RuntimeException("injected transient capacity exhaustion (#336 probe)"));
 }

--- a/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/ScaleUpFiveToSevenProbeTest.java
+++ b/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/ScaleUpFiveToSevenProbeTest.java
@@ -2,7 +2,27 @@
 // Copyright (c) 2025 Pragmatica Labs - Sergiy Yevtushenko
 // Licensed under Business Source License 1.1. Change Date: 2030-01-01. Change License: Apache-2.0.
 // See LICENSE in the repository root for full terms.
+
 package org.pragmatica.aether.forge;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.pragmatica.aether.deployment.cluster.ClusterTopologyManager.CircuitBreakerState;
+import org.pragmatica.aether.ember.EmberCluster;
+import org.pragmatica.aether.node.AetherNode;
+import org.pragmatica.consensus.NodeId;
+import org.pragmatica.http.HttpOperations;
+import org.pragmatica.http.HttpResult;
+import org.pragmatica.lang.Cause;
+import org.pragmatica.lang.Option;
+import org.pragmatica.lang.TerminalOperation;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.net.URI;
 import java.net.http.HttpRequest;
@@ -13,31 +33,10 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
-import org.pragmatica.aether.deployment.cluster.ClusterTopologyManager.CircuitBreakerState;
-import org.pragmatica.aether.ember.EmberCluster;
-import org.pragmatica.aether.node.AetherNode;
-import org.pragmatica.consensus.NodeId;
-import org.pragmatica.http.HttpOperations;
-import org.pragmatica.http.HttpResult;
-import org.pragmatica.lang.Cause;
-import org.pragmatica.lang.Option;
-import org.pragmatica.lang.TerminalOperation;
-
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import static org.pragmatica.aether.ember.EmberCluster.emberCluster;
-import static org.pragmatica.http.JdkHttpOperations.jdkHttpOperations;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
-
+import static org.pragmatica.aether.ember.EmberCluster.emberCluster;
+import static org.pragmatica.http.JdkHttpOperations.jdkHttpOperations;
 
 /// Diagnostic probe — does the cloud-only 5→7 scale-up stall (#336) reproduce IN-JVM with the
 /// Ember single-process provider, where there is NO DNS, NO advertise-host, NO container boot, and
@@ -83,6 +82,7 @@ import static org.awaitility.Awaitility.await;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class ScaleUpFiveToSevenProbeTest {
     private static final Logger log = LoggerFactory.getLogger(ScaleUpFiveToSevenProbeTest.class);
+
     private static final int INITIAL_CORES = 5;
     private static final int TARGET_CORES = 7;
     // Ember's slot pool is sized 2 * targetClusterSize at start() => 10 slots for a 5-core cluster.
@@ -90,10 +90,12 @@ class ScaleUpFiveToSevenProbeTest {
     private static final int BASE_PORT = 5660;
     private static final int BASE_MGMT_PORT = 5760;
     private static final int BASE_APP_HTTP_PORT = 5860;
+
     private static final Duration FORM_TIMEOUT = Duration.ofSeconds(60);
     private static final Duration SCALE_TIMEOUT = Duration.ofSeconds(120);
     private static final Duration POLL = Duration.ofMillis(500);
     private static final Duration LOG_EVERY = Duration.ofSeconds(5);
+
     private static final Pattern CONFIG_VERSION = Pattern.compile("\"configVersion\"\\s*:\\s*(\\d+)");
 
     private EmberCluster cluster;
@@ -104,8 +106,8 @@ class ScaleUpFiveToSevenProbeTest {
     void setUp() {
         cluster = emberCluster(INITIAL_CORES, BASE_PORT, BASE_MGMT_PORT, BASE_APP_HTTP_PORT, "scale");
         LifecycleAwait.settled("cluster start in setUp()", cluster, cluster.start());
-        await().atMost(FORM_TIMEOUT).pollInterval(POLL).until(() -> cluster.currentLeader()
-                                                                           .isPresent());
+
+        await().atMost(FORM_TIMEOUT).pollInterval(POLL).until(() -> cluster.currentLeader().isPresent());
         await().atMost(FORM_TIMEOUT).pollInterval(POLL).until(() -> countedCores() == INITIAL_CORES);
         // Membership forms BEFORE the bootstrap-seed ClusterConfigKey.CURRENT is committed to KV. On a
         // fast host the probe otherwise races ahead and POSTs /api/v1/cluster/scale before any config is
@@ -113,20 +115,16 @@ class ScaleUpFiveToSevenProbeTest {
         // expectedVersion=0 would be rejected as an unfenced overwrite, #289). Gate on the seed config
         // being durable (configVersion >= 1) so the scale carries the real fencing version.
         await().atMost(FORM_TIMEOUT)
-             .pollInterval(POLL)
-             .until(() -> cluster.getLeaderManagementPort()
-                                 .map(port -> readConfigVersion(port) >= 1)
-                                 .or(false));
+               .pollInterval(POLL)
+               .until(() -> cluster.getLeaderManagementPort().map(port -> readConfigVersion(port) >= 1).or(false));
         log.info("SCALE-PROBE: {}-core cluster formed, leader={}, countedCores={}",
-                 INITIAL_CORES,
-                 cluster.currentLeader().or("none"),
-                 countedCores());
+                 INITIAL_CORES, cluster.currentLeader().or("none"), countedCores());
     }
 
     @AfterAll
     @TerminalOperation
     void tearDown() {
-        Option.option(cluster).onPresent(c -> LifecycleAwait.settled("cluster stop in tearDown()", c, c.stop()));
+        Option.option(cluster).onPresent(c -> LifecycleAwait.bestEffort("cluster stop in tearDown()", c, c.stop()));
     }
 
     @Test
@@ -136,72 +134,59 @@ class ScaleUpFiveToSevenProbeTest {
                                 .toResult(ProbeError.NO_LEADER)
                                 .onFailure(ScaleUpFiveToSevenProbeTest::failScenario)
                                 .or(-1);
+
         var preScaleCounted = countedCores();
         var version = readConfigVersion(leaderPort);
-
         log.info("SCALE-PROBE: pre-scale countedCores={} leaderMgmtPort={} configVersion={}",
-                 preScaleCounted,
-                 leaderPort,
-                 version);
-        var scaleResponse = postScale(leaderPort, TARGET_CORES, version);
+                 preScaleCounted, leaderPort, version);
 
+        var scaleResponse = postScale(leaderPort, TARGET_CORES, version);
         log.info("SCALE-PROBE: POST /api/v1/cluster/scale {{coreCount:{}, expectedVersion:{}}} -> {}",
-                 TARGET_CORES,
-                 version,
-                 scaleResponse);
+                 TARGET_CORES, version, scaleResponse);
+
         var t0 = System.nanoTime();
         var reached = observeUntilTargetCounted(leaderPort, t0);
         var finalCounted = countedCores();
 
         log.info("SCALE-PROBE RESULT: target={} reachedAtMs={} (-1=NOT within {}s) finalCountedCores={}",
-                 TARGET_CORES,
-                 reached,
-                 SCALE_TIMEOUT.toSeconds(),
-                 finalCounted);
+                 TARGET_CORES, reached, SCALE_TIMEOUT.toSeconds(), finalCounted);
         dumpDiagnostics(leaderPort);
-        assertThat(reached).as("EXPECTED: 5→7 scale via /api/v1/cluster/scale converges to %d counted core members "
-                              + "within %ds. Reached=%d, finalCounted=%d. -1 = STALL — the 2 new cores never got "
-                              + "counted (this is #336 reproducing IN-JVM => a provider-independent logic bug, not "
-                              + "cloud-only). See the diagnostic dump above for whether the new nodes were never "
-                              + "provisioned, provisioned-but-never-joined, or joined-but-not-counted.",
-                               TARGET_CORES,
-                               SCALE_TIMEOUT.toSeconds(),
-                               reached,
-                               finalCounted)
-                  .isGreaterThanOrEqualTo(0L);
+
+        assertThat(reached)
+            .as("EXPECTED: 5→7 scale via /api/v1/cluster/scale converges to %d counted core members "
+                + "within %ds. Reached=%d, finalCounted=%d. -1 = STALL — the 2 new cores never got "
+                + "counted (this is #336 reproducing IN-JVM => a provider-independent logic bug, not "
+                + "cloud-only). See the diagnostic dump above for whether the new nodes were never "
+                + "provisioned, provisioned-but-never-joined, or joined-but-not-counted.",
+                TARGET_CORES, SCALE_TIMEOUT.toSeconds(), reached, finalCounted)
+            .isGreaterThanOrEqualTo(0L);
     }
 
     /// Polls the in-process counted-core denominator until it reaches the target or the budget
     /// expires. Returns the first-observed convergence latency in ms, or -1 if never observed.
     private long observeUntilTargetCounted(int leaderPort, long t0) {
-        var latch = new long[]{ - 1L};
+        var latch = new long[]{-1L};
         var lastLog = new long[]{0L};
-
         await().pollInterval(POLL)
-             .pollDelay(Duration.ZERO)
-             .timeout(SCALE_TIMEOUT.plusSeconds(5))
-             .until(() -> recordTick(leaderPort, t0, latch, lastLog));
-
+               .pollDelay(Duration.ZERO)
+               .timeout(SCALE_TIMEOUT.plusSeconds(5))
+               .until(() -> recordTick(leaderPort, t0, latch, lastLog));
         return latch[0];
     }
 
     private boolean recordTick(int leaderPort, long t0, long[] latch, long[] lastLog) {
         var elapsed = (System.nanoTime() - t0) / 1_000_000L;
-
-        if (countedCores() >= TARGET_CORES && latch[0]< 0) {
+        if (countedCores() >= TARGET_CORES && latch[0] < 0) {
             latch[0] = elapsed;
         }
-
         maybeLog(leaderPort, elapsed, lastLog);
-
-        return latch[0]>= 0 || elapsed >= SCALE_TIMEOUT.toMillis();
+        return latch[0] >= 0 || elapsed >= SCALE_TIMEOUT.toMillis();
     }
 
     private void maybeLog(int leaderPort, long elapsedMs, long[] lastLog) {
-        if (elapsedMs - lastLog[0]< LOG_EVERY.toMillis()) {
+        if (elapsedMs - lastLog[0] < LOG_EVERY.toMillis()) {
             return;
         }
-
         lastLog[0] = elapsedMs;
         log.info("SCALE-PROBE: t+{}ms countedCores={} emberNodeCount={} leaderPresent={} breaker={}",
                  elapsedMs,
@@ -212,13 +197,11 @@ class ScaleUpFiveToSevenProbeTest {
     }
 
     // ----- in-process membership reads -----
+
     /// The counted-core denominator the reconciler itself uses for deficit math, read off the
     /// leader's `MembershipFsm` (falls back to any node if the leader handle is momentarily absent).
     private int countedCores() {
-        return leaderOrAnyNode().map(node -> node.membershipFsm()
-                                                 .coreCountedMembers()
-                                                 .size())
-                              .or(0);
+        return leaderOrAnyNode().map(node -> node.membershipFsm().coreCountedMembers().size()).or(0);
     }
 
     private Option<AetherNode> leaderOrAnyNode() {
@@ -228,70 +211,58 @@ class ScaleUpFiveToSevenProbeTest {
     }
 
     // ----- failure diagnostics -----
+
     @TerminalOperation
     private void dumpDiagnostics(int leaderPort) {
         var leaderNode = leaderOrAnyNode();
-        var countedSet = leaderNode.map(node -> node.membershipFsm()
-                                                    .coreCountedMembers()).or(Set.of());
+        var countedSet = leaderNode.map(node -> node.membershipFsm().coreCountedMembers()).or(Set.of());
         var connectedPeers = leaderNode.map(AetherNode::connectedPeerIds).or(Set.of());
 
         log.info("SCALE-PROBE DUMP: leader={} configuredTarget={} countedCores={}/{} ember.nodeCount={}",
                  cluster.currentLeader().or("none"),
-                 readConfigVersion(leaderPort) < 0
-                 ? "?"
-                 : Integer.toString(TARGET_CORES),
-                 countedSet.size(),
-                 TARGET_CORES,
-                 cluster.nodeCount());
+                 readConfigVersion(leaderPort) < 0 ? "?" : Integer.toString(TARGET_CORES),
+                 countedSet.size(), TARGET_CORES, cluster.nodeCount());
         log.info("SCALE-PROBE DUMP: leader counted-core set = {}", idStrings(countedSet));
         log.info("SCALE-PROBE DUMP: leader connected-peer set = {}", idStrings(connectedPeers));
         log.info("SCALE-PROBE DUMP: provisioning circuit-breaker = {}", breakerSummary());
         log.info("SCALE-PROBE DUMP: /api/v1/cluster/config = {}", httpGet(leaderPort, "/api/v1/cluster/config"));
         log.info("SCALE-PROBE DUMP: /api/v1/cluster/generation = {}", httpGet(leaderPort, "/api/v1/cluster/generation"));
         log.info("SCALE-PROBE DUMP: /api/v1/nodes/status = {}", httpGet(leaderPort, "/api/v1/nodes/status"));
+
         cluster.allNodes().forEach(node -> dumpNode(node, countedSet, connectedPeers));
     }
 
     private void dumpNode(AetherNode node, Set<NodeId> countedSet, Set<NodeId> connectedPeers) {
         var id = node.self();
-        var inMesh = leaderOrAnyNode().map(leader -> leader.membershipView()
-                                                           .isPresent(id)).or(false);
-
+        var inMesh = leaderOrAnyNode().map(leader -> leader.membershipView().isPresent(id)).or(false);
         log.info("SCALE-PROBE DUMP: node={} started=true leader={} inLeaderSwimView={} countedAsCore={} "
-                + "leaderSeesAsPeer={}",
-                 id.id(),
-                 node.isLeader(),
-                 inMesh,
-                 countedSet.contains(id),
-                 connectedPeers.contains(id));
+                 + "leaderSeesAsPeer={}",
+                 id.id(), node.isLeader(), inMesh, countedSet.contains(id), connectedPeers.contains(id));
     }
 
     /// `consecutiveFailures` here is the "provision failed N times" counter; `tripped=true` means
     /// the breaker is open and further provisioning is being deferred (a likely stall cause).
     private String breakerSummary() {
         return leaderOrAnyNode().flatMap(AetherNode::clusterTopologyManager)
-                              .map(ctm -> formatBreaker(ctm.circuitBreakerState()))
-                              .or("no-ctm");
+                                .map(ctm -> formatBreaker(ctm.circuitBreakerState()))
+                                .or("no-ctm");
     }
 
     private static String formatBreaker(CircuitBreakerState state) {
         return "consecutiveFailures=" + state.consecutiveFailures()
-             + " tripped=" + state.tripped()
-             + " trippedAt=" + state.trippedAt()
-             + " nextAllowedMs=" + state.nextAllowedMs();
+               + " tripped=" + state.tripped()
+               + " trippedAt=" + state.trippedAt()
+               + " nextAllowedMs=" + state.nextAllowedMs();
     }
 
     private static String idStrings(Set<NodeId> ids) {
-        return ids.stream()
-                  .map(NodeId::id)
-                  .sorted()
-                  .collect(Collectors.joining(","));
+        return ids.stream().map(NodeId::id).sorted().collect(Collectors.joining(","));
     }
 
     // ----- HTTP helpers (scale trigger + read-only diagnostics) -----
+
     private int readConfigVersion(int port) {
         var matcher = CONFIG_VERSION.matcher(httpGet(port, "/api/v1/cluster/config"));
-
         return matcher.find()
                ? Integer.parseInt(matcher.group(1))
                : 0;
@@ -306,7 +277,6 @@ class ScaleUpFiveToSevenProbeTest {
                                  .POST(HttpRequest.BodyPublishers.ofString(body))
                                  .timeout(Duration.ofSeconds(10))
                                  .build();
-
         return http.sendString(request)
                    .await()
                    .map(ScaleUpFiveToSevenProbeTest::renderResponse)
@@ -324,16 +294,12 @@ class ScaleUpFiveToSevenProbeTest {
                                  .GET()
                                  .timeout(Duration.ofSeconds(5))
                                  .build();
-
         return http.sendString(request)
                    .await()
                    .map(HttpResult::body)
                    .or("{}");
     }
 
-    private static void failStart(Cause cause) {
-        throw new AssertionError("Cluster start failed: " + cause.message());
-    }
 
     private static void failScenario(Cause cause) {
         throw new AssertionError("Scenario setup failed: " + cause.message());
@@ -341,10 +307,13 @@ class ScaleUpFiveToSevenProbeTest {
 
     private enum ProbeError implements Cause {
         NO_LEADER("No leader available to receive the scale request");
+
         private final String message;
+
         ProbeError(String message) {
             this.message = message;
         }
+
         @Override
         public String message() {
             return message;

--- a/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/ScaleUpFiveToSevenProbeTest.java
+++ b/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/ScaleUpFiveToSevenProbeTest.java
@@ -2,27 +2,7 @@
 // Copyright (c) 2025 Pragmatica Labs - Sergiy Yevtushenko
 // Licensed under Business Source License 1.1. Change Date: 2030-01-01. Change License: Apache-2.0.
 // See LICENSE in the repository root for full terms.
-
 package org.pragmatica.aether.forge;
-
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
-import org.pragmatica.aether.deployment.cluster.ClusterTopologyManager.CircuitBreakerState;
-import org.pragmatica.aether.ember.EmberCluster;
-import org.pragmatica.aether.node.AetherNode;
-import org.pragmatica.consensus.NodeId;
-import org.pragmatica.http.HttpOperations;
-import org.pragmatica.http.HttpResult;
-import org.pragmatica.lang.Cause;
-import org.pragmatica.lang.Option;
-import org.pragmatica.lang.TerminalOperation;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.net.URI;
 import java.net.http.HttpRequest;
@@ -33,10 +13,31 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.awaitility.Awaitility.await;
+import org.pragmatica.aether.deployment.cluster.ClusterTopologyManager.CircuitBreakerState;
+import org.pragmatica.aether.ember.EmberCluster;
+import org.pragmatica.aether.node.AetherNode;
+import org.pragmatica.consensus.NodeId;
+import org.pragmatica.http.HttpOperations;
+import org.pragmatica.http.HttpResult;
+import org.pragmatica.lang.Cause;
+import org.pragmatica.lang.Option;
+import org.pragmatica.lang.TerminalOperation;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import static org.pragmatica.aether.ember.EmberCluster.emberCluster;
 import static org.pragmatica.http.JdkHttpOperations.jdkHttpOperations;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
 
 /// Diagnostic probe — does the cloud-only 5→7 scale-up stall (#336) reproduce IN-JVM with the
 /// Ember single-process provider, where there is NO DNS, NO advertise-host, NO container boot, and
@@ -82,7 +83,6 @@ import static org.pragmatica.http.JdkHttpOperations.jdkHttpOperations;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class ScaleUpFiveToSevenProbeTest {
     private static final Logger log = LoggerFactory.getLogger(ScaleUpFiveToSevenProbeTest.class);
-
     private static final int INITIAL_CORES = 5;
     private static final int TARGET_CORES = 7;
     // Ember's slot pool is sized 2 * targetClusterSize at start() => 10 slots for a 5-core cluster.
@@ -90,12 +90,10 @@ class ScaleUpFiveToSevenProbeTest {
     private static final int BASE_PORT = 5660;
     private static final int BASE_MGMT_PORT = 5760;
     private static final int BASE_APP_HTTP_PORT = 5860;
-
     private static final Duration FORM_TIMEOUT = Duration.ofSeconds(60);
     private static final Duration SCALE_TIMEOUT = Duration.ofSeconds(120);
     private static final Duration POLL = Duration.ofMillis(500);
     private static final Duration LOG_EVERY = Duration.ofSeconds(5);
-
     private static final Pattern CONFIG_VERSION = Pattern.compile("\"configVersion\"\\s*:\\s*(\\d+)");
 
     private EmberCluster cluster;
@@ -105,11 +103,9 @@ class ScaleUpFiveToSevenProbeTest {
     @TerminalOperation
     void setUp() {
         cluster = emberCluster(INITIAL_CORES, BASE_PORT, BASE_MGMT_PORT, BASE_APP_HTTP_PORT, "scale");
-        cluster.start()
-               .await()
-               .onFailure(ScaleUpFiveToSevenProbeTest::failStart);
-
-        await().atMost(FORM_TIMEOUT).pollInterval(POLL).until(() -> cluster.currentLeader().isPresent());
+        LifecycleAwait.settled("cluster start in setUp()", cluster, cluster.start());
+        await().atMost(FORM_TIMEOUT).pollInterval(POLL).until(() -> cluster.currentLeader()
+                                                                           .isPresent());
         await().atMost(FORM_TIMEOUT).pollInterval(POLL).until(() -> countedCores() == INITIAL_CORES);
         // Membership forms BEFORE the bootstrap-seed ClusterConfigKey.CURRENT is committed to KV. On a
         // fast host the probe otherwise races ahead and POSTs /api/v1/cluster/scale before any config is
@@ -117,16 +113,20 @@ class ScaleUpFiveToSevenProbeTest {
         // expectedVersion=0 would be rejected as an unfenced overwrite, #289). Gate on the seed config
         // being durable (configVersion >= 1) so the scale carries the real fencing version.
         await().atMost(FORM_TIMEOUT)
-               .pollInterval(POLL)
-               .until(() -> cluster.getLeaderManagementPort().map(port -> readConfigVersion(port) >= 1).or(false));
+             .pollInterval(POLL)
+             .until(() -> cluster.getLeaderManagementPort()
+                                 .map(port -> readConfigVersion(port) >= 1)
+                                 .or(false));
         log.info("SCALE-PROBE: {}-core cluster formed, leader={}, countedCores={}",
-                 INITIAL_CORES, cluster.currentLeader().or("none"), countedCores());
+                 INITIAL_CORES,
+                 cluster.currentLeader().or("none"),
+                 countedCores());
     }
 
     @AfterAll
     @TerminalOperation
     void tearDown() {
-        Option.option(cluster).onPresent(c -> c.stop().await());
+        Option.option(cluster).onPresent(c -> LifecycleAwait.settled("cluster stop in tearDown()", c, c.stop()));
     }
 
     @Test
@@ -136,59 +136,72 @@ class ScaleUpFiveToSevenProbeTest {
                                 .toResult(ProbeError.NO_LEADER)
                                 .onFailure(ScaleUpFiveToSevenProbeTest::failScenario)
                                 .or(-1);
-
         var preScaleCounted = countedCores();
         var version = readConfigVersion(leaderPort);
+
         log.info("SCALE-PROBE: pre-scale countedCores={} leaderMgmtPort={} configVersion={}",
-                 preScaleCounted, leaderPort, version);
-
+                 preScaleCounted,
+                 leaderPort,
+                 version);
         var scaleResponse = postScale(leaderPort, TARGET_CORES, version);
-        log.info("SCALE-PROBE: POST /api/v1/cluster/scale {{coreCount:{}, expectedVersion:{}}} -> {}",
-                 TARGET_CORES, version, scaleResponse);
 
+        log.info("SCALE-PROBE: POST /api/v1/cluster/scale {{coreCount:{}, expectedVersion:{}}} -> {}",
+                 TARGET_CORES,
+                 version,
+                 scaleResponse);
         var t0 = System.nanoTime();
         var reached = observeUntilTargetCounted(leaderPort, t0);
         var finalCounted = countedCores();
 
         log.info("SCALE-PROBE RESULT: target={} reachedAtMs={} (-1=NOT within {}s) finalCountedCores={}",
-                 TARGET_CORES, reached, SCALE_TIMEOUT.toSeconds(), finalCounted);
+                 TARGET_CORES,
+                 reached,
+                 SCALE_TIMEOUT.toSeconds(),
+                 finalCounted);
         dumpDiagnostics(leaderPort);
-
-        assertThat(reached)
-            .as("EXPECTED: 5→7 scale via /api/v1/cluster/scale converges to %d counted core members "
-                + "within %ds. Reached=%d, finalCounted=%d. -1 = STALL — the 2 new cores never got "
-                + "counted (this is #336 reproducing IN-JVM => a provider-independent logic bug, not "
-                + "cloud-only). See the diagnostic dump above for whether the new nodes were never "
-                + "provisioned, provisioned-but-never-joined, or joined-but-not-counted.",
-                TARGET_CORES, SCALE_TIMEOUT.toSeconds(), reached, finalCounted)
-            .isGreaterThanOrEqualTo(0L);
+        assertThat(reached).as("EXPECTED: 5→7 scale via /api/v1/cluster/scale converges to %d counted core members "
+                              + "within %ds. Reached=%d, finalCounted=%d. -1 = STALL — the 2 new cores never got "
+                              + "counted (this is #336 reproducing IN-JVM => a provider-independent logic bug, not "
+                              + "cloud-only). See the diagnostic dump above for whether the new nodes were never "
+                              + "provisioned, provisioned-but-never-joined, or joined-but-not-counted.",
+                               TARGET_CORES,
+                               SCALE_TIMEOUT.toSeconds(),
+                               reached,
+                               finalCounted)
+                  .isGreaterThanOrEqualTo(0L);
     }
 
     /// Polls the in-process counted-core denominator until it reaches the target or the budget
     /// expires. Returns the first-observed convergence latency in ms, or -1 if never observed.
     private long observeUntilTargetCounted(int leaderPort, long t0) {
-        var latch = new long[]{-1L};
+        var latch = new long[]{ - 1L};
         var lastLog = new long[]{0L};
+
         await().pollInterval(POLL)
-               .pollDelay(Duration.ZERO)
-               .timeout(SCALE_TIMEOUT.plusSeconds(5))
-               .until(() -> recordTick(leaderPort, t0, latch, lastLog));
+             .pollDelay(Duration.ZERO)
+             .timeout(SCALE_TIMEOUT.plusSeconds(5))
+             .until(() -> recordTick(leaderPort, t0, latch, lastLog));
+
         return latch[0];
     }
 
     private boolean recordTick(int leaderPort, long t0, long[] latch, long[] lastLog) {
         var elapsed = (System.nanoTime() - t0) / 1_000_000L;
-        if (countedCores() >= TARGET_CORES && latch[0] < 0) {
+
+        if (countedCores() >= TARGET_CORES && latch[0]< 0) {
             latch[0] = elapsed;
         }
+
         maybeLog(leaderPort, elapsed, lastLog);
-        return latch[0] >= 0 || elapsed >= SCALE_TIMEOUT.toMillis();
+
+        return latch[0]>= 0 || elapsed >= SCALE_TIMEOUT.toMillis();
     }
 
     private void maybeLog(int leaderPort, long elapsedMs, long[] lastLog) {
-        if (elapsedMs - lastLog[0] < LOG_EVERY.toMillis()) {
+        if (elapsedMs - lastLog[0]< LOG_EVERY.toMillis()) {
             return;
         }
+
         lastLog[0] = elapsedMs;
         log.info("SCALE-PROBE: t+{}ms countedCores={} emberNodeCount={} leaderPresent={} breaker={}",
                  elapsedMs,
@@ -199,11 +212,13 @@ class ScaleUpFiveToSevenProbeTest {
     }
 
     // ----- in-process membership reads -----
-
     /// The counted-core denominator the reconciler itself uses for deficit math, read off the
     /// leader's `MembershipFsm` (falls back to any node if the leader handle is momentarily absent).
     private int countedCores() {
-        return leaderOrAnyNode().map(node -> node.membershipFsm().coreCountedMembers().size()).or(0);
+        return leaderOrAnyNode().map(node -> node.membershipFsm()
+                                                 .coreCountedMembers()
+                                                 .size())
+                              .or(0);
     }
 
     private Option<AetherNode> leaderOrAnyNode() {
@@ -213,58 +228,70 @@ class ScaleUpFiveToSevenProbeTest {
     }
 
     // ----- failure diagnostics -----
-
     @TerminalOperation
     private void dumpDiagnostics(int leaderPort) {
         var leaderNode = leaderOrAnyNode();
-        var countedSet = leaderNode.map(node -> node.membershipFsm().coreCountedMembers()).or(Set.of());
+        var countedSet = leaderNode.map(node -> node.membershipFsm()
+                                                    .coreCountedMembers()).or(Set.of());
         var connectedPeers = leaderNode.map(AetherNode::connectedPeerIds).or(Set.of());
 
         log.info("SCALE-PROBE DUMP: leader={} configuredTarget={} countedCores={}/{} ember.nodeCount={}",
                  cluster.currentLeader().or("none"),
-                 readConfigVersion(leaderPort) < 0 ? "?" : Integer.toString(TARGET_CORES),
-                 countedSet.size(), TARGET_CORES, cluster.nodeCount());
+                 readConfigVersion(leaderPort) < 0
+                 ? "?"
+                 : Integer.toString(TARGET_CORES),
+                 countedSet.size(),
+                 TARGET_CORES,
+                 cluster.nodeCount());
         log.info("SCALE-PROBE DUMP: leader counted-core set = {}", idStrings(countedSet));
         log.info("SCALE-PROBE DUMP: leader connected-peer set = {}", idStrings(connectedPeers));
         log.info("SCALE-PROBE DUMP: provisioning circuit-breaker = {}", breakerSummary());
         log.info("SCALE-PROBE DUMP: /api/v1/cluster/config = {}", httpGet(leaderPort, "/api/v1/cluster/config"));
         log.info("SCALE-PROBE DUMP: /api/v1/cluster/generation = {}", httpGet(leaderPort, "/api/v1/cluster/generation"));
         log.info("SCALE-PROBE DUMP: /api/v1/nodes/status = {}", httpGet(leaderPort, "/api/v1/nodes/status"));
-
         cluster.allNodes().forEach(node -> dumpNode(node, countedSet, connectedPeers));
     }
 
     private void dumpNode(AetherNode node, Set<NodeId> countedSet, Set<NodeId> connectedPeers) {
         var id = node.self();
-        var inMesh = leaderOrAnyNode().map(leader -> leader.membershipView().isPresent(id)).or(false);
+        var inMesh = leaderOrAnyNode().map(leader -> leader.membershipView()
+                                                           .isPresent(id)).or(false);
+
         log.info("SCALE-PROBE DUMP: node={} started=true leader={} inLeaderSwimView={} countedAsCore={} "
-                 + "leaderSeesAsPeer={}",
-                 id.id(), node.isLeader(), inMesh, countedSet.contains(id), connectedPeers.contains(id));
+                + "leaderSeesAsPeer={}",
+                 id.id(),
+                 node.isLeader(),
+                 inMesh,
+                 countedSet.contains(id),
+                 connectedPeers.contains(id));
     }
 
     /// `consecutiveFailures` here is the "provision failed N times" counter; `tripped=true` means
     /// the breaker is open and further provisioning is being deferred (a likely stall cause).
     private String breakerSummary() {
         return leaderOrAnyNode().flatMap(AetherNode::clusterTopologyManager)
-                                .map(ctm -> formatBreaker(ctm.circuitBreakerState()))
-                                .or("no-ctm");
+                              .map(ctm -> formatBreaker(ctm.circuitBreakerState()))
+                              .or("no-ctm");
     }
 
     private static String formatBreaker(CircuitBreakerState state) {
         return "consecutiveFailures=" + state.consecutiveFailures()
-               + " tripped=" + state.tripped()
-               + " trippedAt=" + state.trippedAt()
-               + " nextAllowedMs=" + state.nextAllowedMs();
+             + " tripped=" + state.tripped()
+             + " trippedAt=" + state.trippedAt()
+             + " nextAllowedMs=" + state.nextAllowedMs();
     }
 
     private static String idStrings(Set<NodeId> ids) {
-        return ids.stream().map(NodeId::id).sorted().collect(Collectors.joining(","));
+        return ids.stream()
+                  .map(NodeId::id)
+                  .sorted()
+                  .collect(Collectors.joining(","));
     }
 
     // ----- HTTP helpers (scale trigger + read-only diagnostics) -----
-
     private int readConfigVersion(int port) {
         var matcher = CONFIG_VERSION.matcher(httpGet(port, "/api/v1/cluster/config"));
+
         return matcher.find()
                ? Integer.parseInt(matcher.group(1))
                : 0;
@@ -279,6 +306,7 @@ class ScaleUpFiveToSevenProbeTest {
                                  .POST(HttpRequest.BodyPublishers.ofString(body))
                                  .timeout(Duration.ofSeconds(10))
                                  .build();
+
         return http.sendString(request)
                    .await()
                    .map(ScaleUpFiveToSevenProbeTest::renderResponse)
@@ -296,6 +324,7 @@ class ScaleUpFiveToSevenProbeTest {
                                  .GET()
                                  .timeout(Duration.ofSeconds(5))
                                  .build();
+
         return http.sendString(request)
                    .await()
                    .map(HttpResult::body)
@@ -312,13 +341,10 @@ class ScaleUpFiveToSevenProbeTest {
 
     private enum ProbeError implements Cause {
         NO_LEADER("No leader available to receive the scale request");
-
         private final String message;
-
         ProbeError(String message) {
             this.message = message;
         }
-
         @Override
         public String message() {
             return message;

--- a/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/SliceDeploymentTest.java
+++ b/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/SliceDeploymentTest.java
@@ -2,31 +2,31 @@
 // Copyright (c) 2025 Pragmatica Labs - Sergiy Yevtushenko
 // Licensed under Business Source License 1.1. Change Date: 2030-01-01. Change License: Apache-2.0.
 // See LICENSE in the repository root for full terms.
-
 package org.pragmatica.aether.forge;
-
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
-import org.pragmatica.aether.slice.SliceState;
-import org.pragmatica.http.HttpResult;
-import org.pragmatica.http.HttpOperations;
 
 import java.net.URI;
 import java.net.http.HttpRequest;
 import java.time.Duration;
 
+import org.pragmatica.aether.slice.SliceState;
+import org.pragmatica.http.HttpResult;
+import org.pragmatica.http.HttpOperations;
+import org.pragmatica.aether.ember.EmberCluster;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.awaitility.Awaitility.await;
-import org.pragmatica.aether.ember.EmberCluster;
 import static org.pragmatica.aether.ember.EmberCluster.emberCluster;
 import static org.pragmatica.http.JdkHttpOperations.jdkHttpOperations;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
 
 /// Tests for slice deployment and lifecycle operations.
 ///
@@ -60,20 +60,10 @@ class SliceDeploymentTest {
     @BeforeAll
     void setUp() {
         cluster = emberCluster(3, BASE_PORT, BASE_MGMT_PORT, BASE_APP_HTTP_PORT, "sd");
-
-        cluster.start()
-               .await()
-               .onFailure(cause -> {
-                   throw new AssertionError("Cluster start failed: " + cause.message());
-               });
-
-        await().atMost(WAIT_TIMEOUT)
-               .pollInterval(POLL_INTERVAL)
-               .until(() -> cluster.currentLeader().isPresent());
-
-        await().atMost(WAIT_TIMEOUT)
-               .pollInterval(POLL_INTERVAL)
-               .until(this::allNodesHealthy);
+        LifecycleAwait.settled("cluster start in setUp()", cluster, cluster.start());
+        await().atMost(WAIT_TIMEOUT).pollInterval(POLL_INTERVAL).until(() -> cluster.currentLeader()
+                                                                                    .isPresent());
+        await().atMost(WAIT_TIMEOUT).pollInterval(POLL_INTERVAL).until(this::allNodesHealthy);
     }
 
     @BeforeEach
@@ -89,41 +79,35 @@ class SliceDeploymentTest {
     @AfterAll
     void tearDown() {
         if (cluster != null) {
-            cluster.stop()
-                   .await();
+            LifecycleAwait.settled("cluster stop in tearDown()", cluster, cluster.stop());
         }
     }
 
     @Test
     void deploySlice_becomesActive() {
         var leaderPort = cluster.getLeaderManagementPort().unwrap();
-
         var response = deploy(leaderPort, TEST_ARTIFACT, 1);
+
         assertThat(response).doesNotContain("\"error\"");
-
-        await().atMost(DEPLOY_TIMEOUT)
-               .pollInterval(POLL_INTERVAL)
-               .until(() -> sliceIsActive(TEST_ARTIFACT));
-
+        await().atMost(DEPLOY_TIMEOUT).pollInterval(POLL_INTERVAL).until(() -> sliceIsActive(TEST_ARTIFACT));
         var slices = getSlices(leaderPort);
+
         assertThat(slices).contains(TEST_ARTIFACT);
     }
 
     @Test
     void deploySlice_multipleInstances_distributedAcrossNodes() {
         var leaderPort = cluster.getLeaderManagementPort().unwrap();
-
         var response = deploy(leaderPort, TEST_ARTIFACT, 3);
+
         assertThat(response).doesNotContain("\"error\"");
-
-        await().atMost(DEPLOY_TIMEOUT)
-               .pollInterval(POLL_INTERVAL)
-               .until(() -> sliceIsActive(TEST_ARTIFACT));
-
+        await().atMost(DEPLOY_TIMEOUT).pollInterval(POLL_INTERVAL).until(() -> sliceIsActive(TEST_ARTIFACT));
         // Check that instances are distributed - each node should report the slice
         var status = cluster.status();
+
         for (var node : status.nodes()) {
             var nodeSlices = getSlices(node.mgmtPort());
+
             assertThat(nodeSlices).contains(TEST_ARTIFACT);
         }
     }
@@ -131,53 +115,46 @@ class SliceDeploymentTest {
     @Test
     void scaleSlice_adjustsInstanceCount() {
         var leaderPort = cluster.getLeaderManagementPort().unwrap();
-
         // Deploy with 1 instance
         deploy(leaderPort, TEST_ARTIFACT, 1);
-        await().atMost(DEPLOY_TIMEOUT)
-               .pollInterval(POLL_INTERVAL)
-               .until(() -> sliceIsActive(TEST_ARTIFACT));
-
+        await().atMost(DEPLOY_TIMEOUT).pollInterval(POLL_INTERVAL).until(() -> sliceIsActive(TEST_ARTIFACT));
         // Scale to 3 instances
         var scaleResponse = scale(leaderPort, TEST_ARTIFACT, 3);
-        assertThat(scaleResponse).doesNotContain("\"error\"");
 
+        assertThat(scaleResponse).doesNotContain("\"error\"");
         // Wait for scale operation to complete
         await().atMost(DEPLOY_TIMEOUT)
-               .pollInterval(Duration.ofSeconds(2))
-               .until(() -> {
-                   var slices = getSlices(leaderPort);
-                   return slices.contains(TEST_ARTIFACT);
-               });
+             .pollInterval(Duration.ofSeconds(2))
+             .until(() -> {
+                 var slices = getSlices(leaderPort);
+
+                 return slices.contains(TEST_ARTIFACT);
+             });
     }
 
     @Test
     void undeploySlice_removesFromCluster() {
         var leaderPort = cluster.getLeaderManagementPort().unwrap();
-
         // Deploy
         deploy(leaderPort, TEST_ARTIFACT, 1);
-        await().atMost(DEPLOY_TIMEOUT)
-               .pollInterval(POLL_INTERVAL)
-               .until(() -> sliceIsActive(TEST_ARTIFACT));
-
+        await().atMost(DEPLOY_TIMEOUT).pollInterval(POLL_INTERVAL).until(() -> sliceIsActive(TEST_ARTIFACT));
         // Undeploy
         var undeployResponse = undeploy(leaderPort, TEST_ARTIFACT);
-        assertThat(undeployResponse).doesNotContain("\"error\"");
 
+        assertThat(undeployResponse).doesNotContain("\"error\"");
         // Wait for slice to be removed
         await().atMost(DEPLOY_TIMEOUT)
-               .pollInterval(POLL_INTERVAL)
-               .until(() -> {
-                   var slices = getSlices(leaderPort);
-                   return !slices.contains(TEST_ARTIFACT);
-               });
+             .pollInterval(POLL_INTERVAL)
+             .until(() -> {
+                 var slices = getSlices(leaderPort);
+
+                 return ! slices.contains(TEST_ARTIFACT);
+             });
     }
 
     @Test
     void blueprintApply_deploysMultipleSlices() {
         var leaderPort = cluster.getLeaderManagementPort().unwrap();
-
         var blueprint = """
             id = "org.test:blueprint:1.0.0"
 
@@ -185,17 +162,13 @@ class SliceDeploymentTest {
             artifact = "%s"
             instances = 2
             """.formatted(TEST_ARTIFACT);
-
         var response = applyBlueprint(leaderPort, blueprint);
-        assertThat(response).doesNotContain("\"error\"");
 
-        await().atMost(DEPLOY_TIMEOUT)
-               .pollInterval(POLL_INTERVAL)
-               .until(() -> sliceIsActive(TEST_ARTIFACT));
+        assertThat(response).doesNotContain("\"error\"");
+        await().atMost(DEPLOY_TIMEOUT).pollInterval(POLL_INTERVAL).until(() -> sliceIsActive(TEST_ARTIFACT));
     }
 
     // ===== HTTP Helper Methods =====
-
     private String deploy(int port, String artifact, int instances) {
         var blueprint = """
             id = "%s"
@@ -204,16 +177,19 @@ class SliceDeploymentTest {
             artifact = "%s"
             instances = %d
             """.formatted(BLUEPRINT_ID, artifact, instances);
+
         return postBlueprintWithRetry(port, blueprint);
     }
 
     private String postBlueprintWithRetry(int port, String body) {
         String lastResponse = null;
+
         for (int attempt = 1; attempt <= 3; attempt++) {
             lastResponse = post(port, "/api/v1/blueprints", body, "application/toml");
             if (!lastResponse.contains("\"error\"")) {
                 return lastResponse;
             }
+
             if (attempt < 3) {
                 try {
                     Thread.sleep(2000);
@@ -223,11 +199,13 @@ class SliceDeploymentTest {
                 }
             }
         }
+
         return lastResponse;
     }
 
     private String scale(int port, String artifact, int instances) {
         var body = String.format("{\"artifact\": \"%s\", \"instances\": %d}", artifact, instances);
+
         return post(port, "/api/v1/scale", body, "application/json");
     }
 
@@ -245,6 +223,7 @@ class SliceDeploymentTest {
                                  .GET()
                                  .timeout(Duration.ofSeconds(10))
                                  .build();
+
         return http.sendString(request)
                    .await()
                    .map(HttpResult::body)
@@ -257,6 +236,7 @@ class SliceDeploymentTest {
                                  .DELETE()
                                  .timeout(Duration.ofSeconds(10))
                                  .build();
+
         return http.sendString(request)
                    .await()
                    .map(HttpResult::body)
@@ -270,6 +250,7 @@ class SliceDeploymentTest {
                                  .POST(HttpRequest.BodyPublishers.ofString(body))
                                  .timeout(Duration.ofSeconds(10))
                                  .build();
+
         return http.sendString(request)
                    .await()
                    .map(HttpResult::body)
@@ -279,9 +260,11 @@ class SliceDeploymentTest {
     private boolean sliceIsActive(String artifact) {
         try {
             var slicesStatus = cluster.slicesStatus();
+
             return slicesStatus.stream()
-                               .anyMatch(status -> status.artifact().equals(artifact)
-                                                   && status.state().equals(SliceState.ACTIVE.name()));
+                               .anyMatch(status -> status.artifact()
+                                                         .equals(artifact) && status.state()
+                                                                                    .equals(SliceState.ACTIVE.name()));
         } catch (Exception e) {
             return false;
         }
@@ -289,7 +272,9 @@ class SliceDeploymentTest {
 
     private boolean allNodesHealthy() {
         var status = cluster.status();
-        return status.nodes().stream()
+
+        return status.nodes()
+                     .stream()
                      .allMatch(node -> checkNodeHealth(node.mgmtPort()));
     }
 
@@ -299,9 +284,11 @@ class SliceDeploymentTest {
                                  .GET()
                                  .timeout(Duration.ofSeconds(5))
                                  .build();
+
         return http.sendString(request)
                    .await()
-                   .map(r -> r.statusCode() == 200 && r.body().contains("\"quorum\":true"))
+                   .map(r -> r.statusCode() == 200 && r.body()
+                                                       .contains("\"quorum\":true"))
                    .or(false);
     }
 }

--- a/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/SliceDeploymentTest.java
+++ b/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/SliceDeploymentTest.java
@@ -2,31 +2,31 @@
 // Copyright (c) 2025 Pragmatica Labs - Sergiy Yevtushenko
 // Licensed under Business Source License 1.1. Change Date: 2030-01-01. Change License: Apache-2.0.
 // See LICENSE in the repository root for full terms.
+
 package org.pragmatica.aether.forge;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.pragmatica.aether.slice.SliceState;
+import org.pragmatica.http.HttpResult;
+import org.pragmatica.http.HttpOperations;
 
 import java.net.URI;
 import java.net.http.HttpRequest;
 import java.time.Duration;
 
-import org.pragmatica.aether.slice.SliceState;
-import org.pragmatica.http.HttpResult;
-import org.pragmatica.http.HttpOperations;
-import org.pragmatica.aether.ember.EmberCluster;
-
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
 
-import static org.pragmatica.aether.ember.EmberCluster.emberCluster;
-import static org.pragmatica.http.JdkHttpOperations.jdkHttpOperations;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
-
+import org.pragmatica.aether.ember.EmberCluster;
+import static org.pragmatica.aether.ember.EmberCluster.emberCluster;
+import static org.pragmatica.http.JdkHttpOperations.jdkHttpOperations;
 
 /// Tests for slice deployment and lifecycle operations.
 ///
@@ -60,10 +60,16 @@ class SliceDeploymentTest {
     @BeforeAll
     void setUp() {
         cluster = emberCluster(3, BASE_PORT, BASE_MGMT_PORT, BASE_APP_HTTP_PORT, "sd");
+
         LifecycleAwait.settled("cluster start in setUp()", cluster, cluster.start());
-        await().atMost(WAIT_TIMEOUT).pollInterval(POLL_INTERVAL).until(() -> cluster.currentLeader()
-                                                                                    .isPresent());
-        await().atMost(WAIT_TIMEOUT).pollInterval(POLL_INTERVAL).until(this::allNodesHealthy);
+
+        await().atMost(WAIT_TIMEOUT)
+               .pollInterval(POLL_INTERVAL)
+               .until(() -> cluster.currentLeader().isPresent());
+
+        await().atMost(WAIT_TIMEOUT)
+               .pollInterval(POLL_INTERVAL)
+               .until(this::allNodesHealthy);
     }
 
     @BeforeEach
@@ -79,35 +85,40 @@ class SliceDeploymentTest {
     @AfterAll
     void tearDown() {
         if (cluster != null) {
-            LifecycleAwait.settled("cluster stop in tearDown()", cluster, cluster.stop());
+            LifecycleAwait.bestEffort("cluster stop in tearDown()", cluster, cluster.stop());
         }
     }
 
     @Test
     void deploySlice_becomesActive() {
         var leaderPort = cluster.getLeaderManagementPort().unwrap();
+
         var response = deploy(leaderPort, TEST_ARTIFACT, 1);
-
         assertThat(response).doesNotContain("\"error\"");
-        await().atMost(DEPLOY_TIMEOUT).pollInterval(POLL_INTERVAL).until(() -> sliceIsActive(TEST_ARTIFACT));
-        var slices = getSlices(leaderPort);
 
+        await().atMost(DEPLOY_TIMEOUT)
+               .pollInterval(POLL_INTERVAL)
+               .until(() -> sliceIsActive(TEST_ARTIFACT));
+
+        var slices = getSlices(leaderPort);
         assertThat(slices).contains(TEST_ARTIFACT);
     }
 
     @Test
     void deploySlice_multipleInstances_distributedAcrossNodes() {
         var leaderPort = cluster.getLeaderManagementPort().unwrap();
-        var response = deploy(leaderPort, TEST_ARTIFACT, 3);
 
+        var response = deploy(leaderPort, TEST_ARTIFACT, 3);
         assertThat(response).doesNotContain("\"error\"");
-        await().atMost(DEPLOY_TIMEOUT).pollInterval(POLL_INTERVAL).until(() -> sliceIsActive(TEST_ARTIFACT));
+
+        await().atMost(DEPLOY_TIMEOUT)
+               .pollInterval(POLL_INTERVAL)
+               .until(() -> sliceIsActive(TEST_ARTIFACT));
+
         // Check that instances are distributed - each node should report the slice
         var status = cluster.status();
-
         for (var node : status.nodes()) {
             var nodeSlices = getSlices(node.mgmtPort());
-
             assertThat(nodeSlices).contains(TEST_ARTIFACT);
         }
     }
@@ -115,46 +126,53 @@ class SliceDeploymentTest {
     @Test
     void scaleSlice_adjustsInstanceCount() {
         var leaderPort = cluster.getLeaderManagementPort().unwrap();
+
         // Deploy with 1 instance
         deploy(leaderPort, TEST_ARTIFACT, 1);
-        await().atMost(DEPLOY_TIMEOUT).pollInterval(POLL_INTERVAL).until(() -> sliceIsActive(TEST_ARTIFACT));
+        await().atMost(DEPLOY_TIMEOUT)
+               .pollInterval(POLL_INTERVAL)
+               .until(() -> sliceIsActive(TEST_ARTIFACT));
+
         // Scale to 3 instances
         var scaleResponse = scale(leaderPort, TEST_ARTIFACT, 3);
-
         assertThat(scaleResponse).doesNotContain("\"error\"");
+
         // Wait for scale operation to complete
         await().atMost(DEPLOY_TIMEOUT)
-             .pollInterval(Duration.ofSeconds(2))
-             .until(() -> {
-                 var slices = getSlices(leaderPort);
-
-                 return slices.contains(TEST_ARTIFACT);
-             });
+               .pollInterval(Duration.ofSeconds(2))
+               .until(() -> {
+                   var slices = getSlices(leaderPort);
+                   return slices.contains(TEST_ARTIFACT);
+               });
     }
 
     @Test
     void undeploySlice_removesFromCluster() {
         var leaderPort = cluster.getLeaderManagementPort().unwrap();
+
         // Deploy
         deploy(leaderPort, TEST_ARTIFACT, 1);
-        await().atMost(DEPLOY_TIMEOUT).pollInterval(POLL_INTERVAL).until(() -> sliceIsActive(TEST_ARTIFACT));
+        await().atMost(DEPLOY_TIMEOUT)
+               .pollInterval(POLL_INTERVAL)
+               .until(() -> sliceIsActive(TEST_ARTIFACT));
+
         // Undeploy
         var undeployResponse = undeploy(leaderPort, TEST_ARTIFACT);
-
         assertThat(undeployResponse).doesNotContain("\"error\"");
+
         // Wait for slice to be removed
         await().atMost(DEPLOY_TIMEOUT)
-             .pollInterval(POLL_INTERVAL)
-             .until(() -> {
-                 var slices = getSlices(leaderPort);
-
-                 return ! slices.contains(TEST_ARTIFACT);
-             });
+               .pollInterval(POLL_INTERVAL)
+               .until(() -> {
+                   var slices = getSlices(leaderPort);
+                   return !slices.contains(TEST_ARTIFACT);
+               });
     }
 
     @Test
     void blueprintApply_deploysMultipleSlices() {
         var leaderPort = cluster.getLeaderManagementPort().unwrap();
+
         var blueprint = """
             id = "org.test:blueprint:1.0.0"
 
@@ -162,13 +180,17 @@ class SliceDeploymentTest {
             artifact = "%s"
             instances = 2
             """.formatted(TEST_ARTIFACT);
-        var response = applyBlueprint(leaderPort, blueprint);
 
+        var response = applyBlueprint(leaderPort, blueprint);
         assertThat(response).doesNotContain("\"error\"");
-        await().atMost(DEPLOY_TIMEOUT).pollInterval(POLL_INTERVAL).until(() -> sliceIsActive(TEST_ARTIFACT));
+
+        await().atMost(DEPLOY_TIMEOUT)
+               .pollInterval(POLL_INTERVAL)
+               .until(() -> sliceIsActive(TEST_ARTIFACT));
     }
 
     // ===== HTTP Helper Methods =====
+
     private String deploy(int port, String artifact, int instances) {
         var blueprint = """
             id = "%s"
@@ -177,19 +199,16 @@ class SliceDeploymentTest {
             artifact = "%s"
             instances = %d
             """.formatted(BLUEPRINT_ID, artifact, instances);
-
         return postBlueprintWithRetry(port, blueprint);
     }
 
     private String postBlueprintWithRetry(int port, String body) {
         String lastResponse = null;
-
         for (int attempt = 1; attempt <= 3; attempt++) {
             lastResponse = post(port, "/api/v1/blueprints", body, "application/toml");
             if (!lastResponse.contains("\"error\"")) {
                 return lastResponse;
             }
-
             if (attempt < 3) {
                 try {
                     Thread.sleep(2000);
@@ -199,13 +218,11 @@ class SliceDeploymentTest {
                 }
             }
         }
-
         return lastResponse;
     }
 
     private String scale(int port, String artifact, int instances) {
         var body = String.format("{\"artifact\": \"%s\", \"instances\": %d}", artifact, instances);
-
         return post(port, "/api/v1/scale", body, "application/json");
     }
 
@@ -223,7 +240,6 @@ class SliceDeploymentTest {
                                  .GET()
                                  .timeout(Duration.ofSeconds(10))
                                  .build();
-
         return http.sendString(request)
                    .await()
                    .map(HttpResult::body)
@@ -236,7 +252,6 @@ class SliceDeploymentTest {
                                  .DELETE()
                                  .timeout(Duration.ofSeconds(10))
                                  .build();
-
         return http.sendString(request)
                    .await()
                    .map(HttpResult::body)
@@ -250,7 +265,6 @@ class SliceDeploymentTest {
                                  .POST(HttpRequest.BodyPublishers.ofString(body))
                                  .timeout(Duration.ofSeconds(10))
                                  .build();
-
         return http.sendString(request)
                    .await()
                    .map(HttpResult::body)
@@ -260,11 +274,9 @@ class SliceDeploymentTest {
     private boolean sliceIsActive(String artifact) {
         try {
             var slicesStatus = cluster.slicesStatus();
-
             return slicesStatus.stream()
-                               .anyMatch(status -> status.artifact()
-                                                         .equals(artifact) && status.state()
-                                                                                    .equals(SliceState.ACTIVE.name()));
+                               .anyMatch(status -> status.artifact().equals(artifact)
+                                                   && status.state().equals(SliceState.ACTIVE.name()));
         } catch (Exception e) {
             return false;
         }
@@ -272,9 +284,7 @@ class SliceDeploymentTest {
 
     private boolean allNodesHealthy() {
         var status = cluster.status();
-
-        return status.nodes()
-                     .stream()
+        return status.nodes().stream()
                      .allMatch(node -> checkNodeHealth(node.mgmtPort()));
     }
 
@@ -284,11 +294,9 @@ class SliceDeploymentTest {
                                  .GET()
                                  .timeout(Duration.ofSeconds(5))
                                  .build();
-
         return http.sendString(request)
                    .await()
-                   .map(r -> r.statusCode() == 200 && r.body()
-                                                       .contains("\"quorum\":true"))
+                   .map(r -> r.statusCode() == 200 && r.body().contains("\"quorum\":true"))
                    .or(false);
     }
 }

--- a/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/SliceMediaTypeTest.java
+++ b/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/SliceMediaTypeTest.java
@@ -2,15 +2,8 @@
 // Copyright (c) 2025 Pragmatica Labs - Sergiy Yevtushenko
 // Licensed under Business Source License 1.1. Change Date: 2030-01-01. Change License: Apache-2.0.
 // See LICENSE in the repository root for full terms.
+
 package org.pragmatica.aether.forge;
-
-import java.net.URI;
-import java.net.http.HttpRequest;
-import java.time.Duration;
-
-import org.pragmatica.http.HttpOperations;
-import org.pragmatica.http.HttpResult;
-import org.pragmatica.aether.ember.EmberCluster;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -18,12 +11,18 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.pragmatica.http.HttpOperations;
+import org.pragmatica.http.HttpResult;
 
-import static org.pragmatica.aether.ember.EmberCluster.emberCluster;
-import static org.pragmatica.http.JdkHttpOperations.jdkHttpOperations;
+import java.net.URI;
+import java.net.http.HttpRequest;
+import java.time.Duration;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
-
+import org.pragmatica.aether.ember.EmberCluster;
+import static org.pragmatica.aether.ember.EmberCluster.emberCluster;
+import static org.pragmatica.http.JdkHttpOperations.jdkHttpOperations;
 
 /// Proves the #339 `produces` media types reach the wire: a deployed slice route declared with
 /// `produces = "text/csv"` returns the `text/csv` Content-Type, and a route declared with
@@ -52,15 +51,18 @@ class SliceMediaTypeTest {
     void setUp() {
         cluster = emberCluster(3, BASE_PORT, BASE_MGMT_PORT, BASE_APP_HTTP_PORT, "smt");
         LifecycleAwait.settled("cluster start in setUp()", cluster, cluster.start());
-        await().atMost(WAIT_TIMEOUT).pollInterval(POLL_INTERVAL).until(() -> cluster.currentLeader()
-                                                                                    .isPresent());
+
+        await().atMost(WAIT_TIMEOUT)
+               .pollInterval(POLL_INTERVAL)
+               .until(() -> cluster.currentLeader().isPresent());
+
         deployEchoSlice();
     }
 
     @AfterAll
     void tearDown() {
         if (cluster != null) {
-            LifecycleAwait.settled("cluster stop in tearDown()", cluster, cluster.stop());
+            LifecycleAwait.bestEffort("cluster stop in tearDown()", cluster, cluster.stop());
         }
     }
 
@@ -83,7 +85,11 @@ class SliceMediaTypeTest {
     @Test
     void binaryRoute_returnsVerbatimBytesUnderOctetStream() {
         var port = appPort();
-        var expected = new byte[]{(byte) BINARY_SEED, (byte)(BINARY_SEED + 1), (byte)(BINARY_SEED + 2), (byte)(BINARY_SEED + 3)};
+        var expected = new byte[]{(byte) BINARY_SEED,
+                                  (byte) (BINARY_SEED + 1),
+                                  (byte) (BINARY_SEED + 2),
+                                  (byte) (BINARY_SEED + 3)};
+
         var response = http.sendBytes(getRequest(port, "/binary/" + BINARY_SEED))
                            .await()
                            .onFailure(cause -> {
@@ -100,30 +106,28 @@ class SliceMediaTypeTest {
 
     private void deployEchoSlice() {
         var deployResponse = deploy(TEST_ARTIFACT);
+        assertThat(deployResponse)
+            .describedAs("Deployment response")
+            .doesNotContain("\"error\"")
+            .contains("\"status\":\"applied\"");
 
-        assertThat(deployResponse).describedAs("Deployment response")
-                  .doesNotContain("\"error\"")
-                  .contains("\"status\":\"applied\"");
         await().atMost(WAIT_TIMEOUT)
-             .pollInterval(POLL_INTERVAL)
-             .failFast(() -> {
-                           if (sliceHasFailed()) {
-                           throw new AssertionError("Slice deployment failed: " + TEST_ARTIFACT);
-                       }
-                       })
-             .until(this::routesReady);
+               .pollInterval(POLL_INTERVAL)
+               .failFast(() -> {
+                   if (sliceHasFailed()) {
+                       throw new AssertionError("Slice deployment failed: " + TEST_ARTIFACT);
+                   }
+               })
+               .until(this::routesReady);
     }
 
     private boolean routesReady() {
-        return getSlices().contains("echo-slice") && !cluster.getAvailableAppHttpPorts()
-                                                             .isEmpty();
+        return getSlices().contains("echo-slice") && !cluster.getAvailableAppHttpPorts().isEmpty();
     }
 
     private int appPort() {
         var ports = cluster.getAvailableAppHttpPorts();
-
         assertThat(ports).describedAs("available app HTTP ports").isNotEmpty();
-
         return ports.getFirst();
     }
 
@@ -144,24 +148,20 @@ class SliceMediaTypeTest {
             instances = 1
             """.formatted(BLUEPRINT_ID, artifact);
         var leaderPort = cluster.getLeaderManagementPort().or(anyMgmtPort());
-
         return postBlueprintWithRetry(leaderPort, blueprint);
     }
 
     private String postBlueprintWithRetry(int port, String body) {
         String lastResponse = null;
-
         for (int attempt = 1; attempt <= 3; attempt++) {
             lastResponse = httpRequestBlueprint(port, body);
             if (!lastResponse.contains("\"error\"")) {
                 return lastResponse;
             }
-
             if (attempt < 3) {
                 sleepQuietly();
             }
         }
-
         return lastResponse;
     }
 
@@ -180,7 +180,6 @@ class SliceMediaTypeTest {
                                  .POST(HttpRequest.BodyPublishers.ofString(body))
                                  .timeout(Duration.ofSeconds(10))
                                  .build();
-
         return http.sendString(request)
                    .await()
                    .map(HttpResult::body)
@@ -190,9 +189,7 @@ class SliceMediaTypeTest {
     private boolean sliceHasFailed() {
         return cluster.slicesStatus()
                       .stream()
-                      .anyMatch(s -> s.artifact()
-                                      .equals(TEST_ARTIFACT) && s.state()
-                                                                 .equals("FAILED"));
+                      .anyMatch(s -> s.artifact().equals(TEST_ARTIFACT) && s.state().equals("FAILED"));
     }
 
     private String getSlices() {
@@ -207,9 +204,6 @@ class SliceMediaTypeTest {
     }
 
     private int anyMgmtPort() {
-        return cluster.status()
-                      .nodes()
-                      .getFirst()
-                      .mgmtPort();
+        return cluster.status().nodes().getFirst().mgmtPort();
     }
 }

--- a/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/SliceMediaTypeTest.java
+++ b/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/SliceMediaTypeTest.java
@@ -2,8 +2,15 @@
 // Copyright (c) 2025 Pragmatica Labs - Sergiy Yevtushenko
 // Licensed under Business Source License 1.1. Change Date: 2030-01-01. Change License: Apache-2.0.
 // See LICENSE in the repository root for full terms.
-
 package org.pragmatica.aether.forge;
+
+import java.net.URI;
+import java.net.http.HttpRequest;
+import java.time.Duration;
+
+import org.pragmatica.http.HttpOperations;
+import org.pragmatica.http.HttpResult;
+import org.pragmatica.aether.ember.EmberCluster;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -11,18 +18,12 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
-import org.pragmatica.http.HttpOperations;
-import org.pragmatica.http.HttpResult;
 
-import java.net.URI;
-import java.net.http.HttpRequest;
-import java.time.Duration;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.awaitility.Awaitility.await;
-import org.pragmatica.aether.ember.EmberCluster;
 import static org.pragmatica.aether.ember.EmberCluster.emberCluster;
 import static org.pragmatica.http.JdkHttpOperations.jdkHttpOperations;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
 
 /// Proves the #339 `produces` media types reach the wire: a deployed slice route declared with
 /// `produces = "text/csv"` returns the `text/csv` Content-Type, and a route declared with
@@ -50,24 +51,16 @@ class SliceMediaTypeTest {
     @BeforeAll
     void setUp() {
         cluster = emberCluster(3, BASE_PORT, BASE_MGMT_PORT, BASE_APP_HTTP_PORT, "smt");
-        cluster.start()
-               .await()
-               .onFailure(cause -> {
-                   throw new AssertionError("Cluster start failed: " + cause.message());
-               });
-
-        await().atMost(WAIT_TIMEOUT)
-               .pollInterval(POLL_INTERVAL)
-               .until(() -> cluster.currentLeader().isPresent());
-
+        LifecycleAwait.settled("cluster start in setUp()", cluster, cluster.start());
+        await().atMost(WAIT_TIMEOUT).pollInterval(POLL_INTERVAL).until(() -> cluster.currentLeader()
+                                                                                    .isPresent());
         deployEchoSlice();
     }
 
     @AfterAll
     void tearDown() {
         if (cluster != null) {
-            cluster.stop()
-                   .await();
+            LifecycleAwait.settled("cluster stop in tearDown()", cluster, cluster.stop());
         }
     }
 
@@ -90,11 +83,7 @@ class SliceMediaTypeTest {
     @Test
     void binaryRoute_returnsVerbatimBytesUnderOctetStream() {
         var port = appPort();
-        var expected = new byte[]{(byte) BINARY_SEED,
-                                  (byte) (BINARY_SEED + 1),
-                                  (byte) (BINARY_SEED + 2),
-                                  (byte) (BINARY_SEED + 3)};
-
+        var expected = new byte[]{(byte) BINARY_SEED, (byte)(BINARY_SEED + 1), (byte)(BINARY_SEED + 2), (byte)(BINARY_SEED + 3)};
         var response = http.sendBytes(getRequest(port, "/binary/" + BINARY_SEED))
                            .await()
                            .onFailure(cause -> {
@@ -111,28 +100,30 @@ class SliceMediaTypeTest {
 
     private void deployEchoSlice() {
         var deployResponse = deploy(TEST_ARTIFACT);
-        assertThat(deployResponse)
-            .describedAs("Deployment response")
-            .doesNotContain("\"error\"")
-            .contains("\"status\":\"applied\"");
 
+        assertThat(deployResponse).describedAs("Deployment response")
+                  .doesNotContain("\"error\"")
+                  .contains("\"status\":\"applied\"");
         await().atMost(WAIT_TIMEOUT)
-               .pollInterval(POLL_INTERVAL)
-               .failFast(() -> {
-                   if (sliceHasFailed()) {
-                       throw new AssertionError("Slice deployment failed: " + TEST_ARTIFACT);
-                   }
-               })
-               .until(this::routesReady);
+             .pollInterval(POLL_INTERVAL)
+             .failFast(() -> {
+                           if (sliceHasFailed()) {
+                           throw new AssertionError("Slice deployment failed: " + TEST_ARTIFACT);
+                       }
+                       })
+             .until(this::routesReady);
     }
 
     private boolean routesReady() {
-        return getSlices().contains("echo-slice") && !cluster.getAvailableAppHttpPorts().isEmpty();
+        return getSlices().contains("echo-slice") && !cluster.getAvailableAppHttpPorts()
+                                                             .isEmpty();
     }
 
     private int appPort() {
         var ports = cluster.getAvailableAppHttpPorts();
+
         assertThat(ports).describedAs("available app HTTP ports").isNotEmpty();
+
         return ports.getFirst();
     }
 
@@ -153,20 +144,24 @@ class SliceMediaTypeTest {
             instances = 1
             """.formatted(BLUEPRINT_ID, artifact);
         var leaderPort = cluster.getLeaderManagementPort().or(anyMgmtPort());
+
         return postBlueprintWithRetry(leaderPort, blueprint);
     }
 
     private String postBlueprintWithRetry(int port, String body) {
         String lastResponse = null;
+
         for (int attempt = 1; attempt <= 3; attempt++) {
             lastResponse = httpRequestBlueprint(port, body);
             if (!lastResponse.contains("\"error\"")) {
                 return lastResponse;
             }
+
             if (attempt < 3) {
                 sleepQuietly();
             }
         }
+
         return lastResponse;
     }
 
@@ -185,6 +180,7 @@ class SliceMediaTypeTest {
                                  .POST(HttpRequest.BodyPublishers.ofString(body))
                                  .timeout(Duration.ofSeconds(10))
                                  .build();
+
         return http.sendString(request)
                    .await()
                    .map(HttpResult::body)
@@ -194,7 +190,9 @@ class SliceMediaTypeTest {
     private boolean sliceHasFailed() {
         return cluster.slicesStatus()
                       .stream()
-                      .anyMatch(s -> s.artifact().equals(TEST_ARTIFACT) && s.state().equals("FAILED"));
+                      .anyMatch(s -> s.artifact()
+                                      .equals(TEST_ARTIFACT) && s.state()
+                                                                 .equals("FAILED"));
     }
 
     private String getSlices() {
@@ -209,6 +207,9 @@ class SliceMediaTypeTest {
     }
 
     private int anyMgmtPort() {
-        return cluster.status().nodes().getFirst().mgmtPort();
+        return cluster.status()
+                      .nodes()
+                      .getFirst()
+                      .mgmtPort();
     }
 }

--- a/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/SliceVersionLifecycleTest.java
+++ b/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/SliceVersionLifecycleTest.java
@@ -2,16 +2,8 @@
 // Copyright (c) 2025 Pragmatica Labs - Sergiy Yevtushenko
 // Licensed under Business Source License 1.1. Change Date: 2030-01-01. Change License: Apache-2.0.
 // See LICENSE in the repository root for full terms.
+
 package org.pragmatica.aether.forge;
-
-import java.net.URI;
-import java.net.http.HttpRequest;
-import java.time.Duration;
-
-import org.pragmatica.http.HttpOperations;
-import org.pragmatica.http.HttpResult;
-import org.pragmatica.lang.Result;
-import org.pragmatica.aether.ember.EmberCluster;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -19,12 +11,19 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.pragmatica.http.HttpOperations;
+import org.pragmatica.http.HttpResult;
+import org.pragmatica.lang.Result;
 
-import static org.pragmatica.aether.ember.EmberCluster.emberCluster;
-import static org.pragmatica.http.JdkHttpOperations.jdkHttpOperations;
+import java.net.URI;
+import java.net.http.HttpRequest;
+import java.time.Duration;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
-
+import org.pragmatica.aether.ember.EmberCluster;
+import static org.pragmatica.aether.ember.EmberCluster.emberCluster;
+import static org.pragmatica.http.JdkHttpOperations.jdkHttpOperations;
 
 /// Proves #198 §8.2 deprecation/sunset/successor response headers and §11.3 version-registry
 /// introspection reach the wire.
@@ -55,15 +54,18 @@ class SliceVersionLifecycleTest {
     void setUp() {
         cluster = emberCluster(3, BASE_PORT, BASE_MGMT_PORT, BASE_APP_HTTP_PORT, "svl");
         LifecycleAwait.settled("cluster start in setUp()", cluster, cluster.start());
-        await().atMost(WAIT_TIMEOUT).pollInterval(POLL_INTERVAL).until(() -> cluster.currentLeader()
-                                                                                    .isPresent());
+
+        await().atMost(WAIT_TIMEOUT)
+               .pollInterval(POLL_INTERVAL)
+               .until(() -> cluster.currentLeader().isPresent());
+
         deployVersionedSlice();
     }
 
     @AfterAll
     void tearDown() {
         if (cluster != null) {
-            LifecycleAwait.settled("cluster stop in tearDown()", cluster, cluster.stop());
+            LifecycleAwait.bestEffort("cluster stop in tearDown()", cluster, cluster.stop());
         }
     }
 
@@ -73,8 +75,8 @@ class SliceVersionLifecycleTest {
             assertThat(result.statusCode()).isEqualTo(200);
             assertThat(result.header("Deprecation").or("")).isEqualTo("true");
             assertThat(result.header("Sunset").or("")).isEqualTo("Thu, 31 Dec 2026 00:00:00 GMT");
-            assertThat(result.header("Link").or("")).isEqualTo("</api/orders/v2/" + ITEM_ID
-                                                              + ">; rel=\"successor-version\"");
+            assertThat(result.header("Link").or(""))
+                .isEqualTo("</api/orders/v2/" + ITEM_ID + ">; rel=\"successor-version\"");
         });
     }
 
@@ -113,27 +115,26 @@ class SliceVersionLifecycleTest {
 
     private void deployVersionedSlice() {
         var deployResponse = deploy(TEST_ARTIFACT);
+        assertThat(deployResponse)
+            .describedAs("Deployment response")
+            .doesNotContain("\"error\"")
+            .contains("\"status\":\"applied\"");
 
-        assertThat(deployResponse).describedAs("Deployment response")
-                  .doesNotContain("\"error\"")
-                  .contains("\"status\":\"applied\"");
         await().atMost(WAIT_TIMEOUT)
-             .pollInterval(POLL_INTERVAL)
-             .failFast(() -> {
-                           if (sliceHasFailed()) {
-                           throw new AssertionError("Slice deployment failed: " + TEST_ARTIFACT);
-                       }
-                       })
-             .until(this::v1RouteServes);
+               .pollInterval(POLL_INTERVAL)
+               .failFast(() -> {
+                   if (sliceHasFailed()) {
+                       throw new AssertionError("Slice deployment failed: " + TEST_ARTIFACT);
+                   }
+               })
+               .until(this::v1RouteServes);
     }
 
     private boolean v1RouteServes() {
         if (cluster.getAvailableAppHttpPorts().isEmpty()) {
             return false;
         }
-
-        return http.sendString(getRequest(appPort(),
-                                          "/api/orders/v1/" + ITEM_ID))
+        return http.sendString(getRequest(appPort(), "/api/orders/v1/" + ITEM_ID))
                    .await()
                    .map(result -> result.statusCode() == 200)
                    .or(false);
@@ -141,9 +142,7 @@ class SliceVersionLifecycleTest {
 
     private int appPort() {
         var ports = cluster.getAvailableAppHttpPorts();
-
         assertThat(ports).describedAs("available app HTTP ports").isNotEmpty();
-
         return ports.getFirst();
     }
 
@@ -164,24 +163,20 @@ class SliceVersionLifecycleTest {
             instances = 1
             """.formatted(BLUEPRINT_ID, artifact);
         var leaderPort = cluster.getLeaderManagementPort().or(anyMgmtPort());
-
         return postBlueprintWithRetry(leaderPort, blueprint);
     }
 
     private String postBlueprintWithRetry(int port, String body) {
         String lastResponse = null;
-
         for (int attempt = 1; attempt <= 3; attempt++) {
             lastResponse = httpRequestBlueprint(port, body);
             if (!lastResponse.contains("\"error\"")) {
                 return lastResponse;
             }
-
             if (attempt < 3) {
                 sleepQuietly();
             }
         }
-
         return lastResponse;
     }
 
@@ -200,7 +195,6 @@ class SliceVersionLifecycleTest {
                                  .POST(HttpRequest.BodyPublishers.ofString(body))
                                  .timeout(Duration.ofSeconds(10))
                                  .build();
-
         return http.sendString(request)
                    .await()
                    .map(HttpResult::body)
@@ -210,15 +204,10 @@ class SliceVersionLifecycleTest {
     private boolean sliceHasFailed() {
         return cluster.slicesStatus()
                       .stream()
-                      .anyMatch(s -> s.artifact()
-                                      .equals(TEST_ARTIFACT) && s.state()
-                                                                 .equals("FAILED"));
+                      .anyMatch(s -> s.artifact().equals(TEST_ARTIFACT) && s.state().equals("FAILED"));
     }
 
     private int anyMgmtPort() {
-        return cluster.status()
-                      .nodes()
-                      .getFirst()
-                      .mgmtPort();
+        return cluster.status().nodes().getFirst().mgmtPort();
     }
 }

--- a/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/SliceVersionLifecycleTest.java
+++ b/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/SliceVersionLifecycleTest.java
@@ -2,8 +2,16 @@
 // Copyright (c) 2025 Pragmatica Labs - Sergiy Yevtushenko
 // Licensed under Business Source License 1.1. Change Date: 2030-01-01. Change License: Apache-2.0.
 // See LICENSE in the repository root for full terms.
-
 package org.pragmatica.aether.forge;
+
+import java.net.URI;
+import java.net.http.HttpRequest;
+import java.time.Duration;
+
+import org.pragmatica.http.HttpOperations;
+import org.pragmatica.http.HttpResult;
+import org.pragmatica.lang.Result;
+import org.pragmatica.aether.ember.EmberCluster;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -11,19 +19,12 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
-import org.pragmatica.http.HttpOperations;
-import org.pragmatica.http.HttpResult;
-import org.pragmatica.lang.Result;
 
-import java.net.URI;
-import java.net.http.HttpRequest;
-import java.time.Duration;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.awaitility.Awaitility.await;
-import org.pragmatica.aether.ember.EmberCluster;
 import static org.pragmatica.aether.ember.EmberCluster.emberCluster;
 import static org.pragmatica.http.JdkHttpOperations.jdkHttpOperations;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
 
 /// Proves #198 §8.2 deprecation/sunset/successor response headers and §11.3 version-registry
 /// introspection reach the wire.
@@ -53,24 +54,16 @@ class SliceVersionLifecycleTest {
     @BeforeAll
     void setUp() {
         cluster = emberCluster(3, BASE_PORT, BASE_MGMT_PORT, BASE_APP_HTTP_PORT, "svl");
-        cluster.start()
-               .await()
-               .onFailure(cause -> {
-                   throw new AssertionError("Cluster start failed: " + cause.message());
-               });
-
-        await().atMost(WAIT_TIMEOUT)
-               .pollInterval(POLL_INTERVAL)
-               .until(() -> cluster.currentLeader().isPresent());
-
+        LifecycleAwait.settled("cluster start in setUp()", cluster, cluster.start());
+        await().atMost(WAIT_TIMEOUT).pollInterval(POLL_INTERVAL).until(() -> cluster.currentLeader()
+                                                                                    .isPresent());
         deployVersionedSlice();
     }
 
     @AfterAll
     void tearDown() {
         if (cluster != null) {
-            cluster.stop()
-                   .await();
+            LifecycleAwait.settled("cluster stop in tearDown()", cluster, cluster.stop());
         }
     }
 
@@ -80,8 +73,8 @@ class SliceVersionLifecycleTest {
             assertThat(result.statusCode()).isEqualTo(200);
             assertThat(result.header("Deprecation").or("")).isEqualTo("true");
             assertThat(result.header("Sunset").or("")).isEqualTo("Thu, 31 Dec 2026 00:00:00 GMT");
-            assertThat(result.header("Link").or(""))
-                .isEqualTo("</api/orders/v2/" + ITEM_ID + ">; rel=\"successor-version\"");
+            assertThat(result.header("Link").or("")).isEqualTo("</api/orders/v2/" + ITEM_ID
+                                                              + ">; rel=\"successor-version\"");
         });
     }
 
@@ -120,26 +113,27 @@ class SliceVersionLifecycleTest {
 
     private void deployVersionedSlice() {
         var deployResponse = deploy(TEST_ARTIFACT);
-        assertThat(deployResponse)
-            .describedAs("Deployment response")
-            .doesNotContain("\"error\"")
-            .contains("\"status\":\"applied\"");
 
+        assertThat(deployResponse).describedAs("Deployment response")
+                  .doesNotContain("\"error\"")
+                  .contains("\"status\":\"applied\"");
         await().atMost(WAIT_TIMEOUT)
-               .pollInterval(POLL_INTERVAL)
-               .failFast(() -> {
-                   if (sliceHasFailed()) {
-                       throw new AssertionError("Slice deployment failed: " + TEST_ARTIFACT);
-                   }
-               })
-               .until(this::v1RouteServes);
+             .pollInterval(POLL_INTERVAL)
+             .failFast(() -> {
+                           if (sliceHasFailed()) {
+                           throw new AssertionError("Slice deployment failed: " + TEST_ARTIFACT);
+                       }
+                       })
+             .until(this::v1RouteServes);
     }
 
     private boolean v1RouteServes() {
         if (cluster.getAvailableAppHttpPorts().isEmpty()) {
             return false;
         }
-        return http.sendString(getRequest(appPort(), "/api/orders/v1/" + ITEM_ID))
+
+        return http.sendString(getRequest(appPort(),
+                                          "/api/orders/v1/" + ITEM_ID))
                    .await()
                    .map(result -> result.statusCode() == 200)
                    .or(false);
@@ -147,7 +141,9 @@ class SliceVersionLifecycleTest {
 
     private int appPort() {
         var ports = cluster.getAvailableAppHttpPorts();
+
         assertThat(ports).describedAs("available app HTTP ports").isNotEmpty();
+
         return ports.getFirst();
     }
 
@@ -168,20 +164,24 @@ class SliceVersionLifecycleTest {
             instances = 1
             """.formatted(BLUEPRINT_ID, artifact);
         var leaderPort = cluster.getLeaderManagementPort().or(anyMgmtPort());
+
         return postBlueprintWithRetry(leaderPort, blueprint);
     }
 
     private String postBlueprintWithRetry(int port, String body) {
         String lastResponse = null;
+
         for (int attempt = 1; attempt <= 3; attempt++) {
             lastResponse = httpRequestBlueprint(port, body);
             if (!lastResponse.contains("\"error\"")) {
                 return lastResponse;
             }
+
             if (attempt < 3) {
                 sleepQuietly();
             }
         }
+
         return lastResponse;
     }
 
@@ -200,6 +200,7 @@ class SliceVersionLifecycleTest {
                                  .POST(HttpRequest.BodyPublishers.ofString(body))
                                  .timeout(Duration.ofSeconds(10))
                                  .build();
+
         return http.sendString(request)
                    .await()
                    .map(HttpResult::body)
@@ -209,10 +210,15 @@ class SliceVersionLifecycleTest {
     private boolean sliceHasFailed() {
         return cluster.slicesStatus()
                       .stream()
-                      .anyMatch(s -> s.artifact().equals(TEST_ARTIFACT) && s.state().equals("FAILED"));
+                      .anyMatch(s -> s.artifact()
+                                      .equals(TEST_ARTIFACT) && s.state()
+                                                                 .equals("FAILED"));
     }
 
     private int anyMgmtPort() {
-        return cluster.status().nodes().getFirst().mgmtPort();
+        return cluster.status()
+                      .nodes()
+                      .getFirst()
+                      .mgmtPort();
     }
 }

--- a/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/SliceVersioningHeaderModeTest.java
+++ b/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/SliceVersioningHeaderModeTest.java
@@ -2,8 +2,17 @@
 // Copyright (c) 2025 Pragmatica Labs - Sergiy Yevtushenko
 // Licensed under Business Source License 1.1. Change Date: 2030-01-01. Change License: Apache-2.0.
 // See LICENSE in the repository root for full terms.
-
 package org.pragmatica.aether.forge;
+
+import java.net.URI;
+import java.net.http.HttpRequest;
+import java.time.Duration;
+
+import org.pragmatica.aether.config.ApiVersioningDetection;
+import org.pragmatica.http.HttpOperations;
+import org.pragmatica.http.HttpResult;
+import org.pragmatica.lang.Result;
+import org.pragmatica.aether.ember.EmberCluster;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -11,20 +20,12 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
-import org.pragmatica.aether.config.ApiVersioningDetection;
-import org.pragmatica.http.HttpOperations;
-import org.pragmatica.http.HttpResult;
-import org.pragmatica.lang.Result;
 
-import java.net.URI;
-import java.net.http.HttpRequest;
-import java.time.Duration;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.awaitility.Awaitility.await;
-import org.pragmatica.aether.ember.EmberCluster;
 import static org.pragmatica.aether.ember.EmberCluster.emberCluster;
 import static org.pragmatica.http.JdkHttpOperations.jdkHttpOperations;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
 
 /// Proves #198 §7 HEADER-mode versioning reaches the wire: the SAME compiled two-version slices
 /// deployed earlier in path mode are here deployed into a cluster configured with
@@ -59,16 +60,9 @@ class SliceVersioningHeaderModeTest {
     void setUp() {
         cluster = emberCluster(3, BASE_PORT, BASE_MGMT_PORT, BASE_APP_HTTP_PORT, "smh");
         cluster.withApiVersioningDetection(ApiVersioningDetection.HEADER, VERSION_HEADER);
-        cluster.start()
-               .await()
-               .onFailure(cause -> {
-                   throw new AssertionError("Cluster start failed: " + cause.message());
-               });
-
-        await().atMost(WAIT_TIMEOUT)
-               .pollInterval(POLL_INTERVAL)
-               .until(() -> cluster.currentLeader().isPresent());
-
+        LifecycleAwait.settled("cluster start in setUp()", cluster, cluster.start());
+        await().atMost(WAIT_TIMEOUT).pollInterval(POLL_INTERVAL).until(() -> cluster.currentLeader()
+                                                                                    .isPresent());
         deploy(ORDERS_BLUEPRINT_ID, VERSIONED_SLICE);
         deploy(STRICT_BLUEPRINT_ID, STRICT_SLICE);
         awaitRouteReady("/api/orders/" + ITEM_ID, "1");
@@ -78,8 +72,7 @@ class SliceVersioningHeaderModeTest {
     @AfterAll
     void tearDown() {
         if (cluster != null) {
-            cluster.stop()
-                   .await();
+            LifecycleAwait.settled("cluster stop in tearDown()", cluster, cluster.stop());
         }
     }
 
@@ -132,38 +125,44 @@ class SliceVersioningHeaderModeTest {
     }
 
     private void awaitRouteReady(String path, String version) {
-        await().atMost(WAIT_TIMEOUT)
-               .pollInterval(POLL_INTERVAL)
-               .until(() -> routeServes(path, version));
+        await().atMost(WAIT_TIMEOUT).pollInterval(POLL_INTERVAL).until(() -> routeServes(path, version));
     }
 
     private boolean routeServes(String path, String version) {
         if (cluster.getAvailableAppHttpPorts().isEmpty()) {
             return false;
         }
+
         return send(path, version).map(result -> result.statusCode() == 200)
-                                  .or(false);
+                   .or(false);
     }
 
     private Result<HttpResult<String>> send(String path, String version) {
-        return http.sendString(versionedRequest(appPort(), path, version))
+        return http.sendString(versionedRequest(appPort(),
+                                                path,
+                                                version))
                    .await()
                    .onFailure(cause -> {
-                       throw new AssertionError("request " + path + " (v" + version + ") failed: " + cause.message());
-                   });
+                                  throw new AssertionError("request " + path
+                                                          + " (v" + version
+                                                          + ") failed: " + cause.message());
+                              });
     }
 
     private Result<HttpResult<String>> sendNoHeader(String path) {
-        return http.sendString(getRequest(appPort(), path))
+        return http.sendString(getRequest(appPort(),
+                                          path))
                    .await()
                    .onFailure(cause -> {
-                       throw new AssertionError("request " + path + " (no header) failed: " + cause.message());
-                   });
+                                  throw new AssertionError("request " + path + " (no header) failed: " + cause.message());
+                              });
     }
 
     private int appPort() {
         var ports = cluster.getAvailableAppHttpPorts();
+
         assertThat(ports).describedAs("available app HTTP ports").isNotEmpty();
+
         return ports.getFirst();
     }
 
@@ -186,10 +185,10 @@ class SliceVersioningHeaderModeTest {
 
     private void deploy(String blueprintId, String artifact) {
         var deployResponse = postBlueprint(blueprintId, artifact);
-        assertThat(deployResponse)
-            .describedAs("Deployment response for " + artifact)
-            .doesNotContain("\"error\"")
-            .contains("\"status\":\"applied\"");
+
+        assertThat(deployResponse).describedAs("Deployment response for " + artifact)
+                  .doesNotContain("\"error\"")
+                  .contains("\"status\":\"applied\"");
     }
 
     private String postBlueprint(String blueprintId, String artifact) {
@@ -201,20 +200,24 @@ class SliceVersioningHeaderModeTest {
             instances = 1
             """.formatted(blueprintId, artifact);
         var leaderPort = cluster.getLeaderManagementPort().or(anyMgmtPort());
+
         return postBlueprintWithRetry(leaderPort, blueprint);
     }
 
     private String postBlueprintWithRetry(int port, String body) {
         String lastResponse = null;
+
         for (int attempt = 1; attempt <= 3; attempt++) {
             lastResponse = httpRequestBlueprint(port, body);
             if (!lastResponse.contains("\"error\"")) {
                 return lastResponse;
             }
+
             if (attempt < 3) {
                 sleepQuietly();
             }
         }
+
         return lastResponse;
     }
 
@@ -233,6 +236,7 @@ class SliceVersioningHeaderModeTest {
                                  .POST(HttpRequest.BodyPublishers.ofString(body))
                                  .timeout(Duration.ofSeconds(10))
                                  .build();
+
         return http.sendString(request)
                    .await()
                    .map(HttpResult::body)
@@ -240,6 +244,9 @@ class SliceVersioningHeaderModeTest {
     }
 
     private int anyMgmtPort() {
-        return cluster.status().nodes().getFirst().mgmtPort();
+        return cluster.status()
+                      .nodes()
+                      .getFirst()
+                      .mgmtPort();
     }
 }

--- a/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/SliceVersioningHeaderModeTest.java
+++ b/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/SliceVersioningHeaderModeTest.java
@@ -2,17 +2,8 @@
 // Copyright (c) 2025 Pragmatica Labs - Sergiy Yevtushenko
 // Licensed under Business Source License 1.1. Change Date: 2030-01-01. Change License: Apache-2.0.
 // See LICENSE in the repository root for full terms.
+
 package org.pragmatica.aether.forge;
-
-import java.net.URI;
-import java.net.http.HttpRequest;
-import java.time.Duration;
-
-import org.pragmatica.aether.config.ApiVersioningDetection;
-import org.pragmatica.http.HttpOperations;
-import org.pragmatica.http.HttpResult;
-import org.pragmatica.lang.Result;
-import org.pragmatica.aether.ember.EmberCluster;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -20,12 +11,20 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.pragmatica.aether.config.ApiVersioningDetection;
+import org.pragmatica.http.HttpOperations;
+import org.pragmatica.http.HttpResult;
+import org.pragmatica.lang.Result;
 
-import static org.pragmatica.aether.ember.EmberCluster.emberCluster;
-import static org.pragmatica.http.JdkHttpOperations.jdkHttpOperations;
+import java.net.URI;
+import java.net.http.HttpRequest;
+import java.time.Duration;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
-
+import org.pragmatica.aether.ember.EmberCluster;
+import static org.pragmatica.aether.ember.EmberCluster.emberCluster;
+import static org.pragmatica.http.JdkHttpOperations.jdkHttpOperations;
 
 /// Proves #198 §7 HEADER-mode versioning reaches the wire: the SAME compiled two-version slices
 /// deployed earlier in path mode are here deployed into a cluster configured with
@@ -61,8 +60,11 @@ class SliceVersioningHeaderModeTest {
         cluster = emberCluster(3, BASE_PORT, BASE_MGMT_PORT, BASE_APP_HTTP_PORT, "smh");
         cluster.withApiVersioningDetection(ApiVersioningDetection.HEADER, VERSION_HEADER);
         LifecycleAwait.settled("cluster start in setUp()", cluster, cluster.start());
-        await().atMost(WAIT_TIMEOUT).pollInterval(POLL_INTERVAL).until(() -> cluster.currentLeader()
-                                                                                    .isPresent());
+
+        await().atMost(WAIT_TIMEOUT)
+               .pollInterval(POLL_INTERVAL)
+               .until(() -> cluster.currentLeader().isPresent());
+
         deploy(ORDERS_BLUEPRINT_ID, VERSIONED_SLICE);
         deploy(STRICT_BLUEPRINT_ID, STRICT_SLICE);
         awaitRouteReady("/api/orders/" + ITEM_ID, "1");
@@ -72,7 +74,7 @@ class SliceVersioningHeaderModeTest {
     @AfterAll
     void tearDown() {
         if (cluster != null) {
-            LifecycleAwait.settled("cluster stop in tearDown()", cluster, cluster.stop());
+            LifecycleAwait.bestEffort("cluster stop in tearDown()", cluster, cluster.stop());
         }
     }
 
@@ -125,44 +127,38 @@ class SliceVersioningHeaderModeTest {
     }
 
     private void awaitRouteReady(String path, String version) {
-        await().atMost(WAIT_TIMEOUT).pollInterval(POLL_INTERVAL).until(() -> routeServes(path, version));
+        await().atMost(WAIT_TIMEOUT)
+               .pollInterval(POLL_INTERVAL)
+               .until(() -> routeServes(path, version));
     }
 
     private boolean routeServes(String path, String version) {
         if (cluster.getAvailableAppHttpPorts().isEmpty()) {
             return false;
         }
-
         return send(path, version).map(result -> result.statusCode() == 200)
-                   .or(false);
+                                  .or(false);
     }
 
     private Result<HttpResult<String>> send(String path, String version) {
-        return http.sendString(versionedRequest(appPort(),
-                                                path,
-                                                version))
+        return http.sendString(versionedRequest(appPort(), path, version))
                    .await()
                    .onFailure(cause -> {
-                                  throw new AssertionError("request " + path
-                                                          + " (v" + version
-                                                          + ") failed: " + cause.message());
-                              });
+                       throw new AssertionError("request " + path + " (v" + version + ") failed: " + cause.message());
+                   });
     }
 
     private Result<HttpResult<String>> sendNoHeader(String path) {
-        return http.sendString(getRequest(appPort(),
-                                          path))
+        return http.sendString(getRequest(appPort(), path))
                    .await()
                    .onFailure(cause -> {
-                                  throw new AssertionError("request " + path + " (no header) failed: " + cause.message());
-                              });
+                       throw new AssertionError("request " + path + " (no header) failed: " + cause.message());
+                   });
     }
 
     private int appPort() {
         var ports = cluster.getAvailableAppHttpPorts();
-
         assertThat(ports).describedAs("available app HTTP ports").isNotEmpty();
-
         return ports.getFirst();
     }
 
@@ -185,10 +181,10 @@ class SliceVersioningHeaderModeTest {
 
     private void deploy(String blueprintId, String artifact) {
         var deployResponse = postBlueprint(blueprintId, artifact);
-
-        assertThat(deployResponse).describedAs("Deployment response for " + artifact)
-                  .doesNotContain("\"error\"")
-                  .contains("\"status\":\"applied\"");
+        assertThat(deployResponse)
+            .describedAs("Deployment response for " + artifact)
+            .doesNotContain("\"error\"")
+            .contains("\"status\":\"applied\"");
     }
 
     private String postBlueprint(String blueprintId, String artifact) {
@@ -200,24 +196,20 @@ class SliceVersioningHeaderModeTest {
             instances = 1
             """.formatted(blueprintId, artifact);
         var leaderPort = cluster.getLeaderManagementPort().or(anyMgmtPort());
-
         return postBlueprintWithRetry(leaderPort, blueprint);
     }
 
     private String postBlueprintWithRetry(int port, String body) {
         String lastResponse = null;
-
         for (int attempt = 1; attempt <= 3; attempt++) {
             lastResponse = httpRequestBlueprint(port, body);
             if (!lastResponse.contains("\"error\"")) {
                 return lastResponse;
             }
-
             if (attempt < 3) {
                 sleepQuietly();
             }
         }
-
         return lastResponse;
     }
 
@@ -236,7 +228,6 @@ class SliceVersioningHeaderModeTest {
                                  .POST(HttpRequest.BodyPublishers.ofString(body))
                                  .timeout(Duration.ofSeconds(10))
                                  .build();
-
         return http.sendString(request)
                    .await()
                    .map(HttpResult::body)
@@ -244,9 +235,6 @@ class SliceVersioningHeaderModeTest {
     }
 
     private int anyMgmtPort() {
-        return cluster.status()
-                      .nodes()
-                      .getFirst()
-                      .mgmtPort();
+        return cluster.status().nodes().getFirst().mgmtPort();
     }
 }

--- a/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/SliceVersioningTest.java
+++ b/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/SliceVersioningTest.java
@@ -2,15 +2,8 @@
 // Copyright (c) 2025 Pragmatica Labs - Sergiy Yevtushenko
 // Licensed under Business Source License 1.1. Change Date: 2030-01-01. Change License: Apache-2.0.
 // See LICENSE in the repository root for full terms.
+
 package org.pragmatica.aether.forge;
-
-import java.net.URI;
-import java.net.http.HttpRequest;
-import java.time.Duration;
-
-import org.pragmatica.http.HttpOperations;
-import org.pragmatica.http.HttpResult;
-import org.pragmatica.aether.ember.EmberCluster;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -18,12 +11,18 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.pragmatica.http.HttpOperations;
+import org.pragmatica.http.HttpResult;
 
-import static org.pragmatica.aether.ember.EmberCluster.emberCluster;
-import static org.pragmatica.http.JdkHttpOperations.jdkHttpOperations;
+import java.net.URI;
+import java.net.http.HttpRequest;
+import java.time.Duration;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
-
+import org.pragmatica.aether.ember.EmberCluster;
+import static org.pragmatica.aether.ember.EmberCluster.emberCluster;
+import static org.pragmatica.http.JdkHttpOperations.jdkHttpOperations;
 
 /// Proves #198 API path-mode versioning reaches the wire: a deployed two-version slice serves
 /// BOTH `GET {api.prefix}/v1/{id}` and `GET {api.prefix}/v2/{id}`, and each path returns its
@@ -52,22 +51,24 @@ class SliceVersioningTest {
     void setUp() {
         cluster = emberCluster(3, BASE_PORT, BASE_MGMT_PORT, BASE_APP_HTTP_PORT, "smt");
         LifecycleAwait.settled("cluster start in setUp()", cluster, cluster.start());
-        await().atMost(WAIT_TIMEOUT).pollInterval(POLL_INTERVAL).until(() -> cluster.currentLeader()
-                                                                                    .isPresent());
+
+        await().atMost(WAIT_TIMEOUT)
+               .pollInterval(POLL_INTERVAL)
+               .until(() -> cluster.currentLeader().isPresent());
+
         deployVersionedSlice();
     }
 
     @AfterAll
     void tearDown() {
         if (cluster != null) {
-            LifecycleAwait.settled("cluster stop in tearDown()", cluster, cluster.stop());
+            LifecycleAwait.bestEffort("cluster stop in tearDown()", cluster, cluster.stop());
         }
     }
 
     @Test
     void v1Route_servesVersionOneResponse() {
-        var response = http.sendString(getRequest(appPort(),
-                                                  "/api/orders/v1/" + ITEM_ID))
+        var response = http.sendString(getRequest(appPort(), "/api/orders/v1/" + ITEM_ID))
                            .await()
                            .onFailure(cause -> {
                                throw new AssertionError("v1 request failed: " + cause.message());
@@ -82,8 +83,7 @@ class SliceVersioningTest {
 
     @Test
     void v2Route_servesVersionTwoResponse() {
-        var response = http.sendString(getRequest(appPort(),
-                                                  "/api/orders/v2/" + ITEM_ID))
+        var response = http.sendString(getRequest(appPort(), "/api/orders/v2/" + ITEM_ID))
                            .await()
                            .onFailure(cause -> {
                                throw new AssertionError("v2 request failed: " + cause.message());
@@ -98,14 +98,12 @@ class SliceVersioningTest {
 
     @Test
     void bothVersionsServeDistinctResponsesFromOneBindKey() {
-        var v1 = http.sendString(getRequest(appPort(),
-                                            "/api/orders/v1/" + ITEM_ID))
+        var v1 = http.sendString(getRequest(appPort(), "/api/orders/v1/" + ITEM_ID))
                      .await()
                      .onFailure(cause -> {
                          throw new AssertionError("v1 request failed: " + cause.message());
                      });
-        var v2 = http.sendString(getRequest(appPort(),
-                                            "/api/orders/v2/" + ITEM_ID))
+        var v2 = http.sendString(getRequest(appPort(), "/api/orders/v2/" + ITEM_ID))
                      .await()
                      .onFailure(cause -> {
                          throw new AssertionError("v2 request failed: " + cause.message());
@@ -123,27 +121,26 @@ class SliceVersioningTest {
 
     private void deployVersionedSlice() {
         var deployResponse = deploy(TEST_ARTIFACT);
+        assertThat(deployResponse)
+            .describedAs("Deployment response")
+            .doesNotContain("\"error\"")
+            .contains("\"status\":\"applied\"");
 
-        assertThat(deployResponse).describedAs("Deployment response")
-                  .doesNotContain("\"error\"")
-                  .contains("\"status\":\"applied\"");
         await().atMost(WAIT_TIMEOUT)
-             .pollInterval(POLL_INTERVAL)
-             .failFast(() -> {
-                           if (sliceHasFailed()) {
-                           throw new AssertionError("Slice deployment failed: " + TEST_ARTIFACT);
-                       }
-                       })
-             .until(this::v1RouteServes);
+               .pollInterval(POLL_INTERVAL)
+               .failFast(() -> {
+                   if (sliceHasFailed()) {
+                       throw new AssertionError("Slice deployment failed: " + TEST_ARTIFACT);
+                   }
+               })
+               .until(this::v1RouteServes);
     }
 
     private boolean v1RouteServes() {
         if (cluster.getAvailableAppHttpPorts().isEmpty()) {
             return false;
         }
-
-        return http.sendString(getRequest(appPort(),
-                                          "/api/orders/v1/" + ITEM_ID))
+        return http.sendString(getRequest(appPort(), "/api/orders/v1/" + ITEM_ID))
                    .await()
                    .map(result -> result.statusCode() == 200)
                    .or(false);
@@ -151,9 +148,7 @@ class SliceVersioningTest {
 
     private int appPort() {
         var ports = cluster.getAvailableAppHttpPorts();
-
         assertThat(ports).describedAs("available app HTTP ports").isNotEmpty();
-
         return ports.getFirst();
     }
 
@@ -174,24 +169,20 @@ class SliceVersioningTest {
             instances = 1
             """.formatted(BLUEPRINT_ID, artifact);
         var leaderPort = cluster.getLeaderManagementPort().or(anyMgmtPort());
-
         return postBlueprintWithRetry(leaderPort, blueprint);
     }
 
     private String postBlueprintWithRetry(int port, String body) {
         String lastResponse = null;
-
         for (int attempt = 1; attempt <= 3; attempt++) {
             lastResponse = httpRequestBlueprint(port, body);
             if (!lastResponse.contains("\"error\"")) {
                 return lastResponse;
             }
-
             if (attempt < 3) {
                 sleepQuietly();
             }
         }
-
         return lastResponse;
     }
 
@@ -210,7 +201,6 @@ class SliceVersioningTest {
                                  .POST(HttpRequest.BodyPublishers.ofString(body))
                                  .timeout(Duration.ofSeconds(10))
                                  .build();
-
         return http.sendString(request)
                    .await()
                    .map(HttpResult::body)
@@ -220,15 +210,10 @@ class SliceVersioningTest {
     private boolean sliceHasFailed() {
         return cluster.slicesStatus()
                       .stream()
-                      .anyMatch(s -> s.artifact()
-                                      .equals(TEST_ARTIFACT) && s.state()
-                                                                 .equals("FAILED"));
+                      .anyMatch(s -> s.artifact().equals(TEST_ARTIFACT) && s.state().equals("FAILED"));
     }
 
     private int anyMgmtPort() {
-        return cluster.status()
-                      .nodes()
-                      .getFirst()
-                      .mgmtPort();
+        return cluster.status().nodes().getFirst().mgmtPort();
     }
 }

--- a/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/SliceVersioningTest.java
+++ b/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/SliceVersioningTest.java
@@ -2,8 +2,15 @@
 // Copyright (c) 2025 Pragmatica Labs - Sergiy Yevtushenko
 // Licensed under Business Source License 1.1. Change Date: 2030-01-01. Change License: Apache-2.0.
 // See LICENSE in the repository root for full terms.
-
 package org.pragmatica.aether.forge;
+
+import java.net.URI;
+import java.net.http.HttpRequest;
+import java.time.Duration;
+
+import org.pragmatica.http.HttpOperations;
+import org.pragmatica.http.HttpResult;
+import org.pragmatica.aether.ember.EmberCluster;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -11,18 +18,12 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
-import org.pragmatica.http.HttpOperations;
-import org.pragmatica.http.HttpResult;
 
-import java.net.URI;
-import java.net.http.HttpRequest;
-import java.time.Duration;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.awaitility.Awaitility.await;
-import org.pragmatica.aether.ember.EmberCluster;
 import static org.pragmatica.aether.ember.EmberCluster.emberCluster;
 import static org.pragmatica.http.JdkHttpOperations.jdkHttpOperations;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
 
 /// Proves #198 API path-mode versioning reaches the wire: a deployed two-version slice serves
 /// BOTH `GET {api.prefix}/v1/{id}` and `GET {api.prefix}/v2/{id}`, and each path returns its
@@ -50,30 +51,23 @@ class SliceVersioningTest {
     @BeforeAll
     void setUp() {
         cluster = emberCluster(3, BASE_PORT, BASE_MGMT_PORT, BASE_APP_HTTP_PORT, "smt");
-        cluster.start()
-               .await()
-               .onFailure(cause -> {
-                   throw new AssertionError("Cluster start failed: " + cause.message());
-               });
-
-        await().atMost(WAIT_TIMEOUT)
-               .pollInterval(POLL_INTERVAL)
-               .until(() -> cluster.currentLeader().isPresent());
-
+        LifecycleAwait.settled("cluster start in setUp()", cluster, cluster.start());
+        await().atMost(WAIT_TIMEOUT).pollInterval(POLL_INTERVAL).until(() -> cluster.currentLeader()
+                                                                                    .isPresent());
         deployVersionedSlice();
     }
 
     @AfterAll
     void tearDown() {
         if (cluster != null) {
-            cluster.stop()
-                   .await();
+            LifecycleAwait.settled("cluster stop in tearDown()", cluster, cluster.stop());
         }
     }
 
     @Test
     void v1Route_servesVersionOneResponse() {
-        var response = http.sendString(getRequest(appPort(), "/api/orders/v1/" + ITEM_ID))
+        var response = http.sendString(getRequest(appPort(),
+                                                  "/api/orders/v1/" + ITEM_ID))
                            .await()
                            .onFailure(cause -> {
                                throw new AssertionError("v1 request failed: " + cause.message());
@@ -88,7 +82,8 @@ class SliceVersioningTest {
 
     @Test
     void v2Route_servesVersionTwoResponse() {
-        var response = http.sendString(getRequest(appPort(), "/api/orders/v2/" + ITEM_ID))
+        var response = http.sendString(getRequest(appPort(),
+                                                  "/api/orders/v2/" + ITEM_ID))
                            .await()
                            .onFailure(cause -> {
                                throw new AssertionError("v2 request failed: " + cause.message());
@@ -103,12 +98,14 @@ class SliceVersioningTest {
 
     @Test
     void bothVersionsServeDistinctResponsesFromOneBindKey() {
-        var v1 = http.sendString(getRequest(appPort(), "/api/orders/v1/" + ITEM_ID))
+        var v1 = http.sendString(getRequest(appPort(),
+                                            "/api/orders/v1/" + ITEM_ID))
                      .await()
                      .onFailure(cause -> {
                          throw new AssertionError("v1 request failed: " + cause.message());
                      });
-        var v2 = http.sendString(getRequest(appPort(), "/api/orders/v2/" + ITEM_ID))
+        var v2 = http.sendString(getRequest(appPort(),
+                                            "/api/orders/v2/" + ITEM_ID))
                      .await()
                      .onFailure(cause -> {
                          throw new AssertionError("v2 request failed: " + cause.message());
@@ -126,26 +123,27 @@ class SliceVersioningTest {
 
     private void deployVersionedSlice() {
         var deployResponse = deploy(TEST_ARTIFACT);
-        assertThat(deployResponse)
-            .describedAs("Deployment response")
-            .doesNotContain("\"error\"")
-            .contains("\"status\":\"applied\"");
 
+        assertThat(deployResponse).describedAs("Deployment response")
+                  .doesNotContain("\"error\"")
+                  .contains("\"status\":\"applied\"");
         await().atMost(WAIT_TIMEOUT)
-               .pollInterval(POLL_INTERVAL)
-               .failFast(() -> {
-                   if (sliceHasFailed()) {
-                       throw new AssertionError("Slice deployment failed: " + TEST_ARTIFACT);
-                   }
-               })
-               .until(this::v1RouteServes);
+             .pollInterval(POLL_INTERVAL)
+             .failFast(() -> {
+                           if (sliceHasFailed()) {
+                           throw new AssertionError("Slice deployment failed: " + TEST_ARTIFACT);
+                       }
+                       })
+             .until(this::v1RouteServes);
     }
 
     private boolean v1RouteServes() {
         if (cluster.getAvailableAppHttpPorts().isEmpty()) {
             return false;
         }
-        return http.sendString(getRequest(appPort(), "/api/orders/v1/" + ITEM_ID))
+
+        return http.sendString(getRequest(appPort(),
+                                          "/api/orders/v1/" + ITEM_ID))
                    .await()
                    .map(result -> result.statusCode() == 200)
                    .or(false);
@@ -153,7 +151,9 @@ class SliceVersioningTest {
 
     private int appPort() {
         var ports = cluster.getAvailableAppHttpPorts();
+
         assertThat(ports).describedAs("available app HTTP ports").isNotEmpty();
+
         return ports.getFirst();
     }
 
@@ -174,20 +174,24 @@ class SliceVersioningTest {
             instances = 1
             """.formatted(BLUEPRINT_ID, artifact);
         var leaderPort = cluster.getLeaderManagementPort().or(anyMgmtPort());
+
         return postBlueprintWithRetry(leaderPort, blueprint);
     }
 
     private String postBlueprintWithRetry(int port, String body) {
         String lastResponse = null;
+
         for (int attempt = 1; attempt <= 3; attempt++) {
             lastResponse = httpRequestBlueprint(port, body);
             if (!lastResponse.contains("\"error\"")) {
                 return lastResponse;
             }
+
             if (attempt < 3) {
                 sleepQuietly();
             }
         }
+
         return lastResponse;
     }
 
@@ -206,6 +210,7 @@ class SliceVersioningTest {
                                  .POST(HttpRequest.BodyPublishers.ofString(body))
                                  .timeout(Duration.ofSeconds(10))
                                  .build();
+
         return http.sendString(request)
                    .await()
                    .map(HttpResult::body)
@@ -215,10 +220,15 @@ class SliceVersioningTest {
     private boolean sliceHasFailed() {
         return cluster.slicesStatus()
                       .stream()
-                      .anyMatch(s -> s.artifact().equals(TEST_ARTIFACT) && s.state().equals("FAILED"));
+                      .anyMatch(s -> s.artifact()
+                                      .equals(TEST_ARTIFACT) && s.state()
+                                                                 .equals("FAILED"));
     }
 
     private int anyMgmtPort() {
-        return cluster.status().nodes().getFirst().mgmtPort();
+        return cluster.status()
+                      .nodes()
+                      .getFirst()
+                      .mgmtPort();
     }
 }

--- a/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/StreamCrashDurabilityTest.java
+++ b/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/StreamCrashDurabilityTest.java
@@ -2,7 +2,21 @@
 // Copyright (c) 2025 Pragmatica Labs - Sergiy Yevtushenko
 // Licensed under Business Source License 1.1. Change Date: 2030-01-01. Change License: Apache-2.0.
 // See LICENSE in the repository root for full terms.
+
 package org.pragmatica.aether.forge;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.pragmatica.http.HttpOperations;
+import org.pragmatica.http.HttpResult;
+import org.pragmatica.config.ConfigurationProvider;
+import org.pragmatica.lang.Option;
 
 import java.io.IOException;
 import java.net.URI;
@@ -16,26 +30,12 @@ import java.util.concurrent.locks.LockSupport;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.pragmatica.http.HttpOperations;
-import org.pragmatica.http.HttpResult;
-import org.pragmatica.config.ConfigurationProvider;
-import org.pragmatica.lang.Option;
-import org.pragmatica.aether.ember.EmberCluster;
-
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
-import org.junit.jupiter.api.io.TempDir;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
-
-import static org.pragmatica.aether.ember.EmberCluster.emberCluster;
-import static org.pragmatica.http.JdkHttpOperations.jdkHttpOperations;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
+import static org.pragmatica.aether.ember.EmberCluster.emberCluster;
+import static org.pragmatica.http.JdkHttpOperations.jdkHttpOperations;
 
+import org.pragmatica.aether.ember.EmberCluster;
 
 /// Streaming-persistence A6 — full-cluster restart crash-durability proof for the per-partition WAL.
 ///
@@ -97,22 +97,26 @@ class StreamCrashDurabilityTest {
     private static final int NODES = 5;
     private static final int INSTANCES = 5;
     private static final int EVENT_COUNT = 50;
+
     private static final Duration WAIT_TIMEOUT = Duration.ofSeconds(240);
     private static final Duration POLL_INTERVAL = Duration.ofMillis(500);
     private static final Duration DRAIN_TIMEOUT = Duration.ofSeconds(90);
     private static final Duration RECOVERY_TIMEOUT = Duration.ofSeconds(240);
     private static final long POLL_GAP_NANOS = Duration.ofMillis(20).toNanos();
+
     private static final String STREAM_SLICE = TestArtifacts.STREAM_SLICE;
     private static final String STREAM_NAME = "test-events";
     private static final int PARTITION = 0;
     private static final String BLUEPRINT_ID = "forge.test:stream-crash-durability:1.0.0";
     private static final String ERROR_FALLBACK = "{\"error\":\"request failed\"}";
+
     private static final Pattern EVENT_OBJECT = Pattern.compile("\\{[^{}]*\"offset\"[^{}]*}");
     private static final Pattern OFFSET_FIELD = Pattern.compile("\"offset\"\\s*:\\s*(\\d+)");
     private static final Pattern PAYLOAD_FIELD = Pattern.compile("\"payload\"\\s*:\\s*\"([^\"]*)\"");
     private static final Pattern NODE_COUNT_FIELD = Pattern.compile("\"nodeCount\"\\s*:\\s*(\\d+)");
 
     Path baseDir;
+
     private EmberCluster cluster;
     private final HttpOperations http = jdkHttpOperations();
 
@@ -122,6 +126,7 @@ class StreamCrashDurabilityTest {
     @BeforeAll
     void setUp(@TempDir Path tempDir) {
         this.baseDir = tempDir;
+
         // A ConfigurationProvider must be present for the node to enable resource provisioning
         // (StreamPublisher / StreamAccess); without it AetherNode installs a no-op facade that fails
         // every resource-backed slice (mirrors StreamFanoutConsumerTest / ForgeServer).
@@ -129,10 +134,10 @@ class StreamCrashDurabilityTest {
                                                   .withSystemProperties("aether.")
                                                   .withEnvironment("AETHER_")
                                                   .build();
-
         cluster = emberCluster(NODES, BASE_PORT, BASE_MGMT_PORT, BASE_APP_HTTP_PORT, "scd", Option.some(configProvider));
         // Opt in to a writable, restart-stable per-node data dir -> disk tier + per-partition WAL ON.
         cluster.withDataBaseDir(baseDir);
+
         startAndAwaitReady();
     }
 
@@ -140,9 +145,8 @@ class StreamCrashDurabilityTest {
     void tearDown() {
         if (cluster != null) {
             var leaderPort = cluster.getLeaderManagementPort().or(anyMgmtPort());
-
             httpDelete(leaderPort, "/api/v1/blueprints/" + BLUEPRINT_ID);
-            LifecycleAwait.settled("cluster stop in tearDown()", cluster, cluster.stop());
+            LifecycleAwait.bestEffort("cluster stop in tearDown()", cluster, cluster.stop());
         }
     }
 
@@ -153,15 +157,20 @@ class StreamCrashDurabilityTest {
         var port = appPort();
         var base = head(port);
 
-        assertThat(base).describedAs("fresh dedicated cluster: 'test-events' starts empty (offset 0)").isZero();
-        publishBatch(port, "crash", EVENT_COUNT);
-        var published = drain(port, base, EVENT_COUNT, deadlineNanos());
+        assertThat(base)
+            .describedAs("fresh dedicated cluster: 'test-events' starts empty (offset 0)")
+            .isZero();
 
+        publishBatch(port, "crash", EVENT_COUNT);
+
+        var published = drain(port, base, EVENT_COUNT, deadlineNanos());
         assertContiguousBatch(published, base, "crash");
+
         // Guard against a false-green where the dir was writable but the WAL silently stayed OFF (or
         // events were never appended): a NON-EMPTY 'test-events' WAL must exist on disk, proving the
         // owner appended + fsync'd the acked events before ack. WAL OFF would leave none.
         assertWalActiveForTestEvents();
+
         // Full-cluster graceful restart preserving per-node data dirs (same stable node ids -> same
         // dirs). The in-memory ring is lost; only the WAL can bring the 50 events back. Recovery is
         // reconcile-driven: after restart the deterministic HRW owner re-materializes its partition,
@@ -169,53 +178,70 @@ class StreamCrashDurabilityTest {
         // self-promotes to CAUGHT_UP after a bounded wait, then serves owner-routed reads. So the read
         // is drained with a generous deadline until all N reappear (returns as soon as they do).
         restartCluster();
+
         var recoveredPort = appPort();
         var recovered = drain(recoveredPort, 0L, EVENT_COUNT, recoveryDeadlineNanos());
 
         dumpIfShort(recovered, EVENT_COUNT);
-        assertThat(recovered).describedAs("WAL replay must recover ALL %d acked events after full-cluster restart "
-                                         + "(ring was in-memory and lost; nothing was sealed)",
-                                          EVENT_COUNT)
-                  .hasSize(EVENT_COUNT);
+        assertThat(recovered)
+            .describedAs("WAL replay must recover ALL %d acked events after full-cluster restart "
+                         + "(ring was in-memory and lost; nothing was sealed)", EVENT_COUNT)
+            .hasSize(EVENT_COUNT);
         assertContiguousBatch(recovered, 0L, "crash");
     }
 
     // --- restart ------------------------------------------------------------
+
     private void restartCluster() {
         LifecycleAwait.settled("cluster stop in restartCluster()", cluster, cluster.stop());
+
         startAndAwaitReady();
     }
 
     private void startAndAwaitReady() {
         LifecycleAwait.settled("cluster start in startAndAwaitReady()", cluster, cluster.start());
-        await().atMost(WAIT_TIMEOUT).pollInterval(POLL_INTERVAL).until(() -> cluster.currentLeader()
-                                                                                    .isPresent());
-        await().atMost(WAIT_TIMEOUT).pollInterval(POLL_INTERVAL).until(this::allNodesHealthy);
+
+        await().atMost(WAIT_TIMEOUT)
+               .pollInterval(POLL_INTERVAL)
+               .until(() -> cluster.currentLeader().isPresent());
+
+        await().atMost(WAIT_TIMEOUT)
+               .pollInterval(POLL_INTERVAL)
+               .until(this::allNodesHealthy);
+
         // A6: gate on FULL membership. allNodesHealthy() only checks each node's LOCAL quorum flag, which
         // turns true at quorum (3/5). After a full-cluster restart the cold-boot convergence window must
         // let ALL NODES nodes re-form before we publish (pre-restart) or read (post-restart): with RF=1
         // the deterministic HRW owner of test-events[0] must be a rejoined node holding the WAL, not an
         // empty-WAL survivor picked because a straggler was prematurely evicted.
-        await().atMost(WAIT_TIMEOUT).pollInterval(POLL_INTERVAL).until(() -> allNodesAreMembers(NODES));
+        await().atMost(WAIT_TIMEOUT)
+               .pollInterval(POLL_INTERVAL)
+               .until(() -> allNodesAreMembers(NODES));
+
         // Re-deploy: Forge KV is in-memory, so a full-cluster restart wiped the stream config. This
         // re-puts the deterministic `test-events` config -> owner re-materializes partition 0 ->
         // partition build opens-or-recovers the WAL and replays the un-sealed tail. Idempotent if KV
         // survived. Carries NO events (only the stream config); events come from the WAL.
         deployStreamSlice();
+
         await().atMost(WAIT_TIMEOUT)
-             .pollInterval(POLL_INTERVAL)
-             .failFast(this::failIfSliceFailed)
-             .until(this::appHttpReady);
+               .pollInterval(POLL_INTERVAL)
+               .failFast(this::failIfSliceFailed)
+               .until(this::appHttpReady);
     }
 
     // --- WAL on-disk assertion ---------------------------------------------
-    private void assertWalActiveForTestEvents() throws IOException {
-        var testEventsWals = walFiles(baseDir).stream().filter(StreamCrashDurabilityTest::isTestEventsWal).toList();
 
-        assertThat(testEventsWals).describedAs("stream WAL must be ACTIVE: a 'test-events' WAL file must exist under %s "
-                                              + "(WAL OFF -> none; acked events would not survive restart)",
-                                               baseDir)
-                  .isNotEmpty();
+    private void assertWalActiveForTestEvents() throws IOException {
+        var testEventsWals = walFiles(baseDir).stream()
+                                              .filter(StreamCrashDurabilityTest::isTestEventsWal)
+                                              .toList();
+
+        assertThat(testEventsWals)
+            .describedAs("stream WAL must be ACTIVE: a 'test-events' WAL file must exist under %s "
+                         + "(WAL OFF -> none; acked events would not survive restart)", baseDir)
+            .isNotEmpty();
+
         // Stronger than mere existence (every node opens an empty WAL on materialization): the owner
         // must have actually APPENDED + fsync'd the acked events, so the total on-disk WAL bytes for
         // 'test-events' must be positive.
@@ -225,46 +251,45 @@ class StreamCrashDurabilityTest {
             totalBytes += Files.size(wal);
         }
 
-        assertThat(totalBytes).describedAs("the owner's 'test-events' WAL must hold the acked events (non-empty) — proof they "
-                                          + "were appended + fsync'd before ack, not just that the WAL dir was writable")
-                  .isPositive();
+        assertThat(totalBytes)
+            .describedAs("the owner's 'test-events' WAL must hold the acked events (non-empty) — proof they "
+                         + "were appended + fsync'd before ack, not just that the WAL dir was writable")
+            .isPositive();
     }
 
     private static boolean isTestEventsWal(Path walFile) {
         var parent = walFile.getParent();
 
-        return parent != null && parent.getFileName()
-                                       .toString()
-                                       .equals("test-events");
+        return parent != null && parent.getFileName().toString().equals("test-events");
     }
 
     private static List<Path> walFiles(Path base) throws IOException {
         try (var paths = Files.walk(base)) {
             return paths.filter(Files::isRegularFile)
-                        .filter(p -> p.getFileName()
-                                      .toString()
-                                      .endsWith(".wal"))
+                        .filter(p -> p.getFileName().toString().endsWith(".wal"))
                         .toList();
         }
     }
 
     // --- assertions ---------------------------------------------------------
+
     private void assertContiguousBatch(List<Event> events, long base, String tag) {
-        assertThat(events).describedAs("consumer must receive exactly %d events (no dups, no gaps)",
-                                       EVENT_COUNT)
-                  .hasSize(EVENT_COUNT);
+        assertThat(events)
+            .describedAs("consumer must receive exactly %d events (no dups, no gaps)", EVENT_COUNT)
+            .hasSize(EVENT_COUNT);
+
         for (int i = 0; i < EVENT_COUNT; i++) {
-            assertThat(events.get(i).offset()).describedAs("event %d offset (contiguous from base %d)",
-                                                           i,
-                                                           base)
-                      .isEqualTo(base + i);
-            assertThat(events.get(i).payload()).describedAs("event %d payload (in publish order)",
-                                                            i)
-                      .isEqualTo(tag + "-" + i);
+            assertThat(events.get(i).offset())
+                .describedAs("event %d offset (contiguous from base %d)", i, base)
+                .isEqualTo(base + i);
+            assertThat(events.get(i).payload())
+                .describedAs("event %d payload (in publish order)", i)
+                .isEqualTo(tag + "-" + i);
         }
     }
 
     // --- failure-path observability ----------------------------------------
+
     private void dumpIfShort(List<Event> recovered, int expected) {
         if (recovered.size() < expected) {
             dumpAllNodeStreamState();
@@ -286,6 +311,7 @@ class StreamCrashDurabilityTest {
     }
 
     // --- consumers ----------------------------------------------------------
+
     private List<Event> drain(int port, long base, int count, long deadlineNanos) {
         var collected = new ArrayList<Event>();
         var offset = base;
@@ -326,6 +352,7 @@ class StreamCrashDurabilityTest {
     }
 
     // --- publishing ---------------------------------------------------------
+
     private void publishBatch(int port, String tag, int count) {
         for (int i = 0; i < count; i++) {
             publish(port, tag + "-" + i);
@@ -336,10 +363,10 @@ class StreamCrashDurabilityTest {
         var body = "{\"payload\":\"" + payload + "\"}";
         var response = httpPost(port, "/api/stream/publish", body);
 
-        assertThat(response).describedAs("publish '%s' must succeed (and thus be WAL-fsync'd before ack)",
-                                         payload)
-                  .doesNotContain("\"error\"")
-                  .contains("published");
+        assertThat(response)
+            .describedAs("publish '%s' must succeed (and thus be WAL-fsync'd before ack)", payload)
+            .doesNotContain("\"error\"")
+            .contains("published");
     }
 
     private List<Event> readEvents(int port, long fromOffset, int maxEvents) {
@@ -358,8 +385,7 @@ class StreamCrashDurabilityTest {
             Matcher payload = PAYLOAD_FIELD.matcher(object);
 
             if (offset.find() && payload.find()) {
-                events.add(new Event(Long.parseLong(offset.group(1)),
-                                     payload.group(1)));
+                events.add(new Event(Long.parseLong(offset.group(1)), payload.group(1)));
             }
         }
 
@@ -367,6 +393,7 @@ class StreamCrashDurabilityTest {
     }
 
     // --- deployment + readiness --------------------------------------------
+
     private void deployStreamSlice() {
         var blueprint = """
             id = "%s"
@@ -378,9 +405,10 @@ class StreamCrashDurabilityTest {
         var leaderPort = cluster.getLeaderManagementPort().or(anyMgmtPort());
         var response = postBlueprintWithRetry(leaderPort, blueprint);
 
-        assertThat(response).describedAs("stream-slice deployment")
-                  .doesNotContain("\"error\"")
-                  .contains("\"status\":\"applied\"");
+        assertThat(response)
+            .describedAs("stream-slice deployment")
+            .doesNotContain("\"error\"")
+            .contains("\"status\":\"applied\"");
     }
 
     private boolean appHttpReady() {
@@ -392,15 +420,13 @@ class StreamCrashDurabilityTest {
 
         var body = httpPost(ports.getFirst(), "/api/stream/read", "{\"fromOffset\":0,\"maxEvents\":1}");
 
-        return ! body.contains("\"error\"") && body.contains("events");
+        return !body.contains("\"error\"") && body.contains("events");
     }
 
     private void failIfSliceFailed() {
         var failed = cluster.slicesStatus()
                             .stream()
-                            .anyMatch(s -> s.artifact()
-                                            .equals(STREAM_SLICE) && s.state()
-                                                                      .equals("FAILED"));
+                            .anyMatch(s -> s.artifact().equals(STREAM_SLICE) && s.state().equals("FAILED"));
 
         if (failed) {
             throw new AssertionError("Stream slice deployment FAILED: " + STREAM_SLICE);
@@ -415,10 +441,7 @@ class StreamCrashDurabilityTest {
     }
 
     private int anyMgmtPort() {
-        return cluster.status()
-                      .nodes()
-                      .getFirst()
-                      .mgmtPort();
+        return cluster.status().nodes().getFirst().mgmtPort();
     }
 
     private long deadlineNanos() {
@@ -442,11 +465,9 @@ class StreamCrashDurabilityTest {
                                  .GET()
                                  .timeout(Duration.ofSeconds(5))
                                  .build();
-
         return http.sendString(request)
                    .await()
-                   .map(r -> r.statusCode() == 200 && r.body()
-                                                       .contains("\"quorum\":true"))
+                   .map(r -> r.statusCode() == 200 && r.body().contains("\"quorum\":true"))
                    .or(false);
     }
 
@@ -460,11 +481,9 @@ class StreamCrashDurabilityTest {
                                  .GET()
                                  .timeout(Duration.ofSeconds(5))
                                  .build();
-
         return http.sendString(request)
                    .await()
-                   .map(r -> r.statusCode() == 200 && healthHasFullMembership(r.body(),
-                                                                              expected))
+                   .map(r -> r.statusCode() == 200 && healthHasFullMembership(r.body(), expected))
                    .or(false);
     }
 
@@ -479,11 +498,13 @@ class StreamCrashDurabilityTest {
     }
 
     // --- HTTP ---------------------------------------------------------------
+
     private String postBlueprintWithRetry(int port, String body) {
         var lastResponse = ERROR_FALLBACK;
 
         for (int attempt = 1; attempt <= 3; attempt++) {
             lastResponse = httpPostToml(port, "/api/v1/blueprints", body);
+
             if (!lastResponse.contains("\"error\"")) {
                 return lastResponse;
             }
@@ -503,7 +524,6 @@ class StreamCrashDurabilityTest {
                                  .POST(HttpRequest.BodyPublishers.ofString(body))
                                  .timeout(Duration.ofSeconds(10))
                                  .build();
-
         return http.sendString(request)
                    .await()
                    .map(HttpResult::body)
@@ -517,7 +537,6 @@ class StreamCrashDurabilityTest {
                                  .POST(HttpRequest.BodyPublishers.ofString(body))
                                  .timeout(Duration.ofSeconds(15))
                                  .build();
-
         return http.sendString(request)
                    .await()
                    .map(HttpResult::body)
@@ -530,7 +549,6 @@ class StreamCrashDurabilityTest {
                                  .DELETE()
                                  .timeout(Duration.ofSeconds(10))
                                  .build();
-
         return http.sendString(request)
                    .await()
                    .map(HttpResult::body)

--- a/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/StreamCrashDurabilityTest.java
+++ b/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/StreamCrashDurabilityTest.java
@@ -2,21 +2,7 @@
 // Copyright (c) 2025 Pragmatica Labs - Sergiy Yevtushenko
 // Licensed under Business Source License 1.1. Change Date: 2030-01-01. Change License: Apache-2.0.
 // See LICENSE in the repository root for full terms.
-
 package org.pragmatica.aether.forge;
-
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
-import org.junit.jupiter.api.io.TempDir;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
-import org.pragmatica.http.HttpOperations;
-import org.pragmatica.http.HttpResult;
-import org.pragmatica.config.ConfigurationProvider;
-import org.pragmatica.lang.Option;
 
 import java.io.IOException;
 import java.net.URI;
@@ -30,12 +16,26 @@ import java.util.concurrent.locks.LockSupport;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.awaitility.Awaitility.await;
+import org.pragmatica.http.HttpOperations;
+import org.pragmatica.http.HttpResult;
+import org.pragmatica.config.ConfigurationProvider;
+import org.pragmatica.lang.Option;
+import org.pragmatica.aether.ember.EmberCluster;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+
 import static org.pragmatica.aether.ember.EmberCluster.emberCluster;
 import static org.pragmatica.http.JdkHttpOperations.jdkHttpOperations;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
 
-import org.pragmatica.aether.ember.EmberCluster;
 
 /// Streaming-persistence A6 — full-cluster restart crash-durability proof for the per-partition WAL.
 ///
@@ -97,26 +97,22 @@ class StreamCrashDurabilityTest {
     private static final int NODES = 5;
     private static final int INSTANCES = 5;
     private static final int EVENT_COUNT = 50;
-
     private static final Duration WAIT_TIMEOUT = Duration.ofSeconds(240);
     private static final Duration POLL_INTERVAL = Duration.ofMillis(500);
     private static final Duration DRAIN_TIMEOUT = Duration.ofSeconds(90);
     private static final Duration RECOVERY_TIMEOUT = Duration.ofSeconds(240);
     private static final long POLL_GAP_NANOS = Duration.ofMillis(20).toNanos();
-
     private static final String STREAM_SLICE = TestArtifacts.STREAM_SLICE;
     private static final String STREAM_NAME = "test-events";
     private static final int PARTITION = 0;
     private static final String BLUEPRINT_ID = "forge.test:stream-crash-durability:1.0.0";
     private static final String ERROR_FALLBACK = "{\"error\":\"request failed\"}";
-
     private static final Pattern EVENT_OBJECT = Pattern.compile("\\{[^{}]*\"offset\"[^{}]*}");
     private static final Pattern OFFSET_FIELD = Pattern.compile("\"offset\"\\s*:\\s*(\\d+)");
     private static final Pattern PAYLOAD_FIELD = Pattern.compile("\"payload\"\\s*:\\s*\"([^\"]*)\"");
     private static final Pattern NODE_COUNT_FIELD = Pattern.compile("\"nodeCount\"\\s*:\\s*(\\d+)");
 
     Path baseDir;
-
     private EmberCluster cluster;
     private final HttpOperations http = jdkHttpOperations();
 
@@ -126,7 +122,6 @@ class StreamCrashDurabilityTest {
     @BeforeAll
     void setUp(@TempDir Path tempDir) {
         this.baseDir = tempDir;
-
         // A ConfigurationProvider must be present for the node to enable resource provisioning
         // (StreamPublisher / StreamAccess); without it AetherNode installs a no-op facade that fails
         // every resource-backed slice (mirrors StreamFanoutConsumerTest / ForgeServer).
@@ -134,10 +129,10 @@ class StreamCrashDurabilityTest {
                                                   .withSystemProperties("aether.")
                                                   .withEnvironment("AETHER_")
                                                   .build();
+
         cluster = emberCluster(NODES, BASE_PORT, BASE_MGMT_PORT, BASE_APP_HTTP_PORT, "scd", Option.some(configProvider));
         // Opt in to a writable, restart-stable per-node data dir -> disk tier + per-partition WAL ON.
         cluster.withDataBaseDir(baseDir);
-
         startAndAwaitReady();
     }
 
@@ -145,9 +140,9 @@ class StreamCrashDurabilityTest {
     void tearDown() {
         if (cluster != null) {
             var leaderPort = cluster.getLeaderManagementPort().or(anyMgmtPort());
+
             httpDelete(leaderPort, "/api/v1/blueprints/" + BLUEPRINT_ID);
-            cluster.stop()
-                   .await();
+            LifecycleAwait.settled("cluster stop in tearDown()", cluster, cluster.stop());
         }
     }
 
@@ -158,20 +153,15 @@ class StreamCrashDurabilityTest {
         var port = appPort();
         var base = head(port);
 
-        assertThat(base)
-            .describedAs("fresh dedicated cluster: 'test-events' starts empty (offset 0)")
-            .isZero();
-
+        assertThat(base).describedAs("fresh dedicated cluster: 'test-events' starts empty (offset 0)").isZero();
         publishBatch(port, "crash", EVENT_COUNT);
-
         var published = drain(port, base, EVENT_COUNT, deadlineNanos());
-        assertContiguousBatch(published, base, "crash");
 
+        assertContiguousBatch(published, base, "crash");
         // Guard against a false-green where the dir was writable but the WAL silently stayed OFF (or
         // events were never appended): a NON-EMPTY 'test-events' WAL must exist on disk, proving the
         // owner appended + fsync'd the acked events before ack. WAL OFF would leave none.
         assertWalActiveForTestEvents();
-
         // Full-cluster graceful restart preserving per-node data dirs (same stable node ids -> same
         // dirs). The in-memory ring is lost; only the WAL can bring the 50 events back. Recovery is
         // reconcile-driven: after restart the deterministic HRW owner re-materializes its partition,
@@ -179,78 +169,53 @@ class StreamCrashDurabilityTest {
         // self-promotes to CAUGHT_UP after a bounded wait, then serves owner-routed reads. So the read
         // is drained with a generous deadline until all N reappear (returns as soon as they do).
         restartCluster();
-
         var recoveredPort = appPort();
         var recovered = drain(recoveredPort, 0L, EVENT_COUNT, recoveryDeadlineNanos());
 
         dumpIfShort(recovered, EVENT_COUNT);
-        assertThat(recovered)
-            .describedAs("WAL replay must recover ALL %d acked events after full-cluster restart "
-                         + "(ring was in-memory and lost; nothing was sealed)", EVENT_COUNT)
-            .hasSize(EVENT_COUNT);
+        assertThat(recovered).describedAs("WAL replay must recover ALL %d acked events after full-cluster restart "
+                                         + "(ring was in-memory and lost; nothing was sealed)",
+                                          EVENT_COUNT)
+                  .hasSize(EVENT_COUNT);
         assertContiguousBatch(recovered, 0L, "crash");
     }
 
     // --- restart ------------------------------------------------------------
-
     private void restartCluster() {
-        cluster.stop()
-               .await()
-               .onFailure(cause -> {
-                   throw new AssertionError("Cluster stop failed: " + cause.message());
-               });
-
+        LifecycleAwait.settled("cluster stop in restartCluster()", cluster, cluster.stop());
         startAndAwaitReady();
     }
 
     private void startAndAwaitReady() {
-        cluster.start()
-               .await()
-               .onFailure(cause -> {
-                   throw new AssertionError("Cluster start failed: " + cause.message());
-               });
-
-        await().atMost(WAIT_TIMEOUT)
-               .pollInterval(POLL_INTERVAL)
-               .until(() -> cluster.currentLeader().isPresent());
-
-        await().atMost(WAIT_TIMEOUT)
-               .pollInterval(POLL_INTERVAL)
-               .until(this::allNodesHealthy);
-
+        LifecycleAwait.settled("cluster start in startAndAwaitReady()", cluster, cluster.start());
+        await().atMost(WAIT_TIMEOUT).pollInterval(POLL_INTERVAL).until(() -> cluster.currentLeader()
+                                                                                    .isPresent());
+        await().atMost(WAIT_TIMEOUT).pollInterval(POLL_INTERVAL).until(this::allNodesHealthy);
         // A6: gate on FULL membership. allNodesHealthy() only checks each node's LOCAL quorum flag, which
         // turns true at quorum (3/5). After a full-cluster restart the cold-boot convergence window must
         // let ALL NODES nodes re-form before we publish (pre-restart) or read (post-restart): with RF=1
         // the deterministic HRW owner of test-events[0] must be a rejoined node holding the WAL, not an
         // empty-WAL survivor picked because a straggler was prematurely evicted.
-        await().atMost(WAIT_TIMEOUT)
-               .pollInterval(POLL_INTERVAL)
-               .until(() -> allNodesAreMembers(NODES));
-
+        await().atMost(WAIT_TIMEOUT).pollInterval(POLL_INTERVAL).until(() -> allNodesAreMembers(NODES));
         // Re-deploy: Forge KV is in-memory, so a full-cluster restart wiped the stream config. This
         // re-puts the deterministic `test-events` config -> owner re-materializes partition 0 ->
         // partition build opens-or-recovers the WAL and replays the un-sealed tail. Idempotent if KV
         // survived. Carries NO events (only the stream config); events come from the WAL.
         deployStreamSlice();
-
         await().atMost(WAIT_TIMEOUT)
-               .pollInterval(POLL_INTERVAL)
-               .failFast(this::failIfSliceFailed)
-               .until(this::appHttpReady);
+             .pollInterval(POLL_INTERVAL)
+             .failFast(this::failIfSliceFailed)
+             .until(this::appHttpReady);
     }
 
     // --- WAL on-disk assertion ---------------------------------------------
-
     private void assertWalActiveForTestEvents() throws IOException {
-        var testEventsWals = walFiles(baseDir).stream()
-                                              .filter(StreamCrashDurabilityTest::isTestEventsWal)
-                                              .toList();
+        var testEventsWals = walFiles(baseDir).stream().filter(StreamCrashDurabilityTest::isTestEventsWal).toList();
 
-        assertThat(testEventsWals)
-            .describedAs("stream WAL must be ACTIVE: a 'test-events' WAL file must exist under %s "
-                         + "(WAL OFF -> none; acked events would not survive restart)", baseDir)
-            .isNotEmpty();
-
+        assertThat(testEventsWals).describedAs("stream WAL must be ACTIVE: a 'test-events' WAL file must exist under %s "
+                                              + "(WAL OFF -> none; acked events would not survive restart)",
+                                               baseDir)
+                  .isNotEmpty();
         // Stronger than mere existence (every node opens an empty WAL on materialization): the owner
         // must have actually APPENDED + fsync'd the acked events, so the total on-disk WAL bytes for
         // 'test-events' must be positive.
@@ -260,45 +225,46 @@ class StreamCrashDurabilityTest {
             totalBytes += Files.size(wal);
         }
 
-        assertThat(totalBytes)
-            .describedAs("the owner's 'test-events' WAL must hold the acked events (non-empty) — proof they "
-                         + "were appended + fsync'd before ack, not just that the WAL dir was writable")
-            .isPositive();
+        assertThat(totalBytes).describedAs("the owner's 'test-events' WAL must hold the acked events (non-empty) — proof they "
+                                          + "were appended + fsync'd before ack, not just that the WAL dir was writable")
+                  .isPositive();
     }
 
     private static boolean isTestEventsWal(Path walFile) {
         var parent = walFile.getParent();
 
-        return parent != null && parent.getFileName().toString().equals("test-events");
+        return parent != null && parent.getFileName()
+                                       .toString()
+                                       .equals("test-events");
     }
 
     private static List<Path> walFiles(Path base) throws IOException {
         try (var paths = Files.walk(base)) {
             return paths.filter(Files::isRegularFile)
-                        .filter(p -> p.getFileName().toString().endsWith(".wal"))
+                        .filter(p -> p.getFileName()
+                                      .toString()
+                                      .endsWith(".wal"))
                         .toList();
         }
     }
 
     // --- assertions ---------------------------------------------------------
-
     private void assertContiguousBatch(List<Event> events, long base, String tag) {
-        assertThat(events)
-            .describedAs("consumer must receive exactly %d events (no dups, no gaps)", EVENT_COUNT)
-            .hasSize(EVENT_COUNT);
-
+        assertThat(events).describedAs("consumer must receive exactly %d events (no dups, no gaps)",
+                                       EVENT_COUNT)
+                  .hasSize(EVENT_COUNT);
         for (int i = 0; i < EVENT_COUNT; i++) {
-            assertThat(events.get(i).offset())
-                .describedAs("event %d offset (contiguous from base %d)", i, base)
-                .isEqualTo(base + i);
-            assertThat(events.get(i).payload())
-                .describedAs("event %d payload (in publish order)", i)
-                .isEqualTo(tag + "-" + i);
+            assertThat(events.get(i).offset()).describedAs("event %d offset (contiguous from base %d)",
+                                                           i,
+                                                           base)
+                      .isEqualTo(base + i);
+            assertThat(events.get(i).payload()).describedAs("event %d payload (in publish order)",
+                                                            i)
+                      .isEqualTo(tag + "-" + i);
         }
     }
 
     // --- failure-path observability ----------------------------------------
-
     private void dumpIfShort(List<Event> recovered, int expected) {
         if (recovered.size() < expected) {
             dumpAllNodeStreamState();
@@ -320,7 +286,6 @@ class StreamCrashDurabilityTest {
     }
 
     // --- consumers ----------------------------------------------------------
-
     private List<Event> drain(int port, long base, int count, long deadlineNanos) {
         var collected = new ArrayList<Event>();
         var offset = base;
@@ -361,7 +326,6 @@ class StreamCrashDurabilityTest {
     }
 
     // --- publishing ---------------------------------------------------------
-
     private void publishBatch(int port, String tag, int count) {
         for (int i = 0; i < count; i++) {
             publish(port, tag + "-" + i);
@@ -372,10 +336,10 @@ class StreamCrashDurabilityTest {
         var body = "{\"payload\":\"" + payload + "\"}";
         var response = httpPost(port, "/api/stream/publish", body);
 
-        assertThat(response)
-            .describedAs("publish '%s' must succeed (and thus be WAL-fsync'd before ack)", payload)
-            .doesNotContain("\"error\"")
-            .contains("published");
+        assertThat(response).describedAs("publish '%s' must succeed (and thus be WAL-fsync'd before ack)",
+                                         payload)
+                  .doesNotContain("\"error\"")
+                  .contains("published");
     }
 
     private List<Event> readEvents(int port, long fromOffset, int maxEvents) {
@@ -394,7 +358,8 @@ class StreamCrashDurabilityTest {
             Matcher payload = PAYLOAD_FIELD.matcher(object);
 
             if (offset.find() && payload.find()) {
-                events.add(new Event(Long.parseLong(offset.group(1)), payload.group(1)));
+                events.add(new Event(Long.parseLong(offset.group(1)),
+                                     payload.group(1)));
             }
         }
 
@@ -402,7 +367,6 @@ class StreamCrashDurabilityTest {
     }
 
     // --- deployment + readiness --------------------------------------------
-
     private void deployStreamSlice() {
         var blueprint = """
             id = "%s"
@@ -414,10 +378,9 @@ class StreamCrashDurabilityTest {
         var leaderPort = cluster.getLeaderManagementPort().or(anyMgmtPort());
         var response = postBlueprintWithRetry(leaderPort, blueprint);
 
-        assertThat(response)
-            .describedAs("stream-slice deployment")
-            .doesNotContain("\"error\"")
-            .contains("\"status\":\"applied\"");
+        assertThat(response).describedAs("stream-slice deployment")
+                  .doesNotContain("\"error\"")
+                  .contains("\"status\":\"applied\"");
     }
 
     private boolean appHttpReady() {
@@ -429,13 +392,15 @@ class StreamCrashDurabilityTest {
 
         var body = httpPost(ports.getFirst(), "/api/stream/read", "{\"fromOffset\":0,\"maxEvents\":1}");
 
-        return !body.contains("\"error\"") && body.contains("events");
+        return ! body.contains("\"error\"") && body.contains("events");
     }
 
     private void failIfSliceFailed() {
         var failed = cluster.slicesStatus()
                             .stream()
-                            .anyMatch(s -> s.artifact().equals(STREAM_SLICE) && s.state().equals("FAILED"));
+                            .anyMatch(s -> s.artifact()
+                                            .equals(STREAM_SLICE) && s.state()
+                                                                      .equals("FAILED"));
 
         if (failed) {
             throw new AssertionError("Stream slice deployment FAILED: " + STREAM_SLICE);
@@ -450,7 +415,10 @@ class StreamCrashDurabilityTest {
     }
 
     private int anyMgmtPort() {
-        return cluster.status().nodes().getFirst().mgmtPort();
+        return cluster.status()
+                      .nodes()
+                      .getFirst()
+                      .mgmtPort();
     }
 
     private long deadlineNanos() {
@@ -474,9 +442,11 @@ class StreamCrashDurabilityTest {
                                  .GET()
                                  .timeout(Duration.ofSeconds(5))
                                  .build();
+
         return http.sendString(request)
                    .await()
-                   .map(r -> r.statusCode() == 200 && r.body().contains("\"quorum\":true"))
+                   .map(r -> r.statusCode() == 200 && r.body()
+                                                       .contains("\"quorum\":true"))
                    .or(false);
     }
 
@@ -490,9 +460,11 @@ class StreamCrashDurabilityTest {
                                  .GET()
                                  .timeout(Duration.ofSeconds(5))
                                  .build();
+
         return http.sendString(request)
                    .await()
-                   .map(r -> r.statusCode() == 200 && healthHasFullMembership(r.body(), expected))
+                   .map(r -> r.statusCode() == 200 && healthHasFullMembership(r.body(),
+                                                                              expected))
                    .or(false);
     }
 
@@ -507,13 +479,11 @@ class StreamCrashDurabilityTest {
     }
 
     // --- HTTP ---------------------------------------------------------------
-
     private String postBlueprintWithRetry(int port, String body) {
         var lastResponse = ERROR_FALLBACK;
 
         for (int attempt = 1; attempt <= 3; attempt++) {
             lastResponse = httpPostToml(port, "/api/v1/blueprints", body);
-
             if (!lastResponse.contains("\"error\"")) {
                 return lastResponse;
             }
@@ -533,6 +503,7 @@ class StreamCrashDurabilityTest {
                                  .POST(HttpRequest.BodyPublishers.ofString(body))
                                  .timeout(Duration.ofSeconds(10))
                                  .build();
+
         return http.sendString(request)
                    .await()
                    .map(HttpResult::body)
@@ -546,6 +517,7 @@ class StreamCrashDurabilityTest {
                                  .POST(HttpRequest.BodyPublishers.ofString(body))
                                  .timeout(Duration.ofSeconds(15))
                                  .build();
+
         return http.sendString(request)
                    .await()
                    .map(HttpResult::body)
@@ -558,6 +530,7 @@ class StreamCrashDurabilityTest {
                                  .DELETE()
                                  .timeout(Duration.ofSeconds(10))
                                  .build();
+
         return http.sendString(request)
                    .await()
                    .map(HttpResult::body)

--- a/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/StreamFanoutConsumerTest.java
+++ b/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/StreamFanoutConsumerTest.java
@@ -2,7 +2,21 @@
 // Copyright (c) 2025 Pragmatica Labs - Sergiy Yevtushenko
 // Licensed under Business Source License 1.1. Change Date: 2030-01-01. Change License: Apache-2.0.
 // See LICENSE in the repository root for full terms.
+
 package org.pragmatica.aether.forge;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.pragmatica.http.HttpOperations;
+import org.pragmatica.http.HttpResult;
+import org.pragmatica.config.ConfigurationProvider;
+import org.pragmatica.lang.Option;
 
 import java.net.URI;
 import java.net.http.HttpRequest;
@@ -15,26 +29,12 @@ import java.util.concurrent.locks.LockSupport;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.pragmatica.http.HttpOperations;
-import org.pragmatica.http.HttpResult;
-import org.pragmatica.config.ConfigurationProvider;
-import org.pragmatica.lang.Option;
-import org.pragmatica.aether.ember.EmberCluster;
-
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
-
-import static org.pragmatica.aether.ember.EmberCluster.emberCluster;
-import static org.pragmatica.http.JdkHttpOperations.jdkHttpOperations;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
+import static org.pragmatica.aether.ember.EmberCluster.emberCluster;
+import static org.pragmatica.http.JdkHttpOperations.jdkHttpOperations;
 
+import org.pragmatica.aether.ember.EmberCluster;
 
 /// #265 STEP 0 — streaming end-to-end BASELINE (regression net for log/Kafka fan-out semantics).
 ///
@@ -66,13 +66,16 @@ class StreamFanoutConsumerTest {
     private static final int NODES = 5;
     private static final int INSTANCES = 5;
     private static final int EVENT_COUNT = 50;
+
     private static final Duration WAIT_TIMEOUT = Duration.ofSeconds(240);
     private static final Duration POLL_INTERVAL = Duration.ofMillis(500);
     private static final Duration DRAIN_TIMEOUT = Duration.ofSeconds(90);
     private static final long POLL_GAP_NANOS = Duration.ofMillis(20).toNanos();
+
     private static final String STREAM_SLICE = TestArtifacts.STREAM_SLICE;
     private static final String BLUEPRINT_ID = "forge.test:stream-fanout:1.0.0";
     private static final String ERROR_FALLBACK = "{\"error\":\"request failed\"}";
+
     private static final Pattern EVENT_OBJECT = Pattern.compile("\\{[^{}]*\"offset\"[^{}]*}");
     private static final Pattern OFFSET_FIELD = Pattern.compile("\"offset\"\\s*:\\s*(\\d+)");
     private static final Pattern PAYLOAD_FIELD = Pattern.compile("\"payload\"\\s*:\\s*\"([^\"]*)\"");
@@ -98,17 +101,24 @@ class StreamFanoutConsumerTest {
                                                   .withSystemProperties("aether.")
                                                   .withEnvironment("AETHER_")
                                                   .build();
-
         cluster = emberCluster(NODES, BASE_PORT, BASE_MGMT_PORT, BASE_APP_HTTP_PORT, "sf", Option.some(configProvider));
         LifecycleAwait.settled("cluster start in setUp()", cluster, cluster.start());
-        await().atMost(WAIT_TIMEOUT).pollInterval(POLL_INTERVAL).until(() -> cluster.currentLeader()
-                                                                                    .isPresent());
-        await().atMost(WAIT_TIMEOUT).pollInterval(POLL_INTERVAL).until(this::allNodesHealthy);
-        deployStreamSlice();
+
         await().atMost(WAIT_TIMEOUT)
-             .pollInterval(POLL_INTERVAL)
-             .failFast(this::failIfSliceFailed)
-             .until(this::appHttpReady);
+               .pollInterval(POLL_INTERVAL)
+               .until(() -> cluster.currentLeader().isPresent());
+
+        await().atMost(WAIT_TIMEOUT)
+               .pollInterval(POLL_INTERVAL)
+               .until(this::allNodesHealthy);
+
+        deployStreamSlice();
+
+        await().atMost(WAIT_TIMEOUT)
+               .pollInterval(POLL_INTERVAL)
+               .failFast(this::failIfSliceFailed)
+               .until(this::appHttpReady);
+
         // appHttpReady only proves the READ path serves. Immediately after deployment a publish can still
         // land before the partition OWNER has materialized its buffer, so the forwarded append briefly
         // fails; gate on a warm-up publish actually succeeding so tests start write-ready.
@@ -119,18 +129,17 @@ class StreamFanoutConsumerTest {
         // fixed at the source (owner-routed publish + self-guard); this gate only smooths genuine
         // owner-materialization lag.
         await().atMost(WAIT_TIMEOUT)
-             .pollInterval(POLL_INTERVAL)
-             .failFast(this::failIfSliceFailed)
-             .until(this::publishReady);
+               .pollInterval(POLL_INTERVAL)
+               .failFast(this::failIfSliceFailed)
+               .until(this::publishReady);
     }
 
     @AfterAll
     void tearDown() {
         if (cluster != null) {
             var leaderPort = cluster.getLeaderManagementPort().or(anyMgmtPort());
-
             httpDelete(leaderPort, "/api/v1/blueprints/" + BLUEPRINT_ID);
-            LifecycleAwait.settled("cluster stop in tearDown()", cluster, cluster.stop());
+            LifecycleAwait.bestEffort("cluster stop in tearDown()", cluster, cluster.stop());
         }
     }
 
@@ -143,25 +152,18 @@ class StreamFanoutConsumerTest {
             var port = appPort();
             var base = head(port);
             var tag = "fanout";
-
             publishBatch(port, tag, EVENT_COUNT);
-            var paces = List.of(new Pace(1,
-                                         Duration.ofMillis(3).toNanos()),
-                                new Pace(5,
-                                         Duration.ofMillis(1).toNanos()),
-                                new Pace(13, 0L),
-                                new Pace(EVENT_COUNT,
-                                         Duration.ofMillis(7).toNanos()));
+
+            var paces = List.of(new Pace(1, Duration.ofMillis(3).toNanos()),
+                                 new Pace(5, Duration.ofMillis(1).toNanos()),
+                                 new Pace(13, 0L),
+                                 new Pace(EVENT_COUNT, Duration.ofMillis(7).toNanos()));
 
             try (var executor = Executors.newVirtualThreadPerTaskExecutor()) {
                 var deadline = deadlineNanos();
                 var futures = paces.stream()
-                                   .map(pace -> CompletableFuture.supplyAsync(() -> drain(port,
-                                                                                          base,
-                                                                                          EVENT_COUNT,
-                                                                                          pace,
-                                                                                          deadline),
-                                                                              executor))
+                                   .map(pace -> CompletableFuture.supplyAsync(
+                                       () -> drain(port, base, EVENT_COUNT, pace, deadline), executor))
                                    .toList();
                 var results = futures.stream().map(CompletableFuture::join).toList();
 
@@ -179,13 +181,12 @@ class StreamFanoutConsumerTest {
             var port = appPort();
             var base = head(port);
             var tag = "replay";
-
             publishBatch(port, tag, EVENT_COUNT);
+
             var firstPass = drain(port, base, EVENT_COUNT, new Pace(7, 0L), deadlineNanos());
-
             assertContiguousBatch(firstPass, base, EVENT_COUNT, tag);
-            var replay = drain(port, base, EVENT_COUNT, new Pace(EVENT_COUNT, 0L), deadlineNanos());
 
+            var replay = drain(port, base, EVENT_COUNT, new Pace(EVENT_COUNT, 0L), deadlineNanos());
             assertContiguousBatch(replay, base, EVENT_COUNT, tag);
         }
     }
@@ -199,16 +200,14 @@ class StreamFanoutConsumerTest {
             var port = appPort();
             var base = head(port);
             var tag = "latejoin";
-
             publishBatch(port, tag, EVENT_COUNT);
+
             var fromOrigin = drain(port, base, EVENT_COUNT, new Pace(11, 0L), deadlineNanos());
-
             assertContiguousBatch(fromOrigin, base, EVENT_COUNT, tag);
-            var fullHistory = drainAll(port);
 
+            var fullHistory = drainAll(port);
             assertThat(fullHistory).hasSizeGreaterThanOrEqualTo((int) base + EVENT_COUNT);
             var tailBlock = fullHistory.subList((int) base, (int) base + EVENT_COUNT);
-
             assertContiguousBatch(tailBlock, base, EVENT_COUNT, tag);
         }
     }
@@ -224,21 +223,15 @@ class StreamFanoutConsumerTest {
             var tag = "slow";
 
             try (var executor = Executors.newVirtualThreadPerTaskExecutor()) {
-                var publisher = CompletableFuture.runAsync(() -> publishPaced(port,
-                                                                              tag,
-                                                                              EVENT_COUNT,
-                                                                              Duration.ofMillis(5).toNanos()),
-                                                           executor);
-                var slow = CompletableFuture.supplyAsync(() -> drain(port,
-                                                                     base,
-                                                                     EVENT_COUNT,
-                                                                     new Pace(1,
-                                                                              Duration.ofMillis(15).toNanos()),
-                                                                     deadlineNanos()),
-                                                         executor);
-                var collected = slow.join();
+                var publisher = CompletableFuture.runAsync(
+                    () -> publishPaced(port, tag, EVENT_COUNT, Duration.ofMillis(5).toNanos()), executor);
+                var slow = CompletableFuture.supplyAsync(
+                    () -> drain(port, base, EVENT_COUNT, new Pace(1, Duration.ofMillis(15).toNanos()), deadlineNanos()),
+                    executor);
 
+                var collected = slow.join();
                 publisher.join();
+
                 assertContiguousBatch(collected, base, EVENT_COUNT, tag);
             }
         }
@@ -253,39 +246,41 @@ class StreamFanoutConsumerTest {
             var port = appPort();
             var base = head(port);
             var tag = "order";
-
             publishBatch(port, tag, EVENT_COUNT);
+
             var events = drain(port, base, EVENT_COUNT, new Pace(EVENT_COUNT, 0L), deadlineNanos());
 
             assertThat(events).hasSize(EVENT_COUNT);
             for (int i = 0; i < EVENT_COUNT; i++) {
-                assertThat(events.get(i).offset()).describedAs("offset at index %d strictly monotonic from base %d",
-                                                               i,
-                                                               base)
-                          .isEqualTo(base + i);
-                assertThat(events.get(i).payload()).describedAs("payload at index %d in publish order", i)
-                          .isEqualTo(tag + "-" + i);
+                assertThat(events.get(i).offset())
+                    .describedAs("offset at index %d strictly monotonic from base %d", i, base)
+                    .isEqualTo(base + i);
+                assertThat(events.get(i).payload())
+                    .describedAs("payload at index %d in publish order", i)
+                    .isEqualTo(tag + "-" + i);
             }
         }
     }
 
     // --- assertions ---------------------------------------------------------
+
     private void assertContiguousBatch(List<Event> events, long base, int count, String tag) {
-        assertThat(events).describedAs("consumer must receive exactly %d events (no dups, no gaps)",
-                                       count)
-                  .hasSize(count);
+        assertThat(events)
+            .describedAs("consumer must receive exactly %d events (no dups, no gaps)", count)
+            .hasSize(count);
+
         for (int i = 0; i < count; i++) {
-            assertThat(events.get(i).offset()).describedAs("event %d offset (contiguous from base %d)",
-                                                           i,
-                                                           base)
-                      .isEqualTo(base + i);
-            assertThat(events.get(i).payload()).describedAs("event %d payload (in publish order)",
-                                                            i)
-                      .isEqualTo(tag + "-" + i);
+            assertThat(events.get(i).offset())
+                .describedAs("event %d offset (contiguous from base %d)", i, base)
+                .isEqualTo(base + i);
+            assertThat(events.get(i).payload())
+                .describedAs("event %d payload (in publish order)", i)
+                .isEqualTo(tag + "-" + i);
         }
     }
 
     // --- consumers ----------------------------------------------------------
+
     private List<Event> drain(int port, long base, int count, Pace pace, long deadlineNanos) {
         var collected = new ArrayList<Event>();
         var offset = base;
@@ -300,6 +295,7 @@ class StreamFanoutConsumerTest {
 
             collected.addAll(events);
             offset = events.getLast().offset() + 1;
+
             if (pace.paceNanos() > 0) {
                 LockSupport.parkNanos(pace.paceNanos());
             }
@@ -329,6 +325,7 @@ class StreamFanoutConsumerTest {
     }
 
     // --- publishing ---------------------------------------------------------
+
     private void publishBatch(int port, String tag, int count) {
         for (int i = 0; i < count; i++) {
             publish(port, tag + "-" + i);
@@ -346,9 +343,10 @@ class StreamFanoutConsumerTest {
         var body = "{\"payload\":\"" + payload + "\"}";
         var response = httpPost(port, "/api/stream/publish", body);
 
-        assertThat(response).describedAs("publish '%s' must succeed", payload)
-                  .doesNotContain("\"error\"")
-                  .contains("published");
+        assertThat(response)
+            .describedAs("publish '%s' must succeed", payload)
+            .doesNotContain("\"error\"")
+            .contains("published");
     }
 
     private List<Event> readEvents(int port, long fromOffset, int maxEvents) {
@@ -367,8 +365,7 @@ class StreamFanoutConsumerTest {
             Matcher payload = PAYLOAD_FIELD.matcher(object);
 
             if (offset.find() && payload.find()) {
-                events.add(new Event(Long.parseLong(offset.group(1)),
-                                     payload.group(1)));
+                events.add(new Event(Long.parseLong(offset.group(1)), payload.group(1)));
             }
         }
 
@@ -376,6 +373,7 @@ class StreamFanoutConsumerTest {
     }
 
     // --- deployment + readiness --------------------------------------------
+
     private void deployStreamSlice() {
         var blueprint = """
             id = "%s"
@@ -387,9 +385,10 @@ class StreamFanoutConsumerTest {
         var leaderPort = cluster.getLeaderManagementPort().or(anyMgmtPort());
         var response = postBlueprintWithRetry(leaderPort, blueprint);
 
-        assertThat(response).describedAs("stream-slice deployment")
-                  .doesNotContain("\"error\"")
-                  .contains("\"status\":\"applied\"");
+        assertThat(response)
+            .describedAs("stream-slice deployment")
+            .doesNotContain("\"error\"")
+            .contains("\"status\":\"applied\"");
     }
 
     private boolean appHttpReady() {
@@ -401,7 +400,7 @@ class StreamFanoutConsumerTest {
 
         var body = httpPost(ports.getFirst(), "/api/stream/read", "{\"fromOffset\":0,\"maxEvents\":1}");
 
-        return ! body.contains("\"error\"") && body.contains("events");
+        return !body.contains("\"error\"") && body.contains("events");
     }
 
     /// Warm-up publish readiness: immediately after deployment a publish can land before the partition
@@ -417,15 +416,13 @@ class StreamFanoutConsumerTest {
 
         var response = httpPost(ports.getFirst(), "/api/stream/publish", "{\"payload\":\"__warmup__\"}");
 
-        return ! response.contains("\"error\"") && response.contains("published");
+        return !response.contains("\"error\"") && response.contains("published");
     }
 
     private void failIfSliceFailed() {
         var failed = cluster.slicesStatus()
                             .stream()
-                            .anyMatch(s -> s.artifact()
-                                            .equals(STREAM_SLICE) && s.state()
-                                                                      .equals("FAILED"));
+                            .anyMatch(s -> s.artifact().equals(STREAM_SLICE) && s.state().equals("FAILED"));
 
         if (failed) {
             throw new AssertionError("Stream slice deployment FAILED: " + STREAM_SLICE);
@@ -440,10 +437,7 @@ class StreamFanoutConsumerTest {
     }
 
     private int anyMgmtPort() {
-        return cluster.status()
-                      .nodes()
-                      .getFirst()
-                      .mgmtPort();
+        return cluster.status().nodes().getFirst().mgmtPort();
     }
 
     private long deadlineNanos() {
@@ -463,20 +457,20 @@ class StreamFanoutConsumerTest {
                                  .GET()
                                  .timeout(Duration.ofSeconds(5))
                                  .build();
-
         return http.sendString(request)
                    .await()
-                   .map(r -> r.statusCode() == 200 && r.body()
-                                                       .contains("\"quorum\":true"))
+                   .map(r -> r.statusCode() == 200 && r.body().contains("\"quorum\":true"))
                    .or(false);
     }
 
     // --- HTTP ---------------------------------------------------------------
+
     private String postBlueprintWithRetry(int port, String body) {
         var lastResponse = ERROR_FALLBACK;
 
         for (int attempt = 1; attempt <= 3; attempt++) {
             lastResponse = httpPostToml(port, "/api/v1/blueprints", body);
+
             if (!lastResponse.contains("\"error\"")) {
                 return lastResponse;
             }
@@ -496,7 +490,6 @@ class StreamFanoutConsumerTest {
                                  .POST(HttpRequest.BodyPublishers.ofString(body))
                                  .timeout(Duration.ofSeconds(10))
                                  .build();
-
         return http.sendString(request)
                    .await()
                    .map(HttpResult::body)
@@ -510,7 +503,6 @@ class StreamFanoutConsumerTest {
                                  .POST(HttpRequest.BodyPublishers.ofString(body))
                                  .timeout(Duration.ofSeconds(15))
                                  .build();
-
         return http.sendString(request)
                    .await()
                    .map(HttpResult::body)
@@ -523,7 +515,6 @@ class StreamFanoutConsumerTest {
                                  .DELETE()
                                  .timeout(Duration.ofSeconds(10))
                                  .build();
-
         return http.sendString(request)
                    .await()
                    .map(HttpResult::body)

--- a/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/StreamFanoutConsumerTest.java
+++ b/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/StreamFanoutConsumerTest.java
@@ -2,21 +2,7 @@
 // Copyright (c) 2025 Pragmatica Labs - Sergiy Yevtushenko
 // Licensed under Business Source License 1.1. Change Date: 2030-01-01. Change License: Apache-2.0.
 // See LICENSE in the repository root for full terms.
-
 package org.pragmatica.aether.forge;
-
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
-import org.pragmatica.http.HttpOperations;
-import org.pragmatica.http.HttpResult;
-import org.pragmatica.config.ConfigurationProvider;
-import org.pragmatica.lang.Option;
 
 import java.net.URI;
 import java.net.http.HttpRequest;
@@ -29,12 +15,26 @@ import java.util.concurrent.locks.LockSupport;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.awaitility.Awaitility.await;
+import org.pragmatica.http.HttpOperations;
+import org.pragmatica.http.HttpResult;
+import org.pragmatica.config.ConfigurationProvider;
+import org.pragmatica.lang.Option;
+import org.pragmatica.aether.ember.EmberCluster;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+
 import static org.pragmatica.aether.ember.EmberCluster.emberCluster;
 import static org.pragmatica.http.JdkHttpOperations.jdkHttpOperations;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
 
-import org.pragmatica.aether.ember.EmberCluster;
 
 /// #265 STEP 0 — streaming end-to-end BASELINE (regression net for log/Kafka fan-out semantics).
 ///
@@ -66,16 +66,13 @@ class StreamFanoutConsumerTest {
     private static final int NODES = 5;
     private static final int INSTANCES = 5;
     private static final int EVENT_COUNT = 50;
-
     private static final Duration WAIT_TIMEOUT = Duration.ofSeconds(240);
     private static final Duration POLL_INTERVAL = Duration.ofMillis(500);
     private static final Duration DRAIN_TIMEOUT = Duration.ofSeconds(90);
     private static final long POLL_GAP_NANOS = Duration.ofMillis(20).toNanos();
-
     private static final String STREAM_SLICE = TestArtifacts.STREAM_SLICE;
     private static final String BLUEPRINT_ID = "forge.test:stream-fanout:1.0.0";
     private static final String ERROR_FALLBACK = "{\"error\":\"request failed\"}";
-
     private static final Pattern EVENT_OBJECT = Pattern.compile("\\{[^{}]*\"offset\"[^{}]*}");
     private static final Pattern OFFSET_FIELD = Pattern.compile("\"offset\"\\s*:\\s*(\\d+)");
     private static final Pattern PAYLOAD_FIELD = Pattern.compile("\"payload\"\\s*:\\s*\"([^\"]*)\"");
@@ -101,28 +98,17 @@ class StreamFanoutConsumerTest {
                                                   .withSystemProperties("aether.")
                                                   .withEnvironment("AETHER_")
                                                   .build();
+
         cluster = emberCluster(NODES, BASE_PORT, BASE_MGMT_PORT, BASE_APP_HTTP_PORT, "sf", Option.some(configProvider));
-        cluster.start()
-               .await()
-               .onFailure(cause -> {
-                   throw new AssertionError("Cluster start failed: " + cause.message());
-               });
-
-        await().atMost(WAIT_TIMEOUT)
-               .pollInterval(POLL_INTERVAL)
-               .until(() -> cluster.currentLeader().isPresent());
-
-        await().atMost(WAIT_TIMEOUT)
-               .pollInterval(POLL_INTERVAL)
-               .until(this::allNodesHealthy);
-
+        LifecycleAwait.settled("cluster start in setUp()", cluster, cluster.start());
+        await().atMost(WAIT_TIMEOUT).pollInterval(POLL_INTERVAL).until(() -> cluster.currentLeader()
+                                                                                    .isPresent());
+        await().atMost(WAIT_TIMEOUT).pollInterval(POLL_INTERVAL).until(this::allNodesHealthy);
         deployStreamSlice();
-
         await().atMost(WAIT_TIMEOUT)
-               .pollInterval(POLL_INTERVAL)
-               .failFast(this::failIfSliceFailed)
-               .until(this::appHttpReady);
-
+             .pollInterval(POLL_INTERVAL)
+             .failFast(this::failIfSliceFailed)
+             .until(this::appHttpReady);
         // appHttpReady only proves the READ path serves. Immediately after deployment a publish can still
         // land before the partition OWNER has materialized its buffer, so the forwarded append briefly
         // fails; gate on a warm-up publish actually succeeding so tests start write-ready.
@@ -133,18 +119,18 @@ class StreamFanoutConsumerTest {
         // fixed at the source (owner-routed publish + self-guard); this gate only smooths genuine
         // owner-materialization lag.
         await().atMost(WAIT_TIMEOUT)
-               .pollInterval(POLL_INTERVAL)
-               .failFast(this::failIfSliceFailed)
-               .until(this::publishReady);
+             .pollInterval(POLL_INTERVAL)
+             .failFast(this::failIfSliceFailed)
+             .until(this::publishReady);
     }
 
     @AfterAll
     void tearDown() {
         if (cluster != null) {
             var leaderPort = cluster.getLeaderManagementPort().or(anyMgmtPort());
+
             httpDelete(leaderPort, "/api/v1/blueprints/" + BLUEPRINT_ID);
-            cluster.stop()
-                   .await();
+            LifecycleAwait.settled("cluster stop in tearDown()", cluster, cluster.stop());
         }
     }
 
@@ -157,18 +143,25 @@ class StreamFanoutConsumerTest {
             var port = appPort();
             var base = head(port);
             var tag = "fanout";
-            publishBatch(port, tag, EVENT_COUNT);
 
-            var paces = List.of(new Pace(1, Duration.ofMillis(3).toNanos()),
-                                 new Pace(5, Duration.ofMillis(1).toNanos()),
-                                 new Pace(13, 0L),
-                                 new Pace(EVENT_COUNT, Duration.ofMillis(7).toNanos()));
+            publishBatch(port, tag, EVENT_COUNT);
+            var paces = List.of(new Pace(1,
+                                         Duration.ofMillis(3).toNanos()),
+                                new Pace(5,
+                                         Duration.ofMillis(1).toNanos()),
+                                new Pace(13, 0L),
+                                new Pace(EVENT_COUNT,
+                                         Duration.ofMillis(7).toNanos()));
 
             try (var executor = Executors.newVirtualThreadPerTaskExecutor()) {
                 var deadline = deadlineNanos();
                 var futures = paces.stream()
-                                   .map(pace -> CompletableFuture.supplyAsync(
-                                       () -> drain(port, base, EVENT_COUNT, pace, deadline), executor))
+                                   .map(pace -> CompletableFuture.supplyAsync(() -> drain(port,
+                                                                                          base,
+                                                                                          EVENT_COUNT,
+                                                                                          pace,
+                                                                                          deadline),
+                                                                              executor))
                                    .toList();
                 var results = futures.stream().map(CompletableFuture::join).toList();
 
@@ -186,12 +179,13 @@ class StreamFanoutConsumerTest {
             var port = appPort();
             var base = head(port);
             var tag = "replay";
+
             publishBatch(port, tag, EVENT_COUNT);
-
             var firstPass = drain(port, base, EVENT_COUNT, new Pace(7, 0L), deadlineNanos());
-            assertContiguousBatch(firstPass, base, EVENT_COUNT, tag);
 
+            assertContiguousBatch(firstPass, base, EVENT_COUNT, tag);
             var replay = drain(port, base, EVENT_COUNT, new Pace(EVENT_COUNT, 0L), deadlineNanos());
+
             assertContiguousBatch(replay, base, EVENT_COUNT, tag);
         }
     }
@@ -205,14 +199,16 @@ class StreamFanoutConsumerTest {
             var port = appPort();
             var base = head(port);
             var tag = "latejoin";
+
             publishBatch(port, tag, EVENT_COUNT);
-
             var fromOrigin = drain(port, base, EVENT_COUNT, new Pace(11, 0L), deadlineNanos());
-            assertContiguousBatch(fromOrigin, base, EVENT_COUNT, tag);
 
+            assertContiguousBatch(fromOrigin, base, EVENT_COUNT, tag);
             var fullHistory = drainAll(port);
+
             assertThat(fullHistory).hasSizeGreaterThanOrEqualTo((int) base + EVENT_COUNT);
             var tailBlock = fullHistory.subList((int) base, (int) base + EVENT_COUNT);
+
             assertContiguousBatch(tailBlock, base, EVENT_COUNT, tag);
         }
     }
@@ -228,15 +224,21 @@ class StreamFanoutConsumerTest {
             var tag = "slow";
 
             try (var executor = Executors.newVirtualThreadPerTaskExecutor()) {
-                var publisher = CompletableFuture.runAsync(
-                    () -> publishPaced(port, tag, EVENT_COUNT, Duration.ofMillis(5).toNanos()), executor);
-                var slow = CompletableFuture.supplyAsync(
-                    () -> drain(port, base, EVENT_COUNT, new Pace(1, Duration.ofMillis(15).toNanos()), deadlineNanos()),
-                    executor);
-
+                var publisher = CompletableFuture.runAsync(() -> publishPaced(port,
+                                                                              tag,
+                                                                              EVENT_COUNT,
+                                                                              Duration.ofMillis(5).toNanos()),
+                                                           executor);
+                var slow = CompletableFuture.supplyAsync(() -> drain(port,
+                                                                     base,
+                                                                     EVENT_COUNT,
+                                                                     new Pace(1,
+                                                                              Duration.ofMillis(15).toNanos()),
+                                                                     deadlineNanos()),
+                                                         executor);
                 var collected = slow.join();
-                publisher.join();
 
+                publisher.join();
                 assertContiguousBatch(collected, base, EVENT_COUNT, tag);
             }
         }
@@ -251,41 +253,39 @@ class StreamFanoutConsumerTest {
             var port = appPort();
             var base = head(port);
             var tag = "order";
-            publishBatch(port, tag, EVENT_COUNT);
 
+            publishBatch(port, tag, EVENT_COUNT);
             var events = drain(port, base, EVENT_COUNT, new Pace(EVENT_COUNT, 0L), deadlineNanos());
 
             assertThat(events).hasSize(EVENT_COUNT);
             for (int i = 0; i < EVENT_COUNT; i++) {
-                assertThat(events.get(i).offset())
-                    .describedAs("offset at index %d strictly monotonic from base %d", i, base)
-                    .isEqualTo(base + i);
-                assertThat(events.get(i).payload())
-                    .describedAs("payload at index %d in publish order", i)
-                    .isEqualTo(tag + "-" + i);
+                assertThat(events.get(i).offset()).describedAs("offset at index %d strictly monotonic from base %d",
+                                                               i,
+                                                               base)
+                          .isEqualTo(base + i);
+                assertThat(events.get(i).payload()).describedAs("payload at index %d in publish order", i)
+                          .isEqualTo(tag + "-" + i);
             }
         }
     }
 
     // --- assertions ---------------------------------------------------------
-
     private void assertContiguousBatch(List<Event> events, long base, int count, String tag) {
-        assertThat(events)
-            .describedAs("consumer must receive exactly %d events (no dups, no gaps)", count)
-            .hasSize(count);
-
+        assertThat(events).describedAs("consumer must receive exactly %d events (no dups, no gaps)",
+                                       count)
+                  .hasSize(count);
         for (int i = 0; i < count; i++) {
-            assertThat(events.get(i).offset())
-                .describedAs("event %d offset (contiguous from base %d)", i, base)
-                .isEqualTo(base + i);
-            assertThat(events.get(i).payload())
-                .describedAs("event %d payload (in publish order)", i)
-                .isEqualTo(tag + "-" + i);
+            assertThat(events.get(i).offset()).describedAs("event %d offset (contiguous from base %d)",
+                                                           i,
+                                                           base)
+                      .isEqualTo(base + i);
+            assertThat(events.get(i).payload()).describedAs("event %d payload (in publish order)",
+                                                            i)
+                      .isEqualTo(tag + "-" + i);
         }
     }
 
     // --- consumers ----------------------------------------------------------
-
     private List<Event> drain(int port, long base, int count, Pace pace, long deadlineNanos) {
         var collected = new ArrayList<Event>();
         var offset = base;
@@ -300,7 +300,6 @@ class StreamFanoutConsumerTest {
 
             collected.addAll(events);
             offset = events.getLast().offset() + 1;
-
             if (pace.paceNanos() > 0) {
                 LockSupport.parkNanos(pace.paceNanos());
             }
@@ -330,7 +329,6 @@ class StreamFanoutConsumerTest {
     }
 
     // --- publishing ---------------------------------------------------------
-
     private void publishBatch(int port, String tag, int count) {
         for (int i = 0; i < count; i++) {
             publish(port, tag + "-" + i);
@@ -348,10 +346,9 @@ class StreamFanoutConsumerTest {
         var body = "{\"payload\":\"" + payload + "\"}";
         var response = httpPost(port, "/api/stream/publish", body);
 
-        assertThat(response)
-            .describedAs("publish '%s' must succeed", payload)
-            .doesNotContain("\"error\"")
-            .contains("published");
+        assertThat(response).describedAs("publish '%s' must succeed", payload)
+                  .doesNotContain("\"error\"")
+                  .contains("published");
     }
 
     private List<Event> readEvents(int port, long fromOffset, int maxEvents) {
@@ -370,7 +367,8 @@ class StreamFanoutConsumerTest {
             Matcher payload = PAYLOAD_FIELD.matcher(object);
 
             if (offset.find() && payload.find()) {
-                events.add(new Event(Long.parseLong(offset.group(1)), payload.group(1)));
+                events.add(new Event(Long.parseLong(offset.group(1)),
+                                     payload.group(1)));
             }
         }
 
@@ -378,7 +376,6 @@ class StreamFanoutConsumerTest {
     }
 
     // --- deployment + readiness --------------------------------------------
-
     private void deployStreamSlice() {
         var blueprint = """
             id = "%s"
@@ -390,10 +387,9 @@ class StreamFanoutConsumerTest {
         var leaderPort = cluster.getLeaderManagementPort().or(anyMgmtPort());
         var response = postBlueprintWithRetry(leaderPort, blueprint);
 
-        assertThat(response)
-            .describedAs("stream-slice deployment")
-            .doesNotContain("\"error\"")
-            .contains("\"status\":\"applied\"");
+        assertThat(response).describedAs("stream-slice deployment")
+                  .doesNotContain("\"error\"")
+                  .contains("\"status\":\"applied\"");
     }
 
     private boolean appHttpReady() {
@@ -405,7 +401,7 @@ class StreamFanoutConsumerTest {
 
         var body = httpPost(ports.getFirst(), "/api/stream/read", "{\"fromOffset\":0,\"maxEvents\":1}");
 
-        return !body.contains("\"error\"") && body.contains("events");
+        return ! body.contains("\"error\"") && body.contains("events");
     }
 
     /// Warm-up publish readiness: immediately after deployment a publish can land before the partition
@@ -421,13 +417,15 @@ class StreamFanoutConsumerTest {
 
         var response = httpPost(ports.getFirst(), "/api/stream/publish", "{\"payload\":\"__warmup__\"}");
 
-        return !response.contains("\"error\"") && response.contains("published");
+        return ! response.contains("\"error\"") && response.contains("published");
     }
 
     private void failIfSliceFailed() {
         var failed = cluster.slicesStatus()
                             .stream()
-                            .anyMatch(s -> s.artifact().equals(STREAM_SLICE) && s.state().equals("FAILED"));
+                            .anyMatch(s -> s.artifact()
+                                            .equals(STREAM_SLICE) && s.state()
+                                                                      .equals("FAILED"));
 
         if (failed) {
             throw new AssertionError("Stream slice deployment FAILED: " + STREAM_SLICE);
@@ -442,7 +440,10 @@ class StreamFanoutConsumerTest {
     }
 
     private int anyMgmtPort() {
-        return cluster.status().nodes().getFirst().mgmtPort();
+        return cluster.status()
+                      .nodes()
+                      .getFirst()
+                      .mgmtPort();
     }
 
     private long deadlineNanos() {
@@ -462,20 +463,20 @@ class StreamFanoutConsumerTest {
                                  .GET()
                                  .timeout(Duration.ofSeconds(5))
                                  .build();
+
         return http.sendString(request)
                    .await()
-                   .map(r -> r.statusCode() == 200 && r.body().contains("\"quorum\":true"))
+                   .map(r -> r.statusCode() == 200 && r.body()
+                                                       .contains("\"quorum\":true"))
                    .or(false);
     }
 
     // --- HTTP ---------------------------------------------------------------
-
     private String postBlueprintWithRetry(int port, String body) {
         var lastResponse = ERROR_FALLBACK;
 
         for (int attempt = 1; attempt <= 3; attempt++) {
             lastResponse = httpPostToml(port, "/api/v1/blueprints", body);
-
             if (!lastResponse.contains("\"error\"")) {
                 return lastResponse;
             }
@@ -495,6 +496,7 @@ class StreamFanoutConsumerTest {
                                  .POST(HttpRequest.BodyPublishers.ofString(body))
                                  .timeout(Duration.ofSeconds(10))
                                  .build();
+
         return http.sendString(request)
                    .await()
                    .map(HttpResult::body)
@@ -508,6 +510,7 @@ class StreamFanoutConsumerTest {
                                  .POST(HttpRequest.BodyPublishers.ofString(body))
                                  .timeout(Duration.ofSeconds(15))
                                  .build();
+
         return http.sendString(request)
                    .await()
                    .map(HttpResult::body)
@@ -520,6 +523,7 @@ class StreamFanoutConsumerTest {
                                  .DELETE()
                                  .timeout(Duration.ofSeconds(10))
                                  .build();
+
         return http.sendString(request)
                    .await()
                    .map(HttpResult::body)

--- a/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/StreamOwnershipDriverFenceTest.java
+++ b/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/StreamOwnershipDriverFenceTest.java
@@ -2,17 +2,13 @@
 // Copyright (c) 2025 Pragmatica Labs - Sergiy Yevtushenko
 // Licensed under Business Source License 1.1. Change Date: 2030-01-01. Change License: Apache-2.0.
 // See LICENSE in the repository root for full terms.
-
 package org.pragmatica.aether.forge;
 
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.TestInstance;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+
 import org.pragmatica.aether.ember.EmberCluster;
 import org.pragmatica.aether.node.AetherNode;
 import org.pragmatica.aether.slice.StreamConfig;
@@ -32,18 +28,23 @@ import org.pragmatica.lang.Cause;
 import org.pragmatica.lang.Option;
 import org.pragmatica.lang.Result;
 import org.pragmatica.lang.TerminalOperation;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.time.Duration;
-import java.util.List;
-import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.Supplier;
-
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.pragmatica.aether.ember.EmberCluster.emberCluster;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
-import static org.pragmatica.aether.ember.EmberCluster.emberCluster;
+
 
 /// #345 item 1d-iii end-to-end gate: the leader-only stream-ownership DRIVER (the
 /// `onReconcilePassComplete` batch seam on [ReplicaSetController] bound to the
@@ -96,21 +97,17 @@ import static org.pragmatica.aether.ember.EmberCluster.emberCluster;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class StreamOwnershipDriverFenceTest {
     private static final Logger log = LoggerFactory.getLogger(StreamOwnershipDriverFenceTest.class);
-
     private static final int SIZE = 5;
     private static final int BASE_PORT = 5960;
     private static final int BASE_MGMT_PORT = 6060;
     private static final int BASE_APP_HTTP_PORT = 6160;
     private static final String PREFIX = "sodf";
-
     private static final Duration FORM_TIMEOUT = Duration.ofSeconds(180);
     private static final Duration OBSERVE_TIMEOUT = Duration.ofSeconds(150);
     private static final Duration POLL = Duration.ofMillis(500);
-
     private static final String FENCE_STREAM = "sodf:fence";
     private static final int PARTITION = 0;
     private static final int REQUESTED_RF = 1;
-
     /// Distinct stream for the same-term-transfer test (test 3), so it shares no committed ownership
     /// state with the auto-commit test (test 1) under the PER_CLASS shared cluster.
     private static final String TRANSFER_STREAM = "sodf:transfer";
@@ -122,16 +119,19 @@ class StreamOwnershipDriverFenceTest {
     @TerminalOperation
     void setUp() {
         cluster = emberCluster(SIZE, BASE_PORT, BASE_MGMT_PORT, BASE_APP_HTTP_PORT, PREFIX);
-        cluster.start().await().onFailure(StreamOwnershipDriverFenceTest::failStart);
-        await().atMost(FORM_TIMEOUT).pollInterval(POLL).until(() -> cluster.currentLeader().isPresent());
+        LifecycleAwait.settled("cluster start in setUp()", cluster, cluster.start());
+        await().atMost(FORM_TIMEOUT).pollInterval(POLL).until(() -> cluster.currentLeader()
+                                                                           .isPresent());
         await().atMost(FORM_TIMEOUT).pollInterval(POLL).until(this::allNodesReady);
-        log.info("OWNERSHIP-DRIVER-FENCE: {}-node cluster formed, leader={}", SIZE, cluster.currentLeader().or("none"));
+        log.info("OWNERSHIP-DRIVER-FENCE: {}-node cluster formed, leader={}",
+                 SIZE,
+                 cluster.currentLeader().or("none"));
     }
 
     @AfterAll
     @TerminalOperation
     void tearDown() {
-        Option.option(cluster).onPresent(c -> c.stop().await());
+        Option.option(cluster).onPresent(c -> LifecycleAwait.settled("cluster stop in tearDown()", c, c.stop()));
     }
 
     /// The DRIVER auto-commits ownership on a membership reconcile, and the resulting committed epoch
@@ -141,13 +141,13 @@ class StreamOwnershipDriverFenceTest {
     @TerminalOperation
     void driverAutoCommitsOwnership_andStaleEpochAppendIsRejected() {
         cluster.allNodes().forEach(node -> materialize(node, FENCE_STREAM));
-
         // The fenced partition's HRW owner, computed from the SAME committed member view the driver uses;
         // it stays ALIVE for the whole test (the deposed-but-alive case).
         var owner0 = hrwOwner(FENCE_STREAM, PARTITION);
-        log.info("OWNERSHIP-DRIVER-FENCE: fenced-partition owner0={} leader={}",
-                 owner0.id(), cluster.currentLeader().or("none"));
 
+        log.info("OWNERSHIP-DRIVER-FENCE: fenced-partition owner0={} leader={}",
+                 owner0.id(),
+                 cluster.currentLeader().or("none"));
         // Drive the leader's ReplicaSetController reconcile with a real MembershipDecision — the SAME
         // event type the production membership tail delivers — so the driver iterates the now-materialized
         // FENCE_STREAM and auto-commits its ownership records. A NodeJoined for an already-present member
@@ -160,30 +160,29 @@ class StreamOwnershipDriverFenceTest {
         // and idempotent, so re-driving until the record appears removes any materialize/reconcile race.
         await().atMost(OBSERVE_TIMEOUT).pollInterval(POLL).until(this::reconcileAndCheckCommitted);
         var committed = committedOwnership(PARTITION).or(StreamOwnershipDriverFenceTest::failNoRecord);
-        assertThat(committed.owner())
-            .as("driver must auto-commit the HRW owner for the fenced partition (no manual commit)")
-            .isEqualTo(owner0);
-        assertThat(committed.ownerEpoch().isStrictlyAfter(Epoch.ZERO))
-            .as("driver-committed epoch %s must strictly dominate the unfenced floor (Epoch.ZERO)", committed.ownerEpoch())
-            .isTrue();
-        assertThat(committed.ownershipTerm())
-            .as("driver's initial ownership record carries ownershipTerm 1")
-            .isEqualTo(1L);
-        log.info("OWNERSHIP-DRIVER-FENCE: driver auto-committed ({}, {}) owner={} epoch={} ownershipTerm={}",
-                 FENCE_STREAM, PARTITION, committed.owner().id(), committed.ownerEpoch(), committed.ownershipTerm());
 
+        assertThat(committed.owner()).as("driver must auto-commit the HRW owner for the fenced partition (no manual commit)")
+                  .isEqualTo(owner0);
+        assertThat(committed.ownerEpoch().isStrictlyAfter(Epoch.ZERO)).as("driver-committed epoch %s must strictly dominate the unfenced floor (Epoch.ZERO)",
+                                                                          committed.ownerEpoch())
+                  .isTrue();
+        assertThat(committed.ownershipTerm()).as("driver's initial ownership record carries ownershipTerm 1")
+                  .isEqualTo(1L);
+        log.info("OWNERSHIP-DRIVER-FENCE: driver auto-committed ({}, {}) owner={} epoch={} ownershipTerm={}",
+                 FENCE_STREAM,
+                 PARTITION,
+                 committed.owner().id(),
+                 committed.ownerEpoch(),
+                 committed.ownershipTerm());
         // The owner under test is still ALIVE. Wait for its OwnershipEpochHighWater to observe the
         // driver-committed ValuePut (the high-water advance is what activates the fence), then assert a
         // stale-epoch (ZERO) append is rejected.
         var ownerNode = resolveNode(owner0);
-        await().atMost(OBSERVE_TIMEOUT).pollInterval(POLL)
-               .until(() -> staleAppend(ownerNode, Epoch.ZERO).isFailure());
 
-        staleAppend(ownerNode, Epoch.ZERO)
-            .onSuccess(offset -> Assertions.fail(
-                "fence: a below-generation (Epoch.ZERO) append on the alive owner must be REJECTED once the "
-                + "driver-committed epoch advanced the high-water, but it was accepted at offset " + offset))
-            .onFailure(StreamOwnershipDriverFenceTest::assertStaleEpochAppend);
+        await().atMost(OBSERVE_TIMEOUT).pollInterval(POLL).until(() -> staleAppend(ownerNode, Epoch.ZERO).isFailure());
+        staleAppend(ownerNode, Epoch.ZERO).onSuccess(offset -> Assertions.fail("fence: a below-generation (Epoch.ZERO) append on the alive owner must be REJECTED once the "
+                                                                              + "driver-committed epoch advanced the high-water, but it was accepted at offset " + offset))
+                   .onFailure(StreamOwnershipDriverFenceTest::assertStaleEpochAppend);
         log.info("OWNERSHIP-DRIVER-FENCE: stale-epoch append on alive owner {} correctly REJECTED — fence live via driver",
                  owner0.id());
     }
@@ -200,53 +199,57 @@ class StreamOwnershipDriverFenceTest {
     @TerminalOperation
     void sameTermOwnerTransfer_deposedButAliveOwnerIsFenced() {
         cluster.allNodes().forEach(node -> materialize(node, TRANSFER_STREAM));
-
         var view = coreMembers(leaderNode());
         var owner0 = hrwOwner(TRANSFER_STREAM, TRANSFER_PARTITION);
         var owner1 = view.stream().filter(n -> !n.equals(owner0)).findFirst().orElse(view.getLast());
         var owner0Node = resolveNode(owner0);
         var term = leaderNode().currentGenerationEpoch().rabiaTerm();
-        log.info("OWNERSHIP-DRIVER-FENCE: same-term transfer owner0={} owner1={} term={}", owner0.id(), owner1.id(), term);
 
+        log.info("OWNERSHIP-DRIVER-FENCE: same-term transfer owner0={} owner1={} term={}",
+                 owner0.id(),
+                 owner1.id(),
+                 term);
         var hrwHolder = new AtomicReference<>(owner0);
         var writer = liveWriter(term, hrwHolder::get);
-
         // The writer commits owner0 at (term, 1) through REAL consensus — no manual Put; the writer mints it.
         commitOwnershipVia(writer, TRANSFER_STREAM, TRANSFER_PARTITION);
-        await().atMost(OBSERVE_TIMEOUT).pollInterval(POLL)
-               .until(() -> committedOwner(TRANSFER_PARTITION).map(v -> v.owner().equals(owner0)).or(false));
+        await().atMost(OBSERVE_TIMEOUT)
+             .pollInterval(POLL)
+             .until(() -> committedOwner(TRANSFER_PARTITION).map(v -> v.owner()
+                                                                       .equals(owner0))
+                                        .or(false));
         var first = committedOwner(TRANSFER_PARTITION).or(StreamOwnershipDriverFenceTest::failNoRecord);
-        assertThat(first.ownerEpoch())
-            .as("writer commits owner0 at (term, ownershipTerm=1)")
-            .isEqualTo(Epoch.epoch(term, 1L));
 
+        assertThat(first.ownerEpoch()).as("writer commits owner0 at (term, ownershipTerm=1)")
+                  .isEqualTo(Epoch.epoch(term, 1L));
         // Same-term reshuffle: HRW now selects owner1. The writer commits the transfer at (term, 2).
         hrwHolder.set(owner1);
         commitOwnershipVia(writer, TRANSFER_STREAM, TRANSFER_PARTITION);
-        await().atMost(OBSERVE_TIMEOUT).pollInterval(POLL)
-               .until(() -> committedOwner(TRANSFER_PARTITION).map(v -> v.owner().equals(owner1)).or(false));
+        await().atMost(OBSERVE_TIMEOUT)
+             .pollInterval(POLL)
+             .until(() -> committedOwner(TRANSFER_PARTITION).map(v -> v.owner()
+                                                                       .equals(owner1))
+                                        .or(false));
         var second = committedOwner(TRANSFER_PARTITION).or(StreamOwnershipDriverFenceTest::failNoRecord);
-        assertThat(second.ownerEpoch())
-            .as("the same-term transfer to owner1 advances the epoch to (term, ownershipTerm=2)")
-            .isEqualTo(Epoch.epoch(term, 2L));
-        assertThat(second.ownerEpoch().isStrictlyAfter(first.ownerEpoch()))
-            .as("owner1's epoch strictly dominates owner0's at the SAME generation term")
-            .isTrue();
+
+        assertThat(second.ownerEpoch()).as("the same-term transfer to owner1 advances the epoch to (term, ownershipTerm=2)")
+                  .isEqualTo(Epoch.epoch(term, 2L));
+        assertThat(second.ownerEpoch().isStrictlyAfter(first.ownerEpoch())).as("owner1's epoch strictly dominates owner0's at the SAME generation term")
+                  .isTrue();
         log.info("OWNERSHIP-DRIVER-FENCE: same-term transfer committed owner1 at {} (was {})",
-                 second.ownerEpoch(), first.ownerEpoch());
-
+                 second.ownerEpoch(),
+                 first.ownerEpoch());
         // owner0 is STILL ALIVE. Once its high-water observes (term, 2), its (term, 1)-stamped append is fenced.
-        await().atMost(OBSERVE_TIMEOUT).pollInterval(POLL)
-               .until(() -> transferAppend(owner0Node, Epoch.epoch(term, 1L)).isFailure());
-
-        transferAppend(owner0Node, Epoch.epoch(term, 1L))
-            .onSuccess(offset -> Assertions.fail(
-                "fence: the deposed-but-alive owner0's (term, 1) append must be REJECTED after the same-term "
-                + "transfer advanced the committed epoch to (term, 2), but it was accepted at offset " + offset))
-            .onFailure(StreamOwnershipDriverFenceTest::assertStaleEpochAppend);
-        assertThat(cluster.getNode(owner0.id()).isPresent())
-            .as("owner0 must remain ALIVE throughout the transfer (the deposed-but-alive case)")
-            .isTrue();
+        await().atMost(OBSERVE_TIMEOUT)
+             .pollInterval(POLL)
+             .until(() -> transferAppend(owner0Node,
+                                         Epoch.epoch(term, 1L)).isFailure());
+        transferAppend(owner0Node,
+                       Epoch.epoch(term, 1L)).onSuccess(offset -> Assertions.fail("fence: the deposed-but-alive owner0's (term, 1) append must be REJECTED after the same-term "
+                                                                                 + "transfer advanced the committed epoch to (term, 2), but it was accepted at offset " + offset))
+                      .onFailure(StreamOwnershipDriverFenceTest::assertStaleEpochAppend);
+        assertThat(cluster.getNode(owner0.id()).isPresent()).as("owner0 must remain ALIVE throughout the transfer (the deposed-but-alive case)")
+                  .isTrue();
         log.info("OWNERSHIP-DRIVER-FENCE: deposed-but-alive owner0 {} (term,1) append correctly REJECTED — same-term fence live",
                  owner0.id());
     }
@@ -267,26 +270,27 @@ class StreamOwnershipDriverFenceTest {
     /// forwards the command it produces, exactly as `AetherNode.driveStreamOwnership` does in production.
     @TerminalOperation
     private void commitOwnershipVia(StreamPartitionOwnershipWriter writer, String stream, int partition) {
-        writer.writeOwnershipChange(stream, partition)
-              .onPresent(this::applyOnLeader);
+        writer.writeOwnershipChange(stream, partition).onPresent(this::applyOnLeader);
     }
 
     @TerminalOperation
     private void applyOnLeader(KVCommand<AetherKey> command) {
-        leaderNode().<Object>apply(List.of(command))
-                    .await()
-                    .onFailure(StreamOwnershipDriverFenceTest::failScenario);
+        leaderNode().<Object> apply(List.of(command)).await().onFailure(StreamOwnershipDriverFenceTest::failScenario);
     }
 
     private Result<Long> transferAppend(AetherNode ownerNode, Epoch staleEpoch) {
         return ownerNode.streamPartitionManager()
-                        .publishLocal(TRANSFER_STREAM, TRANSFER_PARTITION, "stale-write".getBytes(UTF_8), System.currentTimeMillis(), staleEpoch);
+                        .publishLocal(TRANSFER_STREAM,
+                                      TRANSFER_PARTITION,
+                                      "stale-write".getBytes(UTF_8),
+                                      System.currentTimeMillis(),
+                                      staleEpoch);
     }
 
     private Option<StreamPartitionOwnershipValue> committedOwner(int partition) {
         return leaderNode().kvStore()
-                           .getTyped(StreamPartitionOwnershipKey.streamPartitionOwnershipKey(TRANSFER_STREAM, partition),
-                                     StreamPartitionOwnershipValue.class);
+                         .getTyped(StreamPartitionOwnershipKey.streamPartitionOwnershipKey(TRANSFER_STREAM, partition),
+                                   StreamPartitionOwnershipValue.class);
     }
 
     /// Re-deliver the membership reconcile trigger to every node, then check whether the driver has
@@ -314,13 +318,17 @@ class StreamOwnershipDriverFenceTest {
 
     private Result<Long> staleAppend(AetherNode ownerNode, Epoch staleEpoch) {
         return ownerNode.streamPartitionManager()
-                        .publishLocal(FENCE_STREAM, PARTITION, "stale-write".getBytes(UTF_8), System.currentTimeMillis(), staleEpoch);
+                        .publishLocal(FENCE_STREAM,
+                                      PARTITION,
+                                      "stale-write".getBytes(UTF_8),
+                                      System.currentTimeMillis(),
+                                      staleEpoch);
     }
 
     private Option<StreamPartitionOwnershipValue> committedOwnership(int partition) {
         return leaderNode().kvStore()
-                           .getTyped(StreamPartitionOwnershipKey.streamPartitionOwnershipKey(FENCE_STREAM, partition),
-                                     StreamPartitionOwnershipValue.class);
+                         .getTyped(StreamPartitionOwnershipKey.streamPartitionOwnershipKey(FENCE_STREAM, partition),
+                                   StreamPartitionOwnershipValue.class);
     }
 
     /// HRW owner computed from the leader's committed member view (`coreNodes()` / `clusterSize()`) —
@@ -350,7 +358,10 @@ class StreamOwnershipDriverFenceTest {
     }
 
     private int clusterSize(AetherNode node) {
-        return node.clusterTopologyManager().map(ctm -> ctm.observer().clusterSize()).or(SIZE);
+        return node.clusterTopologyManager()
+                   .map(ctm -> ctm.observer()
+                                  .clusterSize())
+                   .or(SIZE);
     }
 
     private AetherNode resolveNode(NodeId nodeId) {
@@ -361,11 +372,15 @@ class StreamOwnershipDriverFenceTest {
     }
 
     private AetherNode leaderNode() {
-        return cluster.currentLeader().flatMap(cluster::getNode).or(cluster.allNodes().getFirst());
+        return cluster.currentLeader()
+                      .flatMap(cluster::getNode)
+                      .or(cluster.allNodes().getFirst());
     }
 
     private boolean allNodesReady() {
-        return cluster.allNodes().stream().allMatch(AetherNode::isReady);
+        return cluster.allNodes()
+                      .stream()
+                      .allMatch(AetherNode::isReady);
     }
 
     private static StreamPartitionOwnershipValue failNoRecord() {
@@ -373,9 +388,9 @@ class StreamOwnershipDriverFenceTest {
     }
 
     private static void assertStaleEpochAppend(Cause cause) {
-        assertThat(cause)
-            .as("the deposed (below-generation) append must be rejected with StaleEpochAppend, but got: %s", cause.message())
-            .isInstanceOf(StreamError.StaleEpochAppend.class);
+        assertThat(cause).as("the deposed (below-generation) append must be rejected with StaleEpochAppend, but got: %s",
+                             cause.message())
+                  .isInstanceOf(StreamError.StaleEpochAppend.class);
     }
 
     private static void failStart(Cause cause) {
@@ -393,13 +408,10 @@ class StreamOwnershipDriverFenceTest {
     private enum FenceError implements Cause {
         NO_PLACEMENT("ReplicaPlacement returned no owner for the partition"),
         NODE_UNRESOLVED("Computed owner NodeId could not be resolved to a cluster node");
-
         private final String message;
-
         FenceError(String message) {
             this.message = message;
         }
-
         @Override
         public String message() {
             return message;

--- a/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/StreamOwnershipDriverFenceTest.java
+++ b/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/StreamOwnershipDriverFenceTest.java
@@ -2,13 +2,17 @@
 // Copyright (c) 2025 Pragmatica Labs - Sergiy Yevtushenko
 // Licensed under Business Source License 1.1. Change Date: 2030-01-01. Change License: Apache-2.0.
 // See LICENSE in the repository root for full terms.
+
 package org.pragmatica.aether.forge;
 
-import java.time.Duration;
-import java.util.List;
-import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.Supplier;
-
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.pragmatica.aether.ember.EmberCluster;
 import org.pragmatica.aether.node.AetherNode;
 import org.pragmatica.aether.slice.StreamConfig;
@@ -28,23 +32,18 @@ import org.pragmatica.lang.Cause;
 import org.pragmatica.lang.Option;
 import org.pragmatica.lang.Result;
 import org.pragmatica.lang.TerminalOperation;
-
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.pragmatica.aether.ember.EmberCluster.emberCluster;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
-
+import static org.pragmatica.aether.ember.EmberCluster.emberCluster;
 
 /// #345 item 1d-iii end-to-end gate: the leader-only stream-ownership DRIVER (the
 /// `onReconcilePassComplete` batch seam on [ReplicaSetController] bound to the
@@ -97,17 +96,21 @@ import static org.awaitility.Awaitility.await;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class StreamOwnershipDriverFenceTest {
     private static final Logger log = LoggerFactory.getLogger(StreamOwnershipDriverFenceTest.class);
+
     private static final int SIZE = 5;
     private static final int BASE_PORT = 5960;
     private static final int BASE_MGMT_PORT = 6060;
     private static final int BASE_APP_HTTP_PORT = 6160;
     private static final String PREFIX = "sodf";
+
     private static final Duration FORM_TIMEOUT = Duration.ofSeconds(180);
     private static final Duration OBSERVE_TIMEOUT = Duration.ofSeconds(150);
     private static final Duration POLL = Duration.ofMillis(500);
+
     private static final String FENCE_STREAM = "sodf:fence";
     private static final int PARTITION = 0;
     private static final int REQUESTED_RF = 1;
+
     /// Distinct stream for the same-term-transfer test (test 3), so it shares no committed ownership
     /// state with the auto-commit test (test 1) under the PER_CLASS shared cluster.
     private static final String TRANSFER_STREAM = "sodf:transfer";
@@ -120,18 +123,15 @@ class StreamOwnershipDriverFenceTest {
     void setUp() {
         cluster = emberCluster(SIZE, BASE_PORT, BASE_MGMT_PORT, BASE_APP_HTTP_PORT, PREFIX);
         LifecycleAwait.settled("cluster start in setUp()", cluster, cluster.start());
-        await().atMost(FORM_TIMEOUT).pollInterval(POLL).until(() -> cluster.currentLeader()
-                                                                           .isPresent());
+        await().atMost(FORM_TIMEOUT).pollInterval(POLL).until(() -> cluster.currentLeader().isPresent());
         await().atMost(FORM_TIMEOUT).pollInterval(POLL).until(this::allNodesReady);
-        log.info("OWNERSHIP-DRIVER-FENCE: {}-node cluster formed, leader={}",
-                 SIZE,
-                 cluster.currentLeader().or("none"));
+        log.info("OWNERSHIP-DRIVER-FENCE: {}-node cluster formed, leader={}", SIZE, cluster.currentLeader().or("none"));
     }
 
     @AfterAll
     @TerminalOperation
     void tearDown() {
-        Option.option(cluster).onPresent(c -> LifecycleAwait.settled("cluster stop in tearDown()", c, c.stop()));
+        Option.option(cluster).onPresent(c -> LifecycleAwait.bestEffort("cluster stop in tearDown()", c, c.stop()));
     }
 
     /// The DRIVER auto-commits ownership on a membership reconcile, and the resulting committed epoch
@@ -141,13 +141,13 @@ class StreamOwnershipDriverFenceTest {
     @TerminalOperation
     void driverAutoCommitsOwnership_andStaleEpochAppendIsRejected() {
         cluster.allNodes().forEach(node -> materialize(node, FENCE_STREAM));
+
         // The fenced partition's HRW owner, computed from the SAME committed member view the driver uses;
         // it stays ALIVE for the whole test (the deposed-but-alive case).
         var owner0 = hrwOwner(FENCE_STREAM, PARTITION);
-
         log.info("OWNERSHIP-DRIVER-FENCE: fenced-partition owner0={} leader={}",
-                 owner0.id(),
-                 cluster.currentLeader().or("none"));
+                 owner0.id(), cluster.currentLeader().or("none"));
+
         // Drive the leader's ReplicaSetController reconcile with a real MembershipDecision — the SAME
         // event type the production membership tail delivers — so the driver iterates the now-materialized
         // FENCE_STREAM and auto-commits its ownership records. A NodeJoined for an already-present member
@@ -160,29 +160,30 @@ class StreamOwnershipDriverFenceTest {
         // and idempotent, so re-driving until the record appears removes any materialize/reconcile race.
         await().atMost(OBSERVE_TIMEOUT).pollInterval(POLL).until(this::reconcileAndCheckCommitted);
         var committed = committedOwnership(PARTITION).or(StreamOwnershipDriverFenceTest::failNoRecord);
-
-        assertThat(committed.owner()).as("driver must auto-commit the HRW owner for the fenced partition (no manual commit)")
-                  .isEqualTo(owner0);
-        assertThat(committed.ownerEpoch().isStrictlyAfter(Epoch.ZERO)).as("driver-committed epoch %s must strictly dominate the unfenced floor (Epoch.ZERO)",
-                                                                          committed.ownerEpoch())
-                  .isTrue();
-        assertThat(committed.ownershipTerm()).as("driver's initial ownership record carries ownershipTerm 1")
-                  .isEqualTo(1L);
+        assertThat(committed.owner())
+            .as("driver must auto-commit the HRW owner for the fenced partition (no manual commit)")
+            .isEqualTo(owner0);
+        assertThat(committed.ownerEpoch().isStrictlyAfter(Epoch.ZERO))
+            .as("driver-committed epoch %s must strictly dominate the unfenced floor (Epoch.ZERO)", committed.ownerEpoch())
+            .isTrue();
+        assertThat(committed.ownershipTerm())
+            .as("driver's initial ownership record carries ownershipTerm 1")
+            .isEqualTo(1L);
         log.info("OWNERSHIP-DRIVER-FENCE: driver auto-committed ({}, {}) owner={} epoch={} ownershipTerm={}",
-                 FENCE_STREAM,
-                 PARTITION,
-                 committed.owner().id(),
-                 committed.ownerEpoch(),
-                 committed.ownershipTerm());
+                 FENCE_STREAM, PARTITION, committed.owner().id(), committed.ownerEpoch(), committed.ownershipTerm());
+
         // The owner under test is still ALIVE. Wait for its OwnershipEpochHighWater to observe the
         // driver-committed ValuePut (the high-water advance is what activates the fence), then assert a
         // stale-epoch (ZERO) append is rejected.
         var ownerNode = resolveNode(owner0);
+        await().atMost(OBSERVE_TIMEOUT).pollInterval(POLL)
+               .until(() -> staleAppend(ownerNode, Epoch.ZERO).isFailure());
 
-        await().atMost(OBSERVE_TIMEOUT).pollInterval(POLL).until(() -> staleAppend(ownerNode, Epoch.ZERO).isFailure());
-        staleAppend(ownerNode, Epoch.ZERO).onSuccess(offset -> Assertions.fail("fence: a below-generation (Epoch.ZERO) append on the alive owner must be REJECTED once the "
-                                                                              + "driver-committed epoch advanced the high-water, but it was accepted at offset " + offset))
-                   .onFailure(StreamOwnershipDriverFenceTest::assertStaleEpochAppend);
+        staleAppend(ownerNode, Epoch.ZERO)
+            .onSuccess(offset -> Assertions.fail(
+                "fence: a below-generation (Epoch.ZERO) append on the alive owner must be REJECTED once the "
+                + "driver-committed epoch advanced the high-water, but it was accepted at offset " + offset))
+            .onFailure(StreamOwnershipDriverFenceTest::assertStaleEpochAppend);
         log.info("OWNERSHIP-DRIVER-FENCE: stale-epoch append on alive owner {} correctly REJECTED — fence live via driver",
                  owner0.id());
     }
@@ -199,57 +200,53 @@ class StreamOwnershipDriverFenceTest {
     @TerminalOperation
     void sameTermOwnerTransfer_deposedButAliveOwnerIsFenced() {
         cluster.allNodes().forEach(node -> materialize(node, TRANSFER_STREAM));
+
         var view = coreMembers(leaderNode());
         var owner0 = hrwOwner(TRANSFER_STREAM, TRANSFER_PARTITION);
         var owner1 = view.stream().filter(n -> !n.equals(owner0)).findFirst().orElse(view.getLast());
         var owner0Node = resolveNode(owner0);
         var term = leaderNode().currentGenerationEpoch().rabiaTerm();
+        log.info("OWNERSHIP-DRIVER-FENCE: same-term transfer owner0={} owner1={} term={}", owner0.id(), owner1.id(), term);
 
-        log.info("OWNERSHIP-DRIVER-FENCE: same-term transfer owner0={} owner1={} term={}",
-                 owner0.id(),
-                 owner1.id(),
-                 term);
         var hrwHolder = new AtomicReference<>(owner0);
         var writer = liveWriter(term, hrwHolder::get);
+
         // The writer commits owner0 at (term, 1) through REAL consensus — no manual Put; the writer mints it.
         commitOwnershipVia(writer, TRANSFER_STREAM, TRANSFER_PARTITION);
-        await().atMost(OBSERVE_TIMEOUT)
-             .pollInterval(POLL)
-             .until(() -> committedOwner(TRANSFER_PARTITION).map(v -> v.owner()
-                                                                       .equals(owner0))
-                                        .or(false));
+        await().atMost(OBSERVE_TIMEOUT).pollInterval(POLL)
+               .until(() -> committedOwner(TRANSFER_PARTITION).map(v -> v.owner().equals(owner0)).or(false));
         var first = committedOwner(TRANSFER_PARTITION).or(StreamOwnershipDriverFenceTest::failNoRecord);
+        assertThat(first.ownerEpoch())
+            .as("writer commits owner0 at (term, ownershipTerm=1)")
+            .isEqualTo(Epoch.epoch(term, 1L));
 
-        assertThat(first.ownerEpoch()).as("writer commits owner0 at (term, ownershipTerm=1)")
-                  .isEqualTo(Epoch.epoch(term, 1L));
         // Same-term reshuffle: HRW now selects owner1. The writer commits the transfer at (term, 2).
         hrwHolder.set(owner1);
         commitOwnershipVia(writer, TRANSFER_STREAM, TRANSFER_PARTITION);
-        await().atMost(OBSERVE_TIMEOUT)
-             .pollInterval(POLL)
-             .until(() -> committedOwner(TRANSFER_PARTITION).map(v -> v.owner()
-                                                                       .equals(owner1))
-                                        .or(false));
+        await().atMost(OBSERVE_TIMEOUT).pollInterval(POLL)
+               .until(() -> committedOwner(TRANSFER_PARTITION).map(v -> v.owner().equals(owner1)).or(false));
         var second = committedOwner(TRANSFER_PARTITION).or(StreamOwnershipDriverFenceTest::failNoRecord);
-
-        assertThat(second.ownerEpoch()).as("the same-term transfer to owner1 advances the epoch to (term, ownershipTerm=2)")
-                  .isEqualTo(Epoch.epoch(term, 2L));
-        assertThat(second.ownerEpoch().isStrictlyAfter(first.ownerEpoch())).as("owner1's epoch strictly dominates owner0's at the SAME generation term")
-                  .isTrue();
+        assertThat(second.ownerEpoch())
+            .as("the same-term transfer to owner1 advances the epoch to (term, ownershipTerm=2)")
+            .isEqualTo(Epoch.epoch(term, 2L));
+        assertThat(second.ownerEpoch().isStrictlyAfter(first.ownerEpoch()))
+            .as("owner1's epoch strictly dominates owner0's at the SAME generation term")
+            .isTrue();
         log.info("OWNERSHIP-DRIVER-FENCE: same-term transfer committed owner1 at {} (was {})",
-                 second.ownerEpoch(),
-                 first.ownerEpoch());
+                 second.ownerEpoch(), first.ownerEpoch());
+
         // owner0 is STILL ALIVE. Once its high-water observes (term, 2), its (term, 1)-stamped append is fenced.
-        await().atMost(OBSERVE_TIMEOUT)
-             .pollInterval(POLL)
-             .until(() -> transferAppend(owner0Node,
-                                         Epoch.epoch(term, 1L)).isFailure());
-        transferAppend(owner0Node,
-                       Epoch.epoch(term, 1L)).onSuccess(offset -> Assertions.fail("fence: the deposed-but-alive owner0's (term, 1) append must be REJECTED after the same-term "
-                                                                                 + "transfer advanced the committed epoch to (term, 2), but it was accepted at offset " + offset))
-                      .onFailure(StreamOwnershipDriverFenceTest::assertStaleEpochAppend);
-        assertThat(cluster.getNode(owner0.id()).isPresent()).as("owner0 must remain ALIVE throughout the transfer (the deposed-but-alive case)")
-                  .isTrue();
+        await().atMost(OBSERVE_TIMEOUT).pollInterval(POLL)
+               .until(() -> transferAppend(owner0Node, Epoch.epoch(term, 1L)).isFailure());
+
+        transferAppend(owner0Node, Epoch.epoch(term, 1L))
+            .onSuccess(offset -> Assertions.fail(
+                "fence: the deposed-but-alive owner0's (term, 1) append must be REJECTED after the same-term "
+                + "transfer advanced the committed epoch to (term, 2), but it was accepted at offset " + offset))
+            .onFailure(StreamOwnershipDriverFenceTest::assertStaleEpochAppend);
+        assertThat(cluster.getNode(owner0.id()).isPresent())
+            .as("owner0 must remain ALIVE throughout the transfer (the deposed-but-alive case)")
+            .isTrue();
         log.info("OWNERSHIP-DRIVER-FENCE: deposed-but-alive owner0 {} (term,1) append correctly REJECTED — same-term fence live",
                  owner0.id());
     }
@@ -270,27 +267,26 @@ class StreamOwnershipDriverFenceTest {
     /// forwards the command it produces, exactly as `AetherNode.driveStreamOwnership` does in production.
     @TerminalOperation
     private void commitOwnershipVia(StreamPartitionOwnershipWriter writer, String stream, int partition) {
-        writer.writeOwnershipChange(stream, partition).onPresent(this::applyOnLeader);
+        writer.writeOwnershipChange(stream, partition)
+              .onPresent(this::applyOnLeader);
     }
 
     @TerminalOperation
     private void applyOnLeader(KVCommand<AetherKey> command) {
-        leaderNode().<Object> apply(List.of(command)).await().onFailure(StreamOwnershipDriverFenceTest::failScenario);
+        leaderNode().<Object>apply(List.of(command))
+                    .await()
+                    .onFailure(StreamOwnershipDriverFenceTest::failScenario);
     }
 
     private Result<Long> transferAppend(AetherNode ownerNode, Epoch staleEpoch) {
         return ownerNode.streamPartitionManager()
-                        .publishLocal(TRANSFER_STREAM,
-                                      TRANSFER_PARTITION,
-                                      "stale-write".getBytes(UTF_8),
-                                      System.currentTimeMillis(),
-                                      staleEpoch);
+                        .publishLocal(TRANSFER_STREAM, TRANSFER_PARTITION, "stale-write".getBytes(UTF_8), System.currentTimeMillis(), staleEpoch);
     }
 
     private Option<StreamPartitionOwnershipValue> committedOwner(int partition) {
         return leaderNode().kvStore()
-                         .getTyped(StreamPartitionOwnershipKey.streamPartitionOwnershipKey(TRANSFER_STREAM, partition),
-                                   StreamPartitionOwnershipValue.class);
+                           .getTyped(StreamPartitionOwnershipKey.streamPartitionOwnershipKey(TRANSFER_STREAM, partition),
+                                     StreamPartitionOwnershipValue.class);
     }
 
     /// Re-deliver the membership reconcile trigger to every node, then check whether the driver has
@@ -318,17 +314,13 @@ class StreamOwnershipDriverFenceTest {
 
     private Result<Long> staleAppend(AetherNode ownerNode, Epoch staleEpoch) {
         return ownerNode.streamPartitionManager()
-                        .publishLocal(FENCE_STREAM,
-                                      PARTITION,
-                                      "stale-write".getBytes(UTF_8),
-                                      System.currentTimeMillis(),
-                                      staleEpoch);
+                        .publishLocal(FENCE_STREAM, PARTITION, "stale-write".getBytes(UTF_8), System.currentTimeMillis(), staleEpoch);
     }
 
     private Option<StreamPartitionOwnershipValue> committedOwnership(int partition) {
         return leaderNode().kvStore()
-                         .getTyped(StreamPartitionOwnershipKey.streamPartitionOwnershipKey(FENCE_STREAM, partition),
-                                   StreamPartitionOwnershipValue.class);
+                           .getTyped(StreamPartitionOwnershipKey.streamPartitionOwnershipKey(FENCE_STREAM, partition),
+                                     StreamPartitionOwnershipValue.class);
     }
 
     /// HRW owner computed from the leader's committed member view (`coreNodes()` / `clusterSize()`) —
@@ -358,10 +350,7 @@ class StreamOwnershipDriverFenceTest {
     }
 
     private int clusterSize(AetherNode node) {
-        return node.clusterTopologyManager()
-                   .map(ctm -> ctm.observer()
-                                  .clusterSize())
-                   .or(SIZE);
+        return node.clusterTopologyManager().map(ctm -> ctm.observer().clusterSize()).or(SIZE);
     }
 
     private AetherNode resolveNode(NodeId nodeId) {
@@ -372,15 +361,11 @@ class StreamOwnershipDriverFenceTest {
     }
 
     private AetherNode leaderNode() {
-        return cluster.currentLeader()
-                      .flatMap(cluster::getNode)
-                      .or(cluster.allNodes().getFirst());
+        return cluster.currentLeader().flatMap(cluster::getNode).or(cluster.allNodes().getFirst());
     }
 
     private boolean allNodesReady() {
-        return cluster.allNodes()
-                      .stream()
-                      .allMatch(AetherNode::isReady);
+        return cluster.allNodes().stream().allMatch(AetherNode::isReady);
     }
 
     private static StreamPartitionOwnershipValue failNoRecord() {
@@ -388,14 +373,11 @@ class StreamOwnershipDriverFenceTest {
     }
 
     private static void assertStaleEpochAppend(Cause cause) {
-        assertThat(cause).as("the deposed (below-generation) append must be rejected with StaleEpochAppend, but got: %s",
-                             cause.message())
-                  .isInstanceOf(StreamError.StaleEpochAppend.class);
+        assertThat(cause)
+            .as("the deposed (below-generation) append must be rejected with StaleEpochAppend, but got: %s", cause.message())
+            .isInstanceOf(StreamError.StaleEpochAppend.class);
     }
 
-    private static void failStart(Cause cause) {
-        throw new AssertionError("Cluster start failed: " + cause.message());
-    }
 
     private static void failScenario(Cause cause) {
         throw new AssertionError("Scenario setup failed: " + cause.message());
@@ -408,10 +390,13 @@ class StreamOwnershipDriverFenceTest {
     private enum FenceError implements Cause {
         NO_PLACEMENT("ReplicaPlacement returned no owner for the partition"),
         NODE_UNRESOLVED("Computed owner NodeId could not be resolved to a cluster node");
+
         private final String message;
+
         FenceError(String message) {
             this.message = message;
         }
+
         @Override
         public String message() {
             return message;

--- a/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/StreamPublishReshuffleTest.java
+++ b/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/StreamPublishReshuffleTest.java
@@ -2,14 +2,7 @@
 // Copyright (c) 2025 Pragmatica Labs - Sergiy Yevtushenko
 // Licensed under Business Source License 1.1. Change Date: 2030-01-01. Change License: Apache-2.0.
 // See LICENSE in the repository root for full terms.
-
 package org.pragmatica.aether.forge;
-
-import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
 
 import java.time.Duration;
 import java.util.ArrayList;
@@ -22,8 +15,15 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.LockSupport;
 
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
+
 
 /// #430 — publish-under-ownership-reshuffle stream chaos test (builds on the #429 `test-stream-multipart`
 /// fixture). A background publisher streams events at a sustained rate through a stable node while the
@@ -95,32 +95,32 @@ class StreamPublishReshuffleTest extends AbstractMultiPartitionStream {
     @Test
     void sustainedPublish_duringOwnerKillReshuffle_everyAckedOffsetSurvivesUniqueAndOrdered() {
         await().atMost(PLACEMENT_TIMEOUT).pollInterval(POLL_INTERVAL).until(this::allPartitionsPlaced);
-
         var killTarget = ownerId(KILL_PARTITION);
-        assertThat(killTarget)
-            .describedAs("partition %d owner identified before the kill", KILL_PARTITION)
-            .isNotBlank();
 
+        assertThat(killTarget).describedAs("partition %d owner identified before the kill", KILL_PARTITION).isNotBlank();
         // Publish through a node that is NOT the kill target, so the ingress + forwarding path stays up
         // across the reshuffle (only the target partition's write path is disrupted).
         var publishPort = appPortForNodeOtherThan(killTarget);
-        var acked = ConcurrentHashMap.<Long>newKeySet();
+        var acked = ConcurrentHashMap.<Long> newKeySet();
         var stop = new AtomicBoolean(false);
 
         try (var executor = Executors.newVirtualThreadPerTaskExecutor()) {
             var publisher = CompletableFuture.runAsync(() -> publishLoop(publishPort, acked, stop), executor);
-
             // Pre-kill: let a healthy batch of acked writes accumulate across all four partitions.
             await().atMost(ACK_TIMEOUT).pollInterval(POLL_INTERVAL).until(() -> acked.size() >= PRE_KILL_ACKS);
             var preKillAcked = acked.size();
-
             // Kill the partition-0 owner MID-STREAM and wait for the partition to re-resolve to a new owner.
-            cluster.killNode(killTarget).await();
-            await().atMost(FAILOVER_TIMEOUT).pollInterval(POLL_INTERVAL).until(() -> ownerReResolved(KILL_PARTITION, killTarget));
-
+            LifecycleAwait.nodeSettled("kill node " + killTarget
+                                      + " in sustainedPublish_duringOwnerKillReshuffle_everyAckedOffsetSurvivesUniqueAndOrdered()",
+                                       cluster,
+                                       cluster.killNode(killTarget));
+            await().atMost(FAILOVER_TIMEOUT)
+                 .pollInterval(POLL_INTERVAL)
+                 .until(() -> ownerReResolved(KILL_PARTITION, killTarget));
             // Keep publishing across/after the reshuffle until a further batch of writes is acked.
-            await().atMost(POST_KILL_TIMEOUT).pollInterval(POLL_INTERVAL).until(() -> acked.size() >= preKillAcked + POST_KILL_ACKS);
-
+            await().atMost(POST_KILL_TIMEOUT)
+                 .pollInterval(POLL_INTERVAL)
+                 .until(() -> acked.size() >= preKillAcked + POST_KILL_ACKS);
             stop.set(true);
             publisher.join();
         }
@@ -129,15 +129,14 @@ class StreamPublishReshuffleTest extends AbstractMultiPartitionStream {
         // The promoted owner (and unaffected owners) must serve every acked write; poll until the
         // read-back covers the full acked set before the final reconciliation.
         await().atMost(FAILOVER_TIMEOUT)
-               .pollInterval(POLL_INTERVAL)
-               .until(() -> readbackSeqs(publishPort).containsAll(ackedSnapshot));
-
+             .pollInterval(POLL_INTERVAL)
+             .until(() -> readbackSeqs(publishPort).containsAll(ackedSnapshot));
         var partitionEvents = drainAllPartitions(publishPort);
+
         assertAckedSurviveUniqueAndOrdered(partitionEvents, ackedSnapshot);
     }
 
     // --- publisher ----------------------------------------------------------
-
     /// Serial sustained publisher: publish monotonically increasing seqs (short client timeout so a
     /// wedged partition's write fails fast instead of stalling the loop), recording every ACKED seq,
     /// until `stop` is set. One in-flight publish at a time keeps each partition's acked suffix in
@@ -156,7 +155,6 @@ class StreamPublishReshuffleTest extends AbstractMultiPartitionStream {
     }
 
     // --- reshuffle helpers --------------------------------------------------
-
     private int appPortForNodeOtherThan(String excludedNodeId) {
         var excludedPort = appPortFor(excludedNodeId);
 
@@ -170,11 +168,10 @@ class StreamPublishReshuffleTest extends AbstractMultiPartitionStream {
     private boolean ownerReResolved(int partition, String oldOwner) {
         var owner = ownerId(partition);
 
-        return !owner.isBlank() && !owner.equals(oldOwner);
+        return ! owner.isBlank() && !owner.equals(oldOwner);
     }
 
     // --- reconciliation -----------------------------------------------------
-
     private Set<Long> readbackSeqs(int port) {
         var seqs = new HashSet<Long>();
 
@@ -191,17 +188,14 @@ class StreamPublishReshuffleTest extends AbstractMultiPartitionStream {
         var allSeqs = new ArrayList<Long>();
 
         partitionEvents.forEach(events -> events.forEach(event -> allSeqs.add(event.seq())));
-
         var uniqueSeqs = new HashSet<>(allSeqs);
 
-        assertThat(uniqueSeqs)
-            .describedAs("no event is duplicated across the log (each seq appears at most once)")
-            .hasSize(allSeqs.size());
-        assertThat(uniqueSeqs)
-            .describedAs("every ACKED publish (min-sync-2, %d acked) survives the owner-kill reshuffle", acked.size())
-            .containsAll(acked);
-        assertThat(acked)
-            .describedAs("acked writes accumulated both before and after the kill")
-            .hasSizeGreaterThanOrEqualTo(PRE_KILL_ACKS + POST_KILL_ACKS);
+        assertThat(uniqueSeqs).describedAs("no event is duplicated across the log (each seq appears at most once)")
+                  .hasSize(allSeqs.size());
+        assertThat(uniqueSeqs).describedAs("every ACKED publish (min-sync-2, %d acked) survives the owner-kill reshuffle",
+                                           acked.size())
+                  .containsAll(acked);
+        assertThat(acked).describedAs("acked writes accumulated both before and after the kill")
+                  .hasSizeGreaterThanOrEqualTo(PRE_KILL_ACKS + POST_KILL_ACKS);
     }
 }

--- a/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/StreamPublishReshuffleTest.java
+++ b/aether/forge/forge-tests/src/test/java/org/pragmatica/aether/forge/StreamPublishReshuffleTest.java
@@ -2,7 +2,14 @@
 // Copyright (c) 2025 Pragmatica Labs - Sergiy Yevtushenko
 // Licensed under Business Source License 1.1. Change Date: 2030-01-01. Change License: Apache-2.0.
 // See LICENSE in the repository root for full terms.
+
 package org.pragmatica.aether.forge;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 
 import java.time.Duration;
 import java.util.ArrayList;
@@ -15,15 +22,8 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.LockSupport;
 
-import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
-
 
 /// #430 — publish-under-ownership-reshuffle stream chaos test (builds on the #429 `test-stream-multipart`
 /// fixture). A background publisher streams events at a sustained rate through a stable node while the
@@ -95,32 +95,35 @@ class StreamPublishReshuffleTest extends AbstractMultiPartitionStream {
     @Test
     void sustainedPublish_duringOwnerKillReshuffle_everyAckedOffsetSurvivesUniqueAndOrdered() {
         await().atMost(PLACEMENT_TIMEOUT).pollInterval(POLL_INTERVAL).until(this::allPartitionsPlaced);
-        var killTarget = ownerId(KILL_PARTITION);
 
-        assertThat(killTarget).describedAs("partition %d owner identified before the kill", KILL_PARTITION).isNotBlank();
+        var killTarget = ownerId(KILL_PARTITION);
+        assertThat(killTarget)
+            .describedAs("partition %d owner identified before the kill", KILL_PARTITION)
+            .isNotBlank();
+
         // Publish through a node that is NOT the kill target, so the ingress + forwarding path stays up
         // across the reshuffle (only the target partition's write path is disrupted).
         var publishPort = appPortForNodeOtherThan(killTarget);
-        var acked = ConcurrentHashMap.<Long> newKeySet();
+        var acked = ConcurrentHashMap.<Long>newKeySet();
         var stop = new AtomicBoolean(false);
 
         try (var executor = Executors.newVirtualThreadPerTaskExecutor()) {
             var publisher = CompletableFuture.runAsync(() -> publishLoop(publishPort, acked, stop), executor);
+
             // Pre-kill: let a healthy batch of acked writes accumulate across all four partitions.
             await().atMost(ACK_TIMEOUT).pollInterval(POLL_INTERVAL).until(() -> acked.size() >= PRE_KILL_ACKS);
             var preKillAcked = acked.size();
+
             // Kill the partition-0 owner MID-STREAM and wait for the partition to re-resolve to a new owner.
-            LifecycleAwait.nodeSettled("kill node " + killTarget
+            LifecycleAwait.nodeBestEffort("kill node " + killTarget
                                       + " in sustainedPublish_duringOwnerKillReshuffle_everyAckedOffsetSurvivesUniqueAndOrdered()",
                                        cluster,
                                        cluster.killNode(killTarget));
-            await().atMost(FAILOVER_TIMEOUT)
-                 .pollInterval(POLL_INTERVAL)
-                 .until(() -> ownerReResolved(KILL_PARTITION, killTarget));
+            await().atMost(FAILOVER_TIMEOUT).pollInterval(POLL_INTERVAL).until(() -> ownerReResolved(KILL_PARTITION, killTarget));
+
             // Keep publishing across/after the reshuffle until a further batch of writes is acked.
-            await().atMost(POST_KILL_TIMEOUT)
-                 .pollInterval(POLL_INTERVAL)
-                 .until(() -> acked.size() >= preKillAcked + POST_KILL_ACKS);
+            await().atMost(POST_KILL_TIMEOUT).pollInterval(POLL_INTERVAL).until(() -> acked.size() >= preKillAcked + POST_KILL_ACKS);
+
             stop.set(true);
             publisher.join();
         }
@@ -129,14 +132,15 @@ class StreamPublishReshuffleTest extends AbstractMultiPartitionStream {
         // The promoted owner (and unaffected owners) must serve every acked write; poll until the
         // read-back covers the full acked set before the final reconciliation.
         await().atMost(FAILOVER_TIMEOUT)
-             .pollInterval(POLL_INTERVAL)
-             .until(() -> readbackSeqs(publishPort).containsAll(ackedSnapshot));
-        var partitionEvents = drainAllPartitions(publishPort);
+               .pollInterval(POLL_INTERVAL)
+               .until(() -> readbackSeqs(publishPort).containsAll(ackedSnapshot));
 
+        var partitionEvents = drainAllPartitions(publishPort);
         assertAckedSurviveUniqueAndOrdered(partitionEvents, ackedSnapshot);
     }
 
     // --- publisher ----------------------------------------------------------
+
     /// Serial sustained publisher: publish monotonically increasing seqs (short client timeout so a
     /// wedged partition's write fails fast instead of stalling the loop), recording every ACKED seq,
     /// until `stop` is set. One in-flight publish at a time keeps each partition's acked suffix in
@@ -155,6 +159,7 @@ class StreamPublishReshuffleTest extends AbstractMultiPartitionStream {
     }
 
     // --- reshuffle helpers --------------------------------------------------
+
     private int appPortForNodeOtherThan(String excludedNodeId) {
         var excludedPort = appPortFor(excludedNodeId);
 
@@ -168,10 +173,11 @@ class StreamPublishReshuffleTest extends AbstractMultiPartitionStream {
     private boolean ownerReResolved(int partition, String oldOwner) {
         var owner = ownerId(partition);
 
-        return ! owner.isBlank() && !owner.equals(oldOwner);
+        return !owner.isBlank() && !owner.equals(oldOwner);
     }
 
     // --- reconciliation -----------------------------------------------------
+
     private Set<Long> readbackSeqs(int port) {
         var seqs = new HashSet<Long>();
 
@@ -188,14 +194,17 @@ class StreamPublishReshuffleTest extends AbstractMultiPartitionStream {
         var allSeqs = new ArrayList<Long>();
 
         partitionEvents.forEach(events -> events.forEach(event -> allSeqs.add(event.seq())));
+
         var uniqueSeqs = new HashSet<>(allSeqs);
 
-        assertThat(uniqueSeqs).describedAs("no event is duplicated across the log (each seq appears at most once)")
-                  .hasSize(allSeqs.size());
-        assertThat(uniqueSeqs).describedAs("every ACKED publish (min-sync-2, %d acked) survives the owner-kill reshuffle",
-                                           acked.size())
-                  .containsAll(acked);
-        assertThat(acked).describedAs("acked writes accumulated both before and after the kill")
-                  .hasSizeGreaterThanOrEqualTo(PRE_KILL_ACKS + POST_KILL_ACKS);
+        assertThat(uniqueSeqs)
+            .describedAs("no event is duplicated across the log (each seq appears at most once)")
+            .hasSize(allSeqs.size());
+        assertThat(uniqueSeqs)
+            .describedAs("every ACKED publish (min-sync-2, %d acked) survives the owner-kill reshuffle", acked.size())
+            .containsAll(acked);
+        assertThat(acked)
+            .describedAs("acked writes accumulated both before and after the kill")
+            .hasSizeGreaterThanOrEqualTo(PRE_KILL_ACKS + POST_KILL_ACKS);
     }
 }

--- a/changelog.d/915-community-smoke-bounded-awaits.md
+++ b/changelog.d/915-community-smoke-bounded-awaits.md
@@ -86,6 +86,18 @@ merged forward onto it, and several of the design decisions below were reversed 
   tag at all. Two cases a healthy cluster never produces now drive the node line directly — a populated
   `ClusterStatus`, and a cleared registry with a retained `StartFailure` — and the populated case is
   asserted as a whole rendered block, so an ADDED field fails it too.
+- **Round 2 — the one-argument accessor's own wiring is now pinned too.** Round 1 fixed an unpinned
+  renderer; the review then found the same shape one level up. Every test drove the two-argument
+  `snapshot(ClusterStatus, Option<StartFailure>)`, so swapping `present.lastStartFailure()` for
+  `Option.none()` inside the one-argument `snapshot(EmberCluster)` — which is what all 92 call sites
+  actually use — left the suite green at 14/14. It was a coverage hole rather than a live defect, but
+  it is the same failure this PR spent a blocking round on, so it gets the same treatment. This is the
+  one case in the set that cannot be supplied directly: `EmberCluster` captures the failure into a
+  private field during `start()` and offers no seam, so the pin makes a start genuinely fail by
+  holding one management port before the cluster is built, then asserts what the accessor renders
+  [verified: `LifecycleAwaitStartFailureTest#aFailedStart_isRenderedByTheOneArgAccessor_fromTheRetainedCapture`;
+  control 15/15 green, and the review's exact substitution turns that test — and only that test — red].
+
 - **Every claim above that rests on a test was mutation-probed, and each probe went red.** Round 1's
   finding was a `[verified:]` tag on a pin that could not fail, so this time each claim's test was
   attacked rather than re-run. Controls first: `LifecycleAwaitTest` + `ClusterSnapshotTest` green at
@@ -139,8 +151,11 @@ merged forward onto it, and several of the design decisions below were reversed 
   `@BeforeAll` and a 240s bounded stop in `@AfterAll` draw separate budgets and cannot sum into it.
 - **Round 1 correction — the gate claim "this change does not add any findings" was false, and the
   arithmetic behind it was wrong too.** Forced with `-Djbct.includeTests=true`, the module reports
-  **807** findings on this branch against **904** on the merged base, a net reduction of 97; at ERROR
-  severity, 146 against 211. The first revision credited a 164-line reduction to the `.onFailure`
+  **804** findings on this branch against **901** on the merged base, a net reduction of 97; at ERROR
+  severity, 146 against 211. (An earlier revision of this bullet said 807/904: that counter matched
+  every `JBCT-<CODE>` mention in the log rather than only finding lines, over-counting by 3 on each
+  side. The ERROR figures are unaffected. A residual 7-finding WARNING-level gap against an
+  independent measurement of the base remains unreconciled and was not chased.) The first revision credited a 164-line reduction to the `.onFailure`
   replacement when most of it was the wholesale reformat that has now been reverted. This PR's own
   four files carry **20 findings, all at WARNING severity and none at ERROR** — the three ERROR-level
   findings review round 1 found in them (`JBCT-EX-01` throw forbidden, `JBCT-TOT-01` partial mapper,

--- a/changelog.d/915-community-smoke-bounded-awaits.md
+++ b/changelog.d/915-community-smoke-bounded-awaits.md
@@ -113,9 +113,20 @@ merged forward onto it, and several of the design decisions below were reversed 
   | `report` drops the snapshot | an expiry carrying no cluster state | same |
   | `bestEffort` ignores its `bound` | an unbounded teardown | `bestEffort_boundsTheWaitButDoesNotFailTheTest` |
   | `bestEffort` throws | the round-1 behaviour change, reinstated | same |
-  | `snapshot` ignores `lastStartFailure` | the empty dump on a failed start | `aClearedRegistryAfterAFailedStart_rendersWhatTheStartFailureRetained` |
+  | one-arg `snapshot` passes `Option.none()` for `present.lastStartFailure()` | the accessor discarding the retained failure | `aFailedStart_isRenderedByTheOneArgAccessor_fromTheRetainedCapture` (1 test) |
+  | two-arg `snapshot` passes `Option.none()` to `ClusterSnapshot.render` | the empty dump on a failed start | that test **plus** `aClearedRegistryAfterAFailedStart_rendersWhatTheStartFailureRetained` (2 tests) |
   | `settled` always throws | a helper that never works | `aPromiseThatSettles_returnsItsValue` (the positive control) |
   | `snapshot` stops delegating | a second, divergent renderer | `aClusterWithNothingToReport_isRenderedByTheModulesOneRenderer` |
+
+  Re-measured 2026-09-07 on a clean tree at `ad73f1bcd`, after `review-921` re-derived its own runs
+  against the same head. The two `Option.none()` rows above were previously ONE row that named the
+  one-arg mutation but recorded the two-arg mutation's red test — corrected here from measurement, not
+  from reasoning. Control 15/15 green; one-arg reddens 1; two-arg reddens 2; and gutting the one-arg
+  accessor to a bare constant reddens 3 (`aClusterWithNothingToReport` and `anAbsentCluster` join,
+  because a constant also destroys the null-cluster branch that neither `Option.none()` substitution
+  touches). Each substitution was confirmed to land on the executable expression before its result was
+  read — a mutation that lands on javadoc compiles and reddens nothing, which is indistinguishable from
+  an unpinned path. `review-921` independently reproduced the first two rows.
 
   The `observedState` probe is the one that matters most: it reddens against a REAL three-node cluster
   that formed and then reported `state=healthy` for every node — the defect in its original shape

--- a/changelog.d/915-community-smoke-bounded-awaits.md
+++ b/changelog.d/915-community-smoke-bounded-awaits.md
@@ -1,0 +1,76 @@
+### Fixed (2026-09-07 — #915: `MultiSourceCommunitySmokeTest` hung to the 8-minute lifecycle backstop on untimed lifecycle awaits, and every other forge class could do the same)
+
+This closes #915 and sweeps the shape out of the whole `forge-tests` module. It is the sibling of
+#727/#913 — same family, different member: #727 is a poll that outlives a rolled-back blueprint,
+this is an unbounded lifecycle await. It does not touch `SliceInvocationTest`, which #913 owns.
+
+- **The two awaits the ticket names were untimed, and a third one was not in the ticket at all.**
+  `cluster.start().await()` in `@BeforeAll`, `cluster.stop().await()` in `@AfterAll`, and
+  `cluster.addNode(..).await()` in the worker-join helper — the last found by the module sweep below,
+  and able to wedge the `@Test` body exactly as the first wedges setup. All three are now bounded and
+  named [verified: `MultiSourceCommunitySmokeTest` green in 40.5s with all three bounded, run
+  2026-09-07 in `pragmatica-stream-h`].
+- **An unbounded `Promise.await()` on a stalled start is not slow — it is unreachable, and interrupting
+  it does not help.** Measured directly, not inferred: a 3-node `EmberCluster` with two of three
+  management ports pre-bound (so quorum can never form and `Promise.allOf` never settles) was awaited
+  without a bound on a separate thread. After 45s it had not settled and the thread was `WAITING`;
+  5s after `Thread.interrupt()` it had still not settled and had flipped to `RUNNABLE` — the
+  interrupted waiter spinning rather than stopping; 10s after the interrupt it was `WAITING` again and
+  still unsettled. **This is why the JUnit lifecycle backstop could not end the hang**: the backstop's
+  only lever is an interrupt, and `Promise.await()` ignores it. That defect is #914 and is NOT fixed
+  here — this ticket makes the caller stop waiting, it does not make the wait interruptible
+  [mechanism: `Promise.java:3282-3306`, a bare `while (result == null) LockSupport.park()` loop with no
+  interrupt check; `park()` returns immediately whenever the interrupt flag is set].
+- **The same stall, awaited WITH the bound, fails in 21.4s and names what it waited for.** Against the
+  identical pre-bound-port cluster the bounded await produced:
+  `3-node cluster start (ports 26700+) did not settle within TimeSpan(20S): Promise is not resolved
+  within specified timeout` followed by `leader=none nodeCount=3` and one line per node reporting
+  `ready=false`. Before: a class-level ERROR at ~515s whose entire text was the backstop's own timeout
+  [verified: forced-stall probe, 2026-09-07, both arms in one run; the probe was scratch and is not
+  committed — the committed pin for the same mechanism is `LifecycleAwaitTest`].
+- **A bound alone would have been a fast silent failure, so the naming is the fix, not a nicety.**
+  `Promise.await(TimeSpan)` expires into the constant string
+  `"Promise is not resolved within specified timeout"` — identical for a cluster that never elected a
+  leader and a node that never bound its port. Every expiry now carries the step's name, the bound,
+  and a cluster snapshot [verified: `LifecycleAwaitTest#aPromiseThatNeverSettles_expiresAtTheBound_andNamesTheStep`;
+  three mutation probes each turn it red — hardcoding a different bound, dropping the step name, and
+  dropping the snapshot — and the control run is green].
+- **The snapshot deliberately does NOT render `NodeStatus.state`.** On this branch
+  `EmberCluster.toNodeStatus` passes the string literal `"healthy"` for every node, so the field cannot
+  distinguish a formed cluster from a wedged one; printing it would put a fabricated observation into
+  the one artifact read when things are already wrong. `ready` is read from the node instead
+  (`AetherNode.isReady()`). #913 fixes the literal at its source; this change neither waits on that nor
+  touches it [verified: `LifecycleAwaitTest#theSnapshotNeverRendersTheFabricatedHealthyLiteral`].
+- **Module sweep: 94 untimed lifecycle awaits found, 92 fixed, 2 deliberately untouched.** Found by
+  scanning every `.await()` in `forge-tests` and keeping those whose statement calls `start`, `stop`,
+  `startHeldBackNodes`, `addNode`, `addWorkerNode`, `killNode` or `blackhole`. The 2 untouched are
+  `SliceInvocationTest.java:68` and `:95`, which PR #913 is bounding in the same round; touching them
+  would collide. 36 test classes changed [verified: after the sweep the same scan reports exactly those
+  2 remaining].
+- **Bounds carry stated margin over a measured healthy run, taken on a LOADED box on purpose.**
+  `MultiSourceCommunitySmokeTest` green in 42.09s at load average ~10 (two sibling trees building):
+  cluster start ~3-8s, whole formation 18.5s, `addNode` 1.1s, `stop` 16.6s. The cluster bound is 240s
+  (~30x the measured start, ~14x the measured stop) and the single-node bound is 120s (~110x the
+  measured join). 240s also matches the longest existing internal guard, which preserves the invariant
+  `junit-platform.properties` states in prose: the 8-minute lifecycle backstop is double the longest
+  internal guard, so the test's own await fires first and the backstop stays an outer net
+  [mechanism: `LifecycleAwait.LIFECYCLE_BOUND` / `NODE_BOUND`; a quiet-box baseline was avoided
+  deliberately because it would understate what a CI runner does].
+- **Residual — 32 of the 36 changed classes are compile-verified only, not executed.** Running the
+  whole module is the 25-minute CI job. Executed locally and green: `MultiSourceCommunitySmokeTest`,
+  `ClusterFormationTest`, `CoreAbsenceFenceOrderingTest`, `EmberAddNodeRoleLabelTest`,
+  `LifecycleAwaitTest` — 19 tests, 0 failures, counted from the failsafe XML. Those include both
+  runnable classes whose call sites had to be restructured by hand rather than mechanically.
+  `CommunityFormationProbeTest` was also hand-restructured but is `@Disabled` at class level (#336), so
+  it is compile-checked only and CI will not exercise it either.
+- **Residual — the format/lint gate does not cover this module's test sources, and this change does not
+  make it.** `mvn jbct:check -pl aether/forge/forge-tests -Djbct.skip=false` exits green while
+  examining NOTHING: the module has no `src/main/java`, and its test files are excluded by
+  `jbct.includeTests=false`. The plugin says so itself rather than reporting a silent pass. Forced with
+  `-Djbct.includeTests=true`, the module reports pre-existing findings in files this PR never touches
+  (`HangDiagnosticExtension`, `TestArtifacts`, `StreamOwnerFailover*`). This change does not add any:
+  886 findings on the pristine base against 722 on this branch, a net reduction of 164, because
+  replacing multi-line `.onFailure(cause -> { throw .. })` chains with one helper call removes flagged
+  constructs. The 722 that remain are out of scope here
+  [verified: both counts produced by the same command, base measured by checking the module out at
+  `origin/release-1.0.0-rc4` in place and restoring afterwards].

--- a/changelog.d/915-community-smoke-bounded-awaits.md
+++ b/changelog.d/915-community-smoke-bounded-awaits.md
@@ -2,51 +2,130 @@
 
 This closes #915 and sweeps the shape out of the whole `forge-tests` module. It is the sibling of
 #727/#913 — same family, different member: #727 is a poll that outlives a rolled-back blueprint,
-this is an unbounded lifecycle await. It does not touch `SliceInvocationTest`, which #913 owns.
+this is an unbounded lifecycle await. #913 merged after this branch was cut; the branch has been
+merged forward onto it, and several of the design decisions below were reversed as a result.
 
 - **The two awaits the ticket names were untimed, and a third one was not in the ticket at all.**
   `cluster.start().await()` in `@BeforeAll`, `cluster.stop().await()` in `@AfterAll`, and
   `cluster.addNode(..).await()` in the worker-join helper — the last found by the module sweep below,
   and able to wedge the `@Test` body exactly as the first wedges setup. All three are now bounded and
-  named [verified: `MultiSourceCommunitySmokeTest` green in 40.5s with all three bounded, run
-  2026-09-07 in `pragmatica-stream-h`].
+  named.
 - **An unbounded `Promise.await()` on a stalled start is not slow — it is unreachable, and interrupting
   it does not help.** Measured directly, not inferred: a 3-node `EmberCluster` with two of three
-  management ports pre-bound (so quorum can never form and `Promise.allOf` never settles) was awaited
-  without a bound on a separate thread. After 45s it had not settled and the thread was `WAITING`;
-  5s after `Thread.interrupt()` it had still not settled and had flipped to `RUNNABLE` — the
-  interrupted waiter spinning rather than stopping; 10s after the interrupt it was `WAITING` again and
-  still unsettled. **This is why the JUnit lifecycle backstop could not end the hang**: the backstop's
-  only lever is an interrupt, and `Promise.await()` ignores it. That defect is #914 and is NOT fixed
-  here — this ticket makes the caller stop waiting, it does not make the wait interruptible
-  [mechanism: `Promise.java:3282-3306`, a bare `while (result == null) LockSupport.park()` loop with no
-  interrupt check; `park()` returns immediately whenever the interrupt flag is set].
-- **The same stall, awaited WITH the bound, fails in 21.4s and names what it waited for.** Against the
-  identical pre-bound-port cluster the bounded await produced:
-  `3-node cluster start (ports 26700+) did not settle within TimeSpan(20S): Promise is not resolved
-  within specified timeout` followed by `leader=none nodeCount=3` and one line per node reporting
-  `ready=false`. Before: a class-level ERROR at ~515s whose entire text was the backstop's own timeout
-  [verified: forced-stall probe, 2026-09-07, both arms in one run; the probe was scratch and is not
-  committed — the committed pin for the same mechanism is `LifecycleAwaitTest`].
+  management ports pre-bound was awaited without a bound on a separate thread. After 45s it had not
+  settled and the thread was `WAITING`; 5s after `Thread.interrupt()` it had still not settled and had
+  flipped to `RUNNABLE` — the interrupted waiter spinning rather than stopping. **This is why the JUnit
+  lifecycle backstop could not end the hang**: the backstop's only lever is an interrupt, and
+  `Promise.await()` ignores it. That defect is #914 and is NOT fixed here — this ticket makes the
+  caller stop waiting, it does not make the wait interruptible
+  [mechanism: `Promise.java:3300-3302`, a bare `while (result == null) { LockSupport.park(); }` loop
+  inside `await()` (declared at `:3282`) with no interrupt check].
 - **A bound alone would have been a fast silent failure, so the naming is the fix, not a nicety.**
   `Promise.await(TimeSpan)` expires into the constant string
   `"Promise is not resolved within specified timeout"` — identical for a cluster that never elected a
   leader and a node that never bound its port. Every expiry now carries the step's name, the bound,
-  and a cluster snapshot [verified: `LifecycleAwaitTest#aPromiseThatNeverSettles_expiresAtTheBound_andNamesTheStep`;
-  three mutation probes each turn it red — hardcoding a different bound, dropping the step name, and
-  dropping the snapshot — and the control run is green].
-- **The snapshot deliberately does NOT render `NodeStatus.state`.** On this branch
-  `EmberCluster.toNodeStatus` passes the string literal `"healthy"` for every node, so the field cannot
-  distinguish a formed cluster from a wedged one; printing it would put a fabricated observation into
-  the one artifact read when things are already wrong. `ready` is read from the node instead
-  (`AetherNode.isReady()`). #913 fixes the literal at its source; this change neither waits on that nor
-  touches it [verified: `LifecycleAwaitTest#theSnapshotNeverRendersTheFabricatedHealthyLiteral`].
-- **Module sweep: 94 untimed lifecycle awaits found, 92 fixed, 2 deliberately untouched.** Found by
-  scanning every `.await()` in `forge-tests` and keeping those whose statement calls `start`, `stop`,
-  `startHeldBackNodes`, `addNode`, `addWorkerNode`, `killNode` or `blackhole`. The 2 untouched are
-  `SliceInvocationTest.java:68` and `:95`, which PR #913 is bounding in the same round; touching them
-  would collide. 36 test classes changed [verified: after the sweep the same scan reports exactly those
-  2 remaining].
+  and a cluster snapshot.
+- **Re-run against the merged base, the forced stall no longer stalls — and that is #913's doing, not
+  this ticket's.** Same probe as before (3-node cluster, two of three management ports pre-bound,
+  ports 27700+), now run on top of #913. It does not reach the 20s bound at all: it fails in **7.65s**
+  with the real cause, because #913 made `start()` settle on the FIRST node failure instead of waiting
+  for a quorum that can no longer form. The bounded await still names its step, and the snapshot is
+  the retained start-failure state #913 captures:
+
+  ```
+  3-node cluster start (ports 27700+) did not settle within TimeSpan(20S): Failed to bind to port 27741: Address already in use
+  Cluster state when the wait ended:
+    leader=none (captured when the start failed; the abort has since cleared the live cluster state, so no health endpoint is probed here)
+    p921-2 state=inactive leader=false port=27701 mgmt=27741
+    p921-1 state=inactive leader=false port=27700 mgmt=27740
+    p921-3 state=inactive leader=false port=27702 mgmt=27742
+    start failures: {p921-2=Failed to bind to port 27741: Address already in use}
+  ```
+
+  Compare the first revision's dump for the same scenario: `leader=none nodeCount=3` and three
+  `ready=false` lines, with no cause and no indication that a start had failed at all. Every field
+  above is either read or a named absence, and the delegation is what supplies the last two lines. Two
+  things follow, and both are worth stating plainly. The bound is no longer what catches THIS
+  scenario — #913 catches it first — so the bound's remaining job is the stalls #913 does not cover,
+  which is why the `[verified:]` weight here sits on the unit pins and their mutations rather than on
+  this probe. And the diagnostic is now doing the work the ticket asked for: a reader of this failure
+  is told the port, the node and the reason, not merely that something did not settle.
+  The probe was scratch, run under the suite lock on non-default ports, and is not committed.
+
+- **Two failure policies, chosen by what each site did BEFORE, not by preference.** 92 lifecycle awaits
+  in this module were untimed. 52 already threw on failure and keep throwing (`settled` /
+  `nodeSettled`). The other 40 read no `Result` at all — a bare `cluster.stop().await()` in `@AfterAll`
+  discarded a stop that failed outright — and get `bestEffort` / `nodeBestEffort`: bounded identically,
+  but an expiry or failure is LOGGED rather than thrown. The first revision threw at all 92, which
+  review round 1 correctly called the highest-risk runtime delta in the PR: it introduced a NEW failure
+  mode across 30+ classes, where a cleanup hiccup could redden an otherwise passing test — the same
+  flakiness this ticket exists to remove. Promoting a discarded cleanup result to a test failure is a
+  real improvement and a SEPARATE change. The bound is the #915 fix; the error policy is not this
+  ticket's to change.
+- **Round 1 correction — the snapshot no longer has its own renderer, and the field it used to omit is
+  now the honest one.** The first revision rendered its own node line and deliberately omitted
+  `EmberCluster.NodeStatus.state`, because `toNodeStatus` passed the string literal `"healthy"` for
+  every node. #913 removed that literal: `state` is now `EmberCluster.observedState`, read from
+  `AetherNode.isReady()` — the SAME sample the old `ready=` field re-derived, and the stronger of the
+  two, because `ready=` re-read a live registry that a start-failure abort has already cleared. The
+  omission is gone, the field is rendered, and rendering is delegated to #913's `ClusterSnapshot`,
+  which is now the module's one renderer. `ClusterSnapshot.nodeLine` gains `port` and `mgmt`: the
+  canonical failure this dump is read for is a port that could not be bound, and the node id alone does
+  not say which port the node was asked to take.
+- **Round 1 correction — the failure path #913 made COMMON was rendering as an empty block.** Since
+  #913, `EmberCluster.start` settles on the first node failure and `abortStart` clears
+  `nodes`/`nodeInfos` before the caller sees the failure. A dump read off `status()` alone therefore
+  said "no node is registered" on exactly the failure it exists for — the un-named empty snapshot
+  #913 added `ClusterSnapshot.NO_STATE` to prevent. The delegation picks up
+  `EmberCluster.lastStartFailure()` with it, so the dump now carries the retained per-node state and
+  each failing node's cause.
+- **Round 1 correction — the honesty pin could not fail, and was tagged as if it could.** The review
+  proved it by mutation: adding `+ " state=" + node.state()` to the old `nodeLine` left all six tests
+  green, because every test passed an unstarted cluster whose registry is empty, so the early return
+  fired and no test ever reached a node line. That `[verified:]` tag was false, which is worse than no
+  tag at all. Two cases a healthy cluster never produces now drive the node line directly — a populated
+  `ClusterStatus`, and a cleared registry with a retained `StartFailure` — and the populated case is
+  asserted as a whole rendered block, so an ADDED field fails it too.
+- **Every claim above that rests on a test was mutation-probed, and each probe went red.** Round 1's
+  finding was a `[verified:]` tag on a pin that could not fail, so this time each claim's test was
+  attacked rather than re-run. Controls first: `LifecycleAwaitTest` + `ClusterSnapshotTest` green at
+  14/14, `EmberClusterObservedNodeStateTest` green at 1/1, counted from the failsafe/surefire XML.
+  Then one mutation at a time, reverted between each:
+
+  | mutation | what it fabricates | red |
+  |---|---|---|
+  | `nodeLine` gains `+ " state=" + node.state()` (the review's exact edit) | a duplicated field in the node line | 4 tests |
+  | `EmberCluster.observedState` returns the literal `"healthy"` | #913's fabrication, reinstated | `everyNodeOfAFormedCluster_reportsItsObservedStateAsActive` |
+  | `report` drops the step name | the pre-#915 nameless expiry | 2 tests |
+  | `settled` ignores its `bound` | a bound that is not what ended the wait | `aPromiseThatNeverSettles_expiresAtTheBound_andNamesTheStep` |
+  | `report` drops the snapshot | an expiry carrying no cluster state | same |
+  | `bestEffort` ignores its `bound` | an unbounded teardown | `bestEffort_boundsTheWaitButDoesNotFailTheTest` |
+  | `bestEffort` throws | the round-1 behaviour change, reinstated | same |
+  | `snapshot` ignores `lastStartFailure` | the empty dump on a failed start | `aClearedRegistryAfterAFailedStart_rendersWhatTheStartFailureRetained` |
+  | `settled` always throws | a helper that never works | `aPromiseThatSettles_returnsItsValue` (the positive control) |
+  | `snapshot` stops delegating | a second, divergent renderer | `aClusterWithNothingToReport_isRenderedByTheModulesOneRenderer` |
+
+  The `observedState` probe is the one that matters most: it reddens against a REAL three-node cluster
+  that formed and then reported `state=healthy` for every node — the defect in its original shape
+  rather than a stand-in for it.
+- **Module sweep: complete, 0 remaining.** Found by scanning every `.await()` in `forge-tests` and
+  keeping those whose statement calls `start`, `stop`, `startHeldBackNodes`, `addNode`,
+  `addWorkerNode`, `killNode` or `blackhole`. The first revision left 2 in `SliceInvocationTest`
+  because #913 owned that file; #913 has since merged and bounded both at its own 240s `WAIT_BOUND`,
+  so after the merge-forward the module has **zero** unbounded lifecycle awaits. 36 test classes
+  changed here, 92 call sites.
+- **Round 1 correction — the diff was 5 912 lines for 92 edits, and the excess was whole-file
+  reformatting.** `jbct:format` had been run over all 36 in-scope files, reordering imports and
+  rejoining lines: `DurableEntityForgeTest` changed 370 lines for 7 lifecycle lines. That churn earns
+  nothing, makes a reviewer read thousands of lines to check 92 bounds, and maximises conflict surface
+  against every other in-flight `forge-tests` branch. Every file was rebuilt from the base with only
+  the lifecycle statements replaced, and each rebuild was checked against the reviewed revision by
+  comparing both with comments, whitespace and import order stripped — 36 of 36 identical. The diff is
+  now **650 insertions / 340 deletions**, and its two largest files are the new helper and its test.
+- **Round 1 correction — 17 helpers the sweep orphaned are removed.** `failStart`/`failScenario`
+  private statics in 13 classes became referenced only by their own declaration once the helper
+  subsumed the `throw` bodies. One further orphan (`DurableEntityForgeTest.firstPort`) was already dead
+  on the base and is left alone as out of scope.
 - **Bounds carry stated margin over a measured healthy run, taken on a LOADED box on purpose.**
   `MultiSourceCommunitySmokeTest` green in 42.09s at load average ~10 (two sibling trees building):
   cluster start ~3-8s, whole formation 18.5s, `addNode` 1.1s, `stop` 16.6s. The cluster bound is 240s
@@ -55,22 +134,35 @@ this is an unbounded lifecycle await. It does not touch `SliceInvocationTest`, w
   `junit-platform.properties` states in prose: the 8-minute lifecycle backstop is double the longest
   internal guard, so the test's own await fires first and the backstop stays an outer net
   [mechanism: `LifecycleAwait.LIFECYCLE_BOUND` / `NODE_BOUND`; a quiet-box baseline was avoided
-  deliberately because it would understate what a CI runner does].
-- **Residual — 32 of the 36 changed classes are compile-verified only, not executed.** Running the
-  whole module is the 25-minute CI job. Executed locally and green: `MultiSourceCommunitySmokeTest`,
-  `ClusterFormationTest`, `CoreAbsenceFenceOrderingTest`, `EmberAddNodeRoleLabelTest`,
-  `LifecycleAwaitTest` — 19 tests, 0 failures, counted from the failsafe XML. Those include both
-  runnable classes whose call sites had to be restructured by hand rather than mechanically.
-  `CommunityFormationProbeTest` was also hand-restructured but is `@Disabled` at class level (#336), so
-  it is compile-checked only and CI will not exercise it either.
-- **Residual — the format/lint gate does not cover this module's test sources, and this change does not
-  make it.** `mvn jbct:check -pl aether/forge/forge-tests -Djbct.skip=false` exits green while
-  examining NOTHING: the module has no `src/main/java`, and its test files are excluded by
-  `jbct.includeTests=false`. The plugin says so itself rather than reporting a silent pass. Forced with
-  `-Djbct.includeTests=true`, the module reports pre-existing findings in files this PR never touches
-  (`HangDiagnosticExtension`, `TestArtifacts`, `StreamOwnerFailover*`). This change does not add any:
-  886 findings on the pristine base against 722 on this branch, a net reduction of 164, because
-  replacing multi-line `.onFailure(cause -> { throw .. })` chains with one helper call removes flagged
-  constructs. The 722 that remain are out of scope here
-  [verified: both counts produced by the same command, base measured by checking the module out at
-  `origin/release-1.0.0-rc4` in place and restoring afterwards].
+  deliberately because it would understate what a CI runner does]. The 8m backstop is
+  `timeout.lifecycle.method.default`, i.e. PER lifecycle method, so a 240s bounded start in
+  `@BeforeAll` and a 240s bounded stop in `@AfterAll` draw separate budgets and cannot sum into it.
+- **Round 1 correction — the gate claim "this change does not add any findings" was false, and the
+  arithmetic behind it was wrong too.** Forced with `-Djbct.includeTests=true`, the module reports
+  **807** findings on this branch against **904** on the merged base, a net reduction of 97; at ERROR
+  severity, 146 against 211. The first revision credited a 164-line reduction to the `.onFailure`
+  replacement when most of it was the wholesale reformat that has now been reverted. This PR's own
+  four files carry **20 findings, all at WARNING severity and none at ERROR** — the three ERROR-level
+  findings review round 1 found in them (`JBCT-EX-01` throw forbidden, `JBCT-TOT-01` partial mapper,
+  `JBCT-RET-06` null check), plus three more `JBCT-RET-01` void returns, are fixed: the failure path
+  goes through AssertJ's `fail` instead of a bare `throw`, `bestEffort` returns `Result<Unit>`, and the
+  null cluster is handled with `Option.option` rather than a null check.
+- **Residual — most of the 36 changed classes are not executed LOCALLY, but CI does run them.** The
+  correction matters, because the first revision of this fragment implied CI would not exercise them.
+  It does: `.github/workflows/ci.yml` has a dedicated `forge-tests` job running
+  `mvn verify -B -Pwith-e2e -pl aether/forge/forge-tests -Dfailsafe.excludedGroups=Heavy`, and it
+  passed in 10m50s on this branch's previous head. NOT covered by that job: the `Heavy`-tagged set, and
+  `CommunityFormationProbeTest`, which is `@Disabled` at class level (#336) and so is compile-checked
+  only wherever it runs. Risk per class is low and uniform — the substitution is mechanical and its
+  failure mode is a compile error. Executed locally and green on this head, counted from the
+  failsafe XML rather than the `.txt` headers: **27 tests, 0 failures** across
+  `LifecycleAwaitTest` (8), `ClusterSnapshotTest` (6), `EmberAddNodeRoleLabelTest` (6),
+  `ClusterFormationTest` (5), `MultiSourceCommunitySmokeTest` (1, green in 48.73s) and
+  `CoreAbsenceFenceOrderingTest` (1) — which includes both hand-restructured classes that are
+  runnable.
+- **Residual — the format/lint gate does not cover this module's test sources.**
+  `aether/forge/forge-tests` is not in the default reactor at all: `aether/forge/pom.xml` puts it
+  behind the `-Pwith-e2e` profile, so `-pl aether/forge/forge-tests` alone fails with "Could not find
+  the selected project in the reactor". Even inside that profile the module has no `src/main/java` and
+  its test files are excluded by `jbct.includeTests=false`. Every finding counted above is therefore
+  measured by an explicitly forced invocation and none of them reach CI.


### PR DESCRIPTION
Closes #915.

Bounds and names every untimed lifecycle await in `forge-tests`. Sibling of #727/#913 — same family,
different member. **Merged forward onto #913** (`6221c5e9c`), which landed after this branch was cut
and changed several things this PR depended on; see *Review round 1* below.

## The defect, measured rather than inferred

A 3-node `EmberCluster` with two of three management ports pre-bound cannot form quorum. Awaited
**without** a bound on a separate thread:

| observation | settled | thread state |
|---|---|---|
| after 45s | false | `WAITING` |
| 5s after `Thread.interrupt()` | false | `RUNNABLE` |
| 10s after interrupt | false | `WAITING` |

The interrupt does not end the wait — it turns a parked waiter into a spinning one. **That is why the
8-minute JUnit lifecycle backstop could not end the hang**: an interrupt is its only lever. That
defect is #914 and is *not* fixed here; this PR makes the caller stop waiting, not the wait
interruptible. Mechanism: `Promise.java:3300-3302`, a bare `while (result == null) { LockSupport.park(); }`
loop with no interrupt check.

## What the bounded failure says now

Re-run on the merged base, the same forced stall **no longer stalls**: #913 made `start()` settle on
the first node failure, so it fails in **7.65s** with the real cause rather than reaching the bound.
The step is still named, and the snapshot is the start-failure state #913 retains:

```
3-node cluster start (ports 27700+) did not settle within TimeSpan(20S): Failed to bind to port 27741: Address already in use
Cluster state when the wait ended:
  leader=none (captured when the start failed; the abort has since cleared the live cluster state, so no health endpoint is probed here)
  p921-2 state=inactive leader=false port=27701 mgmt=27741
  p921-1 state=inactive leader=false port=27700 mgmt=27740
  p921-3 state=inactive leader=false port=27702 mgmt=27742
  start failures: {p921-2=Failed to bind to port 27741: Address already in use}
```

Before this PR: a class-level ERROR at ~515s whose entire text was the backstop's own timeout. Note
honestly that the bound is no longer what catches *this* scenario — #913 catches it first. The
bound's remaining job is the stalls #913 does not cover.

## Sweep — complete

**92 untimed lifecycle awaits across 36 test classes, all bounded. 0 remain in the module.** The
previous revision left 2 in `SliceInvocationTest` as #913's territory; #913 has since merged and
bounded both.

## Two failure policies, chosen by what each site did before

| sites | before | now |
|---|---|---|
| 52 | threw on failure | `settled` / `nodeSettled` — bounded, still throws |
| 40 | read no `Result` at all | `bestEffort` / `nodeBestEffort` — bounded, logs instead of throwing |

Promoting a discarded cleanup result to a test failure is a real improvement and a **separate**
change. The bound is the #915 fix.

## Bounds

Measured on a **loaded** box (load average ~10) on purpose — a quiet-box baseline would understate a
CI runner. `MultiSourceCommunitySmokeTest` green in 42.09s: start ~3-8s, formation 18.5s, `addNode`
1.1s, `stop` 16.6s.

- `LIFECYCLE_BOUND` = 240s — ~30x measured start, ~14x measured stop, equal to the longest existing
  internal guard, which preserves the invariant `junit-platform.properties` states in prose (the 8m
  backstop is double the longest internal guard, and is per lifecycle method, so a bounded
  `@BeforeAll` and a bounded `@AfterAll` cannot sum into it).
- `NODE_BOUND` = 120s — ~110x the measured join.

## Verification

Controls green: `LifecycleAwaitTest` + `ClusterSnapshotTest` 14/14, `EmberClusterObservedNodeStateTest`
1/1. Then **10 mutations, one at a time, reverted between each — all 10 red**:

| mutation | red |
|---|---|
| `nodeLine` gains `+ " state=" + node.state()` (the review's exact edit) | 4 tests |
| `EmberCluster.observedState` returns the literal `"healthy"` | `everyNodeOfAFormedCluster_reportsItsObservedStateAsActive` |
| `report` drops the step name | 2 tests |
| `settled` ignores its `bound` | `aPromiseThatNeverSettles_expiresAtTheBound_andNamesTheStep` |
| `report` drops the snapshot | same |
| `bestEffort` ignores its `bound` | `bestEffort_boundsTheWaitButDoesNotFailTheTest` |
| `bestEffort` throws | same |
| `snapshot` ignores `lastStartFailure` | `aClearedRegistryAfterAFailedStart_rendersWhatTheStartFailureRetained` |
| `settled` always throws | `aPromiseThatSettles_returnsItsValue` (positive control) |
| `snapshot` stops delegating | `aClusterWithNothingToReport_isRenderedByTheModulesOneRenderer` |

Executed locally and green, **27 tests / 0 failures** counted from failsafe XML: `LifecycleAwaitTest`
(8), `ClusterSnapshotTest` (6), `EmberAddNodeRoleLabelTest` (6), `ClusterFormationTest` (5),
`MultiSourceCommunitySmokeTest` (1, 48.73s), `CoreAbsenceFenceOrderingTest` (1).

## Review round 1

Two blocking findings and five should-fix, all addressed.

1. **The honesty pin could not fail.** The reviewer added `+ " state=" + node.state()` to `nodeLine`
   and all six tests stayed green: every test passed an unstarted cluster, so `snapshot` returned at
   its empty-registry branch and no test ever reached a node line. The `[verified:]` tag on it was
   false. Fixed: two cases a healthy cluster never produces now drive the node line directly, the
   populated case is asserted as a whole rendered block, and the reviewer's exact mutation now
   reddens 4 tests. Every other `[verified:]` claim was mutation-probed too — the table above.
2. **Merge-forward.** Merged `6221c5e9c`. #913 makes `NodeStatus.state` a real observation
   (`AetherNode.isReady()`), which is the same sample the old `ready=` field re-derived and the
   stronger of the two, so the omission rationale is deleted and the field is rendered. #913 also
   captures `lastStartFailure` before the abort clears the registry, so rendering now delegates to
   #913's `ClusterSnapshot` — one renderer in the package instead of two that diverge on the common
   failure path. `ClusterSnapshot.nodeLine` gains `port`/`mgmt`, since the canonical failure here is a
   port that could not be bound.
3. **Sweep is complete** (was: "2 untouchables"). 0 remain.
4. **Gate claim corrected.** "Adds none" was false. True figures, same forced command both sides:
   **804** findings on this branch vs **901** on the merged base; at ERROR severity **146** vs **211**.
   (My first figures, 807/904, over-counted by 3: the counter matched every `JBCT-<CODE>` mention in
   the log rather than only finding lines. ERROR counts are unaffected and reproduce exactly on both
   sides. A residual 7-finding gap at WARNING level against the reviewer's base figure of 894 is
   **unreconciled** and not chased.)
   This PR's four files carry **20 findings, all WARNING, none at ERROR** — the three ERROR-level ones
   the review found, plus three more `JBCT-RET-01`, are fixed.
5. **Diff reduced from 5 912 lines to 990** (650 insertions / 340 deletions). The excess was whole-file
   `jbct:format` churn: `DurableEntityForgeTest` changed 370 lines for 7 lifecycle lines. Every file
   was rebuilt from the base with only the lifecycle statements replaced, then checked against the
   reviewed revision with comments, whitespace and import order stripped — 36 of 36 identical.
6. **17 orphaned helpers removed.** One further orphan was already dead on the base; left alone.
7. **Teardowns that now threw: 40 sites, all restored to non-throwing** via `bestEffort` (the review
   estimated ~19; 40 is the counted figure). See the policy table above. Likewise the sweep is **92**
   call sites, not 95.

## `ClusterSnapshot.java` — scope of the change, and what is provably untouched

This PR modifies `ClusterSnapshot.java` (+26/-10), which was #913's file. **#913 has since merged**
(base is now `6221c5e9c` and carries the file), so this is base-branch code, not a competing open PR's
territory. The change is round 1's "delegate to the existing renderer" direction, not a new renderer.

**#913's health-probe path is byte-identical.** Verified by extracting each method from the file at
`6221c5e9c` and at this head and comparing digests, not by reading:

| method | base `6221c5e9c` | head `ad73f1bcd` |
|---|---|---|
| `liveNodeLine` | `39a332cb…` | `39a332cb…` (identical) |
| `healthBody` | `e9ce1a94…` | `e9ce1a94…` (identical) |
| `healthRequest` | `fc375692…` | `fc375692…` (identical) |

What this PR does change, stated exactly so the reader need not re-derive it:

1. `render(live, startFailure, http)` keeps its signature and behaviour; its three branches move into a
   shared private helper parameterised by a per-node line renderer.
2. A new http-free `render(live, startFailure)` overload, for the lifecycle awaits in `@BeforeAll` /
   `@AfterAll` across the swept classes, which hold no `HttpOperations`. A health probe on a failed
   `stop` would answer about the aftermath anyway, and since #913 `NodeStatus.state` already carries
   the consensus-active sample the endpoint would have reported.
3. `nodeLine` gains `port=` and `mgmt=`, because the canonical failure this dump is read for is a port
   that could not be bound and the node id alone does not say which port was asked for. **`nodeLine` is
   shared, so the http path's OUTPUT does gain those two fields** — no probe behaviour changes, but the
   rendered line is not byte-identical, and that is the one visible effect on #913's path.

## The pins have teeth against the exact residue

An earlier, never-pushed commit (`e8b61fc09`) briefly carried a reviewer's mutation — the one-arg
accessor gutted to `return "INSTRUMENT-CHECK";`. It was amended out before any push; origin was at
`966e7c8c7` at the time, so no shared history was rewritten, and `INSTRUMENT-CHECK` occurs 0 times
across `origin/release-1.0.0-rc4..origin/fix/915-community-smoke-bounded-awaits`.

Re-introducing that exact value verbatim at this head turns **3 tests red across both pin classes** —
including `LifecycleAwaitStartFailureTest#aFailedStart_isRenderedByTheOneArgAccessor_fromTheRetainedCapture`
and `LifecycleAwaitTest#anAbsentCluster_isNamedRatherThanNullPrinted` — and the control run is green.
So the pin passing at this head is itself the evidence that the accessor is intact, rather than a claim
about it.

## Stated residuals

- **Most changed classes are not executed locally, but CI does run them.** `ci.yml` has a dedicated
  `forge-tests` job (`mvn verify -B -Pwith-e2e -pl aether/forge/forge-tests
  -Dfailsafe.excludedGroups=Heavy`), green in 10m50s on the previous head. Not covered by it: the
  `Heavy`-tagged set, and `CommunityFormationProbeTest`, `@Disabled` at class level (#336).
- **The format/lint gate does not cover this module's test sources.** `forge-tests` is outside the
  default reactor (behind `-Pwith-e2e`), has no `src/main/java`, and its tests are excluded by
  `jbct.includeTests=false`. Every finding count above comes from an explicitly forced invocation;
  none of them reach CI.

