### PR TITLE
fix: make deployment retry exhaustion terminal instead of re-driving forever (#922)

### DIFF
--- a/aether/aether-deployment/src/main/java/org/pragmatica/aether/deployment/cluster/fsm/ClusterDeploymentContext.java
+++ b/aether/aether-deployment/src/main/java/org/pragmatica/aether/deployment/cluster/fsm/ClusterDeploymentContext.java
@@ -256,6 +256,7 @@ public final class ClusterDeploymentContext {
                                                  ConcurrentHashMap.newKeySet(),
                                                  ConcurrentHashMap.newKeySet(),
                                                  ConcurrentHashMap.newKeySet(),
+                                                 ConcurrentHashMap.newKeySet(),
                                                  new ConcurrentHashMap<>(),
                                                  new ConcurrentHashMap<>(),
                                                  new ConcurrentHashMap<>(),

--- a/aether/aether-deployment/src/main/java/org/pragmatica/aether/deployment/cluster/fsm/ClusterDeploymentState.java
+++ b/aether/aether-deployment/src/main/java/org/pragmatica/aether/deployment/cluster/fsm/ClusterDeploymentState.java
@@ -1689,26 +1689,60 @@ public sealed interface ClusterDeploymentState extends FsmState<ClusterDeploymen
             SharedScheduler.schedule(this::reconcile, timeSpan(jitteredMs).millis());
         }
 
-        /// #922 — retry exhaustion is TERMINAL. It previously logged, cleared the
-        /// counter and routed `DeploymentFailed`, then returned, leaving the artifact absent from
-        /// `permanentlyFailed`. That was not a resting state. [#handleSliceFailure] issues an
-        /// unload on every failure; the node's removal of the `NodeArtifactKey` arrives at
-        /// [#handleSliceNodeRemoval], which — finding the artifact not permanently failed —
-        /// scheduled a reconcile 1 s later; [#reconcileBlueprint] is gated by nothing else, so it
-        /// redeployed the artifact and `retryCounters.merge` restarted at 1. An intermittent cause
-        /// that never settles therefore looped at roughly 1 Hz for the life of the cluster: no
-        /// terminal state, no rollback, and consensus round-trips forever.
+        /// #922 — retry exhaustion is TERMINAL, but only for a deployment that has produced
+        /// nothing. It previously logged, cleared the counter and routed `DeploymentFailed`, then
+        /// returned, leaving the artifact absent from `permanentlyFailed`. That was not a resting
+        /// state. [#handleSliceFailure] issues an unload on every failure; the node's removal of the
+        /// `NodeArtifactKey` arrives at [#handleSliceNodeRemoval], which — finding the artifact not
+        /// permanently failed — scheduled a reconcile 1 s later; [#reconcileBlueprint] is gated by
+        /// nothing else, so it redeployed the artifact and `retryCounters.merge` restarted at 1. An
+        /// intermittent cause that never settles therefore looped at roughly 1 Hz for the life of
+        /// the cluster: no terminal state, no rollback, and consensus round-trips forever.
         ///
-        /// Settling here bounds every intermittent cause at `MAX_RETRIES` + 1 reported failures and
-        /// makes the `ALL_OR_NOTHING` promise hold on this branch as it already did on the
+        /// Settling makes the `ALL_OR_NOTHING` promise hold on this branch as it already did on the
         /// deterministic one. The counter is cleared first so a later redeploy of the same artifact
         /// — which clears `permanentlyFailed` when the blueprint is applied — starts from a clean
         /// budget rather than inheriting an exhausted one.
+        ///
+        /// #924 review, BLOCKING: settling UNCONDITIONALLY here was itself a defect, and a worse
+        /// one than the livelock. The terminal is cluster-wide and permanent; the retry budget it
+        /// was hung on is per artifact AND node. So a slice already deployed and healthy on three
+        /// nodes, whose instance on ONE node suffered a transient longer than ~31 s, was settled
+        /// permanently failed for the WHOLE cluster — and because its blueprint had already left
+        /// `inFlightBlueprints`, [#rollbackBlueprintForArtifact] matched nothing and not even an
+        /// outcome record was written. Auto-heal, rebalancing and scale-up for that artifact were
+        /// then dead until an operator re-applied the blueprint. Before the #922 fix that case
+        /// self-healed, so the fix traded a livelock on a deployment that never succeeded for a
+        /// permanent, silent, cluster-wide failure of one that had.
+        ///
+        /// [#hasActiveInstanceElsewhere] is the discriminator, and the two populations are the ones
+        /// the ticket and the review name: a deployment ATTEMPT with nothing running is abandoned
+        /// (bounded — #922's case), while a RUNNING workload suffering a node-local transient keeps
+        /// being reconciled toward its desired instance count (unbounded — convergence, which is
+        /// what an orchestrator owes a workload the operator believes is up).
         private void handleRetryBudgetExhausted(SliceNodeKey sliceKey, String failureReason) {
             var artifact = sliceKey.artifact();
 
             retryCounters.remove(sliceKey.asString());
             if (permanentlyFailed.contains(artifact)) {
+                return;
+            }
+
+            if (hasActiveInstanceElsewhere(artifact)) {
+                log.warn("Max retries ({}) exceeded for {} on {}: {} — NOT marking permanently failed: "
+                         + "the artifact is ACTIVE on another node, so this is a node-local transient and "
+                         + "reconciliation keeps converging toward the desired instance count",
+                         MAX_RETRIES,
+                         artifact,
+                         sliceKey.nodeId(),
+                         failureReason);
+                ctx.router()
+                   .route(DeploymentFailed.deploymentFailed(artifact,
+                                                            sliceKey.nodeId(),
+                                                            SliceState.FAILED,
+                                                            failureReason,
+                                                            ctx.nowMs()));
+
                 return;
             }
 
@@ -1718,6 +1752,44 @@ public sealed interface ClusterDeploymentState extends FsmState<ClusterDeploymen
                       sliceKey.nodeId(),
                       failureReason);
             settleAsPermanentlyFailed(sliceKey, failureReason);
+        }
+
+        /// Whether ANY instance of this artifact is ACTIVE on a live node — the discriminator
+        /// between a deployment ATTEMPT that has produced nothing and a RUNNING workload suffering a
+        /// node-local transient (#924 review, BLOCKING).
+        ///
+        /// It exists to match the EVIDENCE to the BLAST RADIUS. The terminal reached by
+        /// [#settleAsPermanentlyFailed] is cluster-wide (`permanentlyFailed` is a `Set<Artifact>`)
+        /// and permanent; the retry budget that triggers it is per artifact AND node
+        /// (`retryCounters` is keyed on `sliceKey.asString()`). A cluster-wide permanent verdict
+        /// needs cluster-wide evidence, and "nothing of this artifact is running anywhere" is it.
+        ///
+        /// `inFlightBlueprints` is the cheaper test and the WRONG one. [ClusterDeploymentContext#newActive]
+        /// builds it empty and only a live `AppBlueprintPutReceived` populates it, so it does not
+        /// survive leader failover: gating on it would silently stop settling — reopening #922 — for
+        /// every deployment whose leader changed mid-flight. `sliceStates` is rebuilt from durable
+        /// KV entries by [#rebuildSliceStateFromKVStoreEntries] during [#rebuildStateFromKVStore] on
+        /// activation, so this predicate reads the same answer on a new leader as on the old one.
+        ///
+        /// Strictly ACTIVE, not [#isLiveState]: a sibling instance merely LOADING or LOADED is part
+        /// of the same unproven attempt and must not vote to keep it alive, or a deployment stuck
+        /// short of ACTIVE would never settle at all.
+        ///
+        /// "Elsewhere" is implicit rather than filtered: [#handleSliceFailure] removes the failing
+        /// key from `sliceStates` before either failure branch runs, so the instance that just
+        /// failed cannot count itself. That ordering is load-bearing — moving this call ahead of
+        /// that removal would make every exhaustion look survivable.
+        private boolean hasActiveInstanceElsewhere(Artifact artifact) {
+            var liveNodes = activeNodes();
+
+            return sliceStates.entrySet()
+                              .stream()
+                              .filter(entry -> entry.getKey()
+                                                    .artifact()
+                                                    .equals(artifact))
+                              .filter(entry -> liveNodes.contains(entry.getKey()
+                                                                       .nodeId()))
+                              .anyMatch(entry -> entry.getValue() == SliceState.ACTIVE);
         }
 
         /// The activation gate for a slice's schema migrations, scoped to the slice's OWN blueprint.

--- a/aether/aether-deployment/src/main/java/org/pragmatica/aether/deployment/cluster/fsm/ClusterDeploymentState.java
+++ b/aether/aether-deployment/src/main/java/org/pragmatica/aether/deployment/cluster/fsm/ClusterDeploymentState.java
@@ -74,6 +74,7 @@ import org.pragmatica.aether.slice.kvstore.AetherValue.ActivationDirectiveValue;
 import org.pragmatica.aether.slice.kvstore.AetherValue.AppBlueprintValue;
 import org.pragmatica.aether.slice.kvstore.AetherValue.ClusterConfigValue;
 import org.pragmatica.aether.slice.kvstore.AetherValue.CommunityValue;
+import org.pragmatica.aether.slice.kvstore.AetherValue.DeploymentOutcomeStatus;
 import org.pragmatica.aether.slice.kvstore.AetherValue.DeploymentOutcomeValue;
 import org.pragmatica.aether.slice.kvstore.AetherValue.GovernorAnnouncementValue;
 import org.pragmatica.aether.slice.kvstore.AetherValue.NodeArtifactValue;
@@ -222,6 +223,19 @@ public sealed interface ClusterDeploymentState extends FsmState<ClusterDeploymen
                   Map<String, Integer> retryCounters,
                   Map<BlueprintId, InFlightBlueprint> inFlightBlueprints,
                   Set<BlueprintId> restoringBlueprints,
+                  // Artifacts THIS leader watched reach ACTIVE (#924 review round 2, BLOCKING).
+                  // The fast, artifact-scoped leg of [Active#everReachedActive]; the durable leg
+                  // beside it is the blueprint's SUCCEEDED outcome record. In-memory on purpose,
+                  // and NOT a substitute for the durable leg: it is rebuilt empty on failover,
+                  // which is exactly the lifetime trap that made `inFlightBlueprints` the wrong
+                  // discriminator. What it adds over the durable record is the two windows the
+                  // record cannot cover — the interval before `recordSucceededOutcome`'s write is
+                  // applied back through consensus, and the case where that write is lost and, as
+                  // [Active#handleSucceededOutcomeWriteFailure] documents, never retried.
+                  // Forgotten in [Active#issueDeallocationCommands] — the seam every path that
+                  // takes an artifact OUT of the cluster's desired state funnels through — so a
+                  // later, independent deployment of the same coordinate does not inherit it.
+                  Set<Artifact> everActiveArtifacts,
                   Set<Artifact> permanentlyFailed,
                   Set<NodeId> workerNodes,
                   Map<SliceNodeKey, Long> transitionalStateTimestamps,
@@ -1562,6 +1576,7 @@ public sealed interface ClusterDeploymentState extends FsmState<ClusterDeploymen
 
         private void handleSliceActive(SliceNodeKey sliceKey) {
             retryCounters.remove(sliceKey.asString());
+            everActiveArtifacts.add(sliceKey.artifact());
             activateDependentSlices(sliceKey.artifact());
             trackBlueprintSliceActive(sliceKey.artifact());
         }
@@ -1715,11 +1730,31 @@ public sealed interface ClusterDeploymentState extends FsmState<ClusterDeploymen
         /// self-healed, so the fix traded a livelock on a deployment that never succeeded for a
         /// permanent, silent, cluster-wide failure of one that had.
         ///
-        /// [#hasActiveInstanceElsewhere] is the discriminator, and the two populations are the ones
-        /// the ticket and the review name: a deployment ATTEMPT with nothing running is abandoned
-        /// (bounded — #922's case), while a RUNNING workload suffering a node-local transient keeps
-        /// being reconciled toward its desired instance count (unbounded — convergence, which is
-        /// what an orchestrator owes a workload the operator believes is up).
+        /// #924 review round 2, BLOCKING: asking [#hasActiveInstanceElsewhere] alone — *is an
+        /// instance ACTIVE right now?* — narrowed that defect without closing it. [#handleSliceFailure]
+        /// removes the failing key from `sliceStates` before either branch runs, so the question
+        /// answers "no" whenever the transient reached EVERY instance, and it can never answer "yes"
+        /// for a slice with `instances = 1`, which has no sibling to vote for it. Both shapes were
+        /// previously-healthy workloads condemned cluster-wide and permanently, and both self-healed
+        /// before #922.
+        ///
+        /// [#everReachedActive] is the discriminator instead, and it asks whether the artifact EVER
+        /// reached ACTIVE rather than whether it is ACTIVE now. That separates the two populations
+        /// the ticket and the review name: a deployment ATTEMPT that has produced nothing is
+        /// abandoned (bounded — #922's case, a coordinate that never resolves), while a workload
+        /// that was up and fell over keeps being reconciled toward its desired instance count
+        /// (unbounded — convergence, which is what an orchestrator owes a workload the operator
+        /// believes is up).
+        ///
+        /// The settle is also gated on [#coreMembershipResolved] (#924 review round 2, S2). The
+        /// evidence [#hasActiveInstanceElsewhere] weighs is KV-derived slice state diffed against
+        /// [#activeNodes], and during the boot window that supplier yields
+        /// [MembershipFsm#MEMBERSHIP_NOT_WIRED] — an empty set distinguished only by reference
+        /// identity, which makes every node fail `contains` and every artifact look abandoned.
+        /// `coreMembershipResolved`'s own contract requires exactly this consultation, and
+        /// [StaleEntryCleaner] honours it at four sites. Refusing to settle on an unresolved member
+        /// set costs a re-drive that the next exhaustion re-decides; settling on one is
+        /// irreversible.
         private void handleRetryBudgetExhausted(SliceNodeKey sliceKey, String failureReason) {
             var artifact = sliceKey.artifact();
 
@@ -1728,25 +1763,28 @@ public sealed interface ClusterDeploymentState extends FsmState<ClusterDeploymen
                 return;
             }
 
-            if (hasActiveInstanceElsewhere(artifact)) {
-                log.warn("Max retries ({}) exceeded for {} on {}: {} — NOT marking permanently failed: "
-                        + "the artifact is ACTIVE on another node, so this is a node-local transient and "
-                        + "reconciliation keeps converging toward the desired instance count",
-                         MAX_RETRIES,
-                         artifact,
-                         sliceKey.nodeId(),
-                         failureReason);
-                ctx.router()
-                   .route(DeploymentFailed.deploymentFailed(artifact,
-                                                            sliceKey.nodeId(),
-                                                            SliceState.FAILED,
-                                                            failureReason,
-                                                            ctx.nowMs()));
+            if (!coreMembershipResolved()) {
+                reportUnsettledExhaustion(sliceKey,
+                                          failureReason,
+                                          "core membership is not resolved yet, so the evidence this verdict "
+                                         + "would rest on cannot be read");
 
                 return;
             }
 
-            log.error("Max retries ({}) exceeded for {} on {}: {} — giving up, marking permanently failed",
+            if (everReachedActive(artifact)) {
+                reportUnsettledExhaustion(sliceKey,
+                                          failureReason,
+                                          "the artifact has reached ACTIVE, so this is a transient on a workload "
+                                         + "that was up, and reconciliation keeps converging toward the desired "
+                                         + "instance count");
+
+                return;
+            }
+
+            log.error("Max retries ({}) exceeded for {} on {}: {} — the retry budget for an INTERMITTENT cause is "
+                     + "spent and no instance of this artifact has ever reached ACTIVE, so the deployment attempt "
+                     + "is abandoned and the artifact marked permanently failed",
                       MAX_RETRIES,
                       artifact,
                       sliceKey.nodeId(),
@@ -1754,22 +1792,69 @@ public sealed interface ClusterDeploymentState extends FsmState<ClusterDeploymen
             settleAsPermanentlyFailed(sliceKey, failureReason);
         }
 
-        /// Whether ANY instance of this artifact is ACTIVE on a live node — the discriminator
-        /// between a deployment ATTEMPT that has produced nothing and a RUNNING workload suffering a
-        /// node-local transient (#924 review, BLOCKING).
+        /// The non-terminal exit from [#handleRetryBudgetExhausted]: the budget is spent and the
+        /// counter cleared, but the artifact is NOT condemned, so the unload already issued by
+        /// [#handleSliceFailure] is followed by the reconcile that restores the instance. `why`
+        /// names which guard declined, because the two are diagnosed differently — an unresolved
+        /// member set is a cluster-health question, an ever-active artifact is working as designed.
+        private void reportUnsettledExhaustion(SliceNodeKey sliceKey, String failureReason, String why) {
+            log.warn("Max retries ({}) exceeded for {} on {}: {} — NOT marking permanently failed: {}",
+                     MAX_RETRIES,
+                     sliceKey.artifact(),
+                     sliceKey.nodeId(),
+                     failureReason,
+                     why);
+            ctx.router()
+               .route(DeploymentFailed.deploymentFailed(sliceKey.artifact(),
+                                                        sliceKey.nodeId(),
+                                                        SliceState.FAILED,
+                                                        failureReason,
+                                                        ctx.nowMs()));
+        }
+
+        /// Whether this artifact has EVER reached ACTIVE — the discriminator between a deployment
+        /// ATTEMPT that has produced nothing and a workload that was up and fell over (#924 review
+        /// round 2, BLOCKING).
         ///
         /// It exists to match the EVIDENCE to the BLAST RADIUS. The terminal reached by
         /// [#settleAsPermanentlyFailed] is cluster-wide (`permanentlyFailed` is a `Set<Artifact>`)
         /// and permanent; the retry budget that triggers it is per artifact AND node
         /// (`retryCounters` is keyed on `sliceKey.asString()`). A cluster-wide permanent verdict
-        /// needs cluster-wide evidence, and "nothing of this artifact is running anywhere" is it.
+        /// needs cluster-wide evidence, and "no instance of this artifact ever came up" is it.
         ///
-        /// `inFlightBlueprints` is the cheaper test and the WRONG one. [ClusterDeploymentContext#newActive]
-        /// builds it empty and only a live `AppBlueprintPutReceived` populates it, so it does not
-        /// survive leader failover: gating on it would silently stop settling — reopening #922 — for
-        /// every deployment whose leader changed mid-flight. `sliceStates` is rebuilt from durable
-        /// KV entries by [#rebuildSliceStateFromKVStoreEntries] during [#rebuildStateFromKVStore] on
-        /// activation, so this predicate reads the same answer on a new leader as on the old one.
+        /// The round-1 fix asked the PRESENT-TENSE question — is an instance ACTIVE right now —
+        /// and round 2 showed why that is not the same question. [#handleSliceFailure] removes the
+        /// failing key from `sliceStates` before either branch runs, so a present-tense read
+        /// necessarily answers "no" once the transient has reached every instance; and for a slice
+        /// with `instances = 1` it can never answer "yes", because no sibling exists to vote. The
+        /// past-tense question separates the populations the present-tense one conflates.
+        ///
+        /// It is a DISJUNCTION and every leg is fail-safe: any evidence of a past ACTIVE declines
+        /// the settle. Three legs, because no single one covers every lifetime:
+        ///
+        ///   1. [#hasActiveInstanceElsewhere] — an instance is ACTIVE now. Survives failover:
+        ///      `sliceStates` is rebuilt from durable `NodeArtifactKey` entries by
+        ///      [#rebuildSliceStateFromKVStoreEntries].
+        ///   2. `everActiveArtifacts` — THIS leader watched the artifact reach ACTIVE. In-memory,
+        ///      so empty on a new leader; it is here for the two windows leg 3 cannot cover.
+        ///   3. [#blueprintDeploymentSucceeded] — the owning blueprint has a durable SUCCEEDED
+        ///      outcome record. This is the leg that survives failover, and the reason the
+        ///      discriminator is not merely in-memory bookkeeping.
+        ///
+        /// `inFlightBlueprints` is the cheaper test and the WRONG one, in the opposite direction.
+        /// [ClusterDeploymentContext#newActive] builds it empty and only a live
+        /// `AppBlueprintPutReceived` populates it, so gating on its ABSENCE would stop settling —
+        /// reopening #922 — for every deployment whose leader changed mid-flight.
+        ///
+        /// `activeRoutings` was considered as a fourth leg and rejected. It is rebuilt from durable
+        /// KV by [#processKVEntry], but it is keyed on `ArtifactBase` — version-blind. A running v1
+        /// would vote for a v2 that never came up, which is #922's own case (a coordinate that does
+        /// not resolve) reopened through the guard meant to bound it.
+        private boolean everReachedActive(Artifact artifact) {
+            return hasActiveInstanceElsewhere(artifact) || everActiveArtifacts.contains(artifact) || blueprintDeploymentSucceeded(artifact);
+        }
+
+        /// Leg 1: an instance is ACTIVE right now on a live core node.
         ///
         /// Strictly ACTIVE, not [#isLiveState]: a sibling instance merely LOADING or LOADED is part
         /// of the same unproven attempt and must not vote to keep it alive, or a deployment stuck
@@ -1779,6 +1864,9 @@ public sealed interface ClusterDeploymentState extends FsmState<ClusterDeploymen
         /// key from `sliceStates` before either failure branch runs, so the instance that just
         /// failed cannot count itself. That ordering is load-bearing — moving this call ahead of
         /// that removal would make every exhaustion look survivable.
+        ///
+        /// The [#activeNodes] read here is why [#handleRetryBudgetExhausted] gates on
+        /// [#coreMembershipResolved] before consulting this predicate at all.
         private boolean hasActiveInstanceElsewhere(Artifact artifact) {
             var liveNodes = activeNodes();
 
@@ -1789,6 +1877,36 @@ public sealed interface ClusterDeploymentState extends FsmState<ClusterDeploymen
                                                     .equals(artifact))
                               .filter(entry -> liveNodes.contains(entry.getKey().nodeId()))
                               .anyMatch(entry -> entry.getValue() == SliceState.ACTIVE);
+        }
+
+        /// Leg 3: the durable evidence. `DeploymentOutcomeValue.SUCCEEDED` is written by
+        /// [#recordSucceededOutcome] when every slice of the owning blueprint has reached ACTIVE,
+        /// and its own contract says it survives the blueprint's teardown because it is "the record
+        /// of what happened, not part of the blueprint's active configuration". Reading it back on
+        /// a new leader is what makes [#everReachedActive] a durable question rather than an
+        /// in-memory one — the objection that made `inFlightBlueprints` unusable.
+        ///
+        /// Suppressed while the blueprint is in flight, and this is load-bearing rather than an
+        /// optimisation. Nothing removes a `DeploymentOutcomeKey` entry when a blueprint id is
+        /// re-applied, so a re-used id whose new load order carries a slice that never existed
+        /// before would hand that brand-new slice the previous attempt's SUCCEEDED record and it
+        /// would never settle — #922's livelock, reopened through the guard meant to bound it.
+        /// While the attempt is in flight the record describes the PREVIOUS attempt and must not
+        /// vote; once it fully deploys, [#recordSucceededOutcome] refreshes it.
+        ///
+        /// Absence of the key is NOT evidence of never-active — `AetherValue.DeploymentOutcomeStatus`
+        /// says so explicitly — which is why this is one leg of a disjunction and not the predicate.
+        private boolean blueprintDeploymentSucceeded(Artifact artifact) {
+            return Option.option(blueprints.get(artifact))
+                         .flatMap(Blueprint::owner)
+                         .filter(blueprintId -> !inFlightBlueprints.containsKey(blueprintId))
+                         .map(DeploymentOutcomeKey::deploymentOutcomeKey)
+                         .flatMap(key -> ctx.kvStore()
+                                            .get(key))
+                         .filter(value -> value instanceof DeploymentOutcomeValue)
+                         .map(value -> ((DeploymentOutcomeValue) value).status())
+                         .map(status -> status == DeploymentOutcomeStatus.SUCCEEDED)
+                         .or(false);
         }
 
         /// The activation gate for a slice's schema migrations, scoped to the slice's OWN blueprint.
@@ -2204,7 +2322,18 @@ public sealed interface ClusterDeploymentState extends FsmState<ClusterDeploymen
             stuckRemediator().detectStuckTransitionalStates();
         }
 
+        /// #924 review round 2: this is also where `everActiveArtifacts` is forgotten, because
+        /// this is the one seam every "the artifact leaves the cluster's desired state" path
+        /// already funnels through — blueprint removal, rolling-update cleanup of a superseded
+        /// version, routing removal, and `unloadBlueprintSlices`. The evidence must not outlive the
+        /// deployment it describes: a LATER, independent deployment of the same coordinate that
+        /// never comes up has to settle, and would not if it inherited a previous deployment's
+        /// past-tense ACTIVE. Note the boundary is removal, NOT a re-apply of the same blueprint —
+        /// clearing on re-apply would leave a healthy, running workload one operator re-apply plus
+        /// one cluster-wide transient away from the silent permanent condemnation this whole change
+        /// exists to prevent.
         private void issueDeallocationCommands(Artifact artifact) {
+            everActiveArtifacts.remove(artifact);
             getCurrentInstances(artifact).forEach(this::issueUnloadCommand);
             removeWorkerDirective(artifact);
         }
@@ -2617,9 +2746,15 @@ public sealed interface ClusterDeploymentState extends FsmState<ClusterDeploymen
                              failedArtifact);
                     continue;
                 }
-
-                log.warn("ALL_OR_NOTHING: Deterministic failure of {} triggers rollback of blueprint {}",
+                // #924 review round 2, N5: this used to say "Deterministic failure". Since #922 routed
+                // the exhausted-retry branch into the same terminal, that told an operator
+                // diagnosing an INTERMITTENT cause that the failure had been deterministic. The
+                // branch is already named by the log line that precedes this one in either
+                // #handleDeterministicFailure or #handleRetryBudgetExhausted; this line must not
+                // contradict it, so it names the terminal and the cause instead of the branch.
+                log.warn("ALL_OR_NOTHING: {} settled as permanently failed ({}) — rolling back blueprint {}",
                          failedArtifact,
+                         cause,
                          blueprintId.asString());
                 inFlightBlueprints.remove(blueprintId);
                 inflight.previousBlueprint()

--- a/aether/aether-deployment/src/main/java/org/pragmatica/aether/deployment/cluster/fsm/ClusterDeploymentState.java
+++ b/aether/aether-deployment/src/main/java/org/pragmatica/aether/deployment/cluster/fsm/ClusterDeploymentState.java
@@ -1730,8 +1730,8 @@ public sealed interface ClusterDeploymentState extends FsmState<ClusterDeploymen
 
             if (hasActiveInstanceElsewhere(artifact)) {
                 log.warn("Max retries ({}) exceeded for {} on {}: {} — NOT marking permanently failed: "
-                         + "the artifact is ACTIVE on another node, so this is a node-local transient and "
-                         + "reconciliation keeps converging toward the desired instance count",
+                        + "the artifact is ACTIVE on another node, so this is a node-local transient and "
+                        + "reconciliation keeps converging toward the desired instance count",
                          MAX_RETRIES,
                          artifact,
                          sliceKey.nodeId(),
@@ -1787,8 +1787,7 @@ public sealed interface ClusterDeploymentState extends FsmState<ClusterDeploymen
                               .filter(entry -> entry.getKey()
                                                     .artifact()
                                                     .equals(artifact))
-                              .filter(entry -> liveNodes.contains(entry.getKey()
-                                                                       .nodeId()))
+                              .filter(entry -> liveNodes.contains(entry.getKey().nodeId()))
                               .anyMatch(entry -> entry.getValue() == SliceState.ACTIVE);
         }
 

--- a/aether/aether-deployment/src/main/java/org/pragmatica/aether/deployment/cluster/fsm/ClusterDeploymentState.java
+++ b/aether/aether-deployment/src/main/java/org/pragmatica/aether/deployment/cluster/fsm/ClusterDeploymentState.java
@@ -1587,11 +1587,27 @@ public sealed interface ClusterDeploymentState extends FsmState<ClusterDeploymen
                 return;
             }
 
-            permanentlyFailed.add(artifact);
             log.error("Deterministic failure for {} on {}: {} — will NOT retry",
                       artifact,
                       sliceKey.nodeId(),
                       failureReason);
+            settleAsPermanentlyFailed(sliceKey, failureReason);
+        }
+
+        /// The terminal both failure branches converge on: the artifact is marked permanently
+        /// failed, the operator is told, and the declared atomicity is honoured — `ALL_OR_NOTHING`
+        /// rolls the owning blueprint back, `BEST_EFFORT` records a FAILED outcome.
+        ///
+        /// Adding to `permanentlyFailed` is what makes the state terminal, and it is load-bearing
+        /// in two places rather than one: [#reconcileBlueprint] refuses to redeploy the artifact,
+        /// and [#handleSliceNodeRemoval] refuses to schedule the reconcile that would otherwise
+        /// follow the unload every failure already issued. Reaching a failure branch without it
+        /// leaves the artifact re-driven at roughly 1 Hz indefinitely — see
+        /// [#handleRetryBudgetExhausted], which is where that hole was.
+        private void settleAsPermanentlyFailed(SliceNodeKey sliceKey, String failureReason) {
+            var artifact = sliceKey.artifact();
+
+            permanentlyFailed.add(artifact);
             ctx.router()
                .route(DeploymentFailed.deploymentFailed(artifact,
                                                         sliceKey.nodeId(),
@@ -1610,8 +1626,11 @@ public sealed interface ClusterDeploymentState extends FsmState<ClusterDeploymen
         /// path is no longer the only terminal a BEST_EFFORT artifact can reach. A slice that
         /// reaches ACTIVE is retired via `trackBlueprintSliceActive`, whose own terminal is
         /// `recordSucceededOutcome` once every slice of the owning blueprint is active. This
-        /// method is the terminal for the other branch: `handleDeterministicFailure` marks the
-        /// artifact `permanentlyFailed` and calls here instead of retrying it. A slice with no
+        /// method is the terminal for the other branch: [#settleAsPermanentlyFailed] marks the
+        /// artifact `permanentlyFailed` and calls here instead of retrying it. Since #922 that
+        /// reaches here from BOTH failure branches — a deterministic failure, and an intermittent
+        /// one that exhausted its retry budget — not from the deterministic one alone.
+        /// A slice with no
         /// owning blueprint (`Blueprint::owner` empty — a standalone deploy, not part of any
         /// blueprint) has no `DeploymentOutcomeKey` to write against and is correctly a no-op
         /// here. Merges into any existing FAILED record for the same blueprint (read-then-Put,
@@ -1649,7 +1668,7 @@ public sealed interface ClusterDeploymentState extends FsmState<ClusterDeploymen
             var retryCount = retryCounters.merge(sliceKey.asString(), 1, Integer::sum);
 
             if (retryCount > MAX_RETRIES) {
-                logMaxRetriesExceeded(sliceKey, failureReason);
+                handleRetryBudgetExhausted(sliceKey, failureReason);
 
                 return;
             }
@@ -1670,19 +1689,35 @@ public sealed interface ClusterDeploymentState extends FsmState<ClusterDeploymen
             SharedScheduler.schedule(this::reconcile, timeSpan(jitteredMs).millis());
         }
 
-        private void logMaxRetriesExceeded(SliceNodeKey sliceKey, String failureReason) {
-            log.error("Max retries ({}) exceeded for {} on {}: {} — giving up",
+        /// #922 — retry exhaustion is TERMINAL. It previously logged, cleared the
+        /// counter and routed `DeploymentFailed`, then returned, leaving the artifact absent from
+        /// `permanentlyFailed`. That was not a resting state. [#handleSliceFailure] issues an
+        /// unload on every failure; the node's removal of the `NodeArtifactKey` arrives at
+        /// [#handleSliceNodeRemoval], which — finding the artifact not permanently failed —
+        /// scheduled a reconcile 1 s later; [#reconcileBlueprint] is gated by nothing else, so it
+        /// redeployed the artifact and `retryCounters.merge` restarted at 1. An intermittent cause
+        /// that never settles therefore looped at roughly 1 Hz for the life of the cluster: no
+        /// terminal state, no rollback, and consensus round-trips forever.
+        ///
+        /// Settling here bounds every intermittent cause at `MAX_RETRIES` + 1 reported failures and
+        /// makes the `ALL_OR_NOTHING` promise hold on this branch as it already did on the
+        /// deterministic one. The counter is cleared first so a later redeploy of the same artifact
+        /// — which clears `permanentlyFailed` when the blueprint is applied — starts from a clean
+        /// budget rather than inheriting an exhausted one.
+        private void handleRetryBudgetExhausted(SliceNodeKey sliceKey, String failureReason) {
+            var artifact = sliceKey.artifact();
+
+            retryCounters.remove(sliceKey.asString());
+            if (permanentlyFailed.contains(artifact)) {
+                return;
+            }
+
+            log.error("Max retries ({}) exceeded for {} on {}: {} — giving up, marking permanently failed",
                       MAX_RETRIES,
-                      sliceKey.artifact(),
+                      artifact,
                       sliceKey.nodeId(),
                       failureReason);
-            retryCounters.remove(sliceKey.asString());
-            ctx.router()
-               .route(DeploymentFailed.deploymentFailed(sliceKey.artifact(),
-                                                        sliceKey.nodeId(),
-                                                        SliceState.FAILED,
-                                                        failureReason,
-                                                        ctx.nowMs()));
+            settleAsPermanentlyFailed(sliceKey, failureReason);
         }
 
         /// The activation gate for a slice's schema migrations, scoped to the slice's OWN blueprint.

--- a/aether/aether-deployment/src/test/java/org/pragmatica/aether/deployment/cluster/fsm/RetryExhaustionEverActiveTest.java
+++ b/aether/aether-deployment/src/test/java/org/pragmatica/aether/deployment/cluster/fsm/RetryExhaustionEverActiveTest.java
@@ -265,6 +265,85 @@ class RetryExhaustionEverActiveTest {
                 .doesNotContain(SLICE);
     }
 
+    /// Leg 1 in isolation: a leader that inherited a LIVE instance it never watched start.
+    ///
+    /// This is failover in the middle of a deployment — some instance is ACTIVE, but the blueprint
+    /// never retired, so no SUCCEEDED record exists and `everActiveArtifacts` is empty on the new
+    /// leader. `rebuildSliceStateFromKVStoreEntries` restores the ACTIVE slice state directly,
+    /// without going through `handleSliceActive`, so leg 1 is the only leg that can answer and the
+    /// artifact must not be condemned.
+    @Test
+    void aRestoredActiveInstance_isEnoughOnALeaderThatNeverWatchedItStart() {
+        var expanded = blueprint();
+        var newLeaderCluster = new RecordingClusterNode(SELF);
+        var newLeaderStore = freshStore();
+
+        // No DeploymentOutcomeKey entry: this deployment never finished, so leg 3 cannot answer.
+        seed(newLeaderStore,
+             new KVCommand.Put<>(SliceTargetKey.sliceTargetKey(SLICE.base()),
+                                 SliceTargetValue.sliceTargetValue(SLICE.version(), 3, Option.some(expanded.id()))),
+             new KVCommand.Put<>(NodeArtifactKey.nodeArtifactKey(NODE_A, SLICE), activeInstance()));
+
+        var harness = leaderHarness(newLeaderCluster, newLeaderStore, RESOLVED_MEMBERSHIP);
+        var active = (ClusterDeploymentState.Active) harness.state();
+
+        assertThat(active.everActiveArtifacts())
+                .as("precondition: this leader never watched the artifact start")
+                .isEmpty();
+        assertThat(active.sliceStates())
+                .as("precondition: but it inherited a live instance from the previous one")
+                .containsEntry(SliceNodeKey.sliceNodeKey(SLICE, NODE_A), SliceState.ACTIVE);
+
+        for (var report = 1; report <= TERMINAL_ON_REPORT; report++) {
+            harness.dispatch(new NodeArtifactPutReceived(replayOn(SELF, intermittentFailure())));
+        }
+
+        assertThat(active.permanentlyFailed())
+                .as("an instance that is ACTIVE right now is evidence enough on its own")
+                .doesNotContain(SLICE);
+    }
+
+    /// The other half of the anti-livelock boundary: a durable SUCCEEDED record describes the
+    /// attempt that WROTE it, and must not vote for the attempt currently in flight.
+    ///
+    /// Nothing removes a `DeploymentOutcomeKey` entry when a blueprint id is re-applied, so a
+    /// re-used id whose new load order carries a slice that never existed before would otherwise
+    /// hand that brand-new slice the previous attempt's success and it would never settle. Inputs
+    /// are identical to `durableSucceededOutcome_isEnoughOnANewLeaderWithNoInMemoryEvidence` apart
+    /// from the blueprint being put in flight, and the expectations are opposite — so the pair
+    /// discriminates the suppression on its own.
+    @Test
+    void aDurableSucceededOutcome_doesNotVoteForTheAttemptStillInFlight() {
+        var expanded = blueprint();
+        var newLeaderCluster = new RecordingClusterNode(SELF);
+        var newLeaderStore = freshStore();
+
+        seed(newLeaderStore,
+             new KVCommand.Put<>(SliceTargetKey.sliceTargetKey(SLICE.base()),
+                                 SliceTargetValue.sliceTargetValue(SLICE.version(), 3, Option.some(expanded.id()))),
+             new KVCommand.Put<>(DeploymentOutcomeKey.deploymentOutcomeKey(expanded.id()),
+                                 DeploymentOutcomeValue.succeeded(1L)));
+
+        var harness = leaderHarness(newLeaderCluster, newLeaderStore, RESOLVED_MEMBERSHIP);
+
+        // The blueprint id is applied again — a NEW attempt, against a record written by the old one.
+        harness.dispatch(new AppBlueprintPutReceived(appBlueprintPut(expanded)));
+
+        var active = (ClusterDeploymentState.Active) harness.state();
+
+        assertThat(active.everActiveArtifacts())
+                .as("precondition: the in-memory legs are silent, so only the durable record could vote")
+                .isEmpty();
+
+        for (var report = 1; report <= TERMINAL_ON_REPORT; report++) {
+            harness.dispatch(new NodeArtifactPutReceived(replayOn(SELF, intermittentFailure())));
+        }
+
+        assertThat(active.permanentlyFailed())
+                .as("a record describing the PREVIOUS attempt must not keep the current one alive")
+                .contains(SLICE);
+    }
+
     /// The anti-livelock boundary. "Ever reached ACTIVE" must be scoped to the deployment it
     /// describes, or a coordinate that ran once and has since become unfetchable would be re-driven
     /// forever on every LATER deployment — #922 reopened through the guard meant to bound it. The

--- a/aether/aether-deployment/src/test/java/org/pragmatica/aether/deployment/cluster/fsm/RetryExhaustionEverActiveTest.java
+++ b/aether/aether-deployment/src/test/java/org/pragmatica/aether/deployment/cluster/fsm/RetryExhaustionEverActiveTest.java
@@ -1,0 +1,504 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2025 Pragmatica Labs - Sergiy Yevtushenko
+// Licensed under Business Source License 1.1. Change Date: 2030-01-01. Change License: Apache-2.0.
+// See LICENSE in the repository root for full terms.
+package org.pragmatica.aether.deployment.cluster.fsm;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.pragmatica.aether.artifact.Artifact;
+import org.pragmatica.aether.deployment.cluster.ClusterDeploymentManager.DeploymentAtomicity;
+import org.pragmatica.aether.deployment.cluster.fsm.ClusterDeploymentEvents.Activate;
+import org.pragmatica.aether.deployment.cluster.fsm.ClusterDeploymentEvents.AppBlueprintPutReceived;
+import org.pragmatica.aether.deployment.cluster.fsm.ClusterDeploymentEvents.AppBlueprintRemoveReceived;
+import org.pragmatica.aether.deployment.cluster.fsm.ClusterDeploymentEvents.NodeArtifactPutReceived;
+import org.pragmatica.aether.deployment.cluster.fsm.ClusterDeploymentEvents.SliceTargetPutReceived;
+import org.pragmatica.aether.deployment.membership.fsm.MembershipFsm;
+import org.pragmatica.aether.deployment.schema.SchemaOrchestratorService;
+import org.pragmatica.aether.slice.SliceState;
+import org.pragmatica.aether.slice.blueprint.BlueprintId;
+import org.pragmatica.aether.slice.blueprint.ExpandedBlueprint;
+import org.pragmatica.aether.slice.blueprint.ResolvedSlice;
+import org.pragmatica.aether.slice.kvstore.AetherKey;
+import org.pragmatica.aether.slice.kvstore.AetherKey.AppBlueprintKey;
+import org.pragmatica.aether.slice.kvstore.AetherKey.DeploymentOutcomeKey;
+import org.pragmatica.aether.slice.kvstore.AetherKey.NodeArtifactKey;
+import org.pragmatica.aether.slice.kvstore.AetherKey.SliceNodeKey;
+import org.pragmatica.aether.slice.kvstore.AetherKey.SliceTargetKey;
+import org.pragmatica.aether.slice.kvstore.AetherValue;
+import org.pragmatica.aether.slice.kvstore.AetherValue.AppBlueprintValue;
+import org.pragmatica.aether.slice.kvstore.AetherValue.DeploymentOutcomeValue;
+import org.pragmatica.aether.slice.kvstore.AetherValue.NodeArtifactValue;
+import org.pragmatica.aether.slice.kvstore.AetherValue.SliceTargetValue;
+import org.pragmatica.cluster.node.ClusterNode;
+import org.pragmatica.cluster.state.kvstore.KVCommand;
+import org.pragmatica.cluster.state.kvstore.KVStore;
+import org.pragmatica.cluster.state.kvstore.KVStoreNotification.ValuePut;
+import org.pragmatica.cluster.state.kvstore.KVStoreNotification.ValueRemove;
+import org.pragmatica.consensus.NodeId;
+import org.pragmatica.consensus.fsm.ClusterFsmEvent;
+import org.pragmatica.consensus.net.NodeInfo;
+import org.pragmatica.consensus.topology.NodeState;
+import org.pragmatica.consensus.topology.TopologyManager;
+import org.pragmatica.lang.Option;
+import org.pragmatica.lang.Promise;
+import org.pragmatica.lang.Unit;
+import org.pragmatica.lang.io.CoreError;
+import org.pragmatica.lang.io.TimeSpan;
+import org.pragmatica.messaging.MessageRouter;
+import org.pragmatica.net.tcp.NodeAddress;
+import org.pragmatica.serialization.Deserializer;
+import org.pragmatica.serialization.Serializer;
+import org.pragmatica.statemachine.Fsm;
+import org.pragmatica.statemachine.FsmTestHarness;
+
+import java.net.SocketAddress;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.function.LongSupplier;
+import java.util.function.Supplier;
+
+import io.netty.buffer.ByteBuf;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.pragmatica.lang.io.TimeSpan.timeSpan;
+
+/// #924 review round 2, BLOCKING — retry exhaustion must discriminate on whether the artifact EVER
+/// reached ACTIVE, not on whether it is ACTIVE right now.
+///
+/// The round-1 fix asked the present-tense question, and `handleSliceFailure` removes the failing
+/// key from `sliceStates` before either failure branch runs. So the guard could only ever protect a
+/// transient confined to a strict SUBSET of instances. Two shapes escaped it, both previously
+/// healthy, both silently condemned cluster-wide and permanently with their last outcome record
+/// still reading SUCCEEDED, and both of which self-healed before #922:
+///
+///   - a shared downstream dependency, which by construction reaches every replica at once;
+///   - every `instances = 1` slice, which has no sibling that could ever vote for it and for which
+///     the guard is therefore structurally unreachable.
+///
+/// Assertions here read `Active.permanentlyFailed()` directly. `Active` is a record, so the accessor
+/// IS the terminal — not an inference from command counts, which cannot tell "not condemned" from
+/// "condemned but the rollback matched nothing".
+///
+/// The first four tests are the round-2 verification probe adopted verbatim in scenario and
+/// assertion. Two of them are POLARITY CONTROLS and they are as load-bearing as the probes: without
+/// `control_neverActiveAnywhere` a fix that simply never settles passes everything, and without
+/// `control_siblingStaysActive` the round-1 guarantee could silently regress. The remaining three
+/// pin the legs and the guard that the probe does not reach.
+class RetryExhaustionEverActiveTest {
+    private static final NodeId SELF = new NodeId("node-self");
+    private static final NodeId NODE_A = new NodeId("node-a");
+    private static final Artifact SLICE = Artifact.artifact("com.example:slice-a:1.0.0").unwrap();
+
+    /// `ClusterDeploymentState.Active.MAX_RETRIES` is private; 5 retries means the SIXTH reported
+    /// failure is the one that spends the budget.
+    private static final int TERMINAL_ON_REPORT = 6;
+
+    private static final Supplier<Set<NodeId>> RESOLVED_MEMBERSHIP = () -> Set.of(SELF, NODE_A);
+
+    private RecordingClusterNode leaderSideCluster;
+    private FsmTestHarness<ClusterDeploymentState, ClusterFsmEvent> leaderHarness;
+
+    @BeforeEach
+    void setUp() {
+        leaderSideCluster = new RecordingClusterNode(SELF);
+        leaderHarness = leaderHarness(leaderSideCluster, freshStore(), RESOLVED_MEMBERSHIP);
+    }
+
+    /// CONTROL 1 (negative polarity): a deployment ATTEMPT that never reached ACTIVE anywhere MUST
+    /// settle. If this does not settle, the suite cannot observe settling at all and every other
+    /// result here is meaningless. This is #922's own population.
+    @Test
+    void control_neverActiveAnywhere_doesSettlePermanentlyFailed() {
+        var expanded = blueprint();
+
+        leaderHarness.dispatch(new AppBlueprintPutReceived(appBlueprintPut(expanded)));
+        for (var report = 1; report <= TERMINAL_ON_REPORT; report++) {
+            leaderHarness.dispatch(new NodeArtifactPutReceived(replayOn(SELF, intermittentFailure())));
+        }
+
+        var active = (ClusterDeploymentState.Active) leaderHarness.state();
+
+        assertThat(active.permanentlyFailed())
+                .as("instrument check: the #922 population MUST still settle")
+                .contains(SLICE);
+    }
+
+    /// CONTROL 2 (positive polarity): the round-1 scenario. A sibling instance stays ACTIVE, so
+    /// exhaustion on ONE node must not settle.
+    @Test
+    void control_siblingStaysActive_doesNotSettle() {
+        var expanded = blueprint();
+
+        leaderHarness.dispatch(new AppBlueprintPutReceived(appBlueprintPut(expanded)));
+        leaderHarness.dispatch(new NodeArtifactPutReceived(replayOn(NODE_A, activeInstance())));
+        leaderHarness.dispatch(new NodeArtifactPutReceived(replayOn(SELF, activeInstance())));
+
+        var active = (ClusterDeploymentState.Active) leaderHarness.state();
+
+        assertThat(active.getCurrentInstances(SLICE)).hasSize(2);
+        for (var report = 1; report <= TERMINAL_ON_REPORT; report++) {
+            leaderHarness.dispatch(new NodeArtifactPutReceived(replayOn(SELF, intermittentFailure())));
+        }
+
+        assertThat(active.permanentlyFailed())
+                .as("a node-local transient must not condemn the artifact")
+                .doesNotContain(SLICE);
+    }
+
+    /// Same previously-healthy, fully-deployed artifact as CONTROL 2, but the transient is a SHARED
+    /// DOWNSTREAM DEPENDENCY — the exact cause round 1 named. Such a cause reaches EVERY instance by
+    /// construction, so node-a's instance fails too and no sibling is left to vote.
+    @Test
+    void clusterWideTransient_onPreviouslyHealthyDeployment_doesNotSettle() {
+        var expanded = blueprint();
+
+        leaderHarness.dispatch(new AppBlueprintPutReceived(appBlueprintPut(expanded)));
+        leaderHarness.dispatch(new NodeArtifactPutReceived(replayOn(NODE_A, activeInstance())));
+        leaderHarness.dispatch(new NodeArtifactPutReceived(replayOn(SELF, activeInstance())));
+
+        var active = (ClusterDeploymentState.Active) leaderHarness.state();
+
+        assertThat(active.getCurrentInstances(SLICE))
+                .as("precondition: RUNNING on both nodes, blueprint retired, SUCCEEDED written")
+                .hasSize(2);
+
+        // The shared dependency goes down. node-a's instance reports the same intermittent cause.
+        leaderHarness.dispatch(new NodeArtifactPutReceived(replayOn(NODE_A, intermittentFailure())));
+        // SELF's instance keeps reporting it until its per-node budget is spent.
+        for (var report = 1; report <= TERMINAL_ON_REPORT; report++) {
+            leaderHarness.dispatch(new NodeArtifactPutReceived(replayOn(SELF, intermittentFailure())));
+        }
+
+        leaderSideCluster.commands.clear();
+        active.reconcile();
+
+        assertThat(active.permanentlyFailed())
+                .as("a previously-healthy, fully-deployed artifact hit by a SHARED transient must not "
+                    + "be condemned cluster-wide and permanently")
+                .doesNotContain(SLICE);
+        assertThat(leaderSideCluster.commandKeysFor(SLICE))
+                .as("and reconciliation must still be emitting work for it — a silent terminal is the "
+                    + "harm, not merely the permanentlyFailed entry")
+                .isNotEmpty();
+    }
+
+    /// No shared dependency needed. A SINGLE-INSTANCE slice — the most common shape there is —
+    /// deployed and ACTIVE on its one node, whose own node suffers a transient longer than the
+    /// budget. There is no sibling to vote for it, so a present-tense guard is structurally
+    /// unreachable for this configuration.
+    @Test
+    void singleInstanceSlice_transientOnItsOnlyNode_doesNotSettle() {
+        var expanded = singleInstanceBlueprint();
+
+        leaderHarness.dispatch(new AppBlueprintPutReceived(appBlueprintPut(expanded)));
+        leaderHarness.dispatch(new NodeArtifactPutReceived(replayOn(SELF, activeInstance())));
+
+        var active = (ClusterDeploymentState.Active) leaderHarness.state();
+
+        assertThat(active.getCurrentInstances(SLICE))
+                .as("precondition: the single desired instance is RUNNING")
+                .hasSize(1);
+
+        for (var report = 1; report <= TERMINAL_ON_REPORT; report++) {
+            leaderHarness.dispatch(new NodeArtifactPutReceived(replayOn(SELF, intermittentFailure())));
+        }
+
+        leaderSideCluster.commands.clear();
+        active.reconcile();
+
+        assertThat(active.permanentlyFailed())
+                .as("a healthy single-instance workload must not be permanently condemned by a "
+                    + "transient on its own node")
+                .doesNotContain(SLICE);
+        assertThat(leaderSideCluster.commandKeysFor(SLICE))
+                .as("and reconciliation must still be emitting work for it")
+                .isNotEmpty();
+    }
+
+    /// The DURABLE leg, in isolation, on a leader that has never watched this artifact run.
+    ///
+    /// This is the failover case, and it is why the discriminator is not merely in-memory
+    /// bookkeeping. Nothing is ACTIVE in the rebuilt slice state and `everActiveArtifacts` starts
+    /// empty on a new leader, so the ONLY evidence available is the `SUCCEEDED` outcome record the
+    /// previous leader wrote — read back through `blueprintDeploymentSucceeded`. Deleting the
+    /// durable leg leaves the other two unable to answer, and the artifact settles.
+    @Test
+    void durableSucceededOutcome_isEnoughOnANewLeaderWithNoInMemoryEvidence() {
+        var expanded = blueprint();
+        var newLeaderCluster = new RecordingClusterNode(SELF);
+        var newLeaderStore = freshStore();
+
+        // Exactly what a new leader finds in the KV-Store: the slice target, which is what
+        // repopulates the artifact -> owning-blueprint map, and the terminal outcome of the
+        // deployment that already completed under the previous leader.
+        seed(newLeaderStore,
+             new KVCommand.Put<>(SliceTargetKey.sliceTargetKey(SLICE.base()),
+                                 SliceTargetValue.sliceTargetValue(SLICE.version(), 3, Option.some(expanded.id()))),
+             new KVCommand.Put<>(DeploymentOutcomeKey.deploymentOutcomeKey(expanded.id()),
+                                 DeploymentOutcomeValue.succeeded(1L)));
+
+        var harness = leaderHarness(newLeaderCluster, newLeaderStore, RESOLVED_MEMBERSHIP);
+        var active = (ClusterDeploymentState.Active) harness.state();
+
+        // `getCurrentInstances` is the WRONG instrument for this precondition: it filters on
+        // `isLiveState`, so the instances `Active.onEntry`'s own reconcile has just allocated count
+        // toward it while being nowhere near ACTIVE. Both in-memory legs are asserted directly.
+        assertThat(active.everActiveArtifacts())
+                .as("precondition: this leader has never watched the artifact run")
+                .isEmpty();
+        assertThat(statesOf(active, SLICE))
+                .as("precondition: nothing is ACTIVE in the rebuilt slice state either")
+                .doesNotContain(SliceState.ACTIVE);
+
+        for (var report = 1; report <= TERMINAL_ON_REPORT; report++) {
+            harness.dispatch(new NodeArtifactPutReceived(replayOn(SELF, intermittentFailure())));
+        }
+
+        assertThat(active.permanentlyFailed())
+                .as("the durable SUCCEEDED record is the only evidence a new leader has that this "
+                    + "artifact ever ran, and it must be enough")
+                .doesNotContain(SLICE);
+    }
+
+    /// The anti-livelock boundary. "Ever reached ACTIVE" must be scoped to the deployment it
+    /// describes, or a coordinate that ran once and has since become unfetchable would be re-driven
+    /// forever on every LATER deployment — #922 reopened through the guard meant to bound it. The
+    /// boundary is the artifact leaving the cluster's desired state, which is
+    /// `issueDeallocationCommands`; it is deliberately NOT a re-apply of the same blueprint, since
+    /// clearing on re-apply would put a healthy running workload back one transient away from the
+    /// silent condemnation the tests above pin.
+    @Test
+    void aLaterDeploymentOfARemovedCoordinate_stillSettles() {
+        var expanded = blueprint();
+
+        leaderHarness.dispatch(new AppBlueprintPutReceived(appBlueprintPut(expanded)));
+        leaderHarness.dispatch(new SliceTargetPutReceived(sliceTargetPut(expanded.id())));
+        leaderHarness.dispatch(new NodeArtifactPutReceived(replayOn(SELF, activeInstance())));
+
+        var active = (ClusterDeploymentState.Active) leaderHarness.state();
+
+        assertThat(active.sliceStates()).containsEntry(SliceNodeKey.sliceNodeKey(SLICE, SELF), SliceState.ACTIVE);
+        assertThat(active.everActiveArtifacts())
+                .as("precondition: the artifact reached ACTIVE, so the evidence exists to be forgotten")
+                .contains(SLICE);
+
+        // The artifact leaves the cluster's desired state.
+        leaderHarness.dispatch(new AppBlueprintRemoveReceived(appBlueprintRemove(expanded.id())));
+
+        assertThat(active.everActiveArtifacts())
+                .as("the deallocation seam is where the evidence is forgotten")
+                .doesNotContain(SLICE);
+
+        // A later, independent deployment of the same coordinate, which never comes up.
+        leaderHarness.dispatch(new AppBlueprintPutReceived(appBlueprintPut(expanded)));
+        for (var report = 1; report <= TERMINAL_ON_REPORT; report++) {
+            leaderHarness.dispatch(new NodeArtifactPutReceived(replayOn(SELF, intermittentFailure())));
+        }
+
+        assertThat(active.permanentlyFailed())
+                .as("evidence from a removed deployment must not keep a later one alive")
+                .contains(SLICE);
+    }
+
+    /// #924 review round 2, S2 — the settle must not be taken on an unresolved member set.
+    ///
+    /// During the boot window the core-membership supplier yields `MEMBERSHIP_NOT_WIRED`, an empty
+    /// set distinguished only by reference identity, so every node fails `contains` and every
+    /// artifact looks abandoned. The inputs here are IDENTICAL to `control_neverActiveAnywhere`,
+    /// which settles; the single difference is the member set, so the pair discriminates the guard
+    /// on its own. Refusing to settle costs a re-drive the next exhaustion re-decides; settling on
+    /// an unresolved read is irreversible.
+    @Test
+    void unresolvedCoreMembership_doesNotSettle() {
+        var expanded = blueprint();
+        var bootCluster = new RecordingClusterNode(SELF);
+        var harness = leaderHarness(bootCluster, freshStore(), () -> MembershipFsm.MEMBERSHIP_NOT_WIRED);
+
+        harness.dispatch(new AppBlueprintPutReceived(appBlueprintPut(expanded)));
+        for (var report = 1; report <= TERMINAL_ON_REPORT; report++) {
+            harness.dispatch(new NodeArtifactPutReceived(replayOn(SELF, intermittentFailure())));
+        }
+
+        var active = (ClusterDeploymentState.Active) harness.state();
+
+        assertThat(active.permanentlyFailed())
+                .as("an unresolved member set is not evidence of anything, and this verdict is one-way")
+                .doesNotContain(SLICE);
+    }
+
+    private static List<SliceState> statesOf(ClusterDeploymentState.Active active, Artifact artifact) {
+        return active.sliceStates()
+                     .entrySet()
+                     .stream()
+                     .filter(entry -> entry.getKey().artifact().equals(artifact))
+                     .map(Map.Entry::getValue)
+                     .toList();
+    }
+
+    private static KVStore<AetherKey, AetherValue> freshStore() {
+        return new KVStore<>(MessageRouter.mutable(), stubSerializer(), stubDeserializer());
+    }
+
+    @SafeVarargs
+    private static void seed(KVStore<AetherKey, AetherValue> store, KVCommand<AetherKey>... commands) {
+        var batch = List.of(commands);
+
+        store.process(store.createBatch(batch));
+    }
+
+    private static ExpandedBlueprint singleInstanceBlueprint() {
+        var id = BlueprintId.blueprintId("com.example:app:1.0.0").unwrap();
+        var slice = ResolvedSlice.resolvedSlice(SLICE, 1, false).unwrap();
+
+        return ExpandedBlueprint.expandedBlueprint(id, List.of(slice));
+    }
+
+    private static NodeArtifactValue activeInstance() {
+        return NodeArtifactValue.activeNodeArtifactValue(0, List.of());
+    }
+
+    private static ValuePut<NodeArtifactKey, NodeArtifactValue> replayOn(NodeId node, NodeArtifactValue value) {
+        var key = NodeArtifactKey.nodeArtifactKey(node, SLICE);
+
+        return new ValuePut<>(new KVCommand.Put<>(key, value), Option.none());
+    }
+
+    private static NodeArtifactValue intermittentFailure() {
+        return NodeArtifactValue.failedNodeArtifactValue(new CoreError.Timeout("downstream dependency restarting"));
+    }
+
+    private static ValuePut<AppBlueprintKey, AppBlueprintValue> appBlueprintPut(ExpandedBlueprint expanded) {
+        var key = AppBlueprintKey.appBlueprintKey(expanded.id());
+
+        return new ValuePut<>(new KVCommand.Put<>(key, AppBlueprintValue.appBlueprintValue(expanded)), Option.none());
+    }
+
+    private static ValueRemove<AppBlueprintKey, AppBlueprintValue> appBlueprintRemove(BlueprintId blueprintId) {
+        var key = AppBlueprintKey.appBlueprintKey(blueprintId);
+
+        return new ValueRemove<>(new KVCommand.Remove<>(key), Option.none());
+    }
+
+    private static ValuePut<SliceTargetKey, SliceTargetValue> sliceTargetPut(BlueprintId owner) {
+        var key = SliceTargetKey.sliceTargetKey(SLICE.base());
+        var value = SliceTargetValue.sliceTargetValue(SLICE.version(), 3, Option.some(owner));
+
+        return new ValuePut<>(new KVCommand.Put<>(key, value), Option.none());
+    }
+
+    private static ExpandedBlueprint blueprint() {
+        var id = BlueprintId.blueprintId("com.example:app:1.0.0").unwrap();
+        var slice = ResolvedSlice.resolvedSlice(SLICE, 3, false).unwrap();
+
+        return ExpandedBlueprint.expandedBlueprint(id, List.of(slice));
+    }
+
+    private static FsmTestHarness<ClusterDeploymentState, ClusterFsmEvent> leaderHarness(ClusterNode<KVCommand<AetherKey>> cluster,
+                                                                                        KVStore<AetherKey, AetherValue> kvStore,
+                                                                                        Supplier<Set<NodeId>> coreMembers) {
+        var router = MessageRouter.mutable();
+        LongSupplier clock = () -> 10_000_000L;
+        Function<Fsm<ClusterDeploymentState, ClusterFsmEvent>, ClusterDeploymentState> factory =
+                fsm -> new ClusterDeploymentContext(fsm,
+                                                    SELF,
+                                                    cluster,
+                                                    kvStore,
+                                                    router,
+                                                    stubTopologyManager(SELF),
+                                                    stubSchemaOrchestrator(),
+                                                    coreMembers,
+                                                    () -> Set.of(SELF, NODE_A),
+                                                    Set::of,
+                                                    Set.of(SELF, NODE_A),
+                                                    DeploymentAtomicity.ALL_OR_NOTHING,
+                                                    3,
+                                                    timeSpan(300).seconds(),
+                                                    clock).dormant();
+        var harness = FsmTestHarness.<ClusterDeploymentState, ClusterFsmEvent>harness("ever-active-924-" + SELF.id(), factory);
+
+        harness.dispatch(new Activate());
+
+        return harness;
+    }
+
+    private static final class RecordingClusterNode implements ClusterNode<KVCommand<AetherKey>> {
+        private final NodeId self;
+        private final List<KVCommand<AetherKey>> commands = Collections.synchronizedList(new ArrayList<>());
+
+        private RecordingClusterNode(NodeId self) {this.self = self;}
+
+        @Override public NodeId self() {return self;}
+
+        @Override public TopologyManager topologyManager() {return stubTopologyManager(self);}
+
+        @Override public Promise<Unit> start() {return Promise.unitPromise();}
+
+        @Override public Promise<Unit> stop() {return Promise.unitPromise();}
+
+        @Override public <R> Promise<List<R>> apply(List<KVCommand<AetherKey>> batch) {
+            commands.addAll(batch);
+
+            return Promise.success(Collections.emptyList());
+        }
+
+        private List<AetherKey> commandKeysFor(Artifact artifact) {
+            synchronized (commands) {
+                return commands.stream()
+                               .map(KVCommand::key)
+                               .filter(key -> key.asString().contains(artifact.asString()))
+                               .toList();
+            }
+        }
+    }
+
+    private static SchemaOrchestratorService stubSchemaOrchestrator() {
+        return new SchemaOrchestratorService() {
+            @Override public Promise<Unit> migrateIfNeeded(String datasourceName) {return Promise.success(Unit.unit());}
+
+            @Override public Promise<Unit> undoTo(String datasourceName, int targetVersion) {return Promise.success(Unit.unit());}
+
+            @Override public Promise<Unit> baseline(String datasourceName, int version) {return Promise.success(Unit.unit());}
+        };
+    }
+
+    private static TopologyManager stubTopologyManager(NodeId self) {
+        return new TopologyManager() {
+            @Override public NodeInfo self() {return NodeInfo.nodeInfo(self, new NodeAddress("localhost", 9000));}
+
+            @Override public Option<NodeInfo> get(NodeId id) {return Option.some(NodeInfo.nodeInfo(id, new NodeAddress("localhost", 9000)));}
+
+            @Override public int clusterSize() {return 2;}
+
+            @Override public Option<NodeId> reverseLookup(SocketAddress socketAddress) {return Option.empty();}
+
+            @Override public Promise<Unit> start() {return Promise.unitPromise();}
+
+            @Override public Promise<Unit> stop() {return Promise.unitPromise();}
+
+            @Override public TimeSpan pingInterval() {return timeSpan(5).seconds();}
+
+            @Override public TimeSpan helloTimeout() {return timeSpan(5).seconds();}
+
+            @Override public Option<NodeState> getState(NodeId id) {return Option.empty();}
+
+            @Override public List<NodeId> topology() {return List.of(self);}
+        };
+    }
+
+    private static Serializer stubSerializer() {
+        return new Serializer() {
+            @Override public <T> void write(ByteBuf byteBuf, T object) {}
+        };
+    }
+
+    private static Deserializer stubDeserializer() {
+        return new Deserializer() {
+            @Override public <T> T read(ByteBuf byteBuf) {return null;}
+        };
+    }
+}

--- a/aether/aether-deployment/src/test/java/org/pragmatica/aether/deployment/cluster/fsm/RetryExhaustionTerminalTest.java
+++ b/aether/aether-deployment/src/test/java/org/pragmatica/aether/deployment/cluster/fsm/RetryExhaustionTerminalTest.java
@@ -19,8 +19,10 @@ import org.pragmatica.aether.slice.kvstore.AetherKey;
 import org.pragmatica.aether.slice.kvstore.AetherKey.AppBlueprintKey;
 import org.pragmatica.aether.slice.kvstore.AetherKey.DeploymentOutcomeKey;
 import org.pragmatica.aether.slice.kvstore.AetherKey.NodeArtifactKey;
+import org.pragmatica.aether.slice.kvstore.AetherKey.SliceNodeKey;
 import org.pragmatica.aether.slice.kvstore.AetherValue;
 import org.pragmatica.aether.slice.kvstore.AetherValue.AppBlueprintValue;
+import org.pragmatica.aether.slice.kvstore.AetherValue.DeploymentOutcomeStatus;
 import org.pragmatica.aether.slice.kvstore.AetherValue.DeploymentOutcomeValue;
 import org.pragmatica.aether.slice.kvstore.AetherValue.NodeArtifactValue;
 import org.pragmatica.cluster.node.ClusterNode;
@@ -174,6 +176,108 @@ class RetryExhaustionTerminalTest {
                     + "can read, not an unrecorded disappearance")
                 .isNotEmpty()
                 .allSatisfy(outcome -> assertThat(outcome.failingSlices()).contains(SLICE.asString()));
+    }
+
+    /// #924 review, BLOCKING — the reverse risk, and the reason the terminal needed a scope.
+    ///
+    /// `settleAsPermanentlyFailed` was lifted from the DETERMINISTIC branch, where a cluster-wide
+    /// inference is sound: a deterministic failure is node-independent, so failing on one node does
+    /// mean the artifact is bad everywhere. That inference does not transfer to the transient
+    /// branch — a transient failure on node A says nothing about node B. Carrying it across is the
+    /// actual defect: `retryCounters` is per artifact AND node, while `permanentlyFailed` is a
+    /// cluster-wide `Set<Artifact>`.
+    ///
+    /// Its consequence is worse than the livelock it replaced. The livelock was noisy and kept
+    /// trying; this is silent and terminal on a deployment that had been healthy. The blueprint has
+    /// already left `inFlightBlueprints`, so `rollbackBlueprintForArtifact` matches nothing, no
+    /// FAILED outcome is written, and the artifact's last recorded outcome still reads SUCCEEDED
+    /// while reconcile quietly refuses to replace the lost instance forever.
+    ///
+    /// **This asserts the RECOVERY, not the absence of a rollback.** "No rollback happened" is
+    /// equally true of a system that has silently stopped doing anything, which is precisely the
+    /// bug — so it would pin nothing. What is asserted instead is that reconciliation still
+    /// re-drives the artifact after exhaustion, and that the lost instance actually comes back.
+    @Test
+    void exhaustionOnOneNode_whileTheArtifactIsActiveElsewhere_stillRecoversTheLostInstance() {
+        var expanded = blueprint();
+        var active = deployOnBothNodesThenExhaustSelf(expanded);
+
+        assertThat(active.getCurrentInstances(SLICE))
+                .as("the instance on NODE_A never failed and must survive a sibling node's exhausted "
+                    + "budget — a cluster-wide terminal would have condemned the whole artifact")
+                .extracting(SliceNodeKey::nodeId)
+                .contains(NODE_A);
+
+        leaderSideCluster.commands.clear();
+        active.reconcile();
+
+        assertThat(leaderSideCluster.commandKeysFor(SLICE))
+                .as("#924: after the per-node budget is spent on ONE node, reconciliation must still "
+                    + "act on the artifact. Empty here is the wedge: auto-heal, rebalancing and "
+                    + "scale-up dead forever, with the standing outcome record still reading "
+                    + "SUCCEEDED and nothing written to say otherwise")
+                .isNotEmpty();
+
+        // The transient clears and the node reports the slice up again.
+        leaderHarness.dispatch(new NodeArtifactPutReceived(replayOn(SELF, activeInstance())));
+
+        assertThat(active.getCurrentInstances(SLICE))
+                .as("recovery, stated positively: once the transient clears the artifact is deployable "
+                    + "again and runs on BOTH nodes. This is the assertion a silently-wedged cluster "
+                    + "cannot satisfy")
+                .extracting(SliceNodeKey::nodeId)
+                .containsExactlyInAnyOrder(SELF, NODE_A);
+    }
+
+    /// Consistency check accompanying the pin above rather than a second pin: the standing outcome
+    /// record must not be contradicted. Deliberately NOT load-bearing — a wedged cluster also writes
+    /// no FAILED record, so this cannot discriminate on its own and is not relied on to.
+    @Test
+    void exhaustionOnOneNode_whileTheArtifactIsActiveElsewhere_leavesTheSucceededOutcomeStanding() {
+        var expanded = blueprint();
+
+        deployOnBothNodesThenExhaustSelf(expanded);
+
+        assertThat(leaderSideCluster.outcomeFor(expanded.id()))
+                .as("the blueprint genuinely did deploy, so its outcome record must still say so")
+                .isNotEmpty()
+                .allSatisfy(outcome -> assertThat(outcome.status())
+                        .isEqualTo(DeploymentOutcomeStatus.SUCCEEDED));
+    }
+
+    /// Drives the blueprint to fully deployed on both nodes — which retires it from
+    /// `inFlightBlueprints` and writes SUCCEEDED — then spends the entire retry budget on SELF with
+    /// an intermittent cause, leaving NODE_A untouched.
+    private ClusterDeploymentState.Active deployOnBothNodesThenExhaustSelf(ExpandedBlueprint expanded) {
+        leaderHarness.dispatch(new AppBlueprintPutReceived(appBlueprintPut(expanded)));
+        leaderHarness.dispatch(new NodeArtifactPutReceived(replayOn(NODE_A, activeInstance())));
+        leaderHarness.dispatch(new NodeArtifactPutReceived(replayOn(SELF, activeInstance())));
+
+        var active = (ClusterDeploymentState.Active) leaderHarness.state();
+
+        assertThat(active.getCurrentInstances(SLICE))
+                .as("precondition: the artifact must be RUNNING on both nodes before the transient. "
+                    + "Without it this degenerates into the never-succeeded case the pins above "
+                    + "already cover, and would pass against the very defect it exists to catch")
+                .hasSize(2);
+
+        for (var report = 1; report <= TERMINAL_ON_REPORT; report++) {
+            leaderHarness.dispatch(new NodeArtifactPutReceived(replayOn(SELF, intermittentFailure())));
+        }
+
+        return active;
+    }
+
+    /// A slice instance reported ACTIVE. `methods` is empty deliberately — these tests care that the
+    /// state is ACTIVE, not that the instance published endpoints.
+    private static NodeArtifactValue activeInstance() {
+        return NodeArtifactValue.activeNodeArtifactValue(0, List.of());
+    }
+
+    private static ValuePut<NodeArtifactKey, NodeArtifactValue> replayOn(NodeId node, NodeArtifactValue value) {
+        var key = NodeArtifactKey.nodeArtifactKey(node, SLICE);
+
+        return new ValuePut<>(new KVCommand.Put<>(key, value), Option.none());
     }
 
     /// A failure the leader is REQUIRED to treat as retryable, built from a cause that was already

--- a/aether/aether-deployment/src/test/java/org/pragmatica/aether/deployment/cluster/fsm/RetryExhaustionTerminalTest.java
+++ b/aether/aether-deployment/src/test/java/org/pragmatica/aether/deployment/cluster/fsm/RetryExhaustionTerminalTest.java
@@ -1,0 +1,362 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2025 Pragmatica Labs - Sergiy Yevtushenko
+// Licensed under Business Source License 1.1. Change Date: 2030-01-01. Change License: Apache-2.0.
+// See LICENSE in the repository root for full terms.
+package org.pragmatica.aether.deployment.cluster.fsm;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.pragmatica.aether.artifact.Artifact;
+import org.pragmatica.aether.deployment.cluster.ClusterDeploymentManager.DeploymentAtomicity;
+import org.pragmatica.aether.deployment.cluster.fsm.ClusterDeploymentEvents.Activate;
+import org.pragmatica.aether.deployment.cluster.fsm.ClusterDeploymentEvents.AppBlueprintPutReceived;
+import org.pragmatica.aether.deployment.cluster.fsm.ClusterDeploymentEvents.NodeArtifactPutReceived;
+import org.pragmatica.aether.deployment.schema.SchemaOrchestratorService;
+import org.pragmatica.aether.slice.blueprint.BlueprintId;
+import org.pragmatica.aether.slice.blueprint.ExpandedBlueprint;
+import org.pragmatica.aether.slice.blueprint.ResolvedSlice;
+import org.pragmatica.aether.slice.kvstore.AetherKey;
+import org.pragmatica.aether.slice.kvstore.AetherKey.AppBlueprintKey;
+import org.pragmatica.aether.slice.kvstore.AetherKey.DeploymentOutcomeKey;
+import org.pragmatica.aether.slice.kvstore.AetherKey.NodeArtifactKey;
+import org.pragmatica.aether.slice.kvstore.AetherValue;
+import org.pragmatica.aether.slice.kvstore.AetherValue.AppBlueprintValue;
+import org.pragmatica.aether.slice.kvstore.AetherValue.DeploymentOutcomeValue;
+import org.pragmatica.aether.slice.kvstore.AetherValue.NodeArtifactValue;
+import org.pragmatica.cluster.node.ClusterNode;
+import org.pragmatica.cluster.state.kvstore.KVCommand;
+import org.pragmatica.cluster.state.kvstore.KVStore;
+import org.pragmatica.cluster.state.kvstore.KVStoreNotification.ValuePut;
+import org.pragmatica.consensus.NodeId;
+import org.pragmatica.consensus.fsm.ClusterFsmEvent;
+import org.pragmatica.consensus.net.NodeInfo;
+import org.pragmatica.consensus.topology.NodeState;
+import org.pragmatica.consensus.topology.TopologyManager;
+import org.pragmatica.lang.Option;
+import org.pragmatica.lang.Promise;
+import org.pragmatica.lang.Unit;
+import org.pragmatica.lang.io.CoreError;
+import org.pragmatica.lang.io.TimeSpan;
+import org.pragmatica.messaging.MessageRouter;
+import org.pragmatica.net.tcp.NodeAddress;
+import org.pragmatica.serialization.Deserializer;
+import org.pragmatica.serialization.Serializer;
+import org.pragmatica.statemachine.Fsm;
+import org.pragmatica.statemachine.FsmTestHarness;
+
+import java.net.SocketAddress;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.function.LongSupplier;
+
+import io.netty.buffer.ByteBuf;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.pragmatica.lang.io.TimeSpan.timeSpan;
+
+/// #922 — retry exhaustion on the transient deployment path must reach a TERMINAL state.
+///
+/// Before this fix it did not. `logMaxRetriesExceeded` cleared the retry counter and routed
+/// `DeploymentFailed` but never added the artifact to `permanentlyFailed`, and that is not a
+/// resting state:
+///
+///   1. `handleSliceFailure` issues an unload on EVERY failure;
+///   2. the node's removal of the `NodeArtifactKey` reaches `handleSliceNodeRemoval`, which —
+///      finding the artifact not permanently failed — schedules a reconcile;
+///   3. `reconcileBlueprint` is gated on `permanentlyFailed` and nothing else, so it redeploys the
+///      artifact and `retryCounters.merge` restarts at 1.
+///
+/// An intermittent cause that never settles was therefore re-driven at roughly 1 Hz for the life of
+/// the cluster: no terminal state, no rollback, no record, consensus round-trips forever. The
+/// ticket's own framing ("abandons the blueprint, leaves it in place") was one step milder than the
+/// truth.
+///
+/// **The cause driven here is `CoreError.Timeout`, deliberately.** It is one of the two causes the
+/// ticket names as already legitimately `Intermittent` (the other being resource capacity), it
+/// predates and is independent of #916's typing work, and using it keeps this pin honest: the
+/// livelock is reachable through causes nobody reclassified, so the fix must not depend on #916.
+///
+/// Only the leader FSM is driven. The node half is irrelevant to this defect — what matters is what
+/// the leader does with a repeated non-fatal failure report, so the report is replayed directly.
+class RetryExhaustionTerminalTest {
+    private static final NodeId SELF = new NodeId("node-self");
+    private static final NodeId NODE_A = new NodeId("node-a");
+    private static final Artifact SLICE = Artifact.artifact("com.example:slice-a:1.0.0").unwrap();
+
+    /// `ClusterDeploymentState.Active.MAX_RETRIES` is private; 5 retries means the SIXTH reported
+    /// failure is the one that spends the budget.
+    private static final int TERMINAL_ON_REPORT = 6;
+
+    /// Twice the budget. The pre-fix behaviour was unbounded, so any finite cap distinguishes it.
+    private static final int REPORT_CAP = 12;
+
+    private RecordingClusterNode leaderSideCluster;
+    private FsmTestHarness<ClusterDeploymentState, ClusterFsmEvent> leaderHarness;
+
+    @BeforeEach
+    void setUp() {
+        leaderSideCluster = new RecordingClusterNode(SELF);
+        leaderHarness = leaderHarness(leaderSideCluster);
+    }
+
+    /// The assertion is the ATTEMPT COUNT at which the terminal is reached, not merely that a
+    /// failure eventually happened. Both halves are load-bearing:
+    ///
+    ///   - a test asserting only "the blueprint is rolled back" would pass against a fix that rolled
+    ///     back on the FIRST failure, destroying the bounded retry this path exists to provide;
+    ///   - a test asserting only "it failed eventually" cannot distinguish a bounded terminal from
+    ///     an unbounded loop at all, which is the whole defect.
+    ///
+    /// Reverting the production hunk leaves `reportsUntilTerminal` at 0 after `REPORT_CAP` reports —
+    /// the pre-fix behaviour reported as itself.
+    @Test
+    void intermittentFailureThatNeverSettles_reachesTerminalRollback_withinTheRetryBudget() {
+        var expanded = blueprint();
+        var blueprintKey = AppBlueprintKey.appBlueprintKey(expanded.id());
+        var intermittent = intermittentFailure();
+
+        assertThat(intermittent.fatal())
+                .as("precondition: the cause driven below must be INTERMITTENT, so every report takes "
+                    + "handleTransientFailure's branch. If this flips, the test silently becomes a "
+                    + "test of the deterministic branch, which already had a terminal")
+                .isFalse();
+
+        leaderHarness.dispatch(new AppBlueprintPutReceived(appBlueprintPut(expanded)));
+
+        var reportsUntilTerminal = 0;
+
+        for (var report = 1; report <= REPORT_CAP; report++) {
+            leaderHarness.dispatch(new NodeArtifactPutReceived(replayOf(intermittent)));
+            if (leaderSideCluster.removeKeys().contains(blueprintKey)) {
+                reportsUntilTerminal = report;
+                break;
+            }
+        }
+
+        assertThat(reportsUntilTerminal)
+                .as("#922: an intermittent cause that never settles must reach a terminal state. At 0 "
+                    + "the deployment was still being re-driven after %d reported failures — "
+                    + "unbounded, no rollback, no terminal record, which is the livelock",
+                    REPORT_CAP)
+                .isNotZero();
+        assertThat(reportsUntilTerminal)
+                .as("the terminal must arrive when the retry budget is spent and NOT before — rolling "
+                    + "back earlier would destroy the bounded retry this path exists to provide")
+                .isEqualTo(TERMINAL_ON_REPORT);
+
+        leaderSideCluster.commands.clear();
+        ((ClusterDeploymentState.Active) leaderHarness.state()).reconcile();
+
+        assertThat(leaderSideCluster.commandKeysFor(SLICE))
+                .as("and the terminal must HOLD: a reconcile after exhaustion must not re-drive the "
+                    + "artifact, which is the step that turned the old exhaustion into a loop")
+                .isEmpty();
+    }
+
+    /// #922 acceptance, second half: the operator must be able to SEE that the deployment did not
+    /// apply. A rollback that leaves no record is silence of a different shape, so this asserts the
+    /// explicit `DeploymentOutcomeValue` rather than only the blueprint's removal.
+    @Test
+    void intermittentFailureThatNeverSettles_recordsAnExplicitFailedOutcome() {
+        var expanded = blueprint();
+
+        leaderHarness.dispatch(new AppBlueprintPutReceived(appBlueprintPut(expanded)));
+
+        for (var report = 1; report <= TERMINAL_ON_REPORT; report++) {
+            leaderHarness.dispatch(new NodeArtifactPutReceived(replayOf(intermittentFailure())));
+        }
+
+        assertThat(leaderSideCluster.outcomeFor(expanded.id()))
+                .as("#922: exhaustion must leave an explicit FAILED deployment outcome the operator "
+                    + "can read, not an unrecorded disappearance")
+                .isNotEmpty()
+                .allSatisfy(outcome -> assertThat(outcome.failingSlices()).contains(SLICE.asString()));
+    }
+
+    /// A failure the leader is REQUIRED to treat as retryable, built from a cause that was already
+    /// `Intermittent` before #916 and is untouched by it.
+    private static NodeArtifactValue intermittentFailure() {
+        return NodeArtifactValue.failedNodeArtifactValue(new CoreError.Timeout("consensus stalled"));
+    }
+
+    private static ValuePut<NodeArtifactKey, NodeArtifactValue> replayOf(NodeArtifactValue value) {
+        var key = NodeArtifactKey.nodeArtifactKey(SELF, SLICE);
+
+        return new ValuePut<>(new KVCommand.Put<>(key, value), Option.none());
+    }
+
+    private static ValuePut<AppBlueprintKey, AppBlueprintValue> appBlueprintPut(ExpandedBlueprint expanded) {
+        var key = AppBlueprintKey.appBlueprintKey(expanded.id());
+
+        return new ValuePut<>(new KVCommand.Put<>(key, AppBlueprintValue.appBlueprintValue(expanded)), Option.none());
+    }
+
+    private static ExpandedBlueprint blueprint() {
+        var id = BlueprintId.blueprintId("com.example:app:1.0.0").unwrap();
+        var slice = ResolvedSlice.resolvedSlice(SLICE, 3, false).unwrap();
+
+        return ExpandedBlueprint.expandedBlueprint(id, List.of(slice));
+    }
+
+    private static FsmTestHarness<ClusterDeploymentState, ClusterFsmEvent> leaderHarness(ClusterNode<KVCommand<AetherKey>> cluster) {
+        var router = MessageRouter.mutable();
+        var kvStore = new KVStore<AetherKey, AetherValue>(router, stubSerializer(), stubDeserializer());
+        LongSupplier clock = () -> 10_000_000L;
+        Function<Fsm<ClusterDeploymentState, ClusterFsmEvent>, ClusterDeploymentState> factory =
+                fsm -> new ClusterDeploymentContext(fsm,
+                                                    SELF,
+                                                    cluster,
+                                                    kvStore,
+                                                    router,
+                                                    stubTopologyManager(SELF),
+                                                    stubSchemaOrchestrator(),
+                                                    () -> Set.of(SELF, NODE_A),
+                                                    () -> Set.of(SELF, NODE_A),
+                                                    Set::of,
+                                                    Set.of(SELF, NODE_A),
+                                                    DeploymentAtomicity.ALL_OR_NOTHING,
+                                                    3,
+                                                    timeSpan(300).seconds(),
+                                                    clock).dormant();
+        var harness = FsmTestHarness.<ClusterDeploymentState, ClusterFsmEvent>harness("retry-exhaustion-leader-" + SELF.id(),
+                                                                                      factory);
+
+        harness.dispatch(new Activate());
+
+        return harness;
+    }
+
+    private static final class RecordingClusterNode implements ClusterNode<KVCommand<AetherKey>> {
+        private final NodeId self;
+        private final List<KVCommand<AetherKey>> commands = Collections.synchronizedList(new ArrayList<>());
+
+        private RecordingClusterNode(NodeId self) {this.self = self;}
+
+        @Override public NodeId self() {return self;}
+
+        @Override public TopologyManager topologyManager() {return stubTopologyManager(self);}
+
+        @Override public Promise<Unit> start() {return Promise.unitPromise();}
+
+        @Override public Promise<Unit> stop() {return Promise.unitPromise();}
+
+        @Override public <R> Promise<List<R>> apply(List<KVCommand<AetherKey>> batch) {
+            commands.addAll(batch);
+
+            return Promise.success(Collections.emptyList());
+        }
+
+        private List<AetherKey> removeKeys() {
+            synchronized (commands) {
+                return commands.stream()
+                               .filter(command -> command instanceof KVCommand.Remove<AetherKey>)
+                               .map(KVCommand::key)
+                               .toList();
+            }
+        }
+
+        /// Every recorded command — Put or Remove — whose key names the given artifact. Used to
+        /// assert that a reconcile did NOT re-drive an artifact that has reached its terminal.
+        private List<AetherKey> commandKeysFor(Artifact artifact) {
+            synchronized (commands) {
+                return commands.stream()
+                               .map(KVCommand::key)
+                               .filter(key -> key.asString()
+                                                 .contains(artifact.asString()))
+                               .toList();
+            }
+        }
+
+        /// Every `DeploymentOutcomeValue` written for the given blueprint.
+        private List<DeploymentOutcomeValue> outcomeFor(BlueprintId blueprintId) {
+            var key = DeploymentOutcomeKey.deploymentOutcomeKey(blueprintId);
+
+            synchronized (commands) {
+                return commands.stream()
+                               .filter(command -> command instanceof KVCommand.Put<AetherKey, ?> put
+                                                  && put.key().equals(key))
+                               .map(command -> ((KVCommand.Put<AetherKey, ?>) command).value())
+                               .filter(value -> value instanceof DeploymentOutcomeValue)
+                               .map(value -> (DeploymentOutcomeValue) value)
+                               .toList();
+            }
+        }
+    }
+
+    private static SchemaOrchestratorService stubSchemaOrchestrator() {
+        return new SchemaOrchestratorService() {
+            @Override public Promise<Unit> migrateIfNeeded(String datasourceName) {
+                return Promise.success(Unit.unit());
+            }
+
+            @Override public Promise<Unit> undoTo(String datasourceName, int targetVersion) {
+                return Promise.success(Unit.unit());
+            }
+
+            @Override public Promise<Unit> baseline(String datasourceName, int version) {
+                return Promise.success(Unit.unit());
+            }
+        };
+    }
+
+    private static TopologyManager stubTopologyManager(NodeId self) {
+        return new TopologyManager() {
+            @Override public NodeInfo self() {
+                return NodeInfo.nodeInfo(self, new NodeAddress("localhost", 9000));
+            }
+
+            @Override public Option<NodeInfo> get(NodeId id) {
+                return Option.some(NodeInfo.nodeInfo(id, new NodeAddress("localhost", 9000)));
+            }
+
+            @Override public int clusterSize() {
+                return 2;
+            }
+
+            @Override public Option<NodeId> reverseLookup(SocketAddress socketAddress) {
+                return Option.empty();
+            }
+
+            @Override public Promise<Unit> start() {
+                return Promise.unitPromise();
+            }
+
+            @Override public Promise<Unit> stop() {
+                return Promise.unitPromise();
+            }
+
+            @Override public TimeSpan pingInterval() {
+                return timeSpan(5).seconds();
+            }
+
+            @Override public TimeSpan helloTimeout() {
+                return timeSpan(5).seconds();
+            }
+
+            @Override public Option<NodeState> getState(NodeId id) {
+                return Option.empty();
+            }
+
+            @Override public List<NodeId> topology() {
+                return List.of(self);
+            }
+        };
+    }
+
+    private static Serializer stubSerializer() {
+        return new Serializer() {
+            @Override public <T> void write(ByteBuf byteBuf, T object) {}
+        };
+    }
+
+    private static Deserializer stubDeserializer() {
+        return new Deserializer() {
+            @Override public <T> T read(ByteBuf byteBuf) {
+                return null;
+            }
+        };
+    }
+}

--- a/aether/docs/specs/stream-offheap-budget-spec.md
+++ b/aether/docs/specs/stream-offheap-budget-spec.md
@@ -554,9 +554,12 @@ Visible at `GET /api/events` (the events stream the aggregator publishes to). Se
 6. **Follower can't admit floor.** *Resolution:* create entry anyway, log+event (§8). [DECISION]
 7. **`fatal` flag for deployment failure.** Mapping budget-exceed to non-fatal/transient assumes the
    condition may clear. If a slice's stream genuinely can never fit, it retries `MAX_RETRIES` (5) then
-   `logMaxRetriesExceeded` + `DeploymentFailed` (`:1077-1089`) — still loud, eventually gives up.
+   `handleRetryBudgetExhausted` marks the artifact permanently failed, routes `DeploymentFailed` and
+   honours the declared atomicity — still loud, and it does give up.
    *Resolution:* non-fatal/transient is correct; permanent failure still surfaces after retries.
-   [DECISION]
+   **This resolution was false on disk until #922.** Before that fix the exhaustion arm never marked
+   the artifact permanently failed, so the deployment was re-driven at roughly 1 Hz instead of giving
+   up — the spec was relying on a terminal that did not exist. [DECISION]
 
 ---
 

--- a/changelog.d/922-retry-exhaustion-terminal.md
+++ b/changelog.d/922-retry-exhaustion-terminal.md
@@ -1,0 +1,49 @@
+### Fixed (2026-09-07 — #922: retry exhaustion on the transient deployment path never reached a terminal state)
+
+- **A deployment failing for an intermittent reason that never cleared was redeployed forever.**
+  `handleTransientFailure` retries a non-fatal failure five times with exponential backoff. When the
+  budget was spent, `logMaxRetriesExceeded` cleared the retry counter and routed a `DeploymentFailed`
+  event — but never added the artifact to `permanentlyFailed`, and that is not a resting state.
+  `handleSliceFailure` issues an unload on every failure; the node's removal of the
+  `NodeArtifactKey` reaches `handleSliceNodeRemoval`, which — finding the artifact still deployable —
+  schedules a reconcile; and `reconcileBlueprint` is gated on `permanentlyFailed` and nothing else,
+  so it redeployed the artifact with the counter restarting at 1. The result was an unbounded
+  redeploy loop at roughly 1 Hz for the life of the cluster: no terminal state, no rollback, no
+  outcome record, and consensus round-trips forever
+  [mechanism: `handleSliceFailure` -> `issueUnloadCommand` -> `deleteSliceNodeKey` ->
+  `handleSliceNodeRemoval` -> `reconcile` -> `reconcileBlueprint`, with no arm that adds to
+  `permanentlyFailed`].
+- **Exhaustion is now terminal, and it is the SAME terminal a deterministic failure reaches.** The
+  tail of `handleDeterministicFailure` — mark `permanentlyFailed`, route `DeploymentFailed`, honour
+  the declared atomicity — is extracted as `settleAsPermanentlyFailed`, and both failure branches
+  converge on it. `ALL_OR_NOTHING` rolls the owning blueprint back; `BEST_EFFORT` records a FAILED
+  outcome. The method was renamed from `logMaxRetriesExceeded` to `handleRetryBudgetExhausted`
+  because it no longer merely logs
+  [verified: `RetryExhaustionTerminalTest#intermittentFailureThatNeverSettles_reachesTerminalRollback_withinTheRetryBudget`
+  asserts the terminal arrives on the sixth reported failure and NOT before, and that a reconcile
+  afterwards does not re-drive the artifact; reverting only the production hunk leaves the deployment
+  unsettled after 12 reported failures].
+- **The operator can see that the deployment did not apply.** The rollback's consensus batch carries
+  a `DeploymentOutcomeValue.failed` record naming the failing slice, in the same batch as the
+  blueprint removal, so the removal and the record land atomically
+  [verified: `RetryExhaustionTerminalTest#intermittentFailureThatNeverSettles_recordsAnExplicitFailedOutcome`].
+- **The retry budget, since the guarantee depends on it being finite and knowable.**
+  `ClusterDeploymentState.Active.MAX_RETRIES` = 5, with `MAX_RETRY_DELAY_SECONDS` = 30 and
+  exponential backoff of 1, 2, 4, 8, 16 s, jittered. Both are private compile-time constants: finite
+  and knowable, but **not operator-configurable**. The sixth reported failure spends the budget.
+  Recovery action: the artifact stays undeployable until a redeploy of its blueprint, which clears
+  `permanentlyFailed` when the blueprint is applied.
+- **Scope note.** This is a defect in the exhaustion machinery, reachable through every cause that is
+  legitimately `Intermittent` — `CoreError.Timeout` and resource-capacity exhaustion — and it
+  predates any recent reclassification work. The pin deliberately drives `CoreError.Timeout` rather
+  than a newly-typed cause, so it stays honest about that. Found while reviewing #916, which types
+  two activation-path causes as `Intermittent`; #916 does not widen the set of causes that can reach
+  this loop, because every path that issues an ACTIVATE is gated on the slice having been reported
+  `LOADED` and a genuinely absent artifact fails earlier
+  [mechanism: all four call sites of `tryActivateIfDependenciesReady` filter on `SliceState.LOADED` —
+  `ClusterDeploymentState:1550`, `:694`, `:894`, `:1897`]. The two changes are therefore independent
+  and ship as separate pull requests.
+- **A stale surface corrected with it.** `aether/docs/specs/stream-offheap-budget-spec.md` resolved
+  an open design question ("`fatal` flag for deployment failure") with "permanent failure still
+  surfaces after retries". That was false on disk for as long as the loop existed — the spec was
+  relying on a terminal that did not exist. It is true again with this change.

--- a/changelog.d/922-retry-exhaustion-terminal.md
+++ b/changelog.d/922-retry-exhaustion-terminal.md
@@ -49,6 +49,18 @@
   The pin deliberately asserts the recovery rather than the absence of a rollback, because "no
   rollback happened" is equally true of a cluster that has silently stopped doing anything — which is
   the bug itself.
+- **The exposure was wider than it looks, because a blueprint retires on its FIRST active instance.**
+  `InFlightBlueprint` builds `pendingSlices` with one entry per slice **artifact**, not per instance,
+  so `trackBlueprintSliceActive` removes the blueprint from `inFlightBlueprints` and writes a
+  SUCCEEDED outcome as soon as **one** instance of each slice reaches ACTIVE — whatever the desired
+  instance count. A three-instance slice was therefore unprotected from the moment its first instance
+  came up: from then on an exhaustion on any single node would have condemned it cluster-wide, with
+  no rollback and no record. A corollary worth knowing on its own: a SUCCEEDED deployment outcome
+  attests that every slice started *somewhere*, **not** that the deployment reached its desired
+  instance count
+  [mechanism: `InFlightBlueprint.inFlightBlueprint` fills `pendingSlices` from
+  `expanded.loadOrder()`, one entry per artifact; `trackBlueprintSliceActive` removes on
+  `pendingSlices().remove(artifact)` and calls `recordSucceededOutcome` the moment that set empties].
 - **The discriminator is read from state that survives leader failover.**
   `hasActiveInstanceElsewhere` tests `sliceStates` for an ACTIVE instance on a live node rather than
   asking whether the blueprint is still in `inFlightBlueprints`. The in-flight map is the cheaper test

--- a/changelog.d/922-retry-exhaustion-terminal.md
+++ b/changelog.d/922-retry-exhaustion-terminal.md
@@ -23,52 +23,94 @@
   asserts the terminal arrives on the sixth reported failure and NOT before, and that a reconcile
   afterwards does not re-drive the artifact; reverting only that production hunk fails it and
   `#intermittentFailureThatNeverSettles_recordsAnExplicitFailedOutcome`, and only those two].
-- **The terminal is scoped, because a cluster-wide inference does not transfer to a node-local
-  cause.** `settleAsPermanentlyFailed` came from the DETERMINISTIC branch, where concluding
-  cluster-wide from one node is sound: a deterministic failure is node-independent, so failing on one
-  node really does mean the artifact is bad everywhere. **That inference does not hold on the
-  transient branch** — a transient failure on node A says nothing about node B. Reusing the terminal
-  without re-examining the scope of the flag it sets was the defect, not the choice of flag:
-  `retryCounters` is keyed per artifact AND node, while `permanentlyFailed` is a cluster-wide
-  `Set<Artifact>`. So roughly 31 s of trouble on ONE node condemned a slice that was deployed and
-  healthy on every other node. `handleRetryBudgetExhausted` now settles only when
-  `hasActiveInstanceElsewhere` is false: a deployment **attempt** with nothing ACTIVE anywhere is
-  abandoned, while a **running** workload suffering a node-local transient keeps being reconciled
-  toward its desired instance count
-  [verified:
-  `RetryExhaustionTerminalTest#exhaustionOnOneNode_whileTheArtifactIsActiveElsewhere_stillRecoversTheLostInstance`
-  deploys on both nodes, spends the whole budget on one, and asserts the RECOVERY — reconciliation
-  still re-drives the artifact and the lost instance comes back. Reverting only the
-  `hasActiveInstanceElsewhere` guard fails exactly that test and leaves the other three green].
-- **The regression it prevents was worse than the livelock it replaced, and that is why it is called
-  out separately.** The livelock was noisy and kept trying. Settling unconditionally is silent and
+- **The discriminator is PAST tense: has this artifact EVER reached ACTIVE.** `settleAsPermanentlyFailed`
+  came from the DETERMINISTIC branch, where concluding cluster-wide from one node is sound — a
+  deterministic failure is node-independent. That inference does not hold on the transient branch, and
+  `retryCounters` is keyed per artifact AND node while `permanentlyFailed` is a cluster-wide
+  `Set<Artifact>`. The first attempt at the fix asked the PRESENT-tense question ("is an instance
+  ACTIVE right now?") and that was not enough: `handleSliceFailure` removes the failing key from
+  `sliceStates` before either branch runs, so a present-tense read necessarily answers "no" once the
+  transient has reached every instance, and it can never answer "yes" for a slice with
+  `instances = 1`, which has no sibling to vote for it. Both of those are previously-healthy workloads,
+  both self-healed before #922, and both were being condemned cluster-wide and permanently.
+  `handleRetryBudgetExhausted` now settles only when `everReachedActive` is false: a deployment
+  **attempt** that has produced nothing is abandoned, while a workload that **was up and fell over**
+  keeps being reconciled toward its desired instance count
+  [verified: `RetryExhaustionEverActiveTest#clusterWideTransient_onPreviouslyHealthyDeployment_doesNotSettle`
+  and `#singleInstanceSlice_transientOnItsOnlyNode_doesNotSettle` assert on `Active.permanentlyFailed()`
+  directly, and the round-2 verification probe ran the SAME two scenarios red at the previous
+  head; `#control_neverActiveAnywhere_doesSettlePermanentlyFailed`
+  is the opposite-polarity control and still settles, so the pins are not passing vacuously].
+- **`everReachedActive` is a disjunction of three legs, and each is pinned in isolation.** No single
+  evidence source covers every lifetime, so any evidence of a past ACTIVE declines the settle: an
+  instance ACTIVE right now (`hasActiveInstanceElsewhere`, rebuilt from durable `NodeArtifactKey`
+  entries on a new leader); `everActiveArtifacts`, which this leader watched reach ACTIVE; and the
+  owning blueprint's durable `DeploymentOutcomeValue.SUCCEEDED` record, which is what makes the
+  question survive failover rather than being in-memory bookkeeping. `inFlightBlueprints` remains the
+  cheaper test and the wrong one — `newActive()` builds it empty, so gating on its ABSENCE would
+  silently stop settling, reopening this ticket, for any deployment whose leader changed mid-flight
+  [verified: each leg has a test that fails when only that leg is disabled — mutation A
+  (`everActiveArtifacts.contains(artifact)` -> a non-constant always-false expression) reddens
+  `#clusterWideTransient_...` and `#singleInstanceSlice_...` and nothing else; mutation B
+  (`status == SUCCEEDED` -> `status == FAILED`) reddens `#durableSucceededOutcome_isEnoughOnANewLeaderWithNoInMemoryEvidence`
+  and nothing else; mutation F (same treatment of `hasActiveInstanceElsewhere(artifact)`) reddens
+  `#aRestoredActiveInstance_isEnoughOnALeaderThatNeverWatchedItStart` and nothing else. 13 tests in
+  each phase, applied from a pristine copy, restored sha256-identical].
+- **The settle is refused while core membership is unresolved.** The present-tense leg diffs
+  KV-derived slice state against `activeNodes()`, and during the boot window that supplier yields
+  `MembershipFsm.MEMBERSHIP_NOT_WIRED` — an empty set distinguished only by reference identity — so
+  every node fails `contains` and every artifact looks abandoned; membership churn narrows the same
+  read without a boot window. `coreMembershipResolved()`'s own contract requires this consultation
+  and `StaleEntryCleaner` honours it at four sites. Refusing to settle costs a re-drive that the next
+  exhaustion re-decides; settling on an unresolved read is irreversible
+  [verified: `RetryExhaustionEverActiveTest#unresolvedCoreMembership_doesNotSettle` drives inputs
+  IDENTICAL to `#control_neverActiveAnywhere_doesSettlePermanentlyFailed` apart from the member set,
+  with opposite expectations; mutation C (replacing the `!coreMembershipResolved()` condition with a
+  non-constant always-false expression) reddens exactly that test and nothing else].
+- **"Ever reached ACTIVE" is scoped to the deployment it describes, or it becomes this ticket's own
+  livelock.** Two boundaries, both load-bearing. `everActiveArtifacts` is forgotten in
+  `issueDeallocationCommands` — the seam every path that takes an artifact OUT of the cluster's
+  desired state funnels through — so a LATER, independent deployment of the same coordinate that never
+  comes up still settles. And the durable leg is suppressed while the owning blueprint is in flight,
+  because nothing removes a `DeploymentOutcomeKey` entry when a blueprint id is re-applied, so a
+  re-used id whose new load order carries a brand-new slice would otherwise hand that slice the
+  previous attempt's success. The boundary is deliberately REMOVAL, not a re-apply of the same
+  blueprint: clearing on re-apply would put a healthy running workload one operator re-apply plus one
+  cluster-wide transient away from the silent condemnation this change exists to prevent
+  [verified: `#aLaterDeploymentOfARemovedCoordinate_stillSettles` and
+  `#aDurableSucceededOutcome_doesNotVoteForTheAttemptStillInFlight` assert that the artifact DOES
+  settle; mutations D (deleting the `everActiveArtifacts.remove(artifact)` statement) and E (deleting
+  the in-flight `.filter`) redden exactly one of them each and nothing else].
+- **The regression this replaced was worse than the livelock, and that is why it is called out
+  separately.** The livelock was noisy and kept trying. Settling unconditionally is silent and
   terminal: a fully-deployed blueprint has already left `inFlightBlueprints`, so
   `rollbackBlueprintForArtifact` matches nothing, **no FAILED outcome is written at all**, and the
   artifact's last recorded outcome still reads SUCCEEDED while reconcile quietly refuses to replace
   the lost instance. An operator would see a healthy-looking record and a slice that never came back.
-  The pin deliberately asserts the recovery rather than the absence of a rollback, because "no
-  rollback happened" is equally true of a cluster that has silently stopped doing anything — which is
-  the bug itself.
+  The pins therefore assert the RECOVERY, not the absence of a rollback, because "no rollback
+  happened" is equally true of a cluster that has silently stopped doing anything
+  [mechanism: `trackBlueprintSliceActive` removes the blueprint from `inFlightBlueprints` before
+  `rollbackBlueprintForArtifact` could match it, and `recordBestEffortFailureOutcome` — the only other
+  writer of a FAILED record on this path — is the `BEST_EFFORT` branch alone].
 - **The exposure was wider than it looks, because a blueprint retires on its FIRST active instance.**
   `InFlightBlueprint` builds `pendingSlices` with one entry per slice **artifact**, not per instance,
   so `trackBlueprintSliceActive` removes the blueprint from `inFlightBlueprints` and writes a
   SUCCEEDED outcome as soon as **one** instance of each slice reaches ACTIVE — whatever the desired
-  instance count. A three-instance slice was therefore unprotected from the moment its first instance
-  came up: from then on an exhaustion on any single node would have condemned it cluster-wide, with
-  no rollback and no record. A corollary worth knowing on its own: a SUCCEEDED deployment outcome
-  attests that every slice started *somewhere*, **not** that the deployment reached its desired
-  instance count
+  instance count. A corollary worth knowing on its own: a SUCCEEDED deployment outcome attests that
+  every slice started *somewhere*, **not** that the deployment reached its desired instance count
   [mechanism: `InFlightBlueprint.inFlightBlueprint` fills `pendingSlices` from
   `expanded.loadOrder()`, one entry per artifact; `trackBlueprintSliceActive` removes on
   `pendingSlices().remove(artifact)` and calls `recordSucceededOutcome` the moment that set empties].
-- **The discriminator is read from state that survives leader failover.**
-  `hasActiveInstanceElsewhere` tests `sliceStates` for an ACTIVE instance on a live node rather than
-  asking whether the blueprint is still in `inFlightBlueprints`. The in-flight map is the cheaper test
-  and the wrong one: `newActive()` builds it empty and only a live `AppBlueprintPutReceived` populates
-  it, so gating on it would silently stop settling — reopening this ticket — for any deployment whose
-  leader changed mid-flight. Verifying a condition's meaning is not verifying its lifetime
-  [mechanism: `Active.onEntry` -> `rebuildStateFromKVStore` -> `rebuildSliceStateFromKVStoreEntries`
-  repopulates `sliceStates` from durable KV entries, while nothing repopulates `inFlightBlueprints`].
+- **An operator diagnosing an exhausted retry budget is no longer told the failure was
+  deterministic.** `rollbackBlueprintForArtifact` logged "ALL_OR_NOTHING: Deterministic failure of {}
+  triggers rollback of blueprint {}" — true at base, where its only caller was reached from
+  `handleDeterministicFailure` alone. Routing the intermittent branch into the same terminal made that
+  line contradict the `Intermittent` cause the operator is actually looking at. It now names the
+  terminal and the cause instead of the branch; the branch is already named by the log line that
+  immediately precedes it on either path
+  [mechanism: `settleAsPermanentlyFailed` is the single caller of `rollbackBlueprintForArtifact`, and
+  since this change it is reached from both `handleDeterministicFailure` and
+  `handleRetryBudgetExhausted`, so no message on that path can name one branch truthfully].
 - **The operator can see that the deployment did not apply.** The rollback's consensus batch carries
   a `DeploymentOutcomeValue.failed` record naming the failing slice, in the same batch as the
   blueprint removal, so the removal and the record land atomically
@@ -76,36 +118,46 @@
 - **The retry budget, since the guarantee depends on it being finite and knowable.**
   `ClusterDeploymentState.Active.MAX_RETRIES` = 5 with exponential backoff of 1, 2, 4, 8, 16 s,
   jittered — about 31 s on one node. Both it and `MAX_RETRY_DELAY_SECONDS` = 30 are private
-  compile-time constants: finite and knowable, but **not operator-configurable**. Two things the
-  earlier wording got wrong. The 30 s cap **never binds at the current budget** —
-  `Math.min(1L << (retryCount - 1), 30)` with `retryCount` never exceeding 5 tops out at 16 s — so it
-  guards a larger budget rather than shaping this one. And the bound is **per artifact and node**, not
-  cluster-wide: the sixth reported failure on any ONE node spends that node's budget, but with
-  placement rotating across N allocatable nodes the cluster-wide total can reach
-  N x (`MAX_RETRIES` + 1) reported failures, and the bound holds only while the allocatable node set
-  is stable — a steady supply of fresh nodes gives each a fresh counter. Recovery action: the artifact
-  stays undeployable until a redeploy of its blueprint, which clears `permanentlyFailed` on apply
+  compile-time constants: finite and knowable, but **not operator-configurable**. The 30 s cap
+  **never binds at the current budget** — `Math.min(1L << (retryCount - 1), 30)` with `retryCount`
+  never exceeding 5 tops out at 16 s — so it guards a larger budget rather than shaping this one. And
+  the bound is **per artifact and node**, not cluster-wide: the sixth reported failure on any ONE node
+  spends that node's budget, but with placement rotating across N allocatable nodes the cluster-wide
+  total can reach N x (`MAX_RETRIES` + 1) reported failures, and the bound holds only while the
+  allocatable node set is stable. Recovery action: an artifact that settled stays undeployable until a
+  redeploy of its blueprint, which clears `permanentlyFailed` on apply
   [mechanism: `retryCounters` is keyed on `sliceKey.asString()`, rendering as
   `slices/<nodeId>/<artifact>`; `permanentlyFailed` is keyed on artifact alone and is cleared at
   exactly one site, the blueprint-apply loop].
-- **What this deliberately does not close.** A transient affecting EVERY node for longer than the
-  budget still settles the artifact, since by then nothing is ACTIVE anywhere. The fix narrows the
-  evidence required for a cluster-wide permanent verdict from one node's budget to every node's, and
-  does not remove the case; removing it entirely would mean never settling a previously-healthy
-  artifact, which is the livelock with no terminal at all. Relatedly, a running workload that cannot
-  reach its desired instance count keeps retrying at the reconcile cadence — convergence, not the
-  defect this ticket was filed about, but a candidate for backing off rather than terminating.
+- **What this deliberately does not close — three items, all OPEN.** (1) **No operator knob for the
+  budget.** ~31 s is a short window in which to call a condition permanent, and for a blueprint of two
+  or more slices one slice that never comes up still tears down its healthy siblings via
+  `unloadBlueprintSlices` on that same budget. Configurable retries touch ~20 construction sites; this
+  is a deferral, not a refutation. (2) **The durable leg has two gaps of its own.** The SUCCEEDED
+  record can be lost — `handleSucceededOutcomeWriteFailure` documents that this write is never
+  retried — and the in-flight suppression is in-memory, so a re-used blueprint id whose attempt spans
+  a leader failover reads the previous attempt's record. The in-memory leg covers the first within a
+  leader's lifetime and nothing covers the second; both residues fail toward RE-DRIVING rather than
+  condemning, which is the reversible side of a one-way door and strictly narrower than the pre-#922
+  behaviour, where every exhaustion re-drove. (3) **A workload that was genuinely up and is now
+  permanently unfetchable re-drives at the reconcile cadence rather than settling.** That is the
+  ruling this fix implements, not an oversight: it is convergence, logged and diagnosable, chosen over
+  a silent permanent verdict on a workload the operator believes is running
+  [mechanism: each residue is a leg of `everReachedActive` returning TRUE on stale or absent
+  evidence, and every leg is fail-safe by construction — the disjunction can only decline a settle,
+  never cause one].
 - **Scope note.** This is a defect in the exhaustion machinery, reachable through every cause that is
   legitimately `Intermittent` — `CoreError.Timeout` and resource-capacity exhaustion — and it
-  predates any recent reclassification work. The pin deliberately drives `CoreError.Timeout` rather
-  than a newly-typed cause, so it stays honest about that. Found while reviewing #916 / #920, which
+  predates any recent reclassification work. The pins deliberately drive `CoreError.Timeout` rather
+  than a newly-typed cause, so they stay honest about that. Found while reviewing #916 / #920, which
   type two activation-path causes as `Intermittent`; neither widens the set of causes that can reach
   this loop, because every path that issues an ACTIVATE is gated on the slice having been reported
   `LOADED` and a genuinely absent artifact fails earlier. **#923** — consensus exhaustion raises an
   untyped cause at 90 s, inside the 120 s chain timeout, so it classifies `Fatal` — is the same
   family and is not addressed here
   [mechanism: all four call sites of `tryActivateIfDependenciesReady` filter on `SliceState.LOADED` —
-  `ClusterDeploymentState:1551`, `:700`, `:897`, `:1901`, the last being `activateDependentSlices`].
+  `ClusterDeploymentState:714`, `:911`, `:1565`, `:2090`, the last being `activateDependentSlices`;
+  line numbers re-derived at this branch's head, not carried over].
 - **A stale surface corrected with it.** `aether/docs/specs/stream-offheap-budget-spec.md` resolved
   an open design question ("`fatal` flag for deployment failure") with "permanent failure still
   surfaces after retries". That was false on disk for as long as the loop existed — the spec was

--- a/changelog.d/922-retry-exhaustion-terminal.md
+++ b/changelog.d/922-retry-exhaustion-terminal.md
@@ -21,29 +21,84 @@
   because it no longer merely logs
   [verified: `RetryExhaustionTerminalTest#intermittentFailureThatNeverSettles_reachesTerminalRollback_withinTheRetryBudget`
   asserts the terminal arrives on the sixth reported failure and NOT before, and that a reconcile
-  afterwards does not re-drive the artifact; reverting only the production hunk leaves the deployment
-  unsettled after 12 reported failures].
+  afterwards does not re-drive the artifact; reverting only that production hunk fails it and
+  `#intermittentFailureThatNeverSettles_recordsAnExplicitFailedOutcome`, and only those two].
+- **The terminal is scoped, because a cluster-wide inference does not transfer to a node-local
+  cause.** `settleAsPermanentlyFailed` came from the DETERMINISTIC branch, where concluding
+  cluster-wide from one node is sound: a deterministic failure is node-independent, so failing on one
+  node really does mean the artifact is bad everywhere. **That inference does not hold on the
+  transient branch** — a transient failure on node A says nothing about node B. Reusing the terminal
+  without re-examining the scope of the flag it sets was the defect, not the choice of flag:
+  `retryCounters` is keyed per artifact AND node, while `permanentlyFailed` is a cluster-wide
+  `Set<Artifact>`. So roughly 31 s of trouble on ONE node condemned a slice that was deployed and
+  healthy on every other node. `handleRetryBudgetExhausted` now settles only when
+  `hasActiveInstanceElsewhere` is false: a deployment **attempt** with nothing ACTIVE anywhere is
+  abandoned, while a **running** workload suffering a node-local transient keeps being reconciled
+  toward its desired instance count
+  [verified:
+  `RetryExhaustionTerminalTest#exhaustionOnOneNode_whileTheArtifactIsActiveElsewhere_stillRecoversTheLostInstance`
+  deploys on both nodes, spends the whole budget on one, and asserts the RECOVERY — reconciliation
+  still re-drives the artifact and the lost instance comes back. Reverting only the
+  `hasActiveInstanceElsewhere` guard fails exactly that test and leaves the other three green].
+- **The regression it prevents was worse than the livelock it replaced, and that is why it is called
+  out separately.** The livelock was noisy and kept trying. Settling unconditionally is silent and
+  terminal: a fully-deployed blueprint has already left `inFlightBlueprints`, so
+  `rollbackBlueprintForArtifact` matches nothing, **no FAILED outcome is written at all**, and the
+  artifact's last recorded outcome still reads SUCCEEDED while reconcile quietly refuses to replace
+  the lost instance. An operator would see a healthy-looking record and a slice that never came back.
+  The pin deliberately asserts the recovery rather than the absence of a rollback, because "no
+  rollback happened" is equally true of a cluster that has silently stopped doing anything — which is
+  the bug itself.
+- **The discriminator is read from state that survives leader failover.**
+  `hasActiveInstanceElsewhere` tests `sliceStates` for an ACTIVE instance on a live node rather than
+  asking whether the blueprint is still in `inFlightBlueprints`. The in-flight map is the cheaper test
+  and the wrong one: `newActive()` builds it empty and only a live `AppBlueprintPutReceived` populates
+  it, so gating on it would silently stop settling — reopening this ticket — for any deployment whose
+  leader changed mid-flight. Verifying a condition's meaning is not verifying its lifetime
+  [mechanism: `Active.onEntry` -> `rebuildStateFromKVStore` -> `rebuildSliceStateFromKVStoreEntries`
+  repopulates `sliceStates` from durable KV entries, while nothing repopulates `inFlightBlueprints`].
 - **The operator can see that the deployment did not apply.** The rollback's consensus batch carries
   a `DeploymentOutcomeValue.failed` record naming the failing slice, in the same batch as the
   blueprint removal, so the removal and the record land atomically
   [verified: `RetryExhaustionTerminalTest#intermittentFailureThatNeverSettles_recordsAnExplicitFailedOutcome`].
 - **The retry budget, since the guarantee depends on it being finite and knowable.**
-  `ClusterDeploymentState.Active.MAX_RETRIES` = 5, with `MAX_RETRY_DELAY_SECONDS` = 30 and
-  exponential backoff of 1, 2, 4, 8, 16 s, jittered. Both are private compile-time constants: finite
-  and knowable, but **not operator-configurable**. The sixth reported failure spends the budget.
-  Recovery action: the artifact stays undeployable until a redeploy of its blueprint, which clears
-  `permanentlyFailed` when the blueprint is applied.
+  `ClusterDeploymentState.Active.MAX_RETRIES` = 5 with exponential backoff of 1, 2, 4, 8, 16 s,
+  jittered — about 31 s on one node. Both it and `MAX_RETRY_DELAY_SECONDS` = 30 are private
+  compile-time constants: finite and knowable, but **not operator-configurable**. Two things the
+  earlier wording got wrong. The 30 s cap **never binds at the current budget** —
+  `Math.min(1L << (retryCount - 1), 30)` with `retryCount` never exceeding 5 tops out at 16 s — so it
+  guards a larger budget rather than shaping this one. And the bound is **per artifact and node**, not
+  cluster-wide: the sixth reported failure on any ONE node spends that node's budget, but with
+  placement rotating across N allocatable nodes the cluster-wide total can reach
+  N x (`MAX_RETRIES` + 1) reported failures, and the bound holds only while the allocatable node set
+  is stable — a steady supply of fresh nodes gives each a fresh counter. Recovery action: the artifact
+  stays undeployable until a redeploy of its blueprint, which clears `permanentlyFailed` on apply
+  [mechanism: `retryCounters` is keyed on `sliceKey.asString()`, rendering as
+  `slices/<nodeId>/<artifact>`; `permanentlyFailed` is keyed on artifact alone and is cleared at
+  exactly one site, the blueprint-apply loop].
+- **What this deliberately does not close.** A transient affecting EVERY node for longer than the
+  budget still settles the artifact, since by then nothing is ACTIVE anywhere. The fix narrows the
+  evidence required for a cluster-wide permanent verdict from one node's budget to every node's, and
+  does not remove the case; removing it entirely would mean never settling a previously-healthy
+  artifact, which is the livelock with no terminal at all. Relatedly, a running workload that cannot
+  reach its desired instance count keeps retrying at the reconcile cadence — convergence, not the
+  defect this ticket was filed about, but a candidate for backing off rather than terminating.
 - **Scope note.** This is a defect in the exhaustion machinery, reachable through every cause that is
   legitimately `Intermittent` — `CoreError.Timeout` and resource-capacity exhaustion — and it
   predates any recent reclassification work. The pin deliberately drives `CoreError.Timeout` rather
-  than a newly-typed cause, so it stays honest about that. Found while reviewing #916, which types
-  two activation-path causes as `Intermittent`; #916 does not widen the set of causes that can reach
+  than a newly-typed cause, so it stays honest about that. Found while reviewing #916 / #920, which
+  type two activation-path causes as `Intermittent`; neither widens the set of causes that can reach
   this loop, because every path that issues an ACTIVATE is gated on the slice having been reported
-  `LOADED` and a genuinely absent artifact fails earlier
+  `LOADED` and a genuinely absent artifact fails earlier. **#923** — consensus exhaustion raises an
+  untyped cause at 90 s, inside the 120 s chain timeout, so it classifies `Fatal` — is the same
+  family and is not addressed here
   [mechanism: all four call sites of `tryActivateIfDependenciesReady` filter on `SliceState.LOADED` —
-  `ClusterDeploymentState:1550`, `:694`, `:894`, `:1897`]. The two changes are therefore independent
-  and ship as separate pull requests.
+  `ClusterDeploymentState:1551`, `:700`, `:897`, `:1901`, the last being `activateDependentSlices`].
 - **A stale surface corrected with it.** `aether/docs/specs/stream-offheap-budget-spec.md` resolved
   an open design question ("`fatal` flag for deployment failure") with "permanent failure still
   surfaces after retries". That was false on disk for as long as the loop existed — the spec was
-  relying on a terminal that did not exist. It is true again with this change.
+  relying on a terminal that did not exist. It is true again with this change
+  [verified: open question 7 of that spec, re-read at this branch's head; its resolution now follows
+  from `handleRetryBudgetExhausted` reaching `settleAsPermanentlyFailed` for a deployment whose budget
+  a genuinely unsatisfiable stream requirement will spend, since such a deployment never reaches
+  ACTIVE on any node].


### PR DESCRIPTION
> ## ⚠️ STATUS — head `7941ed668`, round 3. DO NOT MERGE.
>
> **A fourth adversarial verification is in flight.** Two prior reviews BLOCKED this PR.
>
> **The diagnosis below is still accurate and worth reading. The section "The fix, and the scope the
> review made necessary" describes a SUPERSEDED approach** — it was rejected by round-2 verification
> and no longer matches the code.
>
> **What the code does now.** The present-tense predicate (*is an instance ACTIVE?*) is replaced by a
> past-tense one, `everReachedActive` — a fail-safe disjunction of three legs, settling only when all
> three say the artifact never reached ACTIVE, and gated on `coreMembershipResolved()` first:
>
> | Leg | Evidence | Lifetime |
> |---|---|---|
> | 1 | an instance is ACTIVE now | survives failover via the `sliceStates` rebuild |
> | 2 | `everActiveArtifacts` — this leader watched it start | in-memory; empty on a new leader |
> | 3 | the owning blueprint's durable `DeploymentOutcomeValue.SUCCEEDED` | durable KV; survives failover |
>
> **Why round 2 blocked the previous approach:** asking *"is an instance ACTIVE right now?"* cannot
> work, because `handleSliceFailure` removes the failing key from `sliceStates` **before** either
> failure branch runs. For a single-instance slice — the most common deployment shape — the guard was
> structurally unreachable, so every such slice hit by a >31 s transient was condemned permanently and
> cluster-wide, with its last outcome record still reading SUCCEEDED and reconcile emitting nothing.
> That case self-healed before this PR.
>
> **The reframing that produced round 3:** the livelock and the self-heal are the *same mechanism*.
> Before #922, budget exhaustion cleared the counter and re-drove without settling — which is how a
> transient recovered, and equally how `ArtifactNotFound` spun forever. The discriminator has to
> separate *was up and fell over* from *never came up*, which is a question about history, not about
> the present.
>
> **Four residues are stated open in the fix report, not claimed closed** — including one nothing
> covers (a re-used blueprint id whose attempt spans a leader failover reads the previous attempt's
> record). All four fail toward **re-driving** rather than condemning, which is the reversible side of
> a one-way door. That is a deliberate judgment call and is marked as one.
>
> **CI green on this PR is on the OLD head `8d9b8beb9`** and says nothing about `7941ed668`.
> Mergeability is not checks-green.
>
> Fix report: `oss/internal/fix-924-round3-2026-09-07.md` · Round 2: `verify-924-round2-2026-09-07.md`

Closes #922.

**Extracted from #920 after a CTO ruling that the terminal-state change belongs to #922, not #916.** It was written and verified inside #920 first, then moved here intact. #920 types two activation-path causes as `Intermittent`; this changes what happens when *any* intermittent cause exhausts its retry budget. Different tickets, different blast radius, so they ship separately with their own fragments.

**Updated after review (1 BLOCKING, 2 SHOULD-FIX, 4 NOTE).** The blocking finding was real and is fixed and pinned; the first version of this PR traded a livelock for a worse, silent failure. Details below.

**Why this is live, not theoretical.** An artifact coordinate that cannot be resolved — a typo in a blueprint is enough — makes the cluster re-drive the load roughly once a second for the life of the process, logging exhausted retries that nothing acts on. There is no terminal state to stop it and no record an operator can act on.

**Same-mechanism family.** #916 / #920 (activation-path causes misclassified as permanent), this ticket (the exhaustion arm never settles), and **#923** (consensus exhaustion raises an untyped cause at 90 s, inside the 120 s chain timeout, so it classifies `Fatal`) are three faces of one thing: what a deployment failure is *typed* as, and what the machinery does with that type. #923 is not addressed here.

## The defect: exhaustion never reached a terminal state

`handleTransientFailure` retries a non-fatal failure five times with exponential backoff. When the budget was spent, `logMaxRetriesExceeded` cleared the retry counter and routed a `DeploymentFailed` event — and returned. It never added the artifact to `permanentlyFailed`.

That is not a resting state:

1. `handleSliceFailure` issues an unload on **every** failure, before the fatal/transient branch;
2. the node's `handleUnloading` removes the `NodeArtifactKey`;
3. the leader's `handleSliceNodeRemoval` — finding the artifact *not* permanently failed — schedules a reconcile;
4. `reconcileBlueprint` is gated on `permanentlyFailed` and nothing else, so it redeploys the artifact and `retryCounters.merge` restarts at 1.

So an intermittent cause that never settles was re-driven at roughly **1 Hz for the life of the cluster**: no terminal state, no rollback, no outcome record, and consensus round-trips forever.

## The fix, and the scope the review made necessary

`handleDeterministicFailure`'s tail — mark `permanentlyFailed`, route `DeploymentFailed`, honour the declared atomicity — is extracted as `settleAsPermanentlyFailed`, and **both failure branches now converge on it**. `logMaxRetriesExceeded` is renamed `handleRetryBudgetExhausted`, because it no longer merely logs.

**But settling unconditionally was itself a defect, and a worse one than the livelock.** `settleAsPermanentlyFailed` came from the **deterministic** branch, where concluding cluster-wide from a single node is sound *because a deterministic failure is node-independent*. **That inference does not transfer to the transient branch** — a transient failure on node A says nothing about node B. The defect was not the choice of flag but a **scope inference carried across a branch where it does not hold**:

- `retryCounters` is keyed per artifact **and node** (`slices/<nodeId>/<artifact>`);
- `permanentlyFailed` is a cluster-wide `Set<Artifact>`, cleared at exactly one site, on blueprint apply.

So roughly **31 s** of trouble on **one** node condemned a slice that was deployed and healthy on every other node. And it did so **silently**: a fully-deployed blueprint has already left `inFlightBlueprints`, so `rollbackBlueprintForArtifact` matches nothing, **no FAILED outcome is written at all**, and the artifact's last recorded outcome still reads SUCCEEDED while reconcile quietly refuses to replace the lost instance. The livelock was noisy and kept trying; this was a permanent, invisible wedge on a deployment that had been working.

`handleRetryBudgetExhausted` now settles only when **`hasActiveInstanceElsewhere` is false**: a deployment **attempt** with nothing ACTIVE anywhere is abandoned, while a **running** workload suffering a node-local transient keeps being reconciled toward its desired instance count.

### Why that discriminator and not the blueprint being in flight

Gating on `inFlightBlueprints` was the cheaper test, and it is the wrong one. `ClusterDeploymentContext.newActive()` constructs **every** collection empty, and only a live `AppBlueprintPutReceived` populates that map — nothing repopulates it after a leader change. Gating on it would have **silently reopened #922 after any failover**. `sliceStates`, by contrast, is rebuilt from durable KV entries by `rebuildSliceStateFromKVStoreEntries` during `rebuildStateFromKVStore` in `Active.onEntry`, so the predicate reads the same answer on a new leader as on the old one. Verifying a condition's meaning is not verifying its lifetime.

Two smaller points, both deliberate: the check is **strictly ACTIVE** rather than `isLiveState`, because a sibling instance merely LOADING or LOADED belongs to the same unproven attempt and must not vote to keep it alive; and it filters on `activeNodes()`, the identical filter `getCurrentInstances` uses, so the predicate agrees by construction with what `reconcileBlueprint` counts as running.

### What this deliberately leaves open

- A transient affecting **every** node for longer than the budget still settles the artifact, since by then nothing is ACTIVE anywhere. The fix narrows the evidence required for a cluster-wide permanent verdict from one node's budget to every node's; it does not remove the case. Removing it entirely would mean never settling a previously-healthy artifact — the livelock with no terminal at all.
- A running workload that cannot reach its desired instance count keeps retrying at the reconcile cadence. That is convergence, not this defect, but it is a candidate for backing off rather than terminating.
- The retry budget is still not operator-configurable (review S1). Threading a configurable `MAX_RETRIES` touches ~20 construction sites or needs a late-wired setter; that is a feature, not a fix.

### An open design question this fix does not answer, and the reviewer should press on

**This interacts with #926, and the interaction is not resolved here.** #926 reports that cluster-failure events are leader-gated: measured over ten days on the internal test host, a five-node cluster produced 8 SWIM fault detections and **zero** `NodeFailed` emissions, with `LeaderLost` firing 70–86 thousand times while `LeaderElected` never fired at all. A cluster that cannot elect a leader therefore emits nothing about its own failure.

Put that together with this change. With no leader, deployments cannot progress, so a deployment started during such an outage drains its retry budget with nothing ever reaching ACTIVE. `hasActiveInstanceElsewhere` then reads "nothing ACTIVE anywhere" — correctly, but **for the wrong reason** — and settles the artifact permanently failed. Per #926, nothing is emitted about any of it.

That may well be the right outcome: the deployment genuinely did not succeed. But a permanent state cleared only by a fresh blueprint apply is a strong thing to reach through an infrastructure condition the operator cannot see, and distinguishing "this deployment cannot work" from "this cluster currently has no leader" needs a signal #926 says does not exist. It is an argument for fixing emission first and treating the two as one design question. **Deliberately not addressed here** — it is out of scope for #922 and #926 now carries it.

## Retry budget — corrected

`MAX_RETRIES` = 5, backoff 1/2/4/8/16 s jittered, about **31 s on one node**. Both it and `MAX_RETRY_DELAY_SECONDS` = 30 are private compile-time constants: finite and knowable, but **not operator-configurable**.

Two corrections the review was right about:

- **The 30 s cap never binds at the current budget.** `Math.min(1L << (retryCount - 1), 30)` with `retryCount` never exceeding 5 tops out at 16 s. It guards a larger budget; it does not shape this one.
- **The bound is per artifact and node, not cluster-wide.** The sixth reported failure on any one node spends that node's budget, but with placement rotating across N allocatable nodes the cluster-wide total can reach **N x (MAX_RETRIES + 1)** reported failures — and the bound holds only while the allocatable node set is stable, since fresh nodes get fresh counters.

**Operator recovery action:** the artifact stays undeployable until its blueprint is redeployed, which clears `permanentlyFailed` on apply.

## Verification

The pin drives **`CoreError.Timeout`**, deliberately: one of the two causes the ticket names as already legitimately `Intermittent`, independent of #920's typing work, so the fix cannot be said to depend on it.

**The reverse-risk pin asserts the RECOVERY, not the absence of a rollback.** "No rollback happened" is equally true of a cluster that has silently stopped doing anything — which is the bug itself — so such an assertion would pin nothing. `exhaustionOnOneNode_whileTheArtifactIsActiveElsewhere_stillRecoversTheLostInstance` deploys the slice on two nodes, spends the entire budget on one, then asserts that reconciliation still re-drives the artifact **and** that the lost instance comes back ACTIVE on both nodes once the transient clears. A companion test asserting the standing SUCCEEDED record is explicitly labelled non-discriminating in its own javadoc, and nothing is relied on it.

**Red-before, two probes.** Each production hunk is pinned by its own test, and neither masks the other. Both mutations compiled, so both are genuine test failures rather than broken probes. The change was committed *before* probing and each probe reverted as a hunk against the committed base; restores were verified by content hash, not by `git status`.

| Probe | Mutation | Result |
|---|---|---|
| A | `hasActiveInstanceElsewhere` guard removed — settle unconditionally, i.e. the reviewed defect | `Tests run: 960, Failures: 1` — only the new recovery pin. Both original #922 pins stayed green |
| B | `settleAsPermanentlyFailed` call replaced by the pre-#922 log-and-return tail | `Tests run: 960, Failures: 2` — only the two original #922 pins. Both new tests stayed green |

| Check | Result |
|---|---|
| `aether-deployment` tests | **960**, 0 failures |
| `RetryExhaustionTerminalTest` | 4, all pass |
| `jbct:check -Djbct.skip=false` | 0 format issues, 0 lint errors |
| Base | merged forward onto `f3abe5c5b`, which contains #916 (`2cb38bc2d`) and #921 |
| Root reactor `mvn clean install` | **BUILD SUCCESS** — 20:39, **13,153 tests** from surefire XML, **0 modules SKIPPED**, 0 `[ERROR]` lines. Base `f3abe5c5b`, head `8d9b8beb9` |

**Base merged forward before the root build, deliberately.** #916 routes both slice-store-absence causes onto the **transient retry path** — precisely the path this change governs. A root build against the old base would have been evidence about a base nobody will run.

**Residual, stated rather than implied:** I did not construct a test for a transient exhaustion racing an unload/activate crossing from #916. The harness drives the leader FSM through ordered KV notifications, so "mid-crossing" is not a state it can hold — the predicate reads whatever the last notification left. Recorded as a residual.

## Stale surface corrected here

`aether/docs/specs/stream-offheap-budget-spec.md` resolves an open design question ("`fatal` flag for deployment failure") with *"non-fatal/transient is correct; permanent failure still surfaces after retries"*. The second half was **false on disk** for as long as this loop existed. It is true again with this change: a stream budget that genuinely can never fit never reaches ACTIVE on any node, so exhaustion settles it.

