### PR TITLE
fix(aether): publish MembershipFsm transitions outside the per-member monitor (#929)

### DIFF
--- a/aether/aether-deployment/src/main/java/org/pragmatica/aether/deployment/membership/fsm/MembershipFsm.java
+++ b/aether/aether-deployment/src/main/java/org/pragmatica/aether/deployment/membership/fsm/MembershipFsm.java
@@ -4,6 +4,7 @@
 // See LICENSE in the repository root for full terms.
 package org.pragmatica.aether.deployment.membership.fsm;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -436,9 +437,13 @@ public final class MembershipFsm {
     }
 
     /// Register the Wave-1 transition-journal listener invoked once per ACTUAL per-member state
-    /// change, at the central dispatch chokepoint. The listener is called under the per-member
-    /// monitor — implementations must be cheap and non-blocking (the journal ring-buffer append
-    /// is). Diagnostic-only; a `null` argument resets it to the no-op.
+    /// change, at the central dispatch chokepoint. Since #929 the listener runs AFTER the
+    /// per-member monitor is released (still serialised per member by
+    /// [`MemberTracking#transitionGuard`], and still while that member's state is exactly what the
+    /// record names) — it may therefore read the member map without deadlocking, which is what
+    /// `AetherNode.propagateMemberCount` does on the Member-boundary edge. Cheap and non-blocking
+    /// is still the right shape: a slow listener stalls every further transition of THAT member.
+    /// Diagnostic-only; a `null` argument resets it to the no-op.
     @Contract
     public void onTransition(Consumer<MembershipTransitionRecord> listener) {
         this.onTransition = listener == null
@@ -456,9 +461,10 @@ public final class MembershipFsm {
 
     /// Register the Wave-4 membership-delta listener invoked once per counted-set lifecycle
     /// edge (JOINED / REMOVED, see [`MembershipDeltaEdge`]) at the central dispatch chokepoint.
-    /// The listener is called under the per-member monitor — implementations must be cheap and
-    /// non-blocking (the production [`MembershipDeltaProjector`] enqueues into its FIFO and
-    /// returns). A `null` argument resets it to the no-op.
+    /// Since #929 the listener runs AFTER the per-member monitor is released (still serialised per
+    /// member by [`MemberTracking#transitionGuard`]); cheap and non-blocking remains the right
+    /// shape (the production [`MembershipDeltaProjector`] enqueues into its FIFO and returns), but
+    /// it is no longer load-bearing against deadlock. A `null` argument resets it to the no-op.
     @Contract
     public void onMembershipDelta(Consumer<MembershipDeltaEdge> listener) {
         this.onMembershipDelta = listener == null
@@ -917,47 +923,64 @@ public final class MembershipFsm {
     }
 
     // --- Per-member transition drivers (presence sampler promotion + co-confirmation eviction) ---
+    // Each driver below is ONE logical membership operation spanning several per-member steps.
+    // Since #929 they run under the member's transition guard ([`MemberTracking#inTransition`]) so
+    // the whole sequence is atomic against every other transition of that member — the atomicity
+    // that `evictIfStillConfirmedDead` used to get from being `synchronized` on the monitor, and
+    // which the drivers themselves never had (each step took the monitor separately).
     private void healthy(MemberTracking tracking, long incarnation) {
-        tracking.dispatch(new SwimHealthy(incarnation));
-        tracking.clearConfirmedDeath();
-        if (tracking.bumpHealthyStreakReachedThreshold()) {
-            tracking.dispatch(new UpHysteresisMet());
-        }
+        tracking.inTransition(() -> {
+            tracking.dispatch(new SwimHealthy(incarnation));
+            tracking.clearConfirmedDeath();
+            if (tracking.bumpHealthyStreakReachedThreshold()) {
+                tracking.dispatch(new UpHysteresisMet());
+            }
+        });
     }
 
     private void suspect(MemberTracking tracking, long incarnation) {
-        tracking.resetHealthyStreak();
-        tracking.stampDoubt(wallClockMs.getAsLong());
-        tracking.dispatch(new SwimSuspect(incarnation));
+        tracking.inTransition(() -> {
+            tracking.resetHealthyStreak();
+            tracking.stampDoubt(wallClockMs.getAsLong());
+            tracking.dispatch(new SwimSuspect(incarnation));
+        });
     }
 
     private void faulty(MemberTracking tracking, long incarnation) {
-        tracking.resetHealthyStreak();
-        tracking.stampDoubt(wallClockMs.getAsLong());
-        tracking.dispatch(new SwimFaulty(incarnation));
-        tracking.markSwimFaulty();
-        maybeConfirmDeparture(tracking);
+        tracking.inTransition(() -> {
+            tracking.resetHealthyStreak();
+            tracking.stampDoubt(wallClockMs.getAsLong());
+            tracking.dispatch(new SwimFaulty(incarnation));
+            tracking.markSwimFaulty();
+            maybeConfirmDeparture(tracking);
+        });
     }
 
     private void departed(MemberTracking tracking, long incarnation) {
-        tracking.resetHealthyStreak();
-        tracking.dispatch(new SwimDeparted(incarnation));
-        tracking.dispatch(new Stopped());
+        tracking.inTransition(() -> {
+            tracking.resetHealthyStreak();
+            tracking.dispatch(new SwimDeparted(incarnation));
+            tracking.dispatch(new Stopped());
+        });
     }
 
     private void livenessGone(MemberTracking tracking) {
-        tracking.stampDoubt(wallClockMs.getAsLong());
-        tracking.dispatch(new LivenessGone());
-        tracking.markLivenessGone();
-        maybeConfirmDeparture(tracking);
+        tracking.inTransition(() -> {
+            tracking.stampDoubt(wallClockMs.getAsLong());
+            tracking.dispatch(new LivenessGone());
+            tracking.markLivenessGone();
+            maybeConfirmDeparture(tracking);
+        });
     }
 
     /// Transport-disconnect doubt path (MEMBER→SUSPECT on [`PeerDisconnected`]): stamp the doubt
     /// time so the SUSPECT's quiesce hint decays under the #68 TTL, then dispatch. A no-op in any
     /// state with no MEMBER→SUSPECT edge — the stamp is harmless there (the hint stays `none()`).
     private void peerDisconnected(MemberTracking tracking) {
-        tracking.stampDoubt(wallClockMs.getAsLong());
-        tracking.dispatch(new PeerDisconnected());
+        tracking.inTransition(() -> {
+            tracking.stampDoubt(wallClockMs.getAsLong());
+            tracking.dispatch(new PeerDisconnected());
+        });
     }
 
     /// Seed-promote a single id (the one-time formation bootstrap). The (lazily-created) tracking is
@@ -1114,6 +1137,31 @@ public final class MembershipFsm {
         /// is never recreated), matching the descriptor-retention rationale documented on
         /// [`MembershipFsm#memberAgeMs`]. Final → safe to read without the per-member monitor.
         private final long firstTrackedAtMs;
+        /// Serialises one member's WHOLE logical transition — the state change AND the listener
+        /// fan-out — without holding the per-member state monitor across the fan-out (#929).
+        ///
+        /// The state monitor is `this`, and it is what every projection acquires
+        /// ([`#isStrictCoreMember`], [`#countsTowardEffective`], [`#notDead`], …). Publishing to a
+        /// listener while holding it let `AetherNode`'s Member-boundary quorum re-feed — which
+        /// walks `members` calling [`#isStrictCoreMember`] on EVERY member — hold one member's
+        /// monitor while requesting all the others', in `ConcurrentHashMap` iteration order. Two of
+        /// one node's event loops (SWIM `onSwimSuspect`, QUIC `onLivenessGone`) dispatching on two
+        /// different members then wedged AB/BA. That order is a hash order, so no lock-ordering
+        /// discipline can repair it; the nesting itself has to go.
+        ///
+        /// Holding this guard around [`#applyEvent`] plus the fan-out preserves BOTH properties the
+        /// old `synchronized dispatch` gave: one member's transitions stay totally ordered, and a
+        /// listener still observes that member in exactly the state its record names, because no
+        /// other thread can advance the member until the fan-out returns. What it drops is the
+        /// incidental blocking of READERS of this member's state — the deadlock's only edge.
+        ///
+        /// LOCK ORDER IS ALWAYS this guard, THEN the monitor. Never the reverse: every
+        /// check-then-dispatch entry point ([`#promoteIfObserved`], [`#terminalizeIfStillDeparting`],
+        /// [`#expireJoinGrace`], [`#evictIfStillConfirmedDead`]) takes the guard FIRST and reads
+        /// state through a short `synchronized` accessor, rather than being `synchronized` itself.
+        /// Their check-then-dispatch atomicity is preserved by the guard, since [`#dispatch`] is the
+        /// only writer of `fsm` state and it requires the guard.
+        private final Object transitionGuard = new Object();
         private int healthyStreak = 0;
         private boolean swimFaultySeen = false;
         private boolean livenessGoneSeen = false;
@@ -1206,6 +1254,21 @@ public final class MembershipFsm {
             return firstTrackedAtMs;
         }
 
+        /// Run a MULTI-STEP driver operation with this member's [`#transitionGuard`] held (#929).
+        /// The outer-class ingress drivers ([`MembershipFsm#faulty`], [`MembershipFsm#healthy`], …)
+        /// are dispatch-plus-flag-mark-plus-co-confirmation sequences; before #929 each step took
+        /// the per-member monitor SEPARATELY, so another thread could interleave between them.
+        /// Wrapping them here makes each driver atomic against every other transition of the same
+        /// member — strictly stronger than the pre-#929 behaviour, and what keeps
+        /// [`#evictIfStillConfirmedDead`]'s check-march-clear sequence indivisible now that it
+        /// holds the guard rather than the monitor. Reentrant: nested [`#dispatch`] calls re-enter
+        /// the same guard on the same thread.
+        void inTransition(Runnable action) {
+            synchronized (transitionGuard) {
+                action.run();
+            }
+        }
+
         /// Dispatch `event` to the FSM and, on a FRESH edge into DEAD (was not Dead before, is Dead
         /// after), fire the eviction hook exactly once. Centralized here so ALL DEAD paths (co-confirmed
         /// death, graceful departure, join-grace expiry) are covered uniformly without per-ingress
@@ -1236,7 +1299,25 @@ public final class MembershipFsm {
         /// - M10 join-grace re-arm: a fenced rejoin (was DEAD, now OBSERVED) re-arms the reaper for
         ///   the new tenure; death cancels it.
         @Contract
-        synchronized void dispatch(MembershipEvent event) {
+        void dispatch(MembershipEvent event) {
+            synchronized (transitionGuard) {
+                applyEvent(event).forEach(Runnable::run);
+            }
+        }
+
+        /// State half of [`#dispatch`] (#929): mutate under the per-member monitor and STAGE the
+        /// listener fan-out instead of running it, returning the staged calls in the exact order
+        /// the pre-#929 inline code fired them (transition, JOINED delta, DEPARTING hook,
+        /// DEPARTING-recovery hook, then the DEAD hooks). The caller runs them with the monitor
+        /// released and the guard still held.
+        ///
+        /// Every branch's own bookkeeping — timer arm/cancel, death-flag clearing, `everJoined` —
+        /// still runs HERE under the monitor, interleaved exactly as before. None of it touches
+        /// `fsm.current()`, so hoisting the listener calls to the end is not observable to a
+        /// listener: the state it reads is the same state it read before.
+        private synchronized List<Runnable> applyEvent(MembershipEvent event) {
+            var emissions = new ArrayList<Runnable>(4);
+
             trackTransportConnectivity(event);
             trackReachabilityEvidence(event);
             var wasDead = isDead();
@@ -1247,21 +1328,25 @@ public final class MembershipFsm {
             var to = stateName();
 
             if (!from.equals(to)) {
-                transitionSink.accept(new MembershipTransitionRecord(id,
-                                                                     from,
-                                                                     to,
-                                                                     event.getClass().getSimpleName(),
-                                                                     incarnation(),
-                                                                     descriptor.role(),
-                                                                     System.currentTimeMillis()));
+                var record = new MembershipTransitionRecord(id,
+                                                            from,
+                                                            to,
+                                                            event.getClass().getSimpleName(),
+                                                            incarnation(),
+                                                            descriptor.role(),
+                                                            System.currentTimeMillis());
+
+                emissions.add(() -> transitionSink.accept(record));
             }
 
             if (!everJoined && fsm.current() instanceof MembershipState.Member) {
                 everJoined = true;
-                deltaSink.accept(new MembershipDeltaEdge(id,
-                                                         MembershipDeltaEdge.Kind.JOINED,
-                                                         incarnation(),
-                                                         descriptor.role()));
+                var edge = new MembershipDeltaEdge(id,
+                                                   MembershipDeltaEdge.Kind.JOINED,
+                                                   incarnation(),
+                                                   descriptor.role());
+
+                emissions.add(() -> deltaSink.accept(edge));
             }
 
             if (!from.equals(to) && fsm.current() instanceof MembershipState.Member) {
@@ -1269,7 +1354,7 @@ public final class MembershipFsm {
             }
 
             if (!wasDeparting && isDeparting()) {
-                enteredDeparting();
+                enteredDeparting(emissions);
             }
 
             if (wasDeparting && !isDeparting()) {
@@ -1277,7 +1362,7 @@ public final class MembershipFsm {
             }
 
             if (wasDeparting && fsm.current() instanceof MembershipState.Member) {
-                recoveredFromDeparting();
+                recoveredFromDeparting(emissions);
             }
 
             if (wasDead && fsm.current() instanceof MembershipState.Observed) {
@@ -1285,8 +1370,10 @@ public final class MembershipFsm {
             }
 
             if (!wasDead && isDead()) {
-                enteredDead(event);
+                enteredDead(event, emissions);
             }
+
+            return emissions;
         }
 
         /// Track per-member transport connectivity off the transport events flowing through this
@@ -1337,9 +1424,9 @@ public final class MembershipFsm {
         /// (`DrainRequested` / `SwimDeparted` / `DownHysteresisMet`) — the transport-doubt flaps
         /// never reach DEPARTING in the [`MembershipState`] table — so this can never storm per
         /// QUIC flap. The ring prune it actuates is idempotent with the later DEAD-edge prune.
-        private synchronized void enteredDeparting() {
+        private synchronized void enteredDeparting(List<Runnable> emissions) {
             armDepartureTimeout();
-            onEnteredDeparting.accept(id);
+            emissions.add(() -> onEnteredDeparting.accept(id));
         }
 
         /// Fresh DEPARTING→MEMBER recovery fan-out (seed-500 part 2, symmetry fix): fire the
@@ -1350,8 +1437,8 @@ public final class MembershipFsm {
         /// branch in [`#dispatch`]; this branch is scoped to the MEMBER recovery target ONLY (the
         /// DEPARTING→DEAD timeout exit does not match), so it never re-adds a dying node. Idempotent
         /// with the normal `onNodeJoined` ring-add (`ConsistentHashRing.addNode` no-ops a present node).
-        private synchronized void recoveredFromDeparting() {
-            onDepartingRecovery.accept(id);
+        private void recoveredFromDeparting(List<Runnable> emissions) {
+            emissions.add(() -> onDepartingRecovery.accept(id));
         }
 
         /// Fresh-edge-into-DEAD fan-out: cancel both pending timers, fire the manager's death hook
@@ -1361,20 +1448,22 @@ public final class MembershipFsm {
         /// — graceful `SwimDeparted`, co-confirmed eviction, DEPARTING timeout — do NOT fire it), and
         /// emit the REMOVED delta for a previously-JOINED member (clearing `everJoined` so a fenced
         /// rejoin re-emits JOINED).
-        private synchronized void enteredDead(MembershipEvent triggeringEvent) {
+        private synchronized void enteredDead(MembershipEvent triggeringEvent, List<Runnable> emissions) {
             cancelEvictionBackstop();
             cancelJoinGrace();
-            onEnteredDead.accept(id);
+            emissions.add(() -> onEnteredDead.accept(id));
             if (triggeringEvent instanceof JoinGraceExpiredNeverHealthy) {
-                onJoinGraceReaped.accept(id);
+                emissions.add(() -> onJoinGraceReaped.accept(id));
             }
 
             if (everJoined) {
                 everJoined = false;
-                deltaSink.accept(new MembershipDeltaEdge(id,
-                                                         MembershipDeltaEdge.Kind.REMOVED,
-                                                         incarnation(),
-                                                         descriptor.role()));
+                var edge = new MembershipDeltaEdge(id,
+                                                   MembershipDeltaEdge.Kind.REMOVED,
+                                                   incarnation(),
+                                                   descriptor.role());
+
+                emissions.add(() -> deltaSink.accept(edge));
             }
         }
 
@@ -1394,12 +1483,20 @@ public final class MembershipFsm {
         /// and fires the Wave-4 JOINED delta edge exactly like a SWIM-driven promotion — without
         /// this, boot-seeded members would never be baselined by the [`MembershipDeltaProjector`]
         /// and their deaths would emit no `NodeRemoved` (the #245 gap, re-opened for original
-        /// cores). Reentrant-safe: both methods synchronize on this monitor.
+        /// cores). Guard + dispatch are atomic under [`#transitionGuard`] (#929): [`#dispatch`] is
+        /// the only writer of `fsm` state and it requires that guard, so no transition can slip
+        /// between the OBSERVED check and the promotion.
         @Contract
-        synchronized void promoteIfObserved() {
-            if (fsm.current() instanceof MembershipState.Observed) {
-                dispatch(new UpHysteresisMet());
+        void promoteIfObserved() {
+            synchronized (transitionGuard) {
+                if (isObserved()) {
+                    dispatch(new UpHysteresisMet());
+                }
             }
+        }
+
+        private synchronized boolean isObserved() {
+            return fsm.current() instanceof MembershipState.Observed;
         }
 
         synchronized boolean bumpHealthyStreakReachedThreshold() {
@@ -1486,16 +1583,18 @@ public final class MembershipFsm {
             departureTimeoutHandle = Option.none();
         }
 
-        /// DEPARTING timeout firing under the per-member monitor (H2): terminalize ONLY if the
-        /// member is STILL in DEPARTING. A recovery between timer-fire and monitor-acquire has
+        /// DEPARTING timeout firing under the per-member transition guard (H2, #929): terminalize
+        /// ONLY if the member is STILL in DEPARTING. A recovery between timer-fire and guard-acquire has
         /// already moved the FSM to MEMBER (and cancelled the handle), so the re-check no-ops —
         /// closing the `cancel(false)`-cannot-stop-a-running-task race; without it the delayed
         /// `Stopped` would kill a recovered MEMBER. The `Stopped` dispatch routes through the
         /// central chokepoint, so the resulting DEAD edge journals, fires the death hook, and
         /// emits the REMOVED delta exactly like any other death.
-        private synchronized void terminalizeIfStillDeparting() {
-            if (fsm.current() instanceof MembershipState.Departing) {
-                dispatch(new Stopped());
+        private void terminalizeIfStillDeparting() {
+            synchronized (transitionGuard) {
+                if (isDeparting()) {
+                    dispatch(new Stopped());
+                }
             }
         }
 
@@ -1516,7 +1615,8 @@ public final class MembershipFsm {
             joinGraceHandle = Option.none();
         }
 
-        /// Join-grace firing under the per-member monitor (M10 + gate RCA fix, 2026-06-11):
+        /// Join-grace firing under the per-member transition guard (M10 + gate RCA fix, 2026-06-11;
+        /// guard rather than monitor since #929):
         /// reap ONLY if the member is never-healthy (still OBSERVED) AND `transportConnected ==
         /// false` — a true ghost is co-confirmed by BOTH planes (never SWIM-healthy AND no live
         /// transport connection). A still-OBSERVED member with a LIVE transport connection is a
@@ -1527,36 +1627,49 @@ public final class MembershipFsm {
         /// with the unchanged `JoinGraceExpiredNeverHealthy` journal cause; the state table
         /// confines the transition to OBSERVED→DEAD, so a racing promotion can never be killed
         /// by a fired-but-not-yet-run reaper.
-        private synchronized void expireJoinGrace() {
-            if (transportConnected && fsm.current() instanceof MembershipState.Observed) {
-                log.info("Join-grace reaper DEFERRED for {}: never-healthy but transport connection is LIVE — re-arming (window={})",
-                         id,
-                         joinGrace);
-                armJoinGrace();
+        private void expireJoinGrace() {
+            synchronized (transitionGuard) {
+                if (joinGraceReapDeferred()) {
+                    log.info("Join-grace reaper DEFERRED for {}: never-healthy but transport connection is LIVE — re-arming (window={})",
+                             id,
+                             joinGrace);
+                    armJoinGrace();
 
-                return;
+                    return;
+                }
+
+                dispatch(new JoinGraceExpiredNeverHealthy());
             }
-
-            dispatch(new JoinGraceExpiredNeverHealthy());
         }
 
-        /// Backstop firing under the per-member monitor (#131 Model C): terminal-evict ONLY if the
+        /// The reaper's deferral predicate, both reads under ONE monitor acquisition: never-healthy
+        /// (still OBSERVED) but a LIVE transport connection contradicting the ghost verdict.
+        private synchronized boolean joinGraceReapDeferred() {
+            return transportConnected && fsm.current() instanceof MembershipState.Observed;
+        }
+
+        /// Backstop firing under the per-member transition guard (#131 Model C; guard rather than
+        /// monitor since #929, and the co-confirmation drivers take the same guard via
+        /// [`#inTransition`], so the whole check-march-clear sequence stays atomic against them):
+        /// terminal-evict ONLY if the
         /// member is STILL co-confirmed dead. A `SwimHealthy` recovery between timer-fire and
-        /// monitor-acquire runs `clearConfirmedDeath` (flags false + cancel), so `coConfirmedDead()` is
+        /// guard-acquire runs `clearConfirmedDeath` (flags false + cancel), so `coConfirmedDead()` is
         /// false here and we no-op — closing the `cancel(false)`-cannot-stop-a-running-task race. When
         /// it does proceed, the terminal march (Suspect→Departing→Dead via `DownHysteresisMet` then
         /// `Stopped`) runs through `dispatch` (already synchronized/reentrant on this monitor); the
         /// fresh-edge-into-DEAD branch there cancels the now-fired handle and fires `onEnteredDead`
         /// exactly once.
         @Contract
-        synchronized void evictIfStillConfirmedDead() {
-            if (!coConfirmedDead()) {
-                return;
-            }
+        void evictIfStillConfirmedDead() {
+            synchronized (transitionGuard) {
+                if (!coConfirmedDead()) {
+                    return;
+                }
 
-            dispatch(new DownHysteresisMet());
-            dispatch(new Stopped());
-            clearConfirmedDeath();
+                dispatch(new DownHysteresisMet());
+                dispatch(new Stopped());
+                clearConfirmedDeath();
+            }
         }
 
         /// Guarded upsert of the network descriptor from a NodeInfo observation. Orthogonal to the

--- a/aether/aether-deployment/src/main/java/org/pragmatica/aether/deployment/membership/fsm/MembershipFsm.java
+++ b/aether/aether-deployment/src/main/java/org/pragmatica/aether/deployment/membership/fsm/MembershipFsm.java
@@ -1161,6 +1161,21 @@ public final class MembershipFsm {
         /// state through a short `synchronized` accessor, rather than being `synchronized` itself.
         /// Their check-then-dispatch atomicity is preserved by the guard, since [`#dispatch`] is the
         /// only writer of `fsm` state and it requires the guard.
+        ///
+        /// **That lock order is true but it is NOT what earns the safety, and the distinction matters
+        /// because the real invariant is the fragile one.** The fan-out still holds member X's guard
+        /// while acquiring every OTHER member's monitor — that is exactly what
+        /// `AetherNode.propagateMemberCount` does. What makes that acyclic is that **the per-member
+        /// monitor is a LEAF: nothing acquired under it acquires anything else.** [`#applyEvent`]
+        /// reaches only the pure state table ([`MembershipState`] contains no `synchronized`), the
+        /// timer arm/cancel helpers, and a list append.
+        ///
+        /// **The leaf property is therefore a precondition of this fix, not an incidental fact.** It
+        /// can be broken from outside this class: the factories taking an explicit
+        /// [`FsmObserver`] ([`MembershipFsm#membershipFsm`] overloads) run that observer INSIDE
+        /// [`#applyEvent`], under the monitor. Production wires `FsmObserver.noop()`; an observer that
+        /// touched another member — or anything that takes a lock — would reintroduce exactly the
+        /// inversion this guard removes. Keep observers pure, or move them out of the monitor too.
         private final Object transitionGuard = new Object();
         private int healthyStreak = 0;
         private boolean swimFaultySeen = false;

--- a/aether/aether-deployment/src/main/java/org/pragmatica/aether/deployment/membership/fsm/MembershipFsm.java
+++ b/aether/aether-deployment/src/main/java/org/pragmatica/aether/deployment/membership/fsm/MembershipFsm.java
@@ -1263,7 +1263,7 @@ public final class MembershipFsm {
         /// [`#evictIfStillConfirmedDead`]'s check-march-clear sequence indivisible now that it
         /// holds the guard rather than the monitor. Reentrant: nested [`#dispatch`] calls re-enter
         /// the same guard on the same thread.
-        void inTransition(Runnable action) {
+        private void inTransition(Runnable action) {
             synchronized (transitionGuard) {
                 action.run();
             }
@@ -1341,10 +1341,7 @@ public final class MembershipFsm {
 
             if (!everJoined && fsm.current() instanceof MembershipState.Member) {
                 everJoined = true;
-                var edge = new MembershipDeltaEdge(id,
-                                                   MembershipDeltaEdge.Kind.JOINED,
-                                                   incarnation(),
-                                                   descriptor.role());
+                var edge = new MembershipDeltaEdge(id, MembershipDeltaEdge.Kind.JOINED, incarnation(), descriptor.role());
 
                 emissions.add(() -> deltaSink.accept(edge));
             }

--- a/aether/aether-deployment/src/test/java/org/pragmatica/aether/deployment/membership/fsm/MembershipFsmTransitionListenerLockingTest.java
+++ b/aether/aether-deployment/src/test/java/org/pragmatica/aether/deployment/membership/fsm/MembershipFsmTransitionListenerLockingTest.java
@@ -6,6 +6,8 @@ package org.pragmatica.aether.deployment.membership.fsm;
 
 import org.junit.jupiter.api.Test;
 import org.pragmatica.consensus.NodeId;
+import org.pragmatica.statemachine.FsmObserver;
+import org.pragmatica.statemachine.FsmTags;
 
 import java.lang.management.ManagementFactory;
 import java.util.ArrayList;
@@ -19,6 +21,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.LockSupport;
 import java.util.stream.IntStream;
 
@@ -60,6 +63,11 @@ class MembershipFsmTransitionListenerLockingTest {
     /// from "the probe never actually got both threads into position" — the second is scored as a
     /// broken instrument, not as a pass.
     private static final long RENDEZVOUS_BOUND_MS = 5_000L;
+
+    /// Bound for the "did NOT finish" half of the leaf probe. Short on purpose: under the invariant
+    /// the walker is BLOCKED, not slow, so waiting longer proves nothing — and the same test then
+    /// proves the walker was merely blocked by joining it after the monitor is released.
+    private static final long LEAF_PROBE_BOUND_MS = 500L;
 
     private static final int FLIP_THREADS = 4;
     private static final int FLIPS_PER_THREAD = 200;
@@ -212,6 +220,139 @@ class MembershipFsmTransitionListenerLockingTest {
                         + "published sequence chains (#929)", index, index - 1)
                     .isEqualTo(published.get(index - 1).toState());
         }
+    }
+
+    /// Verification round 1, BLOCKING finding. FIVE public ingresses reach `MemberTracking.dispatch`
+    /// WITHOUT passing through `inTransition` — `onSwimUnknown`, `onPeerConnected`,
+    /// `onJoinGraceExpired`, `onDrainRequested`, `onDownHysteresisMet`
+    /// (`MembershipFsm.java:544/550/580/590/599`). For those five, the guard taken INSIDE `dispatch`
+    /// is the ONLY serialisation that exists.
+    ///
+    /// [`#oneMembersTransitions_stayOrderedAndMatchObservedState_underConcurrentDispatch`] drives
+    /// member A exclusively through `onSwimSuspect`/`onSwimHealthy`, which are both
+    /// `inTransition`-wrapped and therefore still guarded when the guard is removed from `dispatch`
+    /// alone. That is why removing it left the suite green — and that green was recorded as "the
+    /// mutation landed somewhere that did not matter". It landed on the only lock protecting five
+    /// public entry points; the label certified as harmless the single acquisition those paths rely
+    /// on, which is a documented reason never to look again.
+    ///
+    /// This drives ONE guarded ingress (`onSwimHealthy`) against ONE direct-dispatch ingress
+    /// (`onDrainRequested`) on the SAME member, so the guard inside `dispatch` is load-bearing and
+    /// its removal is observable. MEMBER -> DEPARTING on the drain, DEPARTING -> MEMBER on a
+    /// strictly-newer healthy incarnation, so both ingresses produce real transitions.
+    @Test
+    void aDirectDispatchIngress_isSerialisedAgainstAGuardedOne_onTheSameMember() {
+        var fsm = MembershipFsm.membershipFsm();
+
+        fsm.onSwimHealthy(A, 1L);
+
+        var transitions = new AtomicInteger();
+        var staleObservations = new AtomicInteger();
+
+        fsm.onTransition(record -> {
+            transitions.incrementAndGet();
+            LockSupport.parkNanos(OBSERVATION_WINDOW_NANOS);
+            if (!record.toState().equals(fsm.memberStates().get(A))) {
+                staleObservations.incrementAndGet();
+            }
+        });
+
+        var incarnation = new AtomicLong(2L);
+        var guarded = daemon("probe-929-guarded-ingress", () -> {
+            for (var i = 0; i < FLIPS_PER_THREAD; i++) {
+                fsm.onSwimHealthy(A, incarnation.incrementAndGet());
+            }
+        });
+        var direct = daemon("probe-929-direct-ingress", () -> {
+            for (var i = 0; i < FLIPS_PER_THREAD; i++) {
+                fsm.onDrainRequested(A);
+            }
+        });
+
+        guarded.start();
+        direct.start();
+        joinQuietly(guarded, PROBE_BOUND_MS);
+        joinQuietly(direct, PROBE_BOUND_MS);
+
+        assertThat(transitions).as("instrument check: the two ingresses must have produced transitions "
+                                   + "to observe, or this probe watches nothing")
+                               .hasValueGreaterThan(0);
+        assertThat(staleObservations)
+                .as("a transition published by the DIRECT-dispatch ingress `onDrainRequested` must "
+                    + "also find its member unmoved: `dispatch`'s own guard is the only serialisation "
+                    + "those five public ingresses have (#929 verification round 1, BLOCKING)")
+                .hasValue(0);
+    }
+
+    /// The PRECONDITION this whole fix rests on, made observable — and it is not the property the
+    /// code comment originally claimed.
+    ///
+    /// "Lock order is always guard then monitor" is true and does not earn the safety: the fan-out
+    /// still holds one member's guard while acquiring every OTHER member's monitor, which is exactly
+    /// what `AetherNode.propagateMemberCount` does. What makes that acyclic is that **the per-member
+    /// monitor is a LEAF — nothing acquired under it acquires anything else.**
+    ///
+    /// That property is breakable from OUTSIDE this class. [`MembershipFsm#membershipFsm`] overloads
+    /// accept an explicit [`FsmObserver`], and `Fsm` invokes it inside the state transition, i.e.
+    /// inside `applyEvent`, i.e. under the monitor. Production happens to wire `FsmObserver.noop()`,
+    /// so today the invariant holds by accident of wiring rather than by construction. This test makes
+    /// the constraint observable: **an observer runs under the per-member monitor, therefore an
+    /// observer that takes any lock reintroduces the inversion this fix removes.**
+    ///
+    /// Read the green result as "the constraint is still real", not as "all is well". If someone moves
+    /// observer invocation out from under the monitor, this test SHOULD go red and be rewritten.
+    @Test
+    void anObserverPassedToThePublicFactory_runsUnderThePerMemberMonitor_soItMustNotTakeLocks() {
+        var fsmRef = new AtomicReference<MembershipFsm>();
+        var observerRan = new AtomicBoolean(false);
+        var walkFinishedWhileObserving = new AtomicBoolean(false);
+        var walkDoneRef = new AtomicReference<CountDownLatch>();
+
+        FsmObserver<MembershipState, MembershipEvent> observer = new FsmObserver<>() {
+            @Override
+            public void onTransition(FsmTags tags, MembershipState from, MembershipState to) {
+                observerRan.set(true);
+                var started = new CountDownLatch(1);
+                var done = new CountDownLatch(1);
+
+                walkDoneRef.set(done);
+                var walker = daemon("probe-929-leaf-walker", () -> {
+                    started.countDown();
+                    fsmRef.get().strictCoreMemberCount();
+                    done.countDown();
+                });
+
+                walker.start();
+                awaitQuietly(started, PROBE_BOUND_MS);
+                walkFinishedWhileObserving.set(awaitQuietly(done, LEAF_PROBE_BOUND_MS));
+            }
+
+            @Override
+            public void onCasLost(FsmTags tags, MembershipState expected, MembershipState actual) {}
+
+            @Override
+            public void onEventIgnored(FsmTags tags, MembershipState state, MembershipEvent event) {}
+        };
+
+        var fsm = MembershipFsm.membershipFsm(observer, System::currentTimeMillis, Long.MAX_VALUE);
+
+        fsmRef.set(fsm);
+        fsm.onSwimHealthy(A, 1L);
+
+        assertThat(observerRan).as("instrument check: the observer must have been invoked at all, or "
+                                   + "this test observes nothing")
+                               .isTrue();
+        assertThat(walkFinishedWhileObserving)
+                .as("an FsmObserver supplied through the public factory runs UNDER the per-member "
+                    + "monitor, so a concurrent member walk cannot complete while it is on the stack. "
+                    + "This is the leaf precondition the #929 fix depends on: an observer that takes "
+                    + "any lock reintroduces the inversion")
+                .isFalse();
+        assertThat(awaitQuietly(walkDoneRef.get(), PROBE_BOUND_MS))
+                .as("control: the walker must finish once the monitor is released — otherwise the "
+                    + "assertion above is satisfied by a thread that never ran rather than by one that "
+                    + "was blocked")
+                .isTrue();
     }
 
     private static void flip(MembershipFsm fsm, AtomicLong incarnation) {

--- a/aether/aether-deployment/src/test/java/org/pragmatica/aether/deployment/membership/fsm/MembershipFsmTransitionListenerLockingTest.java
+++ b/aether/aether-deployment/src/test/java/org/pragmatica/aether/deployment/membership/fsm/MembershipFsmTransitionListenerLockingTest.java
@@ -12,12 +12,14 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.BrokenBarrierException;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.locks.LockSupport;
 import java.util.stream.IntStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -61,6 +63,10 @@ class MembershipFsmTransitionListenerLockingTest {
 
     private static final int FLIP_THREADS = 4;
     private static final int FLIPS_PER_THREAD = 200;
+    /// Deliberate widening of the publish window, so an unserialised fan-out loses the race often
+    /// rather than almost never. 20 us x 1600 dispatches is ~30 ms of added test time under the
+    /// guard, and near-certain detection without it.
+    private static final long OBSERVATION_WINDOW_NANOS = 20_000L;
 
     /// The deadlock probe. Two threads enter `MembershipFsm` through the two production ingress
     /// points that collided in the field — SWIM `onSwimSuspect` and QUIC `onLivenessGone` — on two
@@ -110,7 +116,14 @@ class MembershipFsmTransitionListenerLockingTest {
     /// Direct pin of the invariant: while the transition listener runs, ANOTHER thread must be able
     /// to acquire every `MemberTracking` monitor. `strictCoreMemberCount` is the cheapest full walk
     /// of them. Under the pre-#929 code the walker blocks on the dispatching member's monitor until
-    /// the listener returns — and the listener is waiting for the walker, so it never does.
+    /// the listener returns.
+    ///
+    /// The verdict is SNAPSHOTTED INSIDE the listener, and that is load-bearing. Asserting on the
+    /// walker's flag after `onSwimSuspect` returns is satisfied by the wrong event: the walker is
+    /// merely BLOCKED, and the instant the listener returns the monitor is released, the walk
+    /// finishes, and a later assertion reads `true` for a walk that did not overlap the listener at
+    /// all. A first cut of this pin did exactly that and stayed GREEN against the reintroduced
+    /// defect while the deadlock probe went red.
     @Test
     void transitionListener_runsWithNoMemberTrackingMonitorHeld() {
         var fsm = MembershipFsm.membershipFsm();
@@ -119,43 +132,60 @@ class MembershipFsmTransitionListenerLockingTest {
         fsm.onSwimHealthy(B, 1L);
 
         var listenerRan = new AtomicBoolean(false);
-        var walkCompleted = new AtomicBoolean(false);
+        var walkFinishedWhileListenerRan = new AtomicBoolean(false);
 
         fsm.onTransition(_ -> {
             listenerRan.set(true);
+            var walkDone = new CountDownLatch(1);
             var walker = daemon("probe-929-walker", () -> {
                 fsm.strictCoreMemberCount();
-                walkCompleted.set(true);
+                walkDone.countDown();
             });
 
             walker.start();
-            joinQuietly(walker, PROBE_BOUND_MS);
+            walkFinishedWhileListenerRan.set(awaitQuietly(walkDone, PROBE_BOUND_MS));
         });
 
         fsm.onSwimSuspect(A, 2L);
 
         assertThat(listenerRan).as("instrument check: the transition listener must have run at all")
                                .isTrue();
-        assertThat(walkCompleted).as("a second thread must complete a full member walk (which acquires "
-                                     + "EVERY MemberTracking monitor) WHILE the transition listener is "
-                                     + "running — i.e. no per-member monitor is held across "
-                                     + "transitionSink.accept (#929)")
-                                 .isTrue();
+        assertThat(walkFinishedWhileListenerRan)
+                .as("a second thread must complete a full member walk (which acquires EVERY "
+                    + "MemberTracking monitor) WHILE the transition listener is still on the stack — "
+                    + "i.e. no per-member monitor is held across transitionSink.accept (#929)")
+                .isTrue();
     }
 
-    /// The property the transition guard buys back. Publishing after the monitor is released is only
-    /// correct if ONE member's transitions stay totally ordered: the journal and every other consumer
-    /// see a chain, never a pair swapped by two threads racing to publish. Each record must therefore
-    /// start in the state its predecessor ended in.
+    /// The two properties the transition guard buys back, and the reason a bare "publish after the
+    /// monitor is released" is NOT an acceptable fix.
+    ///
+    /// 1. ONE member's transitions stay totally ordered: consumers see a chain, never a pair swapped
+    ///    by two threads racing to publish. Each record starts in the state its predecessor ended in.
+    /// 2. A listener observes the member in exactly the state its record names — the atomicity the
+    ///    old `synchronized dispatch` provided, and the one thing moving the fan-out could have cost.
+    ///
+    /// Property 2 is the sensitive one and is why this test does not rely on ordering alone: the
+    /// window for an ordering inversion is a handful of instructions wide, so a guardless
+    /// implementation can survive thousands of iterations by luck. Parking briefly inside the
+    /// listener widens that window deliberately — an ordering assertion that could not realistically
+    /// fail is not a pin. (Measured: with the guard removed and no park, all iterations passed.)
     @Test
-    void oneMembersTransitions_stayTotallyOrdered_underConcurrentDispatch() {
+    void oneMembersTransitions_stayOrderedAndMatchObservedState_underConcurrentDispatch() {
         var fsm = MembershipFsm.membershipFsm();
 
         fsm.onSwimHealthy(A, 1L);
 
         var records = Collections.<MembershipTransitionRecord> synchronizedList(new ArrayList<>());
+        var staleObservations = new AtomicInteger();
 
-        fsm.onTransition(records::add);
+        fsm.onTransition(record -> {
+            LockSupport.parkNanos(OBSERVATION_WINDOW_NANOS);
+            if (!record.toState().equals(fsm.memberStates().get(A))) {
+                staleObservations.incrementAndGet();
+            }
+            records.add(record);
+        });
 
         var incarnation = new AtomicLong(2L);
         var flippers = IntStream.range(0, FLIP_THREADS)
@@ -168,6 +198,10 @@ class MembershipFsmTransitionListenerLockingTest {
 
         assertThat(records).as("instrument check: the flippers must have produced transitions to order")
                            .isNotEmpty();
+        assertThat(staleObservations)
+                .as("while a listener runs, the member it names must not have moved on — no other "
+                    + "thread may transition that member until the fan-out returns (#929)")
+                .hasValue(0);
 
         var published = List.copyOf(records);
 
@@ -193,6 +227,16 @@ class MembershipFsmTransitionListenerLockingTest {
         thread.setDaemon(true);
 
         return thread;
+    }
+
+    private static boolean awaitQuietly(CountDownLatch latch, long boundMs) {
+        try {
+            return latch.await(boundMs, TimeUnit.MILLISECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+
+            return false;
+        }
     }
 
     private static void joinQuietly(Thread thread, long boundMs) {

--- a/aether/aether-deployment/src/test/java/org/pragmatica/aether/deployment/membership/fsm/MembershipFsmTransitionListenerLockingTest.java
+++ b/aether/aether-deployment/src/test/java/org/pragmatica/aether/deployment/membership/fsm/MembershipFsmTransitionListenerLockingTest.java
@@ -1,0 +1,216 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2025 Pragmatica Labs - Sergiy Yevtushenko
+// Licensed under Business Source License 1.1. Change Date: 2030-01-01. Change License: Apache-2.0.
+// See LICENSE in the repository root for full terms.
+package org.pragmatica.aether.deployment.membership.fsm;
+
+import org.junit.jupiter.api.Test;
+import org.pragmatica.consensus.NodeId;
+
+import java.lang.management.ManagementFactory;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.BrokenBarrierException;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/// #929 — the transition listener must NOT run while a [`MembershipFsm$MemberTracking`] monitor is
+/// held, and moving it out must not cost the ordering the monitor used to provide.
+///
+/// ## The defect these pin
+///
+/// `MemberTracking.dispatch` was `synchronized` and published to `transitionSink` while holding the
+/// dispatching member's monitor. `AetherNode.onFsmTransition` → `propagateMemberCount` →
+/// `MembershipFsm.strictCoreObservedMemberCount` walks the member map calling the `synchronized`
+/// `isStrictCoreMember` on EVERY member — so the listener held one member's monitor and requested
+/// all the others', in `ConcurrentHashMap` iteration order. One node's SWIM loop (`onSwimSuspect`)
+/// and QUIC loop (`onLivenessGone`) dispatching on two different members each held one monitor and
+/// wanted the other's. That order is a hash order, so lock ordering cannot repair it.
+///
+/// ## Why the probe forces the interleaving instead of hoping for it
+///
+/// The race needs a specific window: both threads must be inside their listener, past the state
+/// change, before either finishes the member walk. A probe that just "runs the code twice"
+/// concurrently passes against the broken code too, and would prove nothing. The barrier below
+/// holds each thread at exactly that point until the other arrives, making the AB/BA cycle
+/// deterministic — the pre-fix code deadlocks every run, the fixed code never does.
+///
+/// [`#oneMembersTransitions_stayTotallyOrdered_underConcurrentDispatch`] is the other half: moving
+/// the fan-out out of the monitor is only correct if per-member ordering survives, which is what
+/// the transition guard buys and what a bare "publish after release" would lose.
+class MembershipFsmTransitionListenerLockingTest {
+    private static final NodeId SELF = new NodeId("node-self");
+    private static final NodeId A = new NodeId("node-a");
+    private static final NodeId B = new NodeId("node-b");
+
+    /// Ceiling on the whole probe. The fixed code finishes in milliseconds; the broken code never
+    /// finishes at all, so this only decides how long a RED run takes.
+    private static final long PROBE_BOUND_MS = 5_000L;
+    /// Ceiling on the rendezvous itself. Distinguishes "the window was opened and nothing wedged"
+    /// from "the probe never actually got both threads into position" — the second is scored as a
+    /// broken instrument, not as a pass.
+    private static final long RENDEZVOUS_BOUND_MS = 5_000L;
+
+    private static final int FLIP_THREADS = 4;
+    private static final int FLIPS_PER_THREAD = 200;
+
+    /// The deadlock probe. Two threads enter `MembershipFsm` through the two production ingress
+    /// points that collided in the field — SWIM `onSwimSuspect` and QUIC `onLivenessGone` — on two
+    /// DIFFERENT members of ONE FSM. Each listener performs the same member walk
+    /// `AetherNode.propagateMemberCount` performs, after both are in position.
+    @Test
+    void concurrentDispatchOnTwoMembers_doesNotDeadlock() {
+        var fsm = MembershipFsm.membershipFsm();
+
+        fsm.onSwimHealthy(A, 1L);
+        fsm.onSwimHealthy(B, 1L);
+
+        var rendezvous = new CyclicBarrier(2);
+        var arrivals = new AtomicInteger();
+        var rendezvousBroken = new AtomicBoolean(false);
+
+        // Installed AFTER the promotions, so only the two probe transitions reach the barrier.
+        fsm.onTransition(_ -> {
+            arrivals.incrementAndGet();
+            rendezvous(rendezvous, rendezvousBroken);
+            // Shape-for-shape AetherNode.propagateMemberCount: acquires EVERY member's monitor.
+            fsm.strictCoreObservedMemberCount(SELF);
+        });
+
+        var swimLoop = daemon("probe-929-swim", () -> fsm.onSwimSuspect(A, 2L));
+        var quicLoop = daemon("probe-929-quic", () -> fsm.onLivenessGone(B));
+
+        swimLoop.start();
+        quicLoop.start();
+        joinQuietly(swimLoop, PROBE_BOUND_MS);
+        joinQuietly(quicLoop, PROBE_BOUND_MS);
+
+        assertThat(arrivals).as("instrument check: both dispatches must have reached the listener, or "
+                                + "the AB/BA window was never opened and this probe proves nothing")
+                            .hasValue(2);
+        assertThat(rendezvousBroken).as("instrument check: the rendezvous must have completed, so both "
+                                        + "threads were inside their listener at the same moment")
+                                    .isFalse();
+        assertThat(ManagementFactory.getThreadMXBean().findDeadlockedThreads())
+                .as("no thread may deadlock: MembershipFsm must not hold a per-member monitor across "
+                    + "the transition listener, which walks every other member's monitor (#929)")
+                .isNull();
+        assertThat(swimLoop.isAlive()).as("the SWIM-side dispatch must have completed").isFalse();
+        assertThat(quicLoop.isAlive()).as("the QUIC-side dispatch must have completed").isFalse();
+    }
+
+    /// Direct pin of the invariant: while the transition listener runs, ANOTHER thread must be able
+    /// to acquire every `MemberTracking` monitor. `strictCoreMemberCount` is the cheapest full walk
+    /// of them. Under the pre-#929 code the walker blocks on the dispatching member's monitor until
+    /// the listener returns — and the listener is waiting for the walker, so it never does.
+    @Test
+    void transitionListener_runsWithNoMemberTrackingMonitorHeld() {
+        var fsm = MembershipFsm.membershipFsm();
+
+        fsm.onSwimHealthy(A, 1L);
+        fsm.onSwimHealthy(B, 1L);
+
+        var listenerRan = new AtomicBoolean(false);
+        var walkCompleted = new AtomicBoolean(false);
+
+        fsm.onTransition(_ -> {
+            listenerRan.set(true);
+            var walker = daemon("probe-929-walker", () -> {
+                fsm.strictCoreMemberCount();
+                walkCompleted.set(true);
+            });
+
+            walker.start();
+            joinQuietly(walker, PROBE_BOUND_MS);
+        });
+
+        fsm.onSwimSuspect(A, 2L);
+
+        assertThat(listenerRan).as("instrument check: the transition listener must have run at all")
+                               .isTrue();
+        assertThat(walkCompleted).as("a second thread must complete a full member walk (which acquires "
+                                     + "EVERY MemberTracking monitor) WHILE the transition listener is "
+                                     + "running — i.e. no per-member monitor is held across "
+                                     + "transitionSink.accept (#929)")
+                                 .isTrue();
+    }
+
+    /// The property the transition guard buys back. Publishing after the monitor is released is only
+    /// correct if ONE member's transitions stay totally ordered: the journal and every other consumer
+    /// see a chain, never a pair swapped by two threads racing to publish. Each record must therefore
+    /// start in the state its predecessor ended in.
+    @Test
+    void oneMembersTransitions_stayTotallyOrdered_underConcurrentDispatch() {
+        var fsm = MembershipFsm.membershipFsm();
+
+        fsm.onSwimHealthy(A, 1L);
+
+        var records = Collections.<MembershipTransitionRecord> synchronizedList(new ArrayList<>());
+
+        fsm.onTransition(records::add);
+
+        var incarnation = new AtomicLong(2L);
+        var flippers = IntStream.range(0, FLIP_THREADS)
+                                .mapToObj(index -> daemon("probe-929-flip-" + index,
+                                                          () -> flip(fsm, incarnation)))
+                                .toList();
+
+        flippers.forEach(Thread::start);
+        flippers.forEach(thread -> joinQuietly(thread, PROBE_BOUND_MS));
+
+        assertThat(records).as("instrument check: the flippers must have produced transitions to order")
+                           .isNotEmpty();
+
+        var published = List.copyOf(records);
+
+        for (var index = 1; index < published.size(); index++) {
+            assertThat(published.get(index).fromState())
+                    .as("published transition %d of one member must start where transition %d ended — "
+                        + "the per-member transition guard serialises state change AND fan-out, so the "
+                        + "published sequence chains (#929)", index, index - 1)
+                    .isEqualTo(published.get(index - 1).toState());
+        }
+    }
+
+    private static void flip(MembershipFsm fsm, AtomicLong incarnation) {
+        for (var i = 0; i < FLIPS_PER_THREAD; i++) {
+            fsm.onSwimSuspect(A, incarnation.incrementAndGet());
+            fsm.onSwimHealthy(A, incarnation.incrementAndGet());
+        }
+    }
+
+    private static Thread daemon(String name, Runnable body) {
+        var thread = new Thread(body, name);
+
+        thread.setDaemon(true);
+
+        return thread;
+    }
+
+    private static void joinQuietly(Thread thread, long boundMs) {
+        try {
+            thread.join(boundMs);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    private static void rendezvous(CyclicBarrier barrier, AtomicBoolean broken) {
+        try {
+            barrier.await(RENDEZVOUS_BOUND_MS, TimeUnit.MILLISECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            broken.set(true);
+        } catch (BrokenBarrierException | TimeoutException e) {
+            broken.set(true);
+        }
+    }
+}

--- a/aether/ember/src/main/java/org/pragmatica/aether/ember/EmberCluster.java
+++ b/aether/ember/src/main/java/org/pragmatica/aether/ember/EmberCluster.java
@@ -797,12 +797,34 @@ public final class EmberCluster {
         log.info("Stopping Ember cluster");
         rollingRestartTask.cancel();
         rollingRestartActive.set(false);
-        var stopPromises = nodes.values().stream().map(node -> node.stop()
-                                                                   .timeout(NODE_TIMEOUT)).toList();
+        var stopPromises = nodes.values()
+                                .stream()
+                                .map(EmberCluster::submitStop)
+                                .toList();
 
         return Promise.allOf(stopPromises)
                       .map(_ -> Unit.unit())
                       .onSuccess(this::clearClusterState);
+    }
+
+    /// Run one node's stop OFF the caller's thread so [`#NODE_TIMEOUT`] can actually see it (#929).
+    ///
+    /// `AetherNode.stop()` runs a long SYNCHRONOUS prologue before it returns its promise, and
+    /// `.toList()` is eager — so every node's prologue used to run to completion on the caller's
+    /// thread (in forge, the JUnit thread) BEFORE there was any promise to bound. #915's
+    /// `.timeout(NODE_TIMEOUT)` therefore decorated only the async tail and could not see the part
+    /// that blocks; the same is true one level up, where `LifecycleAwait.bestEffort("cluster stop",
+    /// c, c.stop())` evaluates `c.stop()` as an ARGUMENT, fully, before its 240 s bound starts
+    /// counting. Submitting the whole call puts the prologue inside the window the timeout covers.
+    ///
+    /// This RAISES stop concurrency — the prologues now overlap instead of running in sequence, so
+    /// teardown produces more simultaneous membership churn. That is precisely the input that
+    /// triggered #929, which is why this lands only together with the `MembershipFsm` transition
+    /// guard; on its own it would make that deadlock more frequent, not less.
+    private static Promise<Unit> submitStop(AetherNode node) {
+        return Promise.<Unit> promise(promise -> node.stop()
+                                                     .onResult(promise::resolve))
+                      .timeout(NODE_TIMEOUT);
     }
 
     private void clearClusterState(Unit unit) {

--- a/aether/ember/src/main/java/org/pragmatica/aether/ember/EmberCluster.java
+++ b/aether/ember/src/main/java/org/pragmatica/aether/ember/EmberCluster.java
@@ -797,10 +797,7 @@ public final class EmberCluster {
         log.info("Stopping Ember cluster");
         rollingRestartTask.cancel();
         rollingRestartActive.set(false);
-        var stopPromises = nodes.values()
-                                .stream()
-                                .map(EmberCluster::submitStop)
-                                .toList();
+        var stopPromises = nodes.values().stream().map(EmberCluster::submitStop).toList();
 
         return Promise.allOf(stopPromises)
                       .map(_ -> Unit.unit())
@@ -823,8 +820,7 @@ public final class EmberCluster {
     /// guard; on its own it would make that deadlock more frequent, not less.
     private static Promise<Unit> submitStop(AetherNode node) {
         return Promise.<Unit> promise(promise -> node.stop()
-                                                     .onResult(promise::resolve))
-                      .timeout(NODE_TIMEOUT);
+                                                     .onResult(promise::resolve)).timeout(NODE_TIMEOUT);
     }
 
     private void clearClusterState(Unit unit) {

--- a/aether/node/src/main/java/org/pragmatica/aether/SelfAddressResolver.java
+++ b/aether/node/src/main/java/org/pragmatica/aether/SelfAddressResolver.java
@@ -148,6 +148,9 @@ public final class SelfAddressResolver {
     /// whether the probe succeeded or failed.
     private static Promise<String> stopThen(SwimTransport transport, Result<String> carried) {
         return transport.stop()
+                        .onFailure(cause -> log.warn("Transient WhoAmI transport stop did not complete: {}",
+                                                     cause.message()))
+                        .recover(_ -> Unit.unit())
                         .flatMap(_ -> carried.async());
     }
 

--- a/aether/node/src/main/java/org/pragmatica/aether/node/AetherNode.java
+++ b/aether/node/src/main/java/org/pragmatica/aether/node/AetherNode.java
@@ -4487,14 +4487,23 @@ public interface AetherNode extends ManageableNode {
     TimeSpan MEMBERSHIP_BASELINE_TRACE_INTERVAL = TimeSpan.timeSpan(30).seconds();
 
     /// Single FSM-transition fan-out installed at the central transition chokepoint
-    /// ([`MembershipFsm#onTransition`], fired once per ACTUAL per-member state change under the FSM's
-    /// synchronized per-member dispatch monitor). Records the transition into the per-node journal
+    /// ([`MembershipFsm#onTransition`], fired once per ACTUAL per-member state change at the FSM's
+    /// central dispatch chokepoint). Records the transition into the per-node journal
     /// (Wave-1 Enrichment A) AND — when the transition crosses the exact-`Member` boundary — re-feeds
     /// the strict-core count to the quorum-loss detector. This prompt re-feed (NOT only the 15s
     /// presence down-hysteresis `onNttReconcile` / DEAD `onMembershipDeath` paths) is what arms the
     /// self-drain window when several cores enter SUSPECT at once, and CANCELS it on a SUSPECT→MEMBER
-    /// refutation. Safe-by-precedent: `onMembershipDeath` already drives the same
-    /// `propagateMemberCount`→`strictCoreMemberCount` chain from inside this same dispatch monitor.
+    /// refutation.
+    ///
+    /// #929: `propagateMemberCount` walks EVERY member calling the `synchronized`
+    /// `MemberTracking.isStrictCoreMember`. Until #929 this listener ran while the FSM held the
+    /// DISPATCHING member's monitor, so this method held one member's monitor and requested all the
+    /// others' — in `ConcurrentHashMap` iteration order. Two of this node's event loops (SWIM
+    /// `onSwimSuspect`, QUIC `onLivenessGone`) dispatching on two different members deadlocked AB/BA,
+    /// wedging both loops. The FSM now publishes with the per-member monitor RELEASED (serialised by
+    /// `MemberTracking.transitionGuard`), which is what makes this member walk safe. The old
+    /// "safe-by-precedent" note here cited `onMembershipDeath` driving the same chain from inside
+    /// that monitor — that was the same defect, not a precedent for it.
     @Contract
     private static void onFsmTransition(TransitionJournal journal,
                                         AtomicReference<QuorumLossDetector> quorumLossDetectorRef,

--- a/changelog.d/929-membership-fsm-monitor-deadlock.md
+++ b/changelog.d/929-membership-fsm-monitor-deadlock.md
@@ -1,0 +1,226 @@
+### Fixed (2026-09-08 — #929: two of a node's event loops deadlocked on per-member membership monitors, wedging SWIM and QUIC processing and hanging cluster shutdown)
+
+- **A transition listener ran while the FSM held one member's monitor, and that listener acquired every
+  other member's.** `MembershipFsm$MemberTracking.dispatch` was `synchronized` and published to
+  `transitionSink` under the dispatching member's monitor. The listener runs synchronously into
+  `AetherNode.onFsmTransition` → `propagateMemberCount` → `strictCoreObservedMemberCount`, which
+  streams the member map calling the `synchronized` `isStrictCoreMember()` on **every** member. A
+  thread therefore held member X's monitor and requested A's, B's, C's… in `ConcurrentHashMap`
+  iteration order. One node's SWIM loop (`onSwimSuspect`) and QUIC loop (`onLivenessGone`) dispatching
+  on two different members each held one monitor and wanted the other's. **The lock order is a hash
+  order, so no ordering discipline can repair it** — the nesting itself had to go. The class already
+  documented the contract this broke ("the listener is called under the per-member monitor —
+  implementations must be cheap and non-blocking"); three javadoc blocks asserting that are now
+  corrected, including one in `AetherNode` that cited the same defect elsewhere as a
+  *safe-by-precedent* justification for this one.
+- **The fix stages the fan-out and publishes it with the monitor released, serialised per member by a
+  separate guard.** `applyEvent` mutates state under the monitor and stages each listener call;
+  `dispatch` runs them under `MemberTracking.transitionGuard`. **All six sinks are staged, not only the
+  one that deadlocked** (`transitionSink`, `deltaSink` JOINED and REMOVED, `onEnteredDead`,
+  `onJoinGraceReaped`, `onEnteredDeparting`, `onDepartingRecovery`) — every one of them was violating
+  the same contract, and fixing one leaves five doors open
+  [verified: `MembershipFsmTransitionListenerLockingTest#concurrentDispatchOnTwoMembers_doesNotDeadlock`
+  and `#transitionListener_runsWithNoMemberTrackingMonitorHeld`; reinstating `synchronized (this)`
+  around the staged fan-out — the defect's exact shape — reddens both].
+- **The guard is what makes this a fix rather than a trade.** It preserves both properties the old
+  `synchronized dispatch` provided: one member's transitions stay totally ordered, and a listener still
+  observes that member in exactly the state its record names. Only the incidental blocking of *readers*
+  of that member's state is dropped, which is the deadlock's single edge; a reader's value is
+  unchanged, since it previously blocked and then read the same post-transition state. A bare
+  "publish after the monitor is released" would have lost both properties
+  [verified: `MembershipFsmTransitionListenerLockingTest#oneMembersTransitions_stayOrderedAndMatchObservedState_underConcurrentDispatch`;
+  removing the guard from **both** `dispatch` and `inTransition` — the naive fix — reddens it].
+- **Five PUBLIC ingresses depend on that guard alone, and the first revision of this work certified
+  that dependence as harmless.** `onSwimUnknown`, `onPeerConnected`, `onJoinGraceExpired`,
+  `onDrainRequested` and `onDownHysteresisMet` reach `dispatch` **without** going through
+  `inTransition`, so for them the guard inside `dispatch` is the entire serialisation. Removing it
+  leaves **225 stale observations of 800 dispatches** while all 959 module tests stay green, because
+  the ordering pin above drives its member only through `inTransition`-wrapped ingresses. The first
+  revision ran that mutation, saw green, and recorded it as *invalid — it landed somewhere that did
+  not matter*. **An exclusion recorded with a reason is stronger than silence, and therefore more
+  dangerous when the reason is wrong**: the label certified as irrelevant the single lock acquisition
+  five public entry points rely on, and became a documented reason never to look again
+  [verified: `MembershipFsmTransitionListenerLockingTest#aDirectDispatchIngress_isSerialisedAgainstAGuardedOne_onTheSameMember`,
+  driving `onSwimHealthy` against `onDrainRequested` on one member; removing the guard from `dispatch`
+  alone reddens it and nothing else in the class. The 225-of-800 figure is the reviewer's measurement of
+  the unpinned gap; the pin closing it is measured separately. Found by adversarial verification, not by
+  the author].
+- **Lock order is always guard-then-monitor, which cost four call sites their `synchronized`.**
+  `promoteIfObserved`, `terminalizeIfStillDeparting`, `expireJoinGrace` and `evictIfStillConfirmedDead`
+  were `synchronized` methods that called `dispatch`; left alone they would have inverted the order and
+  reintroduced a deadlock through the timer paths. Each now takes the guard first and reads state
+  through a short `synchronized` accessor
+  [mechanism: `MembershipFsm.java`, `MemberTracking.transitionGuard` and the four entry points; a
+  static check over the file reports zero `synchronized` methods reaching a guard-taking call, with the
+  six guard-takers as its positive control].
+- **The six ingress drivers are now atomic, which they were not before.** `healthy`, `suspect`,
+  `faulty`, `departed`, `livenessGone` and `peerDisconnected` are multi-step operations whose steps
+  each took the per-member monitor **separately**. They now run under the member's guard — a
+  strengthening, and what keeps `evictIfStillConfirmedDead`'s check-march-clear sequence indivisible
+  against the co-confirmation flag writes [mechanism: `MembershipFsm.inTransition`].
+- **Every `transitionSink` consumer was audited for a dependence on the old timing, and none has one.**
+  All six listener chains terminate in a non-blocking hand-off — a queue plus virtual-thread drain, a
+  CAS-debounced reconcile trigger, an immediately resolved `Promise`, or `Promise`-returning rebalancer
+  calls — none blocks, and none depends on the old semantics. `TransitionJournal` stamps each entry
+  with its own sequence and timestamp under the ring's own monitor, so cross-member append order was
+  never load-bearing. `QuorumLossDetector.onMemberCountChanged` stores the count and schedules or
+  cancels. The one aggregate read, `strictCoreObservedMemberCount`, was already non-atomic across
+  members. `ConsistentHashRing`'s write methods hold a `ReentrantReadWriteLock` over pure map
+  operations with no callbacks — a leaf [mechanism: traced from `AetherNode` wiring to each chain's
+  first asynchronous hand-off; independently re-derived by verification].
+- **Correction to that audit: one chain DOES re-enter the FSM synchronously.** The first statement of
+  this was "no chain synchronously re-enters `dispatch` for **any** member", and that is false. The
+  join-grace reap chain does — `LeaderReconciler` → `ClusterTopologyManagerRecord` → `AetherNode` →
+  `fsm.onDrainRequested(target)` → `dispatch` → the guard. It is safe because the re-entry is on the
+  **same** member, where the guard is reentrant; the true claim is that no chain re-enters for a
+  **different** member, which is what would deadlock. Worth stating precisely rather than broadly,
+  because that re-entry acquires the guard **inside `dispatch`** — the exact acquisition whose removal
+  was wrongly scored harmless above [mechanism: chain traced by verification, not by the author].
+- **The lock order is not what earns the safety, and the real invariant is the fragile one.** The
+  fan-out holds one member's guard while acquiring every OTHER member's monitor — that is precisely
+  what the quorum re-feed does. What makes it acyclic is that **the per-member monitor is a LEAF**:
+  nothing acquired under it acquires anything else (`MembershipState` contains no `synchronized`, and
+  `applyEvent` reaches only the state table, the timer helpers and a list append). That property is a
+  precondition of this fix rather than an incidental fact, and it is breakable from outside the class
+  — the factories taking an explicit `FsmObserver` run it under the monitor, and production only
+  happens to wire `noop()`. Recorded at the guard's declaration, and **pinned**: an observer supplied
+  through the public factory is shown to run under the monitor, so a concurrent member walk cannot
+  complete while it is on the stack — with a control proving the walk finishes once the monitor is
+  released, so the assertion cannot be satisfied by a thread that never ran
+  [verified: `MembershipFsmTransitionListenerLockingTest#anObserverPassedToThePublicFactory_runsUnderThePerMemberMonitor_soItMustNotTakeLocks`;
+  dropping `synchronized` from `applyEvent` reddens it. Read a green result as "the constraint is still
+  real", not as "all is well": if observer invocation ever moves out from under the monitor this test
+  SHOULD go red and be rewritten].
+- **The SWIM transport shutdown is bounded, and it no longer claims success when it did not
+  complete.** Both waits were bare `.sync()`. Netty's own `shutdownGracefully()` timeout cannot rescue
+  that, because it is enforced by `confirmShutdown()` running *on* the event loop — a wedged loop
+  cannot enforce its own timeout. Each wait is now bounded at 5 s. **The unconditional
+  `LOG.info("SWIM transport stopped")` is gone**: it fired even when JUnit's backstop interrupt was
+  what ended the wait, over a transport that was never stopped — dumps show its event-loop thread
+  still RUNNABLE ten seconds later. That false line is why #727, #749 and #750 each read past the wedge
+  underneath it
+  [verified: `NettySwimTransportBoundedShutdownTest#shutdownThatCannotComplete_reportsFailureAndDoesNotLogSuccess`,
+  driven against a genuinely wedged event loop; reinstating the unconditional log reddens it, and
+  removing the bound reddens its failure assertion. Paired with `#healthyShutdown_succeedsAndLogsSuccess`,
+  which requires the same appender to *see* the success line, so the absence cannot go vacuous].
+- **A shutdown future that COMPLETED WITH A FAILURE was still reported as success — a new dishonesty
+  introduced by the change that exists to remove one.** Netty's `Future.await(long)` returns true when
+  the future is **done**, whatever its outcome, and `isSuccess()` was never consulted, so a failed
+  close took the success branch and logged the success line over it. The pre-#934 `.sync()` rethrew
+  that cause. The first revision was honest about timeouts and dishonest about failures, and its own
+  honesty pin could not reach the branch
+  [verified: `NettySwimTransportBoundedShutdownTest#aShutdownFutureThatCompletedWithAFailure_isNotReportedAsSuccess`,
+  with `#aShutdownFutureThatCompletedSuccessfully_isReportedAsSuccess` as the control so the pin
+  discriminates on outcome rather than on `awaitBounded` always failing; new
+  `SwimError.ShutdownFailed` carries the cause. Found by adversarial verification].
+- **`doStop` regained its exception lifting.** It had become a bare `return stopChannel();`, so an
+  unchecked exception from `DnsNameResolver::close` or `ch.close()` would leave `stop()` as a thrown
+  exception rather than a `Result` failure — an errors-as-values regression on a shutdown path
+  [mechanism: `NettySwimTransport.doStop`, `Result.lift` restored with the inner `Result` flattened].
+- **Cleanup no longer gates an already-resolved value.** `SelfAddressResolver.stopThen` used
+  `transport.stop().flatMap(_ -> carried.async())`, so a failing cleanup discarded a
+  successfully-resolved address and the node fell back to an unverified hostname; this change widens
+  the failure set that can trigger it. **Not a regression** — the outer `overallCap()` (5 s) expires at
+  or before the inner bound, so the observable outcome is unchanged from pre-#934, where `.sync()`
+  simply hung until that cap fired. The shape was wrong without the behaviour differing
+  [mechanism: the cleanup failure is now logged and recovered before the carried result is surfaced].
+- **The 2 s quiet period is dropped, and that is worth ~18 s of every nine-node teardown.** SWIM is
+  fire-and-forget UDP with nothing to drain, so Netty's default quiet period bought nothing and was
+  paid on the caller's thread. The 2.00 s per node is a measured constant — a green CI teardown showed
+  2.008 / 2.005 / 2.003 / 2.003 / 2.002 / 2.004 / 2.003 s across seven nodes — so removing it takes
+  ~18 s off a nine-node teardown on any machine
+  [mechanism: `NettySwimTransport.SHUTDOWN_QUIET_PERIOD_MS`; no test pins the timing, and the constant
+  is from the diagnosis's CI control run, not from this branch].
+- **`EmberCluster.stop()` submits each node stop, so the bound can see the part that blocks.**
+  `AetherNode.stop()` runs a long synchronous prologue before returning its promise, and `.toList()` is
+  eager — so every prologue previously ran to completion on the caller's thread before any promise
+  existed to bound, and #915's `.timeout(NODE_TIMEOUT)` decorated only the async tail. The same held
+  one level up, where `LifecycleAwait.bestEffort("cluster stop", c, c.stop())` evaluates `c.stop()` as
+  an argument, fully, before its 240 s bound starts counting. This raises stop concurrency, which is
+  the input that triggers the deadlock, so it ships in the **same commit** as the FSM fix — a revert
+  takes both, which is what the ordering constraint actually required
+  [mechanism: `EmberCluster.submitStop`; no test pins the concurrency. Observed once, in the forge run
+  below: nine `Stopping Aether node` lines within 02:45:14.304–14.305, against sequential before].
+- **Residual: one listener chain is not cheap.** `onEnteredDeparting` fans out to a 1024-partition
+  rebalance while the member's guard is held, so the javadoc's "cheap and non-blocking remains the
+  right shape" understates what that chain does. Not a regression — it did the same under the monitor
+  before — but a slow listener now stalls every further transition of that member rather than every
+  reader of it [mechanism: chain identified by verification].
+- **Residual, not fixed: `NODE_TIMEOUT` can now be exhausted by the transport bound alone.** The SWIM
+  transport's 5 s + 5 s worst case sits inside a prologue that part 4 put under a 10 s `NODE_TIMEOUT`.
+  A node hitting the transport bound exhausts the node bound, `Promise.allOf` fails, and
+  `EmberCluster.stop()`'s `.onSuccess(this::clearClusterState)` is skipped, leaving the registries
+  populated after a failed stop. Same shape as pre-#934, but materially more reachable now. Unlike
+  both start-abort paths, `EmberCluster.stop()` has no `.recover()`
+  [mechanism: `EmberCluster.stop` / `NODE_TIMEOUT`; not exercised by any test today].
+- **Observed teardown, single run, stated load — and its evidence was not retained.**
+  `MultiSourceCommunitySmokeTest` on the dev box (nine nodes in one JVM, box otherwise quiet):
+  **6.249 s** from `Stopping Ember cluster` to `Ember cluster stopped`, all nine SWIM transports
+  stopping within the same millisecond. **This is not compared against the 8-minute CI hang or the
+  ~16.6 s CI healthy baseline** — different machine, and a cross-machine ratio is not a measurement;
+  what transfers is the 2.00 s-per-node constant above. Re-measured with the console log **retained**: **6.358 s**, nine
+  `Stopping Aether node` lines all in the same millisecond, nine transports stopped, and zero hits for
+  `HANG DIAGNOSTIC` / `timed out after` / `TimeoutException` / `ShutdownTimeout` /
+  `ShutdownInterrupted` / `SWIM transport shutdown did NOT complete` — against controls `INFO` = 1930
+  and both teardown markers = 9. The first revision reported the same shape from a log it did not keep,
+  and its zero-hits came from an artifact whose controls were **0**, i.e. an instrument blind to
+  teardown. The log is now kept so anyone can re-derive these. **One green run of an intermittent
+  test is not evidence the race is gone** — the deadlock evidence is the deterministic probe and its
+  mutation.
+- **Negative result — the new failure path bounding the shutdown was expected to surface has NO
+  PRODUCER.** Two mechanisms could make a shutdown wait reach the 5 s bound: the wedged event loop,
+  removed by part 1, and Netty's 2 s quiet period, removed by part 3 itself. Both are gone, leaving a
+  UDP socket that completes about three orders of magnitude below the bound — there is no population
+  between "~1 ms" and "never" for the bound to catch. So the absence is *explained*, not merely
+  observed, and the bound is not decorative: removing it lets the wait outlast a deliberately wedged
+  loop (class time 6.2 s → 10.04 s), which is what proves the bound and not the wedge clearing is what
+  ends it.
+- **An intermittent CI failure, stated as intermittent and NOT as exonerating.** PR #934's
+  `build-and-test` failed once on head `be5cd96e5` (`EmberClusterPartialStartFailureTest`) and
+  **passed on a re-run of the identical commit**; it does not reproduce in **16 local runs** (1
+  in-suite, 10 idle, 5 with all 8 cores saturated — the load was real: test method 8.03 s → 9.23 s).
+  So the failure is **intermittent, not deterministic**, which 16 runs in a different environment could
+  not have established on their own. Separately and more strongly, **the most direct causal route from
+  this change is refuted by construction**: both start-abort paths `.recover(_ -> Unit.unit())` every
+  element, so `Promise.allOf` cannot fail and the registry clear fires unconditionally — part 3's new
+  `ShutdownTimeout`/`ShutdownInterrupted` cannot suppress it — and this change's only `ember` edit is
+  reached from `@AfterEach`, after the assertion that failed. Those are two independent arguments: the
+  re-run removes determinism, the refutation removes the mechanism.
+  **Neither exonerates the change, and the mechanism is not established.** Non-reproduction was
+  measured in a different environment from the one that failed, and an explanation that clears the
+  change under test is the claim that most deserves testing rather than the one that ends the
+  investigation — **which applies to the passing re-run too**, arriving as it did at the moment it was
+  most welcome. An intermittent failure is entirely compatible with a change that introduces a rare
+  race. No cause is offered here, deliberately
+  [mechanism: refutation traced through `abortStart` and `handleStartResults`; non-determinism from a
+  same-commit re-run; non-reproduction over 16 local runs].
+- **Pins that could not fail, and a mutation that proved nothing — all three found by mutating rather
+  than re-running.** The monitor pin asserted its verdict *after* the dispatch returned, where the
+  blocked walker had already completed the instant the monitor was released; it stayed green against
+  the reintroduced defect while the sibling probe went red, and now snapshots the verdict inside the
+  listener. The ordering pin's failure window was a few instructions wide, so 1 600 concurrent
+  dispatches all passed with the guard removed; it now widens the window deliberately and asserts the
+  stronger property. And the guard mutation described above was scored invalid when it was the most
+  informative one in the set.
+- **Verification scope, stated as what it is.** Local, counted from the reporting run's own surefire
+  XML after wiping stale reports (the `.txt` headers report 0 for `@Nested` classes): `aether-deployment`
+  961, `integrations/swim` 178, `aether/ember` 6, `aether/node` 1205 — **2 350 tests, 0 failures**.
+  The format/lint gate is **not lifecycle-bound and skips silently**, so it was forced with
+  `-Djbct.skip=false` and accepted only where the output reported a nonzero file count: 88, 150 and 6
+  files clean for the three `aether/` modules, and **18 files for `swim`**, which the root `jbct.skip`
+  default had previously let exit green having examined nothing. Swim's format ledger: base 1 issue →
+  this change briefly introduced a second → back to 1, the remaining one being `SwimProtocol.java`,
+  proven pre-existing by content identity against the base blob and deliberately left alone rather than
+  folded into a release-blocker diff. **A pre-existing violation in a gate-exempt module also bans every
+  module after it from the same forced invocation**, which is part of why that debt survived unseen.
+  Three `JBCT-CAUSE-02` warnings are added, one per new `SwimError` record, matching the pattern all
+  five records in that file already share.
+- **What is NOT covered, stated because a green suite invites the opposite conclusion.**
+  `aether/dead-surface-gate` exists to scan every prior module's `target/classes` for unreachable public
+  surface. It was executed rather than merely compiled — and executing it does **not** exercise the
+  scan: `DeadSurfaceCommissioningTest` is `@Disabled` at class level ("commissioning-time only … must
+  not gate CI on their resolution", #519), so all three of its tests skip, for this run and for CI
+  alike, since CI reaches the module only inside the reactor where the same annotation applies. This
+  change removes no symbol, which is the direction removal breakage travels, and its dependents'
+  compile closure was confirmed across 99 modules. But the scan itself ran for nobody. Local green is
+  not the merge criterion and is not offered as one.

--- a/integrations/swim/src/main/java/org/pragmatica/swim/NettySwimTransport.java
+++ b/integrations/swim/src/main/java/org/pragmatica/swim/NettySwimTransport.java
@@ -295,8 +295,13 @@ public final class NettySwimTransport implements SwimTransport {
         LOG.info("SWIM transport started on port {}", port);
     }
 
+    /// Exception lifting restored (#929 verification round 1). `stopChannel` calls
+    /// `DnsNameResolver::close` and `ch.close()`, neither inside a `Result.lift`, and
+    /// [`#awaitBounded`] catches only `InterruptedException` — so without this an unchecked exception
+    /// from either would leave `stop()` as a THROWN exception rather than a `Result` failure. The
+    /// inner `Result` is flattened so the two error channels stay one.
     private Result<Unit> doStop() {
-        return stopChannel();
+        return Result.<Result<Unit>> lift(SwimError.TransportFailure::new, this::stopChannel).flatMap(inner -> inner);
     }
 
     /// Stop the transport under a BOUND, and report what actually happened (#929).
@@ -314,15 +319,10 @@ public final class NettySwimTransport implements SwimTransport {
     /// read as clean: those are correctly red, not a regression.
     private Result<Unit> stopChannel() {
         nettyResolver.getAndSet(none()).onPresent(DnsNameResolver::close);
-
-        var channelClosed = channel.getAndSet(none())
-                                   .map(NettySwimTransport::closeChannel)
-                                   .or(SHUTDOWN_OK);
+        var channelClosed = channel.getAndSet(none()).map(NettySwimTransport::closeChannel).or(SHUTDOWN_OK);
         var groupStopped = externalGroup.isPresent()
                            ? SHUTDOWN_OK
-                           : group.getAndSet(none())
-                                  .map(NettySwimTransport::shutdownGroup)
-                                  .or(SHUTDOWN_OK);
+                           : group.getAndSet(none()).map(NettySwimTransport::shutdownGroup).or(SHUTDOWN_OK);
 
         return channelClosed.flatMap(() -> groupStopped)
                             .onSuccess(_ -> LOG.info("SWIM transport stopped"))
@@ -335,20 +335,32 @@ public final class NettySwimTransport implements SwimTransport {
     }
 
     private static Result<Unit> shutdownGroup(EventLoopGroup g) {
-        return awaitBounded(g.shutdownGracefully(SHUTDOWN_QUIET_PERIOD_MS,
-                                                 SHUTDOWN_TIMEOUT_MS,
-                                                 TimeUnit.MILLISECONDS),
+        return awaitBounded(g.shutdownGracefully(SHUTDOWN_QUIET_PERIOD_MS, SHUTDOWN_TIMEOUT_MS, TimeUnit.MILLISECONDS),
                             "event loop group shutdown");
     }
 
-    /// Bounded wait on a Netty future, reporting the two outcomes the pre-#929 code swallowed:
-    /// the bound elapsing, and an interrupt aborting the wait. Neither is success.
+    /// Bounded wait on a Netty future, reporting the THREE outcomes that are not success: the bound
+    /// elapsing, an interrupt aborting the wait, and the future completing with a failure.
+    ///
+    /// That third case is why `isSuccess()` is consulted separately (#929 verification round 1).
+    /// `Future.await(long)` returns true when the future is DONE, irrespective of outcome — so
+    /// testing only its boolean reports a failed close as a clean stop and logs the success line over
+    /// it. The pre-#929 `.sync()` rethrew that cause, so treating it as success would have been a NEW
+    /// dishonesty introduced by the very change that exists to remove one.
+    ///
+    /// Package-private rather than private so the failed-but-completed branch can be pinned directly:
+    /// it is not reachable through `stopChannel` with a real channel, and an honesty claim whose
+    /// third branch no test can reach is exactly the shape this ticket is about.
     @SuppressWarnings("JBCT-EX-01")  // Adapter boundary: wrapping Netty I/O
-    private static Result<Unit> awaitBounded(Future<?> future, String stage) {
+    static Result<Unit> awaitBounded(Future<?> future, String stage) {
         try {
-            return future.await(SHUTDOWN_TIMEOUT_MS)
+            if (!future.await(SHUTDOWN_TIMEOUT_MS)) {
+                return new SwimError.ShutdownTimeout(stage, SHUTDOWN_TIMEOUT_MS).result();
+            }
+
+            return future.isSuccess()
                    ? SHUTDOWN_OK
-                   : new SwimError.ShutdownTimeout(stage, SHUTDOWN_TIMEOUT_MS).result();
+                   : new SwimError.ShutdownFailed(stage, future.cause()).result();
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
 

--- a/integrations/swim/src/main/java/org/pragmatica/swim/NettySwimTransport.java
+++ b/integrations/swim/src/main/java/org/pragmatica/swim/NettySwimTransport.java
@@ -20,6 +20,7 @@ import java.net.InetSocketAddress;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.pragmatica.consensus.net.NodeInfo;
@@ -68,6 +69,17 @@ public final class NettySwimTransport implements SwimTransport {
     private static final int ANNOUNCE_RATE_PER_SECOND = 10;
     /// Evict per-source rate limiter entries idle longer than this.
     private static final long ANNOUNCE_LIMITER_IDLE_EVICT_MS = 5 * 60 * 1_000L;
+    /// Bound on EACH of the two transport-shutdown waits (#929). Netty's own `shutdownGracefully()`
+    /// timeout cannot supply this: it is enforced by `confirmShutdown()`, which runs ON the event
+    /// loop, so a wedged loop cannot enforce its own timeout — the caller must. 5 s is far above the
+    /// healthy path, which a green nine-node forge teardown measures at a constant 2.00 s per node,
+    /// and that 2 s was entirely the quiet period dropped below.
+    private static final long SHUTDOWN_TIMEOUT_MS = 5_000L;
+    /// No quiet period (#929). Netty defaults to 2 s so a graceful protocol can drain in-flight work.
+    /// SWIM is fire-and-forget UDP with nothing to drain, so the wait bought nothing and cost ~2 s
+    /// per node — ~18 s of every nine-node forge teardown, on the caller's thread.
+    private static final long SHUTDOWN_QUIET_PERIOD_MS = 0L;
+    private static final Result<Unit> SHUTDOWN_OK = Result.success(unit());
 
     private final Serializer serializer;
     private final Deserializer deserializer;
@@ -284,34 +296,63 @@ public final class NettySwimTransport implements SwimTransport {
     }
 
     private Result<Unit> doStop() {
-        return Result.lift(SwimError.TransportFailure::new, this::stopChannel);
+        return stopChannel();
     }
 
-    private void stopChannel() {
+    /// Stop the transport under a BOUND, and report what actually happened (#929).
+    ///
+    /// Both waits used to be bare `.sync()` — unbounded — and this method logged
+    /// "SWIM transport stopped" unconditionally at the end. When a deadlocked SWIM event loop could
+    /// neither run the pending close task nor reach `confirmShutdown()`, the wait ran until JUnit's
+    /// 8-minute lifecycle backstop interrupted it; `.sync()` then threw, the interrupt flag was
+    /// re-asserted, and the success line was logged anyway over a transport that was never stopped
+    /// (the surviving `nioEventLoopGroup` thread is visible in the dumps 10 s later). That false
+    /// line is why #727, #749 and #750 each looked past the wedge underneath it.
+    ///
+    /// So a shutdown that does NOT complete now returns a FAILURE and logs a warning INSTEAD of the
+    /// success line — never as well as it. Expect this to surface teardown failures that previously
+    /// read as clean: those are correctly red, not a regression.
+    private Result<Unit> stopChannel() {
         nettyResolver.getAndSet(none()).onPresent(DnsNameResolver::close);
-        channel.getAndSet(none()).onPresent(NettySwimTransport::closeChannel);
-        if (!externalGroup.isPresent()) {
-            group.getAndSet(none()).onPresent(NettySwimTransport::shutdownGroup);
-        }
 
-        LOG.info("SWIM transport stopped");
+        var channelClosed = channel.getAndSet(none())
+                                   .map(NettySwimTransport::closeChannel)
+                                   .or(SHUTDOWN_OK);
+        var groupStopped = externalGroup.isPresent()
+                           ? SHUTDOWN_OK
+                           : group.getAndSet(none())
+                                  .map(NettySwimTransport::shutdownGroup)
+                                  .or(SHUTDOWN_OK);
+
+        return channelClosed.flatMap(() -> groupStopped)
+                            .onSuccess(_ -> LOG.info("SWIM transport stopped"))
+                            .onFailure(cause -> LOG.warn("SWIM transport shutdown did NOT complete: {}",
+                                                         cause.message()));
     }
 
-    @SuppressWarnings("JBCT-EX-01")  // Adapter boundary: wrapping Netty I/O
-    private static void closeChannel(Channel ch) {
-        try {
-            ch.close().sync();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-        }
+    private static Result<Unit> closeChannel(Channel ch) {
+        return awaitBounded(ch.close(), "channel close");
     }
 
+    private static Result<Unit> shutdownGroup(EventLoopGroup g) {
+        return awaitBounded(g.shutdownGracefully(SHUTDOWN_QUIET_PERIOD_MS,
+                                                 SHUTDOWN_TIMEOUT_MS,
+                                                 TimeUnit.MILLISECONDS),
+                            "event loop group shutdown");
+    }
+
+    /// Bounded wait on a Netty future, reporting the two outcomes the pre-#929 code swallowed:
+    /// the bound elapsing, and an interrupt aborting the wait. Neither is success.
     @SuppressWarnings("JBCT-EX-01")  // Adapter boundary: wrapping Netty I/O
-    private static void shutdownGroup(EventLoopGroup g) {
+    private static Result<Unit> awaitBounded(Future<?> future, String stage) {
         try {
-            g.shutdownGracefully().sync();
+            return future.await(SHUTDOWN_TIMEOUT_MS)
+                   ? SHUTDOWN_OK
+                   : new SwimError.ShutdownTimeout(stage, SHUTDOWN_TIMEOUT_MS).result();
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
+
+            return new SwimError.ShutdownInterrupted(stage).result();
         }
     }
 

--- a/integrations/swim/src/main/java/org/pragmatica/swim/SwimError.java
+++ b/integrations/swim/src/main/java/org/pragmatica/swim/SwimError.java
@@ -45,6 +45,26 @@ public sealed interface SwimError extends Cause {
         }
     }
 
+    /// Transport shutdown did not complete within its bound (#929). Distinct from
+    /// [`TransportFailure`] because nothing threw: the wait simply ran out while the event loop was
+    /// still wedged. Reported instead of the pre-#929 unconditional "SWIM transport stopped" log,
+    /// which claimed success on exactly this path.
+    record ShutdownTimeout(String stage, long timeoutMs) implements SwimError {
+        @Override
+        public String message() {
+            return "SWIM transport " + stage + " did not complete within " + timeoutMs + " ms";
+        }
+    }
+
+    /// Transport shutdown was INTERRUPTED before completing (#929). The interrupt flag is
+    /// re-asserted by the caller; this reports that the shutdown was aborted, not finished.
+    record ShutdownInterrupted(String stage) implements SwimError {
+        @Override
+        public String message() {
+            return "SWIM transport " + stage + " was interrupted before completing";
+        }
+    }
+
     /// Serialization failure.
     record SerializationFailure(Throwable cause) implements SwimError {
         @Override

--- a/integrations/swim/src/main/java/org/pragmatica/swim/SwimError.java
+++ b/integrations/swim/src/main/java/org/pragmatica/swim/SwimError.java
@@ -65,6 +65,19 @@ public sealed interface SwimError extends Cause {
         }
     }
 
+    /// Transport shutdown COMPLETED but failed (#929 verification round 1). Netty's
+    /// `Future.await(long)` returns true when the future is DONE, whatever its outcome, so a close or
+    /// group shutdown that completes exceptionally is a third case — distinct from both
+    /// [`ShutdownTimeout`] and [`ShutdownInterrupted`]. The pre-#929 `.sync()` rethrew this cause;
+    /// reporting it as success would have been a NEW dishonesty in the property part 3 exists to
+    /// establish.
+    record ShutdownFailed(String stage, Throwable cause) implements SwimError {
+        @Override
+        public String message() {
+            return "SWIM transport " + stage + " failed: " + Causes.fromThrowable(cause);
+        }
+    }
+
     /// Serialization failure.
     record SerializationFailure(Throwable cause) implements SwimError {
         @Override

--- a/integrations/swim/src/test/java/org/pragmatica/swim/NettySwimTransportBoundedShutdownTest.java
+++ b/integrations/swim/src/test/java/org/pragmatica/swim/NettySwimTransportBoundedShutdownTest.java
@@ -71,10 +71,16 @@ class NettySwimTransportBoundedShutdownTest {
     /// wait, not the wedge clearing.
     private static final long WEDGE_MS = 9_000L;
     private static final long WEDGE_ARMED_BOUND_MS = 5_000L;
+    private static final long GROUP_CLEANUP_TIMEOUT_MS = 10_000L;
 
     private CapturingAppender appender;
     private LoggerConfig loggerConfig;
     private Level originalLevel;
+    /// Every group this test creates, shut down in [`#tearDown`] whatever the outcome. A Netty
+    /// `NioEventLoopGroup` runs NON-daemon threads: a group left alive by a failing assertion keeps
+    /// the surefire fork from exiting, which is how a first cut of this class turned a 6 s run into
+    /// a 17-minute one under mutation. Cleanup that only runs on the happy path is not cleanup.
+    private final List<EventLoopGroup> groups = new CopyOnWriteArrayList<>();
 
     @BeforeEach
     void setUp() {
@@ -97,12 +103,14 @@ class NettySwimTransportBoundedShutdownTest {
         loggerConfig.setLevel(originalLevel);
         ctx.updateLoggers();
         appender.stop();
+        groups.forEach(group -> group.shutdownGracefully(0L, GROUP_CLEANUP_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        groups.clear();
     }
 
     @Test
     void shutdownThatCannotComplete_reportsFailureAndDoesNotLogSuccess() {
-        var group = new NioEventLoopGroup(1);
-        var transport = transport(group);
+        var group = eventLoopGroup();
+        var transport = externalGroupTransport(group);
 
         assertThat(transport.start(WEDGED_PORT, (_, _) -> {}).await().isSuccess())
                 .as("instrument check: the transport must bind before the loop is wedged")
@@ -124,15 +132,15 @@ class NettySwimTransportBoundedShutdownTest {
         assertThat(appender.eventsMentioning(FAILURE_LINE))
                 .as("the failure must be logged instead")
                 .hasSize(1);
-
-        group.shutdownGracefully(0L, 1L, TimeUnit.SECONDS);
     }
 
     /// Positive control for the absence assertion above, and for the appender itself: an
-    /// unobstructed shutdown succeeds AND logs the success line exactly once.
+    /// unobstructed shutdown succeeds AND logs the success line exactly once. Uses the INTERNAL
+    /// event loop group, so this also covers `shutdownGroup` and the dropped quiet period — the
+    /// wedged case above must supply an external group in order to wedge it, which skips that half.
     @Test
     void healthyShutdown_succeedsAndLogsSuccess() {
-        var transport = transport(new NioEventLoopGroup(1));
+        var transport = ownGroupTransport();
 
         assertThat(transport.start(HEALTHY_PORT, (_, _) -> {}).await().isSuccess()).isTrue();
 
@@ -148,11 +156,28 @@ class NettySwimTransportBoundedShutdownTest {
                 .isEmpty();
     }
 
-    private static SwimTransport transport(EventLoopGroup group) {
+    private EventLoopGroup eventLoopGroup() {
+        var group = new NioEventLoopGroup(1);
+
+        groups.add(group);
+
+        return group;
+    }
+
+    private static SwimTransport externalGroupTransport(EventLoopGroup group) {
         return NettySwimTransport.nettySwimTransport(mock(Serializer.class),
                                                      mock(Deserializer.class),
                                                      GossipEncryptor.none(),
                                                      group)
+                                 .unwrap();
+    }
+
+    /// Transport owning its own event loop group — `stopChannel` therefore also shuts the group
+    /// down, so nothing is left running.
+    private static SwimTransport ownGroupTransport() {
+        return NettySwimTransport.nettySwimTransport(mock(Serializer.class),
+                                                     mock(Deserializer.class),
+                                                     GossipEncryptor.none())
                                  .unwrap();
     }
 

--- a/integrations/swim/src/test/java/org/pragmatica/swim/NettySwimTransportBoundedShutdownTest.java
+++ b/integrations/swim/src/test/java/org/pragmatica/swim/NettySwimTransportBoundedShutdownTest.java
@@ -1,0 +1,228 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2025 Pragmatica Labs - Sergiy Yevtushenko
+// Licensed under Business Source License 1.1. Change Date: 2030-01-01. Change License: Apache-2.0.
+// See LICENSE in the repository root for full terms.
+package org.pragmatica.swim;
+
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.nio.NioEventLoopGroup;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.Filter;
+import org.apache.logging.log4j.core.Layout;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.apache.logging.log4j.core.config.Configuration;
+import org.apache.logging.log4j.core.config.LoggerConfig;
+import org.apache.logging.log4j.core.config.Property;
+import org.apache.logging.log4j.core.layout.PatternLayout;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.pragmatica.lang.Cause;
+import org.pragmatica.lang.Result;
+import org.pragmatica.lang.Unit;
+import org.pragmatica.serialization.Deserializer;
+import org.pragmatica.serialization.Serializer;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+/// #929 — the SWIM transport shutdown must be BOUNDED, and must not claim success when it did not
+/// complete.
+///
+/// ## What was wrong
+///
+/// `stopChannel` used bare `.sync()` on both the channel close and the event-loop-group shutdown,
+/// then logged `"SWIM transport stopped"` unconditionally. Netty's own `shutdownGracefully()`
+/// timeout could not save it: that timeout is enforced by `confirmShutdown()`, which runs ON the
+/// event loop, so a wedged loop cannot enforce its own timeout. When a deadlocked SWIM event loop
+/// (#929's root cause) could neither run the pending close task nor reach `confirmShutdown()`, the
+/// wait ran until JUnit's 8-minute lifecycle backstop interrupted it — and the success line was
+/// logged anyway, over a transport that was never stopped. Dumps show the `nioEventLoopGroup` thread
+/// still RUNNABLE ten seconds after that line. #727, #749 and #750 each read that line and looked
+/// past the wedge underneath it.
+///
+/// ## The honesty pin
+///
+/// [`#shutdownThatCannotComplete_reportsFailureAndDoesNotLogSuccess`] asserts the ABSENCE of the
+/// success line. An absence assertion is worthless without a control that produces the thing, so
+/// [`#healthyShutdown_succeedsAndLogsSuccess`] runs the same appender against a shutdown that DOES
+/// complete and requires the line to appear. If the appender ever stops seeing this logger, the
+/// control goes red rather than the pin going quietly vacuous.
+///
+/// The wedge is a real one: the transport is given an external single-thread `EventLoopGroup`, bound
+/// while the loop is free, and the loop is then occupied by a task outlasting the shutdown bound, so
+/// the channel-close future genuinely cannot complete.
+class NettySwimTransportBoundedShutdownTest {
+    private static final String LOGGER_NAME = NettySwimTransport.class.getName();
+    private static final String SUCCESS_LINE = "SWIM transport stopped";
+    private static final String FAILURE_LINE = "SWIM transport shutdown did NOT complete";
+    private static final int WEDGED_PORT = 19731;
+    private static final int HEALTHY_PORT = 19732;
+    /// Must outlast `NettySwimTransport.SHUTDOWN_TIMEOUT_MS` (5 s) so the bound is what ends the
+    /// wait, not the wedge clearing.
+    private static final long WEDGE_MS = 9_000L;
+    private static final long WEDGE_ARMED_BOUND_MS = 5_000L;
+
+    private CapturingAppender appender;
+    private LoggerConfig loggerConfig;
+    private Level originalLevel;
+
+    @BeforeEach
+    void setUp() {
+        appender = CapturingAppender.create("NettySwimTransportBoundedShutdownCapture");
+        appender.start();
+        var ctx = (LoggerContext) LogManager.getContext(false);
+
+        loggerConfig = getOrCreateLoggerConfig(ctx.getConfiguration());
+        originalLevel = loggerConfig.getLevel();
+        loggerConfig.addAppender(appender, Level.ALL, null);
+        loggerConfig.setLevel(Level.ALL);
+        ctx.updateLoggers();
+    }
+
+    @AfterEach
+    void tearDown() {
+        var ctx = (LoggerContext) LogManager.getContext(false);
+
+        loggerConfig.removeAppender(appender.getName());
+        loggerConfig.setLevel(originalLevel);
+        ctx.updateLoggers();
+        appender.stop();
+    }
+
+    @Test
+    void shutdownThatCannotComplete_reportsFailureAndDoesNotLogSuccess() {
+        var group = new NioEventLoopGroup(1);
+        var transport = transport(group);
+
+        assertThat(transport.start(WEDGED_PORT, (_, _) -> {}).await().isSuccess())
+                .as("instrument check: the transport must bind before the loop is wedged")
+                .isTrue();
+
+        wedge(group);
+
+        var result = transport.stop().await();
+
+        assertThat(result.isFailure()).as("a shutdown whose event loop cannot run the close task must "
+                                          + "report FAILURE, not success (#929)")
+                                      .isTrue();
+        assertThat(cause(result)).as("and the failure must name the bound that elapsed")
+                                 .isInstanceOf(SwimError.ShutdownTimeout.class);
+        assertThat(appender.eventsMentioning(SUCCESS_LINE))
+                .as("the success line must NOT be logged on a shutdown that did not complete — that "
+                    + "unconditional line is what hid this defect across #727/#749/#750")
+                .isEmpty();
+        assertThat(appender.eventsMentioning(FAILURE_LINE))
+                .as("the failure must be logged instead")
+                .hasSize(1);
+
+        group.shutdownGracefully(0L, 1L, TimeUnit.SECONDS);
+    }
+
+    /// Positive control for the absence assertion above, and for the appender itself: an
+    /// unobstructed shutdown succeeds AND logs the success line exactly once.
+    @Test
+    void healthyShutdown_succeedsAndLogsSuccess() {
+        var transport = transport(new NioEventLoopGroup(1));
+
+        assertThat(transport.start(HEALTHY_PORT, (_, _) -> {}).await().isSuccess()).isTrue();
+
+        var result = transport.stop().await();
+
+        assertThat(result.isSuccess()).as("an unobstructed shutdown must succeed").isTrue();
+        assertThat(appender.eventsMentioning(SUCCESS_LINE))
+                .as("control: the appender CAN see this logger's success line, so its absence above "
+                    + "is a real absence rather than a blind instrument")
+                .hasSize(1);
+        assertThat(appender.eventsMentioning(FAILURE_LINE))
+                .as("and a healthy shutdown must not report failure")
+                .isEmpty();
+    }
+
+    private static SwimTransport transport(EventLoopGroup group) {
+        return NettySwimTransport.nettySwimTransport(mock(Serializer.class),
+                                                     mock(Deserializer.class),
+                                                     GossipEncryptor.none(),
+                                                     group)
+                                 .unwrap();
+    }
+
+    /// Occupy the group's only event loop for longer than the shutdown bound, and wait until the
+    /// task has actually started — otherwise the shutdown could win the race and the probe would
+    /// measure nothing.
+    private static void wedge(EventLoopGroup group) {
+        var armed = new CountDownLatch(1);
+
+        group.execute(() -> {
+            armed.countDown();
+            sleepQuietly(WEDGE_MS);
+        });
+
+        try {
+            assertThat(armed.await(WEDGE_ARMED_BOUND_MS, TimeUnit.MILLISECONDS))
+                    .as("instrument check: the event loop must actually be occupied before stop()")
+                    .isTrue();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    private static void sleepQuietly(long millis) {
+        try {
+            Thread.sleep(millis);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    private static Cause cause(Result<Unit> result) {
+        return result instanceof Result.Failure<Unit>(var failure)
+               ? failure
+               : null;
+    }
+
+    private static LoggerConfig getOrCreateLoggerConfig(Configuration configuration) {
+        var existing = configuration.getLoggerConfig(LOGGER_NAME);
+
+        if (LOGGER_NAME.equals(existing.getName())) {
+            return existing;
+        }
+
+        var fresh = new LoggerConfig(LOGGER_NAME, Level.ALL, false);
+
+        configuration.addLogger(LOGGER_NAME, fresh);
+
+        return fresh;
+    }
+
+    /// In-memory log4j2 appender capturing every event on the transport's own logger.
+    private static final class CapturingAppender extends AbstractAppender {
+        private final List<String> messages = new CopyOnWriteArrayList<>();
+
+        private CapturingAppender(String name, Layout<?> layout) {
+            super(name, (Filter) null, layout, true, Property.EMPTY_ARRAY);
+        }
+
+        static CapturingAppender create(String name) {
+            return new CapturingAppender(name, PatternLayout.createDefaultLayout());
+        }
+
+        @Override
+        public void append(LogEvent event) {
+            messages.add(event.getMessage().getFormattedMessage());
+        }
+
+        List<String> eventsMentioning(String fragment) {
+            return messages.stream().filter(message -> message.contains(fragment)).toList();
+        }
+    }
+}

--- a/integrations/swim/src/test/java/org/pragmatica/swim/NettySwimTransportBoundedShutdownTest.java
+++ b/integrations/swim/src/test/java/org/pragmatica/swim/NettySwimTransportBoundedShutdownTest.java
@@ -6,6 +6,7 @@ package org.pragmatica.swim;
 
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.util.concurrent.DefaultPromise;
 
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
@@ -154,6 +155,46 @@ class NettySwimTransportBoundedShutdownTest {
         assertThat(appender.eventsMentioning(FAILURE_LINE))
                 .as("and a healthy shutdown must not report failure")
                 .isEmpty();
+    }
+
+    /// The THIRD outcome, and the one the shipped pin could not reach (#929 verification round 1).
+    /// Netty's `Future.await(long)` returns true when the future is DONE, irrespective of outcome, so
+    /// a close that completes EXCEPTIONALLY took the success branch and `"SWIM transport stopped"` was
+    /// logged over a failed shutdown. The pre-#929 `.sync()` rethrew that cause, so this was a NEW
+    /// dishonesty introduced by the change whose whole purpose is to remove one.
+    ///
+    /// Pinned against `awaitBounded` directly because it is not reachable through `stopChannel` with a
+    /// real channel — `ch.close()` and the termination future rarely fail. A branch no scenario
+    /// reaches is precisely the branch that ships wrong.
+    @Test
+    void aShutdownFutureThatCompletedWithAFailure_isNotReportedAsSuccess() {
+        var failed = new DefaultPromise<Void>(eventLoopGroup().next());
+
+        failed.setFailure(new IllegalStateException("close refused by the channel"));
+
+        var result = NettySwimTransport.awaitBounded(failed, "channel close");
+
+        assertThat(result.isFailure()).as("a future that COMPLETED but failed is not a clean shutdown")
+                                      .isTrue();
+        assertThat(cause(result)).isInstanceOf(SwimError.ShutdownFailed.class);
+        assertThat(cause(result).message())
+                .as("and the report must carry the underlying cause, not just the stage")
+                .contains("close refused by the channel");
+    }
+
+    /// Positive control for the assertion above: a future that completes SUCCESSFULLY within the bound
+    /// IS success. Without this, `awaitBounded` failing unconditionally would satisfy the pin.
+    @Test
+    void aShutdownFutureThatCompletedSuccessfully_isReportedAsSuccess() {
+        var succeeded = new DefaultPromise<Void>(eventLoopGroup().next());
+
+        succeeded.setSuccess(null);
+
+        assertThat(NettySwimTransport.awaitBounded(succeeded, "channel close").isSuccess())
+                .as("control: a cleanly completed future must still read as success, so the failure "
+                    + "assertion above discriminates on the OUTCOME rather than on awaitBounded "
+                    + "always failing")
+                .isTrue();
     }
 
     private EventLoopGroup eventLoopGroup() {


### PR DESCRIPTION
Fixes #929 — an AB/BA monitor deadlock between per-member `MembershipFsm$MemberTracking` locks that
wedges two production event loops of a live node. Implements owner ruling parts **1, 3, 4** (not
part 2, not #914).

## The defect

`MemberTracking.dispatch` was `synchronized` and published to `transitionSink` while holding the
dispatching member's monitor. The listener runs synchronously into
`AetherNode.onFsmTransition` → `propagateMemberCount` → `strictCoreObservedMemberCount`, which
streams the member map calling the `synchronized` `isStrictCoreMember()` on **every** member. So a
thread held one member's monitor and requested all the others', in `ConcurrentHashMap` iteration
order. One node's SWIM loop (`onSwimSuspect`) and QUIC loop (`onLivenessGone`) dispatching on two
different members each held one monitor and wanted the other's. That order is a hash order, so lock
ordering cannot repair it.

## What changed

**Part 1 — root fix.** `dispatch` splits into a `synchronized applyEvent` that mutates state and
*stages* the listener calls, and an unsynchronized `dispatch` that runs them under a new per-member
`transitionGuard` with the monitor released. All six sinks are staged, not just `transitionSink` —
the class documents the "cheap and non-blocking" contract that all of them were violating.

The guard preserves both properties the old `synchronized dispatch` gave: one member's transitions
stay totally ordered, and a listener still observes the member in exactly the state its record names.
Only the incidental blocking of *readers* is dropped — the deadlock's one edge. Lock order is always
guard → monitor; the four check-then-dispatch entry points were converted to take the guard first so
there is no inversion. The six ingress drivers now run under the same guard, which makes each driver
atomic against other transitions of that member — strictly stronger than before, since each step
previously took the monitor separately.

**Part 3 — bounded transport shutdown that stops lying.** `NettySwimTransport`'s bare `.sync()` calls
become bounded `await(5s)` (Netty's own timeout is enforced by `confirmShutdown()` *on* the event
loop, so a wedged loop cannot enforce it). The unconditional `LOG.info("SWIM transport stopped")` is
gone: success logs from `onSuccess`, and a shutdown that timed out logs a failure *instead of* it,
returning `SwimError.ShutdownTimeout`. The 2 s quiet period is dropped — SWIM is fire-and-forget UDP
with nothing to drain.

**Part 4 — bound where it can see the blocking code.** `EmberCluster.stop()` submits each
`node.stop()` so the synchronous prologue runs off the caller's thread and inside `NODE_TIMEOUT`.
Landed after part 1, per the ordering constraint.

## Evidence

- **Deterministic deadlock probe** driving the two production ingress points on two members of one
  FSM, with a barrier forcing the interleaving. **Mutation-tested:** restoring `synchronized (this)`
  around the fan-out turns it and the monitor pin RED; the fixed code runs 3/3 in 0.072 s.
- **Ordering/atomicity pin** goes RED when the guard is removed from both `dispatch` and
  `inTransition` (the naive "publish after release" fix).
- **Transport honesty pin** against a genuinely wedged event loop, with a positive control that the
  appender *can* see the success line. Reinserting the unconditional log turns it RED; removing the
  bound turns the failure-report assertion RED.
- **2346 module tests green** (aether-deployment, swim, ember, node), counted from surefire XML.
- **`jbct:check` green** on all four modules (invoked explicitly — it is not lifecycle-bound).
- **`MultiSourceCommunitySmokeTest` teardown: 6.25 s**, node stops concurrent, all 9 SWIM transports
  stopped within one millisecond, zero `HANG DIAGNOSTIC` / timeout hits. Previously this teardown was
  released at exactly T+480 s by the JUnit backstop; the healthy baseline was ~16.6 s.

One green run of an intermittent test is not proof the race is gone — the deadlock evidence is the
deterministic probe plus its mutation, not that run.

Full report, including the `transitionSink` consumer audit and two weak pins the mutations caught:
`oss/internal/fix-929-2026-09-07.md`.

**Do not merge — adversarial verification runs first.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
