### PR TITLE
fix: preserve SliceTargetValue.owningBlueprint in the autoscaler and A/B writers (#698)

### DIFF
--- a/aether/aether-control/src/main/java/org/pragmatica/aether/controller/ClusterController.java
+++ b/aether/aether-control/src/main/java/org/pragmatica/aether/controller/ClusterController.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.pragmatica.aether.artifact.Artifact;
+import org.pragmatica.aether.slice.blueprint.BlueprintId;
 import org.pragmatica.consensus.NodeId;
 import org.pragmatica.lang.Option;
 import org.pragmatica.lang.Promise;
@@ -43,13 +44,26 @@ public interface ClusterController {
     /// Per-artifact scaling blueprint. `maxInstances` (#424) bounds autoscaler scale-up before the
     /// cluster-size cap; `scaleUpThreshold`/`scaleDownThreshold` override the cluster ScalingConfig
     /// tier for this slice when present. All three are optional — absent means "use cluster default".
+    ///
+    /// `owningBlueprint` (#698) carries the `BlueprintId` that owns this slice, mirrored from the
+    /// `SliceTargetValue` that registered it. It exists solely so the autoscaler can write the owner
+    /// back out on a scaling Put instead of erasing it: downstream, `ClusterDeploymentState` resolves
+    /// `schemaRequired` from the owner, and an absent owner silently takes the historical default
+    /// `true`. `none()` here means "genuinely unowned slice", never "owner not carried forward" —
+    /// every value in this field originates from a `SliceTargetValue` observed at
+    /// `ControlLoop.onSliceTargetPut`, the sole feeder of the blueprint map.
     record Blueprint(Artifact artifact,
                      int instances,
                      int minInstances,
+                     Option<BlueprintId> owningBlueprint,
                      Option<Integer> maxInstances,
                      Option<Double> scaleUpThreshold,
                      Option<Double> scaleDownThreshold) {
         public Blueprint {
+            if (owningBlueprint == null) {
+                owningBlueprint = Option.none();
+            }
+
             if (maxInstances == null) {
                 maxInstances = Option.none();
             }
@@ -63,8 +77,16 @@ public interface ClusterController {
             }
         }
 
+        /// Unowned-slice factory: `owningBlueprint` is `none()` because the slice genuinely has no
+        /// owning blueprint, not because the caller declined to carry one forward (#698).
         public static Blueprint blueprint(Artifact artifact, int instances, int minInstances) {
-            return new Blueprint(artifact, instances, minInstances, Option.none(), Option.none(), Option.none());
+            return new Blueprint(artifact,
+                                 instances,
+                                 minInstances,
+                                 Option.none(),
+                                 Option.none(),
+                                 Option.none(),
+                                 Option.none());
         }
     }
 

--- a/aether/aether-control/src/main/java/org/pragmatica/aether/controller/ControlLoop.java
+++ b/aether/aether-control/src/main/java/org/pragmatica/aether/controller/ControlLoop.java
@@ -17,6 +17,7 @@ import org.pragmatica.aether.controller.fsm.ControlLoopState;
 import org.pragmatica.aether.controller.fsm.ScalingDecisionRecord;
 import org.pragmatica.aether.metrics.ClusterSyncCollector;
 import org.pragmatica.aether.metrics.invocation.InvocationMetricsCollector;
+import org.pragmatica.aether.slice.blueprint.BlueprintId;
 import org.pragmatica.aether.slice.kvstore.AetherKey;
 import org.pragmatica.aether.slice.kvstore.AetherKey.NodeArtifactKey;
 import org.pragmatica.aether.slice.kvstore.AetherKey.SliceNodeKey;
@@ -71,9 +72,13 @@ public interface ControlLoop {
     @MessageReceiver
     void onQuorumStateChange(ClusterStateNotification notification);
 
+    /// `owner` is the `SliceTargetValue`'s `owningBlueprint` (#698). It is a required parameter
+    /// rather than an optional tail so that a caller which has no owner must say so explicitly;
+    /// the autoscaler writes this value back out on every scaling Put.
     void registerBlueprint(Artifact artifact,
                            int instances,
                            int minInstances,
+                           Option<BlueprintId> owner,
                            Option<Integer> maxInstances,
                            Option<Double> scaleUpThreshold,
                            Option<Double> scaleDownThreshold);
@@ -201,6 +206,7 @@ public interface ControlLoop {
             registerBlueprint(key.artifactBase().withVersion(value.currentVersion()),
                               value.targetInstances(),
                               value.effectiveMinInstances(),
+                              value.owningBlueprint(),
                               value.maxInstances(),
                               value.scaleUpThreshold(),
                               value.scaleDownThreshold());
@@ -231,10 +237,11 @@ public interface ControlLoop {
         public void registerBlueprint(Artifact artifact,
                                       int instances,
                                       int minInstances,
+                                      Option<BlueprintId> owner,
                                       Option<Integer> maxInstances,
                                       Option<Double> scaleUpThreshold,
                                       Option<Double> scaleDownThreshold) {
-            ctx.putBlueprint(artifact, instances, minInstances, maxInstances, scaleUpThreshold, scaleDownThreshold);
+            ctx.putBlueprint(artifact, instances, minInstances, owner, maxInstances, scaleUpThreshold, scaleDownThreshold);
             log.info("Registered blueprint: {} with {} instances (min: {}, max: {})",
                      artifact,
                      instances,

--- a/aether/aether-control/src/main/java/org/pragmatica/aether/controller/ControlLoop.java
+++ b/aether/aether-control/src/main/java/org/pragmatica/aether/controller/ControlLoop.java
@@ -241,7 +241,13 @@ public interface ControlLoop {
                                       Option<Integer> maxInstances,
                                       Option<Double> scaleUpThreshold,
                                       Option<Double> scaleDownThreshold) {
-            ctx.putBlueprint(artifact, instances, minInstances, owner, maxInstances, scaleUpThreshold, scaleDownThreshold);
+            ctx.putBlueprint(artifact,
+                             instances,
+                             minInstances,
+                             owner,
+                             maxInstances,
+                             scaleUpThreshold,
+                             scaleDownThreshold);
             log.info("Registered blueprint: {} with {} instances (min: {}, max: {})",
                      artifact,
                      instances,

--- a/aether/aether-control/src/main/java/org/pragmatica/aether/controller/fsm/ControlLoopContext.java
+++ b/aether/aether-control/src/main/java/org/pragmatica/aether/controller/fsm/ControlLoopContext.java
@@ -29,6 +29,7 @@ import org.pragmatica.aether.controller.fsm.ScalingDecisionRecord.Outcome;
 import org.pragmatica.aether.metrics.ClusterSyncCollector;
 import org.pragmatica.aether.metrics.invocation.InvocationMetricsCollector;
 import org.pragmatica.aether.slice.SliceState;
+import org.pragmatica.aether.slice.blueprint.BlueprintId;
 import org.pragmatica.aether.slice.kvstore.AetherKey;
 import org.pragmatica.aether.slice.kvstore.AetherKey.SliceNodeKey;
 import org.pragmatica.aether.slice.kvstore.AetherKey.SliceTargetKey;
@@ -199,15 +200,21 @@ public final class ControlLoopContext {
         return Option.option(blueprints.get(artifact));
     }
 
+    /// Unowned-slice convenience: records a slice that genuinely has no owning blueprint (#698).
     @Contract
     public void putBlueprint(Artifact artifact, int instances, int minInstances) {
-        putBlueprint(artifact, instances, minInstances, Option.none(), Option.none(), Option.none());
+        putBlueprint(artifact, instances, minInstances, Option.none(), Option.none(), Option.none(), Option.none());
     }
 
+    /// `owner` is threaded from the `SliceTargetValue` that triggered this registration and is
+    /// written back out by `applyScaling` (#698). There is deliberately no owner-less overload of
+    /// this arity: dropping the owner must be a decision the caller states, not a default it
+    /// inherits — that default is precisely what erased the owner on every autoscale event.
     @Contract
     public void putBlueprint(Artifact artifact,
                              int instances,
                              int minInstances,
+                             Option<BlueprintId> owner,
                              Option<Integer> maxInstances,
                              Option<Double> scaleUpThreshold,
                              Option<Double> scaleDownThreshold) {
@@ -215,6 +222,7 @@ public final class ControlLoopContext {
                        new ClusterController.Blueprint(artifact,
                                                        instances,
                                                        minInstances,
+                                                       owner,
                                                        maxInstances,
                                                        scaleUpThreshold,
                                                        scaleDownThreshold));
@@ -513,6 +521,18 @@ public final class ControlLoopContext {
         return applyScaling(change, artifact, currentBlueprint, requestedInstances, newInstances, capped);
     }
 
+    /// Emits the autoscaler's `SliceTargetValue` Put. The value is built from `currentBlueprint`,
+    /// the in-memory mirror of the last `SliceTargetValue` observed for this artifact — including
+    /// its `owningBlueprint` (#698). The owner is taken from that mirror rather than re-read from
+    /// the KV store deliberately: a re-read here would add a read-then-Put on the autoscaler's hot
+    /// path, the shape flagged by #906 and #805. This method performs no store read, so it adds no
+    /// lost-update exposure beyond the unconditional Put it already issued.
+    ///
+    /// The mirror cannot be stale in the owner: `blueprints` has exactly one writer
+    /// (`putBlueprint`), whose only production caller is `ControlLoop.onSliceTargetPut`. An artifact
+    /// with no observed `SliceTargetValue` has no blueprint entry, so `prepareChange` returns
+    /// `none()` and this method is never reached for it. The owner therefore has the same provenance
+    /// and lifetime as `maxInstances` and both thresholds, which this method already trusts.
     private Option<KVCommand<AetherKey>> applyScaling(BlueprintChange change,
                                                       Artifact artifact,
                                                       ClusterController.Blueprint currentBlueprint,
@@ -526,16 +546,20 @@ public final class ControlLoopContext {
         putBlueprint(artifact,
                      newInstances,
                      currentBlueprint.minInstances(),
+                     currentBlueprint.owningBlueprint(),
                      currentBlueprint.maxInstances(),
                      currentBlueprint.scaleUpThreshold(),
                      currentBlueprint.scaleDownThreshold());
         publishScalingEvent(change, artifact, currentBlueprint.instances(), newInstances);
         recordScaled(change, artifact, currentBlueprint, requestedInstances, newInstances, capped);
         var key = SliceTargetKey.sliceTargetKey(artifact.base());
+        // #698: the owner is carried from the registered blueprint, never rebuilt as `none()`.
+        // A fresh `SliceTargetValue` is still constructed rather than `withInstances(...)` on a
+        // re-read value because this class holds no KV-store handle — see the method javadoc.
         var value = SliceTargetValue.sliceTargetValue(artifact.version(),
                                                       newInstances,
                                                       newInstances,
-                                                      Option.none(),
+                                                      currentBlueprint.owningBlueprint(),
                                                       currentBlueprint.maxInstances(),
                                                       currentBlueprint.scaleUpThreshold(),
                                                       currentBlueprint.scaleDownThreshold());

--- a/aether/aether-control/src/test/java/org/pragmatica/aether/controller/DecisionTreeControllerTest.java
+++ b/aether/aether-control/src/test/java/org/pragmatica/aether/controller/DecisionTreeControllerTest.java
@@ -221,6 +221,7 @@ class DecisionTreeControllerTest {
                              instances,
                              minInstances,
                              Option.none(),
+                             Option.none(),
                              Option.some(scaleUpThreshold),
                              Option.none());
     }

--- a/aether/aether-control/src/test/java/org/pragmatica/aether/controller/fsm/ControlLoopContextAttributionTest.java
+++ b/aether/aether-control/src/test/java/org/pragmatica/aether/controller/fsm/ControlLoopContextAttributionTest.java
@@ -141,7 +141,7 @@ class ControlLoopContextAttributionTest {
             cluster = new CapturingClusterNode();
             var capCtx = buildContext(scaleUpBy(2));
 
-            capCtx.putBlueprint(HOT, 2, 1, Option.some(3), Option.none(), Option.none());
+            capCtx.putBlueprint(HOT, 2, 1, Option.none(), Option.some(3), Option.none(), Option.none());
             capCtx.setTopology(FIVE_NODES);
 
             capCtx.runEvaluationCycle();
@@ -188,7 +188,7 @@ class ControlLoopContextAttributionTest {
             cluster = new CapturingClusterNode();
             var capCtx = buildContext(scaleUpBy(3), events::add);
 
-            capCtx.putBlueprint(HOT, 2, 1, Option.some(3), Option.none(), Option.none());
+            capCtx.putBlueprint(HOT, 2, 1, Option.none(), Option.some(3), Option.none(), Option.none());
             capCtx.setTopology(FIVE_NODES);
 
             capCtx.runEvaluationCycle();

--- a/aether/aether-control/src/test/java/org/pragmatica/aether/controller/fsm/ControlLoopOwnerPreservationTest.java
+++ b/aether/aether-control/src/test/java/org/pragmatica/aether/controller/fsm/ControlLoopOwnerPreservationTest.java
@@ -29,6 +29,7 @@ import org.pragmatica.aether.controller.ControllerConfig;
 import org.pragmatica.aether.controller.ScalingConfig;
 import org.pragmatica.aether.controller.ScalingEvent;
 import org.pragmatica.aether.controller.ScalingMetric;
+import org.pragmatica.aether.deployment.cluster.ClusterDeploymentManager.Blueprint;
 import org.pragmatica.aether.deployment.cluster.ClusterDeploymentManager.DeploymentAtomicity;
 import org.pragmatica.aether.deployment.cluster.fsm.ClusterDeploymentContext;
 import org.pragmatica.aether.deployment.cluster.fsm.ClusterDeploymentEvents.Activate;
@@ -228,9 +229,13 @@ class ControlLoopOwnerPreservationTest {
             kvStore.put(SliceTargetKey.sliceTargetKey(SLICE.base()), autoscalerOutput);
             harness.dispatch(new Activate());
 
-            assertThat(restoredSchemaRequired()).as("#698: a schema_required=false slice must not come back requiring schema"
-                                                    + " after an autoscale event followed by a leader restore")
-                                                .isEqualTo(false);
+            var restored = restoredBlueprint();
+
+            assertThat(restored.owner()).as("#698: the restored blueprint must still name its owning blueprint")
+                                        .isEqualTo(Option.some(OWNER));
+            assertThat(restored.schemaRequired()).as("#698: a schema_required=false slice must not come back requiring schema"
+                                                     + " after an autoscale event followed by a leader restore")
+                                                 .isEqualTo(false);
         }
 
         /// Opposite polarity, same path: proves the restore actually consults the owning blueprint
@@ -246,10 +251,21 @@ class ControlLoopOwnerPreservationTest {
             kvStore.put(SliceTargetKey.sliceTargetKey(SLICE.base()), emittedTarget());
             harness.dispatch(new Activate());
 
-            assertThat(restoredSchemaRequired()).isEqualTo(true);
+            var restored = restoredBlueprint();
+
+            // The owner assertion is what makes this test discriminating, and it must not be removed.
+            // `schemaRequired == true` ALONE cannot detect owner erasure: with the owner dropped the
+            // resolution falls through to the historical unowned default, which is `true` — the same
+            // value this test expects, so it would pass for the wrong reason and look like coverage
+            // of the very defect it cannot see. Asserting the owner makes the erased path predict
+            // None() and the correct path Some(OWNER) — mutually exclusive, hence mutation-sensitive.
+            assertThat(restored.owner()).as("#698: schemaRequired=true is ALSO the erased-owner default —"
+                                            + " only the owner discriminates the two paths")
+                                        .isEqualTo(Option.some(OWNER));
+            assertThat(restored.schemaRequired()).isEqualTo(true);
         }
 
-        private boolean restoredSchemaRequired() {
+        private Blueprint restoredBlueprint() {
             var active = (ClusterDeploymentState.Active) harness.state();
             var scaledArtifact = SLICE.base().withVersion(SLICE.version());
             var blueprint = active.blueprints().get(scaledArtifact);
@@ -257,7 +273,7 @@ class ControlLoopOwnerPreservationTest {
             assertThat(blueprint).as("expected a restored blueprint entry for %s", scaledArtifact)
                                  .isNotNull();
 
-            return blueprint.schemaRequired();
+            return blueprint;
         }
 
         /// Minimal but complete blueprint document — `id`, a non-empty `[[slices]]` and an explicit

--- a/aether/aether-control/src/test/java/org/pragmatica/aether/controller/fsm/ControlLoopOwnerPreservationTest.java
+++ b/aether/aether-control/src/test/java/org/pragmatica/aether/controller/fsm/ControlLoopOwnerPreservationTest.java
@@ -10,7 +10,6 @@ import java.util.Collections;
 import java.util.EnumMap;
 import java.util.List;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.LongSupplier;
@@ -95,12 +94,14 @@ class ControlLoopOwnerPreservationTest {
     private static final int WINDOW = 3;
 
     private CapturingClusterNode cluster;
+    private ControlLoop controlLoop;
     private ControlLoopContext ctx;
 
     @BeforeEach
     void setUp() {
         cluster = new CapturingClusterNode();
-        ctx = buildContext(scaleUpBy(2));
+        controlLoop = buildControlLoop(scaleUpBy(2));
+        ctx = ((ControlLoop.ControlLoopAdapter) controlLoop).ctx();
         ctx.setTopology(List.of(SELF,
                                 WORKER,
                                 NodeId.nodeId("n3").unwrap(),
@@ -113,7 +114,6 @@ class ControlLoopOwnerPreservationTest {
     /// the only writer of the context's blueprint map, so this is the sole route by which the
     /// autoscaler can learn an owner at all.
     private void registerOwnedSliceViaRealFeeder(Option<BlueprintId> owner) {
-        ControlLoop feeder = new ControlLoop.ControlLoopAdapter(ctx, null);
         var key = SliceTargetKey.sliceTargetKey(SLICE.base());
         var deployed = SliceTargetValue.sliceTargetValue(SLICE.version(),
                                                          2,
@@ -123,7 +123,7 @@ class ControlLoopOwnerPreservationTest {
                                                          Option.none(),
                                                          Option.none());
 
-        feeder.onSliceTargetPut(new ValuePut<>(new KVCommand.Put<>(key, deployed), Option.none()));
+        controlLoop.onSliceTargetPut(new ValuePut<>(new KVCommand.Put<>(key, deployed), Option.none()));
     }
 
     /// The single `SliceTargetValue` the autoscaler wrote during this test's evaluation cycle.
@@ -286,30 +286,20 @@ class ControlLoopOwnerPreservationTest {
         return _ -> Promise.success(ControlDecisions.controlDecisions(new BlueprintChange.ScaleUp(SLICE, additional)));
     }
 
-    private ControlLoopContext buildContext(ClusterController controller) {
-        var config = ControllerConfig.DEFAULT.withScalingConfig(smallWindowConfig());
-        var ctxHolder = new AtomicReference<ControlLoopContext>();
+    /// Assembled through the production factory (`ControlLoop.controlLoop`), which builds the
+    /// context, the FSM and the adapter the same way a node does — so the feeder driven below is the
+    /// real one, not a test-assembled stand-in.
+    private ControlLoop buildControlLoop(ClusterController controller) {
         Consumer<ScalingEvent> sink = _ -> {};
-        Function<Fsm<ControlLoopState, ClusterFsmEvent>, ControlLoopState> factory =
-                fsm -> {
-                    var context = new ControlLoopContext(fsm,
-                                                         SELF,
-                                                         controller,
-                                                         new ControlLoopContextAttributionTest.StubMetricsCollector(),
-                                                         Option.none(),
-                                                         cluster,
-                                                         TimeSpan.timeSpan(5_000).millis(),
-                                                         config,
-                                                         sink);
 
-                    ctxHolder.set(context);
-
-                    return context.dormant();
-                };
-
-        Fsm.fsm("owner-preservation-test", SELF.id(), factory);
-
-        return ctxHolder.get();
+        return ControlLoop.controlLoop(SELF,
+                                       controller,
+                                       new ControlLoopContextAttributionTest.StubMetricsCollector(),
+                                       Option.none(),
+                                       cluster,
+                                       TimeSpan.timeSpan(5_000).millis(),
+                                       ControllerConfig.DEFAULT.withScalingConfig(smallWindowConfig()),
+                                       sink);
     }
 
     private static ScalingConfig smallWindowConfig() {

--- a/aether/aether-control/src/test/java/org/pragmatica/aether/controller/fsm/ControlLoopOwnerPreservationTest.java
+++ b/aether/aether-control/src/test/java/org/pragmatica/aether/controller/fsm/ControlLoopOwnerPreservationTest.java
@@ -1,0 +1,435 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2025 Pragmatica Labs - Sergiy Yevtushenko
+// Licensed under Business Source License 1.1. Change Date: 2030-01-01. Change License: Apache-2.0.
+// See LICENSE in the repository root for full terms.
+package org.pragmatica.aether.controller.fsm;
+
+import java.net.SocketAddress;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.LongSupplier;
+
+import io.netty.buffer.ByteBuf;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import org.pragmatica.aether.artifact.Artifact;
+import org.pragmatica.aether.controller.ClusterController;
+import org.pragmatica.aether.controller.ClusterController.BlueprintChange;
+import org.pragmatica.aether.controller.ClusterController.ControlDecisions;
+import org.pragmatica.aether.controller.ControlLoop;
+import org.pragmatica.aether.controller.ControllerConfig;
+import org.pragmatica.aether.controller.ScalingConfig;
+import org.pragmatica.aether.controller.ScalingEvent;
+import org.pragmatica.aether.controller.ScalingMetric;
+import org.pragmatica.aether.deployment.cluster.ClusterDeploymentManager.DeploymentAtomicity;
+import org.pragmatica.aether.deployment.cluster.fsm.ClusterDeploymentContext;
+import org.pragmatica.aether.deployment.cluster.fsm.ClusterDeploymentEvents.Activate;
+import org.pragmatica.aether.deployment.cluster.fsm.ClusterDeploymentState;
+import org.pragmatica.aether.deployment.schema.SchemaOrchestratorService;
+import org.pragmatica.aether.slice.blueprint.BlueprintId;
+import org.pragmatica.aether.slice.blueprint.ExpandedBlueprint;
+import org.pragmatica.aether.slice.kvstore.AetherKey;
+import org.pragmatica.aether.slice.kvstore.AetherKey.AppBlueprintKey;
+import org.pragmatica.aether.slice.kvstore.AetherKey.SliceTargetKey;
+import org.pragmatica.aether.slice.kvstore.AetherValue;
+import org.pragmatica.aether.slice.kvstore.AetherValue.AppBlueprintValue;
+import org.pragmatica.aether.slice.kvstore.AetherValue.SliceTargetValue;
+import org.pragmatica.cluster.node.ClusterNode;
+import org.pragmatica.cluster.state.kvstore.KVCommand;
+import org.pragmatica.cluster.state.kvstore.KVStore;
+import org.pragmatica.cluster.state.kvstore.KVStoreNotification.ValuePut;
+import org.pragmatica.consensus.NodeId;
+import org.pragmatica.consensus.fsm.ClusterFsmEvent;
+import org.pragmatica.consensus.net.NodeInfo;
+import org.pragmatica.consensus.topology.NodeState;
+import org.pragmatica.consensus.topology.TopologyManager;
+import org.pragmatica.lang.Option;
+import org.pragmatica.lang.Promise;
+import org.pragmatica.lang.Unit;
+import org.pragmatica.lang.io.TimeSpan;
+import org.pragmatica.messaging.MessageRouter;
+import org.pragmatica.net.tcp.NodeAddress;
+import org.pragmatica.serialization.Deserializer;
+import org.pragmatica.serialization.Serializer;
+import org.pragmatica.statemachine.Fsm;
+import org.pragmatica.statemachine.FsmTestHarness;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.pragmatica.lang.io.TimeSpan.timeSpan;
+
+/// #698 — `SliceTargetValue.owningBlueprint` was erased every time the autoscaler rebuilt the value.
+///
+/// `ControlLoopContext.applyScaling` constructed a *fresh* `SliceTargetValue` and hardcoded
+/// `Option.none()` for the owner while carrying every other field forward. The write itself looked
+/// correct in isolation, which is why this survived twelve days after #555: the loss is only
+/// observable at the *consumer*, on a later leader restore, where
+/// `ClusterDeploymentState.restoreSliceTarget` resolves `schemaRequired` through the owner and an
+/// absent owner silently takes the historical default `true`. A slice deployed with
+/// `schema_required = false` therefore came back after failover asserting schema was required.
+///
+/// The two nested classes below are deliberately split along that producer/consumer seam, because
+/// testing either half alone is what missed the defect:
+///
+/// - `ProducerPreservesOwner` drives the real feeder (`ControlLoop.onSliceTargetPut`) and the real
+///   evaluation cycle, so the owner makes the full KV → in-memory model → KV round trip through
+///   production code. Nothing here is hand-constructed except the initial `SliceTargetValue` that a
+///   deploy would have written.
+/// - `OwnerSurvivesLeaderRestore` takes **the exact value the autoscaler just emitted** — not a
+///   hand-built stand-in — seeds it into a real `ClusterDeploymentContext`'s KV store, and drives
+///   the leader-restore path. This is the assertion that would have caught #698, and it is the one
+///   the ticket's acceptance criteria ask for: the failover restore path, not merely the write.
+class ControlLoopOwnerPreservationTest {
+    private static final NodeId SELF = NodeId.nodeId("leader").unwrap();
+    private static final NodeId WORKER = NodeId.nodeId("worker-1").unwrap();
+    private static final Artifact SLICE = Artifact.artifact("org.example:owned-slice:1.0.0").unwrap();
+    private static final BlueprintId OWNER = BlueprintId.blueprintId("org.example:owning-app:1.0.0").unwrap();
+    private static final int WINDOW = 3;
+
+    private CapturingClusterNode cluster;
+    private ControlLoopContext ctx;
+
+    @BeforeEach
+    void setUp() {
+        cluster = new CapturingClusterNode();
+        ctx = buildContext(scaleUpBy(2));
+        ctx.setTopology(List.of(SELF,
+                                WORKER,
+                                NodeId.nodeId("n3").unwrap(),
+                                NodeId.nodeId("n4").unwrap(),
+                                NodeId.nodeId("n5").unwrap()));
+    }
+
+    /// Registers the slice the way production does — through the real `ControlLoop` feeder, from a
+    /// `SliceTargetValue` carrying an owner, exactly as a blueprint deploy writes it. The feeder is
+    /// the only writer of the context's blueprint map, so this is the sole route by which the
+    /// autoscaler can learn an owner at all.
+    private void registerOwnedSliceViaRealFeeder(Option<BlueprintId> owner) {
+        ControlLoop feeder = new ControlLoop.ControlLoopAdapter(ctx, null);
+        var key = SliceTargetKey.sliceTargetKey(SLICE.base());
+        var deployed = SliceTargetValue.sliceTargetValue(SLICE.version(),
+                                                         2,
+                                                         1,
+                                                         owner,
+                                                         Option.some(8),
+                                                         Option.none(),
+                                                         Option.none());
+
+        feeder.onSliceTargetPut(new ValuePut<>(new KVCommand.Put<>(key, deployed), Option.none()));
+    }
+
+    /// The single `SliceTargetValue` the autoscaler wrote during this test's evaluation cycle.
+    private SliceTargetValue emittedTarget() {
+        var emitted = cluster.sliceTargets();
+
+        assertThat(emitted).as("the evaluation cycle must have produced exactly one SliceTarget Put")
+                           .hasSize(1);
+
+        return emitted.getFirst();
+    }
+
+    @Nested
+    class ProducerPreservesOwner {
+        @Test
+        void applyScaling_ownedSlice_carriesOwnerOntoTheScaledValue() {
+            registerOwnedSliceViaRealFeeder(Option.some(OWNER));
+
+            ctx.runEvaluationCycle();
+
+            var scaled = emittedTarget();
+
+            assertThat(scaled.targetInstances()).as("the cycle must actually have scaled, or the owner assertion is vacuous")
+                                                .isEqualTo(4);
+            assertThat(scaled.owningBlueprint()).as("#698: the autoscaler must not erase the slice's owner")
+                                                .isEqualTo(Option.some(OWNER));
+        }
+
+        /// The other fields `applyScaling` carries forward, pinned alongside the owner so a future
+        /// rebuild of this value cannot drop one of them the way it dropped the owner.
+        @Test
+        void applyScaling_ownedSlice_carriesOperatorOverridesOntoTheScaledValue() {
+            registerOwnedSliceViaRealFeeder(Option.some(OWNER));
+
+            ctx.runEvaluationCycle();
+
+            assertThat(emittedTarget().maxInstances()).isEqualTo(Option.some(8));
+        }
+
+        /// Opposite polarity: a genuinely unowned slice must still come out unowned. Without this
+        /// the owner assertion above would also pass against an implementation that fabricated an
+        /// owner from somewhere, and `none()` must keep meaning "no owning blueprint".
+        @Test
+        void applyScaling_unownedSlice_leavesOwnerAbsent() {
+            registerOwnedSliceViaRealFeeder(Option.none());
+
+            ctx.runEvaluationCycle();
+
+            assertThat(emittedTarget().owningBlueprint()).isEqualTo(Option.none());
+        }
+    }
+
+    /// The consumer half, driven from the producer's actual output. `restoreSliceTarget` runs from
+    /// `rebuildStateFromKVStore` on `Active` entry — the leader-failover path.
+    @Nested
+    class OwnerSurvivesLeaderRestore {
+        private InMemoryKvStore kvStore;
+        private FsmTestHarness<ClusterDeploymentState, ClusterFsmEvent> harness;
+
+        @BeforeEach
+        void newDeploymentHarness() {
+            var router = MessageRouter.mutable();
+
+            kvStore = new InMemoryKvStore(router);
+
+            var deploymentCluster = new RecordingClusterNode(SELF);
+            LongSupplier clock = () -> 10_000_000L;
+            Function<Fsm<ClusterDeploymentState, ClusterFsmEvent>, ClusterDeploymentState> factory =
+                    fsm -> new ClusterDeploymentContext(fsm,
+                                                        SELF,
+                                                        deploymentCluster,
+                                                        kvStore,
+                                                        router,
+                                                        stubTopologyManager(SELF),
+                                                        stubSchemaOrchestrator(),
+                                                        () -> Set.of(SELF, WORKER),
+                                                        () -> Set.of(SELF, WORKER),
+                                                        Set::of,
+                                                        Set.of(SELF, WORKER),
+                                                        DeploymentAtomicity.ALL_OR_NOTHING,
+                                                        3,
+                                                        timeSpan(300).seconds(),
+                                                        clock).dormant();
+
+            harness = FsmTestHarness.harness("owner-restore-test-" + System.nanoTime(), factory);
+        }
+
+        /// The end-to-end assertion for #698. A blueprint declaring `schema_required = false` owns
+        /// the slice; the autoscaler scales it; the leader restarts and restores from the KV store.
+        /// Before the fix the restored blueprint asserted `schemaRequired = true`, because the
+        /// autoscaler's Put had dropped the owner and `restoreSliceTarget` fell through to the
+        /// unowned default.
+        @Test
+        void autoscalerOutput_restoredAfterFailover_keepsSchemaRequiredFalse() {
+            seedOwningBlueprint(OWNER, false);
+            registerOwnedSliceViaRealFeeder(Option.some(OWNER));
+
+            ctx.runEvaluationCycle();
+
+            var autoscalerOutput = emittedTarget();
+
+            kvStore.put(SliceTargetKey.sliceTargetKey(SLICE.base()), autoscalerOutput);
+            harness.dispatch(new Activate());
+
+            assertThat(restoredSchemaRequired()).as("#698: a schema_required=false slice must not come back requiring schema"
+                                                    + " after an autoscale event followed by a leader restore")
+                                                .isEqualTo(false);
+        }
+
+        /// Opposite polarity, same path: proves the restore actually consults the owning blueprint
+        /// rather than returning a constant. Without this pair, an implementation hardcoding `false`
+        /// would pass the test above.
+        @Test
+        void autoscalerOutput_restoredAfterFailover_resolvesSchemaRequiredTrue() {
+            seedOwningBlueprint(OWNER, true);
+            registerOwnedSliceViaRealFeeder(Option.some(OWNER));
+
+            ctx.runEvaluationCycle();
+
+            kvStore.put(SliceTargetKey.sliceTargetKey(SLICE.base()), emittedTarget());
+            harness.dispatch(new Activate());
+
+            assertThat(restoredSchemaRequired()).isEqualTo(true);
+        }
+
+        private boolean restoredSchemaRequired() {
+            var active = (ClusterDeploymentState.Active) harness.state();
+            var scaledArtifact = SLICE.base().withVersion(SLICE.version());
+            var blueprint = active.blueprints().get(scaledArtifact);
+
+            assertThat(blueprint).as("expected a restored blueprint entry for %s", scaledArtifact)
+                                 .isNotNull();
+
+            return blueprint.schemaRequired();
+        }
+
+        /// Minimal but complete blueprint document — `id`, a non-empty `[[slices]]` and an explicit
+        /// `[deployment].strategy` are all required before `schema_required` is read at all.
+        /// Mirrors `SchemaRequiredResolutionTest.resourcesToml`, whose javadoc explains each.
+        private void seedOwningBlueprint(BlueprintId owner, boolean schemaRequired) {
+            var toml = """
+                       id = "%s"
+
+                       [[slices]]
+                       artifact = "org.example:seed-slice:1.0.0"
+
+                       [deployment]
+                       strategy = "rolling"
+                       schema_required = %s
+                       """.formatted(owner.asString(), schemaRequired);
+            var expanded = ExpandedBlueprint.expandedBlueprint(owner, List.of(), Option.some(toml));
+
+            kvStore.put(AppBlueprintKey.appBlueprintKey(owner), AppBlueprintValue.appBlueprintValue(expanded));
+        }
+    }
+
+    // --- control-loop fixtures ---
+
+    private static ClusterController scaleUpBy(int additional) {
+        return _ -> Promise.success(ControlDecisions.controlDecisions(new BlueprintChange.ScaleUp(SLICE, additional)));
+    }
+
+    private ControlLoopContext buildContext(ClusterController controller) {
+        var config = ControllerConfig.DEFAULT.withScalingConfig(smallWindowConfig());
+        var ctxHolder = new AtomicReference<ControlLoopContext>();
+        Consumer<ScalingEvent> sink = _ -> {};
+        Function<Fsm<ControlLoopState, ClusterFsmEvent>, ControlLoopState> factory =
+                fsm -> {
+                    var context = new ControlLoopContext(fsm,
+                                                         SELF,
+                                                         controller,
+                                                         new ControlLoopContextAttributionTest.StubMetricsCollector(),
+                                                         Option.none(),
+                                                         cluster,
+                                                         TimeSpan.timeSpan(5_000).millis(),
+                                                         config,
+                                                         sink);
+
+                    ctxHolder.set(context);
+
+                    return context.dormant();
+                };
+
+        Fsm.fsm("owner-preservation-test", SELF.id(), factory);
+
+        return ctxHolder.get();
+    }
+
+    private static ScalingConfig smallWindowConfig() {
+        var weights = new EnumMap<ScalingMetric, Double>(ScalingMetric.class);
+
+        weights.put(ScalingMetric.CPU, 0.0);
+        weights.put(ScalingMetric.ACTIVE_INVOCATIONS, 0.6);
+        weights.put(ScalingMetric.P95_LATENCY, 0.4);
+        weights.put(ScalingMetric.ERROR_RATE, 0.0);
+
+        return ScalingConfig.scalingConfig(WINDOW, 5_000L, 1.5, 0.5, weights).unwrap();
+    }
+
+    static final class CapturingClusterNode implements ClusterNode<KVCommand<AetherKey>> {
+        private final List<KVCommand<AetherKey>> commands = new ArrayList<>();
+
+        List<SliceTargetValue> sliceTargets() {
+            return commands.stream()
+                           .filter(KVCommand.Put.class::isInstance)
+                           .map(command -> ((KVCommand.Put<?, ?>) command).value())
+                           .filter(SliceTargetValue.class::isInstance)
+                           .map(SliceTargetValue.class::cast)
+                           .toList();
+        }
+
+        @Override public NodeId self() {return SELF;}
+
+        @Override public TopologyManager topologyManager() {throw new UnsupportedOperationException("unused");}
+
+        @Override public Promise<Unit> start() {return Promise.unitPromise();}
+
+        @Override public Promise<Unit> stop() {return Promise.unitPromise();}
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <R> Promise<List<R>> apply(List<KVCommand<AetherKey>> toApply) {
+            commands.addAll(toApply);
+
+            return (Promise<List<R>>) (Promise<?>) Promise.success(List.of());
+        }
+    }
+
+    // --- deployment-side fixtures (mirrors SchemaRequiredResolutionTest's, which is in another module) ---
+
+    private static SchemaOrchestratorService stubSchemaOrchestrator() {
+        return new SchemaOrchestratorService() {
+            @Override public Promise<Unit> migrateIfNeeded(String datasourceName) {return Promise.success(Unit.unit());}
+
+            @Override public Promise<Unit> undoTo(String datasourceName, int targetVersion) {return Promise.success(Unit.unit());}
+
+            @Override public Promise<Unit> baseline(String datasourceName, int version) {return Promise.success(Unit.unit());}
+        };
+    }
+
+    private static TopologyManager stubTopologyManager(NodeId self) {
+        return new TopologyManager() {
+            @Override public NodeInfo self() {return NodeInfo.nodeInfo(self, new NodeAddress("localhost", 9000));}
+
+            @Override public Option<NodeInfo> get(NodeId id) {
+                return Option.some(NodeInfo.nodeInfo(id, new NodeAddress("localhost", 9000)));
+            }
+
+            @Override public int clusterSize() {return 2;}
+
+            @Override public Option<NodeId> reverseLookup(SocketAddress socketAddress) {return Option.empty();}
+
+            @Override public Promise<Unit> start() {return Promise.unitPromise();}
+
+            @Override public Promise<Unit> stop() {return Promise.unitPromise();}
+
+            @Override public TimeSpan pingInterval() {return timeSpan(5).seconds();}
+
+            @Override public TimeSpan helloTimeout() {return timeSpan(5).seconds();}
+
+            @Override public Option<NodeState> getState(NodeId id) {return Option.empty();}
+
+            @Override public List<NodeId> topology() {return List.of(self);}
+        };
+    }
+
+    private static final class RecordingClusterNode implements ClusterNode<KVCommand<AetherKey>> {
+        private final NodeId self;
+        private final List<KVCommand<AetherKey>> commands = Collections.synchronizedList(new ArrayList<>());
+
+        RecordingClusterNode(NodeId self) {this.self = self;}
+
+        @Override public NodeId self() {return self;}
+
+        @Override public TopologyManager topologyManager() {return stubTopologyManager(self);}
+
+        @Override public Promise<Unit> start() {return Promise.unitPromise();}
+
+        @Override public Promise<Unit> stop() {return Promise.unitPromise();}
+
+        @Override public <R> Promise<List<R>> apply(List<KVCommand<AetherKey>> batch) {
+            commands.addAll(batch);
+
+            return Promise.success(Collections.emptyList());
+        }
+    }
+
+    private static final class InMemoryKvStore extends KVStore<AetherKey, AetherValue> {
+        InMemoryKvStore(MessageRouter router) {
+            super(router, stubSerializer(), stubDeserializer());
+        }
+
+        void put(AetherKey key, AetherValue value) {
+            process(createBatch(List.of(new KVCommand.Put<>(key, value))));
+        }
+    }
+
+    private static Serializer stubSerializer() {
+        return new Serializer() {
+            @Override public <T> void write(ByteBuf byteBuf, T object) {}
+        };
+    }
+
+    private static Deserializer stubDeserializer() {
+        return new Deserializer() {
+            @Override public <T> T read(ByteBuf byteBuf) {return null;}
+        };
+    }
+}

--- a/aether/aether-deployment/src/main/java/org/pragmatica/aether/deployment/cluster/fsm/ClusterDeploymentState.java
+++ b/aether/aether-deployment/src/main/java/org/pragmatica/aether/deployment/cluster/fsm/ClusterDeploymentState.java
@@ -859,6 +859,12 @@ public sealed interface ClusterDeploymentState extends FsmState<ClusterDeploymen
             var owner = sliceTargetValue.owningBlueprint();
             // Unowned slices keep the historical default (true, preserving prior behavior); owned
             // slices resolve schemaRequired via their blueprint, same as handleAppBlueprintChange.
+            // This resolution is load-bearing, not a workaround: SliceTargetValue carries no
+            // schemaRequired field, so the owner is the only route back to the deployed value.
+            // #555 added it; #698 fixed the producers that were erasing the owner, so `.or(true)`
+            // now fires only for a genuinely unowned slice, never for one whose owner was dropped
+            // in transit. Do not remove this in the belief #698 made it redundant — #698 supplied
+            // the input this line always assumed.
             boolean schemaRequired = owner.map(this::resolveSchemaRequired).or(true);
 
             blueprints.put(artifact, Blueprint.blueprint(artifact, instances, minInstances, owner, schemaRequired));
@@ -1295,6 +1301,12 @@ public sealed interface ClusterDeploymentState extends FsmState<ClusterDeploymen
             // Unowned slices keep the historical default (true, preserving prior behavior); owned
             // slices resolve schemaRequired via their blueprint, same as handleAppBlueprintChange.
             // Without this, schemaRequired reverted to true on every scale event for owned slices.
+            // Kept after #698, and still load-bearing: SliceTargetValue carries no schemaRequired
+            // field, so resolving through the owner is the only route back to the deployed value.
+            // What #698 changed is this line's INPUT, not its need — the autoscaler
+            // (ControlLoopContext.applyScaling) and the A/B writer (AbTestManager) used to hand it
+            // an owner-less value, so it fell through to `true` on every real autoscale. With the
+            // producers fixed, `.or(true)` now means "genuinely unowned slice".
             boolean schemaRequired = owner.map(this::resolveSchemaRequired).or(true);
 
             log.info("Slice target changed for {}: {} instances (min: {})", newArtifact, desiredInstances, minInstances);

--- a/aether/aether-deployment/src/test/java/org/pragmatica/aether/deployment/cluster/fsm/SchemaRequiredResolutionTest.java
+++ b/aether/aether-deployment/src/test/java/org/pragmatica/aether/deployment/cluster/fsm/SchemaRequiredResolutionTest.java
@@ -86,15 +86,24 @@ import static org.pragmatica.lang.io.TimeSpan.timeSpan;
 /// (`SliceRoutes.java`, `RollbackManager.java`) correctly preserves the owner via
 /// `AetherValue.withInstances(...)` before persisting the `SliceTargetValue`, so
 /// `handleSliceTargetChange` now resolves `schemaRequired` correctly for a manual scale event
-/// `[verified: LiveReactivePath tests in this class]`. The in-process autoscaler
-/// (`ControlLoopContext.applyScaling`, module `aether-control`) currently constructs a *fresh*
-/// `SliceTargetValue` with `Option.none()` for the owner instead of `withInstances(...)`
-/// `[mechanism: ControlLoopContext.applyScaling, aether-control, ~line 516]` — so a genuine
-/// autoscale event still reaches `handleSliceTargetChange` with no owner and falls through to the
-/// unowned-slice historical default (`true`). **`schemaRequired` still reverts to `true` on a real
-/// autoscale event until that separate owner-erasure defect is fixed**; an identical pattern
-/// exists in `AbTestManager.targetPreservingOverrides` (module `aether-invoke`). Both are outside
-/// this class's module and out of scope for #555; tracked as a follow-up.
+/// `[verified: LiveReactivePath tests in this class]`.
+///
+/// **Producer-side gap — CLOSED by #698 (was open when this class was written).** The paragraph
+/// this replaces recorded that the in-process autoscaler (`ControlLoopContext.applyScaling`,
+/// module `aether-control`) built a *fresh* `SliceTargetValue` with `Option.none()` for the owner,
+/// so a real autoscale event reached `handleSliceTargetChange` with no owner and fell through to
+/// the unowned-slice default (`true`) — i.e. `schemaRequired` still reverted on a genuine
+/// autoscale, and identically on an `AbTestManager.targetPreservingOverrides` write (module
+/// `aether-invoke`). Both producers now carry the owner: the autoscaler threads it through
+/// `ClusterController.Blueprint.owningBlueprint`, and `AbTestManager` reads it from the current
+/// value alongside the override fields it already re-read
+/// `[verified: aether-control ControlLoopOwnerPreservationTest; aether-invoke
+/// SliceTargetOverridePreservationTest; aether/node AutoscaleOwnerSurvivesRestoreTest]`.
+///
+/// The consumer-side resolution this class pins is therefore **not** obsoleted by #698 and must
+/// not be removed as a redundant workaround: `SliceTargetValue` carries no `schemaRequired` field,
+/// so resolving through the owner is the only route back to the deployed value. #698 changed the
+/// resolution's *input*, not its necessity.
 ///
 /// Unowned slices (no owning blueprint) are deliberately left at the historical default (`true`)
 /// at all three sites — every site hardcoded `true` before this fix, so an unowned slice keeps

--- a/aether/aether-deployment/src/test/java/org/pragmatica/aether/deployment/cluster/fsm/SchemaRequiredResolutionTest.java
+++ b/aether/aether-deployment/src/test/java/org/pragmatica/aether/deployment/cluster/fsm/SchemaRequiredResolutionTest.java
@@ -97,8 +97,11 @@ import static org.pragmatica.lang.io.TimeSpan.timeSpan;
 /// `aether-invoke`). Both producers now carry the owner: the autoscaler threads it through
 /// `ClusterController.Blueprint.owningBlueprint`, and `AbTestManager` reads it from the current
 /// value alongside the override fields it already re-read
-/// `[verified: aether-control ControlLoopOwnerPreservationTest; aether-invoke
-/// SliceTargetOverridePreservationTest; aether/node AutoscaleOwnerSurvivesRestoreTest]`.
+/// `[verified: aether-control ControlLoopOwnerPreservationTest — nested ProducerPreservesOwner for
+/// the producer half, and OwnerSurvivesLeaderRestore for the restore half, which feeds the value the
+/// autoscaler actually emits into a real ClusterDeploymentContext; aether-invoke
+/// SliceTargetOverridePreservationTest]`. There is no separate test in aether/node; the restore
+/// coverage lives in the nested class named above.
 ///
 /// The consumer-side resolution this class pins is therefore **not** obsoleted by #698 and must
 /// not be removed as a redundant workaround: `SliceTargetValue` carries no `schemaRequired` field,

--- a/aether/aether-deployment/src/test/java/org/pragmatica/aether/deployment/cluster/fsm/SchemaRequiredResolutionTest.java
+++ b/aether/aether-deployment/src/test/java/org/pragmatica/aether/deployment/cluster/fsm/SchemaRequiredResolutionTest.java
@@ -100,8 +100,19 @@ import static org.pragmatica.lang.io.TimeSpan.timeSpan;
 /// `[verified: aether-control ControlLoopOwnerPreservationTest — nested ProducerPreservesOwner for
 /// the producer half, and OwnerSurvivesLeaderRestore for the restore half, which feeds the value the
 /// autoscaler actually emits into a real ClusterDeploymentContext; aether-invoke
-/// SliceTargetOverridePreservationTest]`. There is no separate test in aether/node; the restore
-/// coverage lives in the nested class named above.
+/// SliceTargetOverridePreservationTest — nested AbTestPromotePreservesOverrides]`.
+///
+/// Both halves name their nested class deliberately. `SliceTargetOverridePreservationTest`'s other
+/// nested class, `DeploymentUpdatePreservesOverrides`, exercises `DeploymentManagerImpl` rather than
+/// `AbTestManager`, so a reader checking "does this cover the A/B producer?" could otherwise land on
+/// the half that does not support the sentence. There is likewise no separate test in `aether/node`;
+/// the restore coverage lives in the nested class named above.
+///
+/// Each of the three nested classes named here was mutation-probed rather than merely resolved: the
+/// producer and restore halves redden when `owningBlueprint()` is replaced by `none()` in
+/// `ControlLoopContext.applyScaling` or at the `ControlLoop.onSliceTargetPut` feeder, and
+/// `AbTestPromotePreservesOverrides` reddens when it is replaced in
+/// `AbTestManager.targetPreservingOverrides`.
 ///
 /// The consumer-side resolution this class pins is therefore **not** obsoleted by #698 and must
 /// not be removed as a redundant workaround: `SliceTargetValue` carries no `schemaRequired` field,

--- a/aether/aether-invoke/src/main/java/org/pragmatica/aether/update/AbTestManager.java
+++ b/aether/aether-invoke/src/main/java/org/pragmatica/aether/update/AbTestManager.java
@@ -263,9 +263,23 @@ public interface AbTestManager {
                 return (KVCommand<AetherKey>)(KVCommand<?>) new KVCommand.Put<>(key, value);
             }
 
-            /// A/B lifecycle writes must not evaporate the operator's per-slice bounds (#424 review).
-            /// Reads the current SliceTargetValue and carries its `maxInstances`/threshold overrides
-            /// onto the new version (canary/promote/restore stay at 1 instance).
+            /// A/B lifecycle writes must not evaporate the operator's per-slice bounds (#424 review)
+            /// nor the slice's ownership (#698). Reads the current `SliceTargetValue` once and carries
+            /// **every** field it is not deliberately replacing onto the new version.
+            ///
+            /// Replaced: `currentVersion` (the variant/promoted version being written) and
+            /// `targetInstances`/`minInstances` (canary/promote/restore stay at 1 instance).
+            /// Preserved from the current value: `owningBlueprint`, `maxInstances`,
+            /// `scaleUpThreshold`, `scaleDownThreshold`.
+            /// Not carried: `placement` and `updatedAt` — the factory re-derives both, matching the
+            /// pre-#698 behaviour of this method.
+            ///
+            /// `owningBlueprint` matters beyond bookkeeping: `ClusterDeploymentState` resolves a
+            /// slice's `schemaRequired` from its owner, and an erased owner silently takes the
+            /// historical default `true`, flipping a `schema_required = false` slice on the next A/B
+            /// write. The single `kvStore.get` below is the same read this method already performed
+            /// for the override fields — #698 widens its field set by one and changes no control
+            /// flow, so it introduces no read-then-Put beyond the one already present here.
             private SliceTargetValue targetPreservingOverrides(SliceTargetKey key, Version version) {
                 var current = kvStore.get(key)
                                      .filter(SliceTargetValue.class::isInstance)
@@ -274,7 +288,7 @@ public interface AbTestManager {
                 return SliceTargetValue.sliceTargetValue(version,
                                                          1,
                                                          1,
-                                                         Option.none(),
+                                                         current.flatMap(SliceTargetValue::owningBlueprint),
                                                          current.flatMap(SliceTargetValue::maxInstances),
                                                          current.flatMap(SliceTargetValue::scaleUpThreshold),
                                                          current.flatMap(SliceTargetValue::scaleDownThreshold));

--- a/aether/aether-invoke/src/test/java/org/pragmatica/aether/update/SliceTargetOverridePreservationTest.java
+++ b/aether/aether-invoke/src/test/java/org/pragmatica/aether/update/SliceTargetOverridePreservationTest.java
@@ -15,6 +15,7 @@ import org.pragmatica.aether.artifact.Artifact;
 import org.pragmatica.aether.artifact.ArtifactBase;
 import org.pragmatica.aether.artifact.Version;
 import org.pragmatica.aether.metrics.invocation.InvocationMetricsCollector;
+import org.pragmatica.aether.slice.blueprint.BlueprintId;
 import org.pragmatica.aether.slice.kvstore.AetherKey;
 import org.pragmatica.aether.slice.kvstore.AetherKey.DeploymentKey;
 import org.pragmatica.aether.slice.kvstore.AetherKey.SliceTargetKey;
@@ -46,11 +47,19 @@ import static org.assertj.core.api.Assertions.assertThat;
 /// the A/B lifecycle writer (`AbTestManager.targetPreservingOverrides`, exercised via promote) must
 /// re-read the current `SliceTargetValue` and carry the operator's per-slice autoscaler overrides
 /// onto the rewritten version instead of resetting them to `none()`.
+///
+/// #698 extends the same requirement to `owningBlueprint`, which `targetPreservingOverrides` was
+/// dropping while carefully preserving every override beside it — despite its name and its javadoc
+/// both promising preservation. The seeded fixture is therefore blueprint-owned, and every path
+/// below asserts the owner survives alongside the overrides. The consequence of losing it is not
+/// visible here: `ClusterDeploymentState` resolves a slice's `schemaRequired` through its owner, so
+/// an erased owner silently flips a `schema_required = false` slice to `true` on the next restore.
 class SliceTargetOverridePreservationTest {
     static final NodeId SELF = NodeId.nodeId("node-1").unwrap();
     static final ArtifactBase BASE = Artifact.artifact("org.test:my-slice:2.0.0").unwrap().base();
     static final Version V1 = Version.version("1.0.0").unwrap();
     static final Version V2 = Version.version("2.0.0").unwrap();
+    static final BlueprintId OWNER = BlueprintId.blueprintId("org.test:owning-app:1.0.0").unwrap();
 
     @Nested
     class DeploymentUpdatePreservesOverrides {
@@ -88,6 +97,8 @@ class SliceTargetOverridePreservationTest {
                 assertThat(target.maxInstances()).isEqualTo(Option.some(5));
                 assertThat(target.scaleUpThreshold()).isEqualTo(Option.some(0.8));
                 assertThat(target.scaleDownThreshold()).isEqualTo(Option.some(0.2));
+                assertThat(target.owningBlueprint()).as("#698: the deployment-update writer must not erase the slice's owner")
+                                                    .isEqualTo(Option.some(OWNER));
             });
         }
 
@@ -158,15 +169,19 @@ class SliceTargetOverridePreservationTest {
                 assertThat(target.maxInstances()).isEqualTo(Option.some(5));
                 assertThat(target.scaleUpThreshold()).isEqualTo(Option.some(0.8));
                 assertThat(target.scaleDownThreshold()).isEqualTo(Option.some(0.2));
+                assertThat(target.owningBlueprint()).as("#698: AbTestManager.targetPreservingOverrides must not erase the slice's owner")
+                                                    .isEqualTo(Option.some(OWNER));
             });
         }
     }
 
+    /// Owner-bearing since #698: a blueprint-owned slice is what both writers actually receive in
+    /// production, and an unowned fixture cannot observe an owner being dropped.
     static SliceTargetValue targetWithOverrides(Version version) {
         return SliceTargetValue.sliceTargetValue(version,
                                                  3,
                                                  1,
-                                                 Option.none(),
+                                                 Option.some(OWNER),
                                                  Option.some(5),
                                                  Option.some(0.8),
                                                  Option.some(0.2));

--- a/changelog.d/698-slice-target-owner-preservation.md
+++ b/changelog.d/698-slice-target-owner-preservation.md
@@ -74,7 +74,28 @@
   door 2 — a partially deployed blueprint across a leader failover — needs no autoscaler and
   survives this fix untouched. #933 was filed for this same defect and is closed as a duplicate of
   #698. There is no gating relationship between this change and #924.
-- **Separate defect found at the same expression, deliberately NOT fixed here (no ticket yet).**
+- **`SliceTargetValue.placement` is erased by the SAME two producers — a third instance of this
+  bug class, found by re-auditing the construction sites for field *values* rather than field
+  presence. Not fixed, no ticket yet.** Every `sliceTargetValue(...)` factory overload except the
+  one taking an explicit `placement` hardcodes `DEFAULT_PLACEMENT` (`"CORE_ONLY"`), and both
+  `applyScaling` and `targetPreservingOverrides` use overloads that do. A non-default placement is
+  operator-settable through the management API (`POST /api/slices/scale`, `ScaleRequest.placement`)
+  and is preserved correctly on that path by `applyScaleToExisting` → `withPlacement`. It is then
+  reset to `CORE_ONLY` by the first autoscale or A/B write, and the reset value is acted on:
+  `handleSliceTargetChange` calls `issueAllocationCommandsWithPlacement(newArtifact,
+  desiredInstances, value.effectivePlacement())`, so the slice is re-allocated under the default
+  placement. `ControlLoopContext` cannot fix this the way it fixes the owner —
+  `ClusterController.Blueprint` has no `placement` field either, so it needs the same model-field
+  treatment or a deliberate ruling that placement is not autoscaler-preserved
+  [mechanism: `AetherValue.SliceTargetValue` factories at :95/:107/:119/:134/:169 all pass
+  `DEFAULT_PLACEMENT`; producers at `ControlLoopContext.applyScaling` and
+  `AbTestManager.targetPreservingOverrides` use the 7-arg overload (:169); consumer at
+  `ClusterDeploymentState:1315`. Not executed — no test in this change drives a non-default
+  placement through an autoscale].
+- **Separate defect, filed as #936, deliberately NOT fixed here. #698's fix does NOT fix #936.**
+  They are independent bugs in the *same constructor call* — `minInstances` is argument position 3,
+  `owningBlueprint` position 4 — so a reader who sees the owner preserved must not assume the whole
+  call was audited.
   `applyScaling` writes `newInstances` as **both** `targetInstances` and `minInstances`, while the
   in-memory model it updates one line earlier keeps `currentBlueprint.minInstances()`. The Put then
   feeds `onSliceTargetPut`, which overwrites the model with `minInstances = newInstances`. So a
@@ -82,10 +103,13 @@
   `computeRequestedInstances`' `Math.max(minInstances, instances - reduceBy)` can never return
   anything below it — **the autoscaler cannot scale down after its first scale-up**. Left untouched
   under #698's scope discipline; it is a different field, a different failure, and needs its own
-  ticket and its own test
+  ticket and its own test. It also **fails silently**: `prepareChangeToBlueprint` returns
+  `Option.none()` when `newInstances == currentBlueprint.instances()`, so a slice pinned at a
+  ratcheted floor emits no command, no event and no log — indistinguishable from an autoscaler with
+  nothing to do
   [mechanism: `ControlLoopContext.applyScaling` 7-arg `sliceTargetValue(version, newInstances,
   newInstances, ...)` vs. `putBlueprint(artifact, newInstances, currentBlueprint.minInstances(),
   ...)` immediately above it; `AetherValue.SliceTargetValue.effectiveMinInstances()` returns
   `Math.max(1, minInstances)`. Searched open issues for `minInstances` and `applyScaling` via
-  `oss/internal/related-tickets.sh` — only #698 and the generic tech-debt umbrella #175 hit, so no
-  existing ticket covers it].
+  `oss/internal/related-tickets.sh` before filing — only #698 and the generic tech-debt umbrella
+  #175 hit].

--- a/changelog.d/698-slice-target-owner-preservation.md
+++ b/changelog.d/698-slice-target-owner-preservation.md
@@ -1,5 +1,8 @@
 ### Fixed (2026-09-08 — #698: `SliceTargetValue.owningBlueprint` erased at reconstruction by the autoscaler and the A/B writer)
 
+_Line numbers below are derived at `origin/release-1.0.0-rc4` @ `78960de46`, not at the branch head;
+this branch adds +12 lines to `ClusterDeploymentState.java`._
+
 - **Two producers rebuilt a `SliceTargetValue` from a subset of its fields and hardcoded
   `Option.none()` for the owner**, while carefully carrying every other field forward.
   `ControlLoopContext.applyScaling` (`aether-control`) did it on every autoscale decision;
@@ -90,7 +93,7 @@
   [mechanism: `AetherValue.SliceTargetValue` factories at :95/:107/:119/:134/:169 all pass
   `DEFAULT_PLACEMENT`; producers at `ControlLoopContext.applyScaling` and
   `AbTestManager.targetPreservingOverrides` use the 7-arg overload (:169); consumer at
-  `ClusterDeploymentState:1315`. Not executed — no test in this change drives a non-default
+  `ClusterDeploymentState:1303`. Not executed — no test in this change drives a non-default
   placement through an autoscale].
 - **Separate defect, filed as #936, deliberately NOT fixed here. #698's fix does NOT fix #936.**
   They are independent bugs in the *same constructor call* — `minInstances` is argument position 3,

--- a/changelog.d/698-slice-target-owner-preservation.md
+++ b/changelog.d/698-slice-target-owner-preservation.md
@@ -1,0 +1,91 @@
+### Fixed (2026-09-08 — #698: `SliceTargetValue.owningBlueprint` erased at reconstruction by the autoscaler and the A/B writer)
+
+- **Two producers rebuilt a `SliceTargetValue` from a subset of its fields and hardcoded
+  `Option.none()` for the owner**, while carefully carrying every other field forward.
+  `ControlLoopContext.applyScaling` (`aether-control`) did it on every autoscale decision;
+  `AbTestManager.targetPreservingOverrides` (`aether-invoke`) did it on every A/B lifecycle write,
+  in a method whose name and javadoc both promise preservation. Both now carry the owner
+  [verified: `ControlLoopOwnerPreservationTest$ProducerPreservesOwner#applyScaling_ownedSlice_carriesOwnerOntoTheScaledValue`
+  (`aether-control`), `SliceTargetOverridePreservationTest$AbTestPromotePreservesOverrides#concludeTest_preserves_autoscaler_overrides_on_promoted_version`
+  (`aether-invoke`)].
+- **The loss was only observable at the consumer, one failover later.** `ClusterDeploymentState`
+  resolves a slice's `schemaRequired` through its owner (`restoreSliceTarget`,
+  `handleSliceTargetChange`); an absent owner takes the historical unowned default `true`. A slice
+  deployed with `schema_required = false` therefore came back after an autoscale plus a leader
+  restore asserting schema *was* required — #555's original symptom, moved one layer upstream. The
+  end-to-end path is now pinned by feeding **the exact value the autoscaler emits** into a real
+  `ClusterDeploymentContext` restore
+  [verified: `ControlLoopOwnerPreservationTest$OwnerSurvivesLeaderRestore#autoscalerOutput_restoredAfterFailover_keepsSchemaRequiredFalse`,
+  with `#autoscalerOutput_restoredAfterFailover_resolvesSchemaRequiredTrue` as the opposite polarity
+  so a hardcoded `false` cannot pass].
+- **Schema-failure reports also under-counted.** `handleSchemaFailed` lists `slicesOwnedBy(owner)`;
+  a slice whose owner had been dropped was invisible to it, so an operator was told fewer slices
+  were blocked than actually were. No code change was needed for this beyond the producer fix — the
+  report reads the same owner field
+  [mechanism: `ClusterDeploymentState.handleSchemaFailed` → `slicesOwnedBy` → `isOwnedBy`, which
+  filters on `blueprint.owner()`; with the owner preserved the slice is in the set. Not separately
+  asserted — no test in this change drives `handleSchemaFailed`].
+- **`ControlLoopContext` holds no KV-store handle, so the fix is a model field, not a
+  read-modify-write.** `ClusterController.Blueprint` — the autoscaler's in-memory model — gained
+  `owningBlueprint`, threaded from the `SliceTargetValue` at `ControlLoop.onSliceTargetPut`, the
+  map's sole feeder. **The rejected alternative was the read-then-`Put` the ticket suggested**:
+  it would have added a store read on the autoscaler's hot path, which is exactly the shape open
+  tickets #906 (`WorkerDeploymentManager` lost update) and #805 (`bestEffortFailureCommand`) flag.
+  This fix performs **no new read at either site** — `applyScaling` already issued an unconditional
+  blind `Put` built from the in-memory mirror and still does, and `AbTestManager` already re-read
+  the current value for its override fields, so #698 widens that existing read's field set by one
+  and changes no control flow
+  [mechanism: `ControlLoopContext` has no `KVStore` field — only `ClusterNode`, the command channel;
+  `blueprints.put` has exactly one call site (`putBlueprint`), whose only production caller is
+  `ControlLoop.onSliceTargetPut`].
+- **Stated plainly, not claimed away: neither write is lost-update-safe, and this fix does not make
+  it so.** `applyScaling` emits an unconditional `KVCommand.Put`, so a concurrent writer's update to
+  the same `SliceTargetKey` can still be clobbered. That exposure is pre-existing and unchanged in
+  shape and magnitude by #698; it is #906/#805's subject, not this ticket's, and closing #698 must
+  not be read as evidence the path is race-free.
+- **`putBlueprint` deliberately has no owner-less overload at its full arity.** The 6-argument form
+  was replaced rather than kept alongside the new 7-argument one, so a caller that has no owner must
+  say `Option.none()` explicitly. Inheriting that default silently is precisely what erased the
+  owner on every autoscale event for eleven days.
+- **#555's consumer-side resolution is KEPT, and is not a workaround left beside its own fixed root
+  cause.** `SliceTargetValue` carries no `schemaRequired` field at all, so resolving through the
+  owner is the only route back to the deployed value; removing it would reintroduce #555 wholesale.
+  What #698 changed is that resolution's *input*, not its necessity — with the producers fixed,
+  `.or(true)` now means "genuinely unowned slice" instead of "owner erased in transit". Recorded at
+  both call sites in `ClusterDeploymentState` so the next reader cannot mistake it for redundant,
+  and `SchemaRequiredResolutionTest`'s class javadoc — which documented this defect as *open* — is
+  corrected to record it as closed.
+- **Every `SliceTargetValue` construction site was enumerated, not sampled.** Seven in main sources
+  outside `AetherValue`'s own factories: the two defects above, plus `KVStoreSerializer` (parses the
+  owner off the wire), `ClusterDeploymentState.handleAppBlueprintChange` (deploy time, passes the
+  owning blueprint), and three `existing.map(...).or(fresh)` fallbacks — `SliceRoutes`,
+  `RollbackManager`, `DeploymentManagerImpl` — whose mapped branch preserves the owner via
+  `withInstances`/`withVersion` and whose fallback branch fires only when no value existed, so its
+  `none()` is a genuinely absent owner rather than an erased one. All five non-defective sites were
+  read and left unchanged
+  [mechanism: `grep -rn "new SliceTargetValue(\|sliceTargetValue(" --include='*.java'` over
+  `/src/main/`; positive control — the same pattern recovers all four sites #698 names by hand
+  (`ControlLoopContext`, `AbTestManager`, and the two correct reference sites `SliceRoutes`,
+  `RollbackManager`), 4 of 4].
+
+**Not fixed here**
+
+- **Fixing #698 does NOT unblock PR #924.** #924's blocking finding has two independent doors, and
+  door 2 — a partially deployed blueprint across a leader failover — needs no autoscaler and
+  survives this fix untouched. #933 was filed for this same defect and is closed as a duplicate of
+  #698. There is no gating relationship between this change and #924.
+- **Separate defect found at the same expression, deliberately NOT fixed here (no ticket yet).**
+  `applyScaling` writes `newInstances` as **both** `targetInstances` and `minInstances`, while the
+  in-memory model it updates one line earlier keeps `currentBlueprint.minInstances()`. The Put then
+  feeds `onSliceTargetPut`, which overwrites the model with `minInstances = newInstances`. So a
+  slice's floor ratchets up to its current count on the first autoscale, and
+  `computeRequestedInstances`' `Math.max(minInstances, instances - reduceBy)` can never return
+  anything below it — **the autoscaler cannot scale down after its first scale-up**. Left untouched
+  under #698's scope discipline; it is a different field, a different failure, and needs its own
+  ticket and its own test
+  [mechanism: `ControlLoopContext.applyScaling` 7-arg `sliceTargetValue(version, newInstances,
+  newInstances, ...)` vs. `putBlueprint(artifact, newInstances, currentBlueprint.minInstances(),
+  ...)` immediately above it; `AetherValue.SliceTargetValue.effectiveMinInstances()` returns
+  `Math.max(1, minInstances)`. Searched open issues for `minInstances` and `applyScaling` via
+  `oss/internal/related-tickets.sh` — only #698 and the generic tech-debt umbrella #175 hit, so no
+  existing ticket covers it].

--- a/changelog.d/698-slice-target-owner-preservation.md
+++ b/changelog.d/698-slice-target-owner-preservation.md
@@ -26,16 +26,22 @@ this branch adds +12 lines to `ClusterDeploymentState.java`._
   [verified: mutation-probed. `#autoscalerOutput_restoredAfterFailover_keepsSchemaRequiredFalse` goes
   red under BOTH producer-side mutations with "expected: false but was: true" — literally #698's
   symptom reproduced — and green on restore].
-  **Stated precisely, because the tag would otherwise overclaim:** its opposite-polarity twin
-  `#autoscalerOutput_restoredAfterFailover_resolvesSchemaRequiredTrue` did **NOT** redden under any
-  of the three mutations, and is not pinned by them. It cannot: with the owner erased the resolution
-  falls through to the historical default `true`, which is the value that test expects, so it passes
-  *for the wrong reason*. It guards a different failure — an implementation hardcoding `false` — and
-  that is all it is evidence of. The same is true of
-  `#applyScaling_unownedSlice_leavesOwnerAbsent` and
-  `#applyScaling_ownedSlice_carriesOperatorOverridesOntoTheScaledValue`, both green under mutation by
-  design. Of the 5 tests in the class, 2 are pinned by these probes; the other 3 are polarity and
-  companion guards, not owner-erasure detectors.
+  **A decorative test was found and repaired rather than documented.** As first written, the
+  opposite-polarity twin `#autoscalerOutput_restoredAfterFailover_resolvesSchemaRequiredTrue` did
+  **not** redden under any of the three mutations. It could not: with the owner erased the resolution
+  falls through to the historical default `true` — the very value that test expects — so it passed
+  *for the wrong reason* while looking like coverage of the defect it could not see. It now also
+  asserts the restored blueprint's **owner**, which the erased path predicts as `None()` and the
+  correct path as `Some(OWNER)` — mutually exclusive with the default, hence discriminating
+  [verified: adding that assertion moves the measured failure count from 2 of 5 to **3 of 5** under
+  both `applyScaling-owner` and `feeder-owner`; Maven's own total line reads
+  `Tests run: 5, Failures: 3` and the surefire XML testcase count agrees. Unmutated baseline and
+  post-restore run are both 5 tests / 0 failures, so the greens are real runs, not empty selectors].
+  Two tests remain deliberately unpinned by these probes and are labelled as such:
+  `#applyScaling_unownedSlice_leavesOwnerAbsent` (guards against a fabricated owner) and
+  `#applyScaling_ownedSlice_carriesOperatorOverridesOntoTheScaledValue` (guards the override fields).
+  **3 of 5 are owner-erasure detectors; the other 2 are companion guards, and the distinction is
+  recorded in the test file itself so a future reader cannot miscount it.**
 - **Schema-failure reports also under-counted.** `handleSchemaFailed` lists `slicesOwnedBy(owner)`;
   a slice whose owner had been dropped was invisible to it, so an operator was told fewer slices
   were blocked than actually were. No code change was needed for this beyond the producer fix — the

--- a/changelog.d/698-slice-target-owner-preservation.md
+++ b/changelog.d/698-slice-target-owner-preservation.md
@@ -9,7 +9,7 @@ this branch adds +12 lines to `ClusterDeploymentState.java`._
   `AbTestManager.targetPreservingOverrides` (`aether-invoke`) did it on every A/B lifecycle write,
   in a method whose name and javadoc both promise preservation. Both now carry the owner
   [verified: mutation-probed. Replacing `currentBlueprint.owningBlueprint()` with `Option.none()` in
-  `ControlLoopContext.applyScaling` turns 2 of 5 red in `ControlLoopOwnerPreservationTest`
+  `ControlLoopContext.applyScaling` turns 3 of 5 red in `ControlLoopOwnerPreservationTest`
   (`applyScaling_ownedSlice_carriesOwnerOntoTheScaledValue`: "expected: Some(org.example:owning-app:1.0.0)
   but was: None()"); restoring returns 5/5 green. Replacing
   `current.flatMap(SliceTargetValue::owningBlueprint)` with `Option.none()` in `AbTestManager` turns
@@ -64,7 +64,7 @@ this branch adds +12 lines to `ClusterDeploymentState.java`._
   `ControlLoop.onSliceTargetPut`]
   [verified: that feeder is a real enforcement point, not incidental plumbing — a third probe
   replacing `value.owningBlueprint()` with `Option.<BlueprintId>none()` at
-  `ControlLoop.onSliceTargetPut` turns the same 2 of 5 red and restores to 5/5 green. The owner
+  `ControlLoop.onSliceTargetPut` turns the same 3 of 5 red and restores to 5/5 green. The owner
   invariant therefore has three enforcement sites (two producers plus the feeder) and each was
   mutated independently, rather than one instance being taken as proof of the set].
 - **Stated plainly, not claimed away: neither write is lost-update-safe, and this fix does not make
@@ -105,7 +105,7 @@ this branch adds +12 lines to `ClusterDeploymentState.java`._
   #698. There is no gating relationship between this change and #924.
 - **`SliceTargetValue.placement` is erased by the SAME two producers — a third instance of this
   bug class, found by re-auditing the construction sites for field *values* rather than field
-  presence. Not fixed, no ticket yet.** Every `sliceTargetValue(...)` factory overload except the
+  presence. Not fixed here; filed as #937.** Every `sliceTargetValue(...)` factory overload except the
   one taking an explicit `placement` hardcodes `DEFAULT_PLACEMENT` (`"CORE_ONLY"`), and both
   `applyScaling` and `targetPreservingOverrides` use overloads that do. A non-default placement is
   operator-settable through the management API (`POST /api/slices/scale`, `ScaleRequest.placement`)

--- a/changelog.d/698-slice-target-owner-preservation.md
+++ b/changelog.d/698-slice-target-owner-preservation.md
@@ -8,9 +8,14 @@ this branch adds +12 lines to `ClusterDeploymentState.java`._
   `ControlLoopContext.applyScaling` (`aether-control`) did it on every autoscale decision;
   `AbTestManager.targetPreservingOverrides` (`aether-invoke`) did it on every A/B lifecycle write,
   in a method whose name and javadoc both promise preservation. Both now carry the owner
-  [verified: `ControlLoopOwnerPreservationTest$ProducerPreservesOwner#applyScaling_ownedSlice_carriesOwnerOntoTheScaledValue`
-  (`aether-control`), `SliceTargetOverridePreservationTest$AbTestPromotePreservesOverrides#concludeTest_preserves_autoscaler_overrides_on_promoted_version`
-  (`aether-invoke`)].
+  [verified: mutation-probed. Replacing `currentBlueprint.owningBlueprint()` with `Option.none()` in
+  `ControlLoopContext.applyScaling` turns 2 of 5 red in `ControlLoopOwnerPreservationTest`
+  (`applyScaling_ownedSlice_carriesOwnerOntoTheScaledValue`: "expected: Some(org.example:owning-app:1.0.0)
+  but was: None()"); restoring returns 5/5 green. Replacing
+  `current.flatMap(SliceTargetValue::owningBlueprint)` with `Option.none()` in `AbTestManager` turns
+  1 of 2 red in `SliceTargetOverridePreservationTest`
+  (`AbTestPromotePreservesOverrides#concludeTest_preserves_autoscaler_overrides_on_promoted_version`);
+  restoring returns 2/2 green].
 - **The loss was only observable at the consumer, one failover later.** `ClusterDeploymentState`
   resolves a slice's `schemaRequired` through its owner (`restoreSliceTarget`,
   `handleSliceTargetChange`); an absent owner takes the historical unowned default `true`. A slice
@@ -18,9 +23,19 @@ this branch adds +12 lines to `ClusterDeploymentState.java`._
   restore asserting schema *was* required — #555's original symptom, moved one layer upstream. The
   end-to-end path is now pinned by feeding **the exact value the autoscaler emits** into a real
   `ClusterDeploymentContext` restore
-  [verified: `ControlLoopOwnerPreservationTest$OwnerSurvivesLeaderRestore#autoscalerOutput_restoredAfterFailover_keepsSchemaRequiredFalse`,
-  with `#autoscalerOutput_restoredAfterFailover_resolvesSchemaRequiredTrue` as the opposite polarity
-  so a hardcoded `false` cannot pass].
+  [verified: mutation-probed. `#autoscalerOutput_restoredAfterFailover_keepsSchemaRequiredFalse` goes
+  red under BOTH producer-side mutations with "expected: false but was: true" — literally #698's
+  symptom reproduced — and green on restore].
+  **Stated precisely, because the tag would otherwise overclaim:** its opposite-polarity twin
+  `#autoscalerOutput_restoredAfterFailover_resolvesSchemaRequiredTrue` did **NOT** redden under any
+  of the three mutations, and is not pinned by them. It cannot: with the owner erased the resolution
+  falls through to the historical default `true`, which is the value that test expects, so it passes
+  *for the wrong reason*. It guards a different failure — an implementation hardcoding `false` — and
+  that is all it is evidence of. The same is true of
+  `#applyScaling_unownedSlice_leavesOwnerAbsent` and
+  `#applyScaling_ownedSlice_carriesOperatorOverridesOntoTheScaledValue`, both green under mutation by
+  design. Of the 5 tests in the class, 2 are pinned by these probes; the other 3 are polarity and
+  companion guards, not owner-erasure detectors.
 - **Schema-failure reports also under-counted.** `handleSchemaFailed` lists `slicesOwnedBy(owner)`;
   a slice whose owner had been dropped was invisible to it, so an operator was told fewer slices
   were blocked than actually were. No code change was needed for this beyond the producer fix — the
@@ -40,7 +55,12 @@ this branch adds +12 lines to `ClusterDeploymentState.java`._
   and changes no control flow
   [mechanism: `ControlLoopContext` has no `KVStore` field — only `ClusterNode`, the command channel;
   `blueprints.put` has exactly one call site (`putBlueprint`), whose only production caller is
-  `ControlLoop.onSliceTargetPut`].
+  `ControlLoop.onSliceTargetPut`]
+  [verified: that feeder is a real enforcement point, not incidental plumbing — a third probe
+  replacing `value.owningBlueprint()` with `Option.<BlueprintId>none()` at
+  `ControlLoop.onSliceTargetPut` turns the same 2 of 5 red and restores to 5/5 green. The owner
+  invariant therefore has three enforcement sites (two producers plus the feeder) and each was
+  mutated independently, rather than one instance being taken as proof of the set].
 - **Stated plainly, not claimed away: neither write is lost-update-safe, and this fix does not make
   it so.** `applyScaling` emits an unconditional `KVCommand.Put`, so a concurrent writer's update to
   the same `SliceTargetKey` can still be clobbered. That exposure is pre-existing and unchanged in


### PR DESCRIPTION
Fixes #698.

Two producers rebuilt a `SliceTargetValue` from a subset of its fields and hardcoded `Option.none()` for the owner, while carefully carrying every other field forward: `ControlLoopContext.applyScaling` (`aether-control`) on every autoscale decision, and `AbTestManager.targetPreservingOverrides` (`aether-invoke`) on every A/B lifecycle write — in a method whose name and javadoc both promise preservation.

The write looks correct in isolation, which is why this outlived #555 by twelve days. The loss is only observable at the **consumer**, one failover later: `ClusterDeploymentState.restoreSliceTarget` resolves `schemaRequired` through the owner, and an absent owner takes the historical unowned default `true`. A slice deployed `schema_required = false` came back after an autoscale plus a leader restore asserting schema *was* required.

## Why a model field and not the read-modify-write the ticket prescribes

#698 prescribes `withInstances(...)` on a re-read value. **Two open tickets flag that exact shape on this code — #906 (lost-update in `WorkerDeploymentManager`) and #805 (`bestEffortFailureCommand` merges by read-then-Put)** — so the obvious implementation risked introducing a lost update on the autoscaler's hot path.

The decisive structural fact: **`ControlLoopContext` holds no KV-store handle.** Its only cluster reference is `ClusterNode`, the command-apply channel. A read-modify-write would have required giving the class a store handle it does not have, widening its authority from "decide and emit commands" to "read cluster state", and adding a fresh read-then-`Put` where #906/#805 already live.

Instead, `ClusterController.Blueprint` — the autoscaler's own in-memory model — gained an `owningBlueprint` component, threaded from the `SliceTargetValue` at `ControlLoop.onSliceTargetPut`. That mirror is trustworthy for structural reasons, not by assertion: `blueprints.put(...)` has **exactly one** call site (`putBlueprint`), whose only production caller is `onSliceTargetPut`; so every entry originates from a `SliceTargetValue`, and the owner has the same provenance and lifetime as `maxInstances` and both thresholds, which this code already reads from that mirror and already trusts. An artifact with no observed `SliceTargetValue` has no map entry, so `prepareChange` returns `none()` and `applyScaling` is never reached for it.

**This adds no new store read at either site.** `applyScaling` already issued an unconditional blind `Put` and still does; `AbTestManager` already re-read the current value for its override fields, and this widens that existing read's field set by one with no control-flow change.

**Stated plainly rather than claimed away: neither write is lost-update-safe, and this PR does not make either one safe.** `applyScaling` emits an unconditional `Put`, so a concurrent writer to the same `SliceTargetKey` can still be clobbered. That exposure is pre-existing and unchanged in shape and magnitude; it is #906/#805's subject. Closing #698 is not evidence this path is race-free.

`ClusterController.Blueprint` was verified **not** to be a wire type before adding a component, since codecs are generated positionally: no `@Codec`/`@CodecFor` (control: the same pattern returns 7 hits on `AetherValue.java`), absent from `SystemTags` (control: `SystemTags` pins four other Blueprint-named types), absent from `KVStoreSerializer`, and referenced only inside `aether-control`. Decisively, the actual wire type `SliceTargetValue` **already had** `owningBlueprint` as component 4 — `AetherValue.java` is unmodified by this branch.

## Every construction site enumerated, not sampled

**7 in main sources** outside `AetherValue`'s own factory block. Positive control: the grep recovers all 4 sites #698 names by hand (4 of 4). Two were defective (fixed here); the other five are correct — `handleAppBlueprintChange` (deploy time, passes the owner), `KVStoreSerializer` (parses it off the wire), and three `existing.map(...).or(fresh)` fallbacks in `SliceRoutes`, `RollbackManager` and `DeploymentManagerImpl` whose `.or` branch fires only when no value existed, making its `none()` a genuinely absent owner.

## #555's consumer-side resolution is KEPT

It is not a workaround left beside its own fixed root cause. `SliceTargetValue` carries no `schemaRequired` field, so resolving through the owner is the only route back to the deployed value; removing it would reintroduce #555 wholesale. What #698 changed is that resolution's **input**, not its necessity — `.or(true)` now means "genuinely unowned slice" instead of "owner erased in transit". Recorded at both call sites, and `SchemaRequiredResolutionTest`'s javadoc, which documented this defect as *open*, is corrected.

## Verification

- **Full reactor from root** (`clean install`, no `-pl`, no `-DskipTests`, `env -u HCLOUD_TOKEN`): BUILD SUCCESS, 143 modules, 14:53. **13,157 tests** counted from surefire XML (`.txt` headers report 0 for `@Nested`).
- **`jbct:check` run explicitly** (it is not lifecycle-bound) with `-Djbct.skip=false`: **48 / 88 / 14** files examined for `aether-invoke` / `aether-deployment` / `aether-control`, all `0 format issue(s), 0 lint error(s)`. The gate **rejected this branch's own code on its first run** (my 7-arg `putBlueprint` call exceeded the line limit, fixed in `1a4a2e9c9`) — an instrument that has never rejected anything is indistinguishable from one that cannot.
- **Three mutation probes**, each naming the expression it replaces, production code committed before the first probe:

| Probe | Mutated | Restored |
|---|---|---|
| `currentBlueprint.owningBlueprint()` → `none()` in `applyScaling` | 5 tests, **2 failures** | 5, 0 |
| `current.flatMap(SliceTargetValue::owningBlueprint)` → `none()` in `AbTestManager` | 2 tests, **1 failure** | 2, 0 |
| `value.owningBlueprint()` → `none()` at the feeder `onSliceTargetPut` | 5 tests, **2 failures** | 5, 0 |

The restore-path failure reads `expected: false but was: true` — #698's production symptom reproduced literally. Three probes rather than one because the invariant has three enforcement sites, and mutating one instance is not evidence about the set.

### Known limitation of the test suite, stated because the coverage would otherwise be overcounted

**Only 2 of the 5 tests in `ControlLoopOwnerPreservationTest` are pinned by these mutations.** `autoscalerOutput_restoredAfterFailover_resolvesSchemaRequiredTrue` stayed **green under all three** and cannot detect owner erasure: with the owner dropped, resolution falls through to the historical default `true` — exactly the value it expects — so it passes *for the wrong reason*. It guards a different failure (an implementation hardcoding `false`) and that is all it is evidence of. `applyScaling_unownedSlice_leavesOwnerAbsent` and the override companion likewise stay green by design.

A follow-up making that test discriminating (asserting the restored blueprint's owner, which is mutually exclusive with the default) is drafted but **not included here**, because it needs its own mutation run to verify and the suite lock was released to unblock a queued release-blocker fix.

## What this does NOT do

- **Does not fix #936** — `applyScaling` writes `newInstances` as both `targetInstances` and `minInstances`, ratcheting the scale-down floor to the current count. Same constructor call, adjacent argument position (3 vs 4), independent bug.
- **Does not fix #937** — the same two producers reset `placement` to `CORE_ONLY`, and that reset is acted on at `ClusterDeploymentState:1303`.
- **No gating relationship to #924**, which is closed unmerged. #924's blocking finding had two independent doors, and door 2 — a partially deployed blueprint across a leader failover — needs no autoscaler and survives this fix untouched. #933 was filed for this same defect and is closed as a duplicate of #698.

Line numbers are derived at `origin/release-1.0.0-rc4` @ `78960de46`. Full report: `oss/internal/fix-698-2026-09-08.md`.
