### PR TITLE
fix: emit cluster-failure events without leader gating (#926)

### DIFF
--- a/aether/node/src/main/java/org/pragmatica/aether/api/AlertEvent.java
+++ b/aether/node/src/main/java/org/pragmatica/aether/api/AlertEvent.java
@@ -60,4 +60,39 @@ public sealed interface AlertEvent {
             return new AlertResolved(alertId, System.currentTimeMillis(), Severity.INFO, resolvedBy);
         }
     }
+
+    /// Node-health alert (#926). Before this variant existed the alert surface had NO node-health path
+    /// at all: the only producers were `AlertManager.onAllInstancesFailed` (slice-level) and
+    /// `checkThreshold` (metric-level), so a cluster member could be confirmed dead without any alert
+    /// being raised anywhere. Measured over ten days on a five-node cluster, three nodes sat unhealthy
+    /// for nine days with nothing to notice.
+    ///
+    /// Raised from the ungated FSM DEAD edge, so it does NOT depend on leader election — the defect
+    /// this variant exists to close. Alert state is per-node local memory exposed through that node's
+    /// own `/api/alerts`, so unlike the cluster-events stream it needs no leader, quorum, replica or
+    /// partition ownership to be raised OR read back.
+    ///
+    /// [`#alertId`] is derived solely from the failed node, so re-observing the same death is
+    /// idempotent (a repeated raise replaces the entry rather than accumulating) and the matching
+    /// clear on rejoin can address it without carrying state. Duplicate-free by construction — each
+    /// node keeps its own alert map, so there is no cross-node fan-out to deduplicate.
+    record NodeHealthAlert(String alertId,
+                           long timestamp,
+                           Severity severity,
+                           NodeId nodeId,
+                           NodeId observedBy,
+                           String reason) implements AlertEvent {
+        public static NodeHealthAlert nodeFailed(NodeId nodeId, NodeId observedBy) {
+            return new NodeHealthAlert(alertId(nodeId),
+                                       System.currentTimeMillis(),
+                                       Severity.CRITICAL,
+                                       nodeId,
+                                       observedBy,
+                                       "Confirmed departure (FSM DEAD edge)");
+        }
+
+        public static String alertId(NodeId nodeId) {
+            return "node.failed:" + nodeId.id();
+        }
+    }
 }

--- a/aether/node/src/main/java/org/pragmatica/aether/api/AlertForwarder.java
+++ b/aether/node/src/main/java/org/pragmatica/aether/api/AlertForwarder.java
@@ -150,6 +150,7 @@ public class AlertForwarder {
             case AlertEvent.SliceFailureAlert sfa -> appendSliceFailureFields(sb, sfa);
             case AlertEvent.ThresholdAlert ta -> appendThresholdFields(sb, ta);
             case AlertEvent.AlertResolved ar -> appendResolvedFields(sb, ar);
+            case AlertEvent.NodeHealthAlert nha -> appendNodeHealthFields(sb, nha);
         }
 
         sb.append("}");
@@ -174,6 +175,16 @@ public class AlertForwarder {
 
         sb.append("],");
         sb.append("\"lastError\":\"").append(escapeJson(sfa.lastError())).append("\"");
+    }
+
+    /// #926: node-health alerts forward to the configured webhooks like every other alert kind. This is
+    /// the one alerting surface that leaves the cluster entirely, so it is the surface least affected by
+    /// the failure being reported — a webhook POST needs no leader, no quorum and no healthy peer.
+    private void appendNodeHealthFields(StringBuilder sb, AlertEvent.NodeHealthAlert nha) {
+        sb.append("\"type\":\"NODE_FAILED\",");
+        sb.append("\"nodeId\":\"").append(nha.nodeId().id()).append("\",");
+        sb.append("\"observedBy\":\"").append(nha.observedBy().id()).append("\",");
+        sb.append("\"reason\":\"").append(escapeJson(nha.reason())).append("\"");
     }
 
     private void appendThresholdFields(StringBuilder sb, AlertEvent.ThresholdAlert ta) {

--- a/aether/node/src/main/java/org/pragmatica/aether/api/AlertManager.java
+++ b/aether/node/src/main/java/org/pragmatica/aether/api/AlertManager.java
@@ -512,7 +512,6 @@ public class AlertManager {
                                    null,
                                    alert.timestamp));
         }
-
         // #926: node-health alerts reach the SAME /api/alerts surface as every other kind. An alert
         // raised but not rendered is not operator-visible, which is the defect this ticket is about one
         // layer up. Discriminated by source="node_health"; nodeId names the FAILED node and message
@@ -813,10 +812,9 @@ public class AlertManager {
     /// reachable as the failure it clears. A no-op when no alert is active for that node.
     @Contract
     public void clearNodeHealthAlert(NodeId rejoined) {
-        Option.option(activeNodeHealthAlerts.remove(AlertEvent.NodeHealthAlert.alertId(rejoined)))
-              .onPresent(cleared -> log.info("Node-health alert resolved for {} — node rejoined (was: {})",
-                                             rejoined.id(),
-                                             cleared.reason()));
+        Option.option(activeNodeHealthAlerts.remove(AlertEvent.NodeHealthAlert.alertId(rejoined))).onPresent(cleared -> log.info("Node-health alert resolved for {} — node rejoined (was: {})",
+                                                                                                                                 rejoined.id(),
+                                                                                                                                 cleared.reason()));
     }
 
     public List<AlertEvent.NodeHealthAlert> getActiveNodeHealthAlerts() {

--- a/aether/node/src/main/java/org/pragmatica/aether/api/AlertManager.java
+++ b/aether/node/src/main/java/org/pragmatica/aether/api/AlertManager.java
@@ -776,10 +776,53 @@ public class AlertManager {
         return List.copyOf(activeSliceFailureAlerts.values());
     }
 
+    /// Hard cap on retained node-health alerts. `activeNodeHealthAlerts` is keyed by the FAILED node's
+    /// id, and CTM auto-heal mints a FRESH random id for a replacement rather than reusing the departed
+    /// one, so an id-exact clear can never match a replaced node. Without a bound, every replacement
+    /// under churn would add a permanent entry, growing heap and the `/api/alerts` payload without
+    /// limit. Mirrors the existing `MAX_ALERT_HISTORY` bound on `alertHistory`.
+    private static final int MAX_NODE_HEALTH_ALERTS = 64;
+
+    /// Membership-event causes that mean the node ANNOUNCED its departure rather than died: a SWIM
+    /// graceful departure (normal shutdown, and therefore every rolling restart) and an operator or
+    /// controller drain. Matched against `MembershipTransitionRecord.cause()`, which is the triggering
+    /// `MembershipEvent`'s simple class name.
+    private static final java.util.Set<String> GRACEFUL_DEPARTURE_CAUSES = java.util.Set.of("SwimDeparted",
+                                                                                            "DrainRequested");
+
     /// Active node-health alerts, keyed by [`AlertEvent.NodeHealthAlert#alertId`] (derived from the
     /// failed node id). Per-node local state — never replicated, never consensus-backed — which is
-    /// precisely why it survives the conditions of #926.
+    /// precisely why it survives the conditions of #926. Bounded by [`#MAX_NODE_HEALTH_ALERTS`].
     private final Map<String, AlertEvent.NodeHealthAlert> activeNodeHealthAlerts = new ConcurrentHashMap<>();
+    /// Node ids observed announcing a graceful departure, id → wall-clock millis. Bounded by
+    /// [`#MAX_NODE_HEALTH_ALERTS`]; when full, new marks are DROPPED rather than evicting, so the
+    /// failure mode is a spurious CRITICAL alert and never a suppressed one.
+    private final Map<String, Long> announcedDeparture = new ConcurrentHashMap<>();
+
+    /// Feed for `MembershipFsm` transitions (#926 round 2). Records that `nodeId` announced a departure,
+    /// so the DEAD edge that follows can be told apart from a crash.
+    ///
+    /// The DEAD edge itself cannot make that distinction — a graceful `SwimDeparted` and a drain both
+    /// reach DEAD through the same `Stopped` transition a failure does — so without this every rolling
+    /// restart raised a CRITICAL node-health alert on every surviving node. An alert surface that fires
+    /// CRITICAL during routine planned operations gets muted, and a muted alert is the same end state
+    /// as the silence #926 exists to fix, reached from the opposite direction.
+    ///
+    /// Ordering is guaranteed, not hoped for: `MembershipFsm` queues the transition-record emission
+    /// BEFORE the confirmed-departure emission in the same `emissions` list, so the mark is always
+    /// recorded before [`#onNodeFailed`] reads it for that departure.
+    @Contract
+    public void noteMembershipTransition(NodeId nodeId, String cause) {
+        if (!GRACEFUL_DEPARTURE_CAUSES.contains(cause)) {
+            return;
+        }
+
+        if (announcedDeparture.size() >= MAX_NODE_HEALTH_ALERTS && !announcedDeparture.containsKey(nodeId.id())) {
+            return;
+        }
+
+        announcedDeparture.put(nodeId.id(), System.currentTimeMillis());
+    }
 
     /// Raise a node-health alert for a confirmed member death (#926).
     ///
@@ -789,29 +832,62 @@ public class AlertManager {
     /// "unhealthy" in `aether/node/src/main` appeared twice, both rendering a status string into an
     /// HTTP response.
     ///
-    /// GUARANTEE: **at-most-one active alert per failed node, per observing node.** The map key is
-    /// derived from the failed node alone, so a repeated observation of the same death replaces rather
-    /// than accumulates — idempotent, needing no dedup token and no coordination. Each node keeps its
-    /// own map, so there is no cross-node duplication to reconcile: the alert is a local judgment about
-    /// a remote peer, exposed on the observing node's own `/api/alerts`.
+    /// GUARANTEE: **at-most-one active alert per ABRUPTLY departed node, per observing node.** The map
+    /// key is derived from the failed node alone, so a repeated observation of the same death replaces
+    /// rather than accumulates — idempotent, needing no dedup token and no coordination. Each node keeps
+    /// its own map, so there is no cross-node duplication to reconcile: the alert is a local judgment
+    /// about a remote peer, exposed on the observing node's own `/api/alerts`.
+    ///
+    /// A departure this node saw ANNOUNCED (see [`#noteMembershipTransition`]) is logged at INFO and
+    /// raises NO alert. The mark is CONSUMED on read, so a node that gracefully departs, rejoins and
+    /// later crashes still alerts on the crash. **The bias is deliberate and one-directional:** an
+    /// unmarked departure always alerts, so a missed or dropped mark costs a spurious CRITICAL, never a
+    /// silent one. Suppressing a real failure would re-create the defect this ticket exists to remove.
     ///
     /// Cleared by [`#clearNodeHealthAlert`] when the node rejoins. Raising without clearing would leave
     /// a permanently red signal, which trains an operator to ignore the surface.
     @Contract
     public void onNodeFailed(NodeId failed, NodeId observedBy) {
+        if (announcedDeparture.remove(failed.id()) != null) {
+            log.info("Node {} departed gracefully (announced; observed by {}) — no alert raised",
+                     failed.id(),
+                     observedBy.id());
+
+            return;
+        }
+
         var alert = AlertEvent.NodeHealthAlert.nodeFailed(failed, observedBy);
 
         activeNodeHealthAlerts.put(alert.alertId(), alert);
+        evictOldestNodeHealthAlertIfOverCap();
         log.error("CRITICAL: node {} confirmed failed (observed by {}) — cluster membership degraded",
                   failed.id(),
                   observedBy.id());
     }
 
+    /// Drop the oldest alert once the map exceeds [`#MAX_NODE_HEALTH_ALERTS`]. A replaced node's alert
+    /// can never be cleared by id (the replacement carries a new one), so the bound — not the clear
+    /// path — is what keeps this map finite under sustained churn.
+    private void evictOldestNodeHealthAlertIfOverCap() {
+        while (activeNodeHealthAlerts.size() > MAX_NODE_HEALTH_ALERTS) {
+            activeNodeHealthAlerts.values()
+                                  .stream()
+                                  .min(java.util.Comparator.comparingLong(AlertEvent.NodeHealthAlert::timestamp))
+                                  .map(AlertEvent.NodeHealthAlert::alertId)
+                                  .ifPresent(activeNodeHealthAlerts::remove);
+        }
+    }
+
     /// Resolve the node-health alert for `rejoined` (#926). Wired to the transport `PeerJoined`
     /// handshake — the same ungated surface that sources NODE_JOINED — so recovery is exactly as
     /// reachable as the failure it clears. A no-op when no alert is active for that node.
+    ///
+    /// This clear is id-exact and therefore CANNOT resolve a CTM-replaced node, whose replacement boots
+    /// under a freshly minted random id. That case is handled by the bound above, not here; the honest
+    /// statement is that a replaced node's alert ages out under churn rather than being resolved.
     @Contract
     public void clearNodeHealthAlert(NodeId rejoined) {
+        announcedDeparture.remove(rejoined.id());
         Option.option(activeNodeHealthAlerts.remove(AlertEvent.NodeHealthAlert.alertId(rejoined))).onPresent(cleared -> log.info("Node-health alert resolved for {} — node rejoined (was: {})",
                                                                                                                                  rejoined.id(),
                                                                                                                                  cleared.reason()));

--- a/aether/node/src/main/java/org/pragmatica/aether/api/AlertManager.java
+++ b/aether/node/src/main/java/org/pragmatica/aether/api/AlertManager.java
@@ -783,17 +783,42 @@ public class AlertManager {
     /// limit. Mirrors the existing `MAX_ALERT_HISTORY` bound on `alertHistory`.
     private static final int MAX_NODE_HEALTH_ALERTS = 64;
 
-    /// Membership-event causes that mean the node ANNOUNCED its departure rather than died: a SWIM
-    /// graceful departure (normal shutdown, and therefore every rolling restart) and an operator or
-    /// controller drain. Matched against `MembershipTransitionRecord.cause()`, which is the triggering
-    /// `MembershipEvent`'s simple class name.
-    private static final java.util.Set<String> GRACEFUL_DEPARTURE_CAUSES = java.util.Set.of("SwimDeparted",
-                                                                                            "DrainRequested");
+    /// Membership-event causes that mean the node ANNOUNCED its departure rather than died.
+    ///
+    /// **`SwimDeparted` is NOT in this set, and putting it here was a blocking regression.** Round 2 of
+    /// #926 included it on the strength of `MembershipFsm.onSwimDeparted`'s docstring ("SWIM reported
+    /// `id` DEPARTED gracefully") — a comment that contradicts its own producer.
+    /// `SwimProtocol.emitFaultyEdgePair` delivers `FaultyObserved` and `DepartedObserved` **as a pair at
+    /// the FAULTY edge**, because "FAULTY IS confirmed death (canonical SWIM) … The death broadcast
+    /// therefore fires AT the FAULTY edge" — deliberately, to cut `NODE_FAILED` latency inside the 60s
+    /// SLO. `DepartedObserved` routes to `onSwimDeparted` (`AetherNode:4968`), which dispatches
+    /// `SwimDeparted`. **So `SwimDeparted` is SWIM's death broadcast and is the PRIMARY crash path**,
+    /// not a graceful goodbye: with it in this set, `kill -9` raised no CRITICAL alert at all.
+    ///
+    /// That is precisely the failure [`#onNodeFailed`] warns against one paragraph down — suppressing a
+    /// real failure re-creates the defect #926 exists to remove — reached by trusting a docstring
+    /// instead of its producer.
+    ///
+    /// `DrainRequested` alone is sound: it is raised only by the operator/controller drain command, and
+    /// nothing in SWIM's failure detection produces it. **Do not add a cause here without tracing it to
+    /// the code that RAISES it.** A graceful shutdown that is not operator-driven is currently
+    /// indistinguishable from a crash at this layer, so it stays noisy — noisy beats silent on a
+    /// failure-detection surface, and no signal SWIM carries can separate them.
+    private static final java.util.Set<String> GRACEFUL_DEPARTURE_CAUSES = java.util.Set.of("DrainRequested");
 
     /// Active node-health alerts, keyed by [`AlertEvent.NodeHealthAlert#alertId`] (derived from the
     /// failed node id). Per-node local state — never replicated, never consensus-backed — which is
     /// precisely why it survives the conditions of #926. Bounded by [`#MAX_NODE_HEALTH_ALERTS`].
     private final Map<String, AlertEvent.NodeHealthAlert> activeNodeHealthAlerts = new ConcurrentHashMap<>();
+
+    /// Insertion order for [`#activeNodeHealthAlerts`], oldest first — the eviction order.
+    ///
+    /// Round 2 ordered eviction by `min(timestamp)`. That was both unpinned (flipping it to `max` left
+    /// the suite green, since the bound test asserted only size) and **unpinnable**: alerts raised in a
+    /// tight loop share a `System.currentTimeMillis()` value, so "oldest" was not even well defined.
+    /// An insertion queue makes the order deterministic and therefore assertable.
+    private final java.util.concurrent.ConcurrentLinkedQueue<String> nodeHealthAlertOrder = new java.util.concurrent.ConcurrentLinkedQueue<>();
+
     /// Node ids observed announcing a graceful departure, id → wall-clock millis. Bounded by
     /// [`#MAX_NODE_HEALTH_ALERTS`]; when full, new marks are DROPPED rather than evicting, so the
     /// failure mode is a spurious CRITICAL alert and never a suppressed one.
@@ -808,9 +833,20 @@ public class AlertManager {
     /// CRITICAL during routine planned operations gets muted, and a muted alert is the same end state
     /// as the silence #926 exists to fix, reached from the opposite direction.
     ///
-    /// Ordering is guaranteed, not hoped for: `MembershipFsm` queues the transition-record emission
-    /// BEFORE the confirmed-departure emission in the same `emissions` list, so the mark is always
-    /// recorded before [`#onNodeFailed`] reads it for that departure.
+    /// Ordering is guaranteed, and by a different mechanism than round 2 claimed. The earlier note said
+    /// the transition and confirmed-departure emissions share one `emissions` list; **that is false** —
+    /// the two arrive from SEPARATE dispatches (e.g. `DrainRequested` then `Stopped`), each building
+    /// its own list. What actually holds the order is `MemberTracking.dispatch`, which runs
+    /// `synchronized (transitionGuard) { applyEvent(event).forEach(Runnable::run) }`: every dispatch for
+    /// a member is serialised on that member's guard and runs its staged fan-out synchronously before
+    /// returning, so an earlier dispatch's transition record has always run before a later dispatch's
+    /// DEAD hooks. **Recorded precisely because a guarantee resting on a fictional mechanism cannot be
+    /// re-checked when the code moves** — if that fan-out ever becomes asynchronous, this ordering is
+    /// what breaks, and the guard is where to look.
+    ///
+    /// Within a single dispatch the order is also fixed: `applyEvent` stages the calls "in the exact
+    /// order the pre-#929 inline code fired them (transition, JOINED delta, DEPARTING hook,
+    /// DEPARTING-recovery hook, then the DEAD hooks)".
     @Contract
     public void noteMembershipTransition(NodeId nodeId, String cause) {
         if (!GRACEFUL_DEPARTURE_CAUSES.contains(cause)) {
@@ -858,23 +894,29 @@ public class AlertManager {
 
         var alert = AlertEvent.NodeHealthAlert.nodeFailed(failed, observedBy);
 
-        activeNodeHealthAlerts.put(alert.alertId(), alert);
+        if (activeNodeHealthAlerts.put(alert.alertId(), alert) == null) {
+            nodeHealthAlertOrder.add(alert.alertId());
+        }
+
         evictOldestNodeHealthAlertIfOverCap();
         log.error("CRITICAL: node {} confirmed failed (observed by {}) — cluster membership degraded",
                   failed.id(),
                   observedBy.id());
     }
 
-    /// Drop the oldest alert once the map exceeds [`#MAX_NODE_HEALTH_ALERTS`]. A replaced node's alert
-    /// can never be cleared by id (the replacement carries a new one), so the bound — not the clear
-    /// path — is what keeps this map finite under sustained churn.
+    /// Drop the OLDEST-INSERTED alerts once the map exceeds [`#MAX_NODE_HEALTH_ALERTS`]. A replaced
+    /// node's alert can never be cleared by id (the replacement carries a new one), so the bound — not
+    /// the clear path — is what keeps this map finite under sustained churn. Oldest-first is the
+    /// deliberate direction: the most recent failures are the ones an operator is still acting on.
     private void evictOldestNodeHealthAlertIfOverCap() {
         while (activeNodeHealthAlerts.size() > MAX_NODE_HEALTH_ALERTS) {
-            activeNodeHealthAlerts.values()
-                                  .stream()
-                                  .min(java.util.Comparator.comparingLong(AlertEvent.NodeHealthAlert::timestamp))
-                                  .map(AlertEvent.NodeHealthAlert::alertId)
-                                  .ifPresent(activeNodeHealthAlerts::remove);
+            var oldest = nodeHealthAlertOrder.poll();
+
+            if (oldest == null) {
+                return;
+            }
+
+            activeNodeHealthAlerts.remove(oldest);
         }
     }
 
@@ -888,6 +930,7 @@ public class AlertManager {
     @Contract
     public void clearNodeHealthAlert(NodeId rejoined) {
         announcedDeparture.remove(rejoined.id());
+        nodeHealthAlertOrder.remove(AlertEvent.NodeHealthAlert.alertId(rejoined));
         Option.option(activeNodeHealthAlerts.remove(AlertEvent.NodeHealthAlert.alertId(rejoined))).onPresent(cleared -> log.info("Node-health alert resolved for {} — node rejoined (was: {})",
                                                                                                                                  rejoined.id(),
                                                                                                                                  cleared.reason()));

--- a/aether/node/src/main/java/org/pragmatica/aether/api/AlertManager.java
+++ b/aether/node/src/main/java/org/pragmatica/aether/api/AlertManager.java
@@ -30,6 +30,7 @@ import org.pragmatica.cluster.state.kvstore.KVStore;
 import org.pragmatica.consensus.NodeId;
 import org.pragmatica.hlc.HlcClock;
 import org.pragmatica.lang.Cause;
+import org.pragmatica.lang.Contract;
 import org.pragmatica.lang.NullReturn;
 import org.pragmatica.lang.Option;
 import org.pragmatica.lang.Promise;
@@ -512,6 +513,24 @@ public class AlertManager {
                                    alert.timestamp));
         }
 
+        // #926: node-health alerts reach the SAME /api/alerts surface as every other kind. An alert
+        // raised but not rendered is not operator-visible, which is the defect this ticket is about one
+        // layer up. Discriminated by source="node_health"; nodeId names the FAILED node and message
+        // carries the reason.
+        for (var alert : activeNodeHealthAlerts.values()) {
+            list.add(new AlertView(alert.alertId(),
+                                   "node.failed",
+                                   alert.severity().name(),
+                                   alert.reason(),
+                                   "node_health",
+                                   null,
+                                   null,
+                                   alert.nodeId().id(),
+                                   null,
+                                   alert.timestamp(),
+                                   alert.timestamp()));
+        }
+
         return appendClusterWideInjectedAlerts(list, seenInjectedIds).map(_ -> List.copyOf(list));
     }
 
@@ -756,6 +775,52 @@ public class AlertManager {
 
     public List<SliceFailureAlert> getActiveSliceFailureAlerts() {
         return List.copyOf(activeSliceFailureAlerts.values());
+    }
+
+    /// Active node-health alerts, keyed by [`AlertEvent.NodeHealthAlert#alertId`] (derived from the
+    /// failed node id). Per-node local state — never replicated, never consensus-backed — which is
+    /// precisely why it survives the conditions of #926.
+    private final Map<String, AlertEvent.NodeHealthAlert> activeNodeHealthAlerts = new ConcurrentHashMap<>();
+
+    /// Raise a node-health alert for a confirmed member death (#926).
+    ///
+    /// Invoked from the ungated `MembershipFsm` DEAD edge on EVERY node that confirms the death, so it
+    /// is reachable with no leader and no quorum. Node health previously had no alerting path at all:
+    /// `AlertEvent` carried only threshold, slice-failure and resolved variants, and repo-wide
+    /// "unhealthy" in `aether/node/src/main` appeared twice, both rendering a status string into an
+    /// HTTP response.
+    ///
+    /// GUARANTEE: **at-most-one active alert per failed node, per observing node.** The map key is
+    /// derived from the failed node alone, so a repeated observation of the same death replaces rather
+    /// than accumulates — idempotent, needing no dedup token and no coordination. Each node keeps its
+    /// own map, so there is no cross-node duplication to reconcile: the alert is a local judgment about
+    /// a remote peer, exposed on the observing node's own `/api/alerts`.
+    ///
+    /// Cleared by [`#clearNodeHealthAlert`] when the node rejoins. Raising without clearing would leave
+    /// a permanently red signal, which trains an operator to ignore the surface.
+    @Contract
+    public void onNodeFailed(NodeId failed, NodeId observedBy) {
+        var alert = AlertEvent.NodeHealthAlert.nodeFailed(failed, observedBy);
+
+        activeNodeHealthAlerts.put(alert.alertId(), alert);
+        log.error("CRITICAL: node {} confirmed failed (observed by {}) — cluster membership degraded",
+                  failed.id(),
+                  observedBy.id());
+    }
+
+    /// Resolve the node-health alert for `rejoined` (#926). Wired to the transport `PeerJoined`
+    /// handshake — the same ungated surface that sources NODE_JOINED — so recovery is exactly as
+    /// reachable as the failure it clears. A no-op when no alert is active for that node.
+    @Contract
+    public void clearNodeHealthAlert(NodeId rejoined) {
+        Option.option(activeNodeHealthAlerts.remove(AlertEvent.NodeHealthAlert.alertId(rejoined)))
+              .onPresent(cleared -> log.info("Node-health alert resolved for {} — node rejoined (was: {})",
+                                             rejoined.id(),
+                                             cleared.reason()));
+    }
+
+    public List<AlertEvent.NodeHealthAlert> getActiveNodeHealthAlerts() {
+        return List.copyOf(activeNodeHealthAlerts.values());
     }
 
     public void clearSliceFailureAlert(Artifact artifact, MethodName method) {

--- a/aether/node/src/main/java/org/pragmatica/aether/api/ClusterEventAggregator.java
+++ b/aether/node/src/main/java/org/pragmatica/aether/api/ClusterEventAggregator.java
@@ -554,10 +554,18 @@ public final class ClusterEventAggregator {
         }
 
         switch (event.state()) {
-            case ACTIVE -> emitLocal(new QuorumEstablished(hlcClock.now(),
-                                                           Severity.INFO,
-                                                           "Quorum established",
-                                                           Map.of("observedBy", selfNode.id())));
+            case ACTIVE -> {
+                // The recovery line is NOT decoration. This class nominates the local log as the
+                // surface that survives a leaderless cluster, and on that surface the pair must be
+                // complete: without this, an operator reading logs sees "Quorum lost" and never sees
+                // it restored — the same latched-red failure the un-gating of QUORUM_ESTABLISHED
+                // exists to prevent, reached on a different surface.
+                LOG.info("Quorum established on {} — consensus available", selfNode.id());
+                emitLocal(new QuorumEstablished(hlcClock.now(),
+                                                Severity.INFO,
+                                                "Quorum established",
+                                                Map.of("observedBy", selfNode.id())));
+            }
             case PASSIVE -> {
                 LOG.warn("Quorum lost on {} — consensus unavailable, cluster observability degraded", selfNode.id());
                 emitLocal(new QuorumLost(hlcClock.now(),

--- a/aether/node/src/main/java/org/pragmatica/aether/api/ClusterEventAggregator.java
+++ b/aether/node/src/main/java/org/pragmatica/aether/api/ClusterEventAggregator.java
@@ -400,10 +400,9 @@ public final class ClusterEventAggregator {
         Option.option(publisherSupplier.get())
               .onPresent(publisher -> Result.lift(Causes::fromThrowable,
                                                   () -> publisher.publish(event))
-                                            .onSuccess(promise -> promise.onFailure(cause -> LOG.warn(
-                                                    "ClusterEventAggregator: publish of {} failed, dropped: {}",
-                                                    event,
-                                                    cause.message())))
+                                            .onSuccess(promise -> promise.onFailure(cause -> LOG.warn("ClusterEventAggregator: publish of {} failed, dropped: {}",
+                                                                                                      event,
+                                                                                                      cause.message())))
                                             .onFailure(cause -> LOG.warn("ClusterEventAggregator: publish of {} threw, dropped: {}",
                                                                          event,
                                                                          cause.message())))
@@ -514,14 +513,14 @@ public final class ClusterEventAggregator {
                                                                    Map.of("leaderId",
                                                                           leaderId.id()))))
              .onEmpty(() -> {
-                 LOG.warn("Leadership lost on {}, election in progress — cluster observability degraded",
-                          selfNode.id());
-
-                 emitLocal(new LeaderLost(hlcClock.now(),
-                                          Severity.WARNING,
-                                          "Leadership lost, election in progress",
-                                          Map.of("observedBy", selfNode.id())));
-             });
+                          LOG.warn("Leadership lost on {}, election in progress — cluster observability degraded",
+                                   selfNode.id());
+                          emitLocal(new LeaderLost(hlcClock.now(),
+                                                   Severity.WARNING,
+                                                   "Leadership lost, election in progress",
+                                                   Map.of("observedBy",
+                                                          selfNode.id())));
+                      });
     }
 
     /// Quorum transitions, UN-gated via {@link #emitLocal} (#926) — previously both leader-gated.
@@ -561,7 +560,6 @@ public final class ClusterEventAggregator {
                                                            Map.of("observedBy", selfNode.id())));
             case PASSIVE -> {
                 LOG.warn("Quorum lost on {} — consensus unavailable, cluster observability degraded", selfNode.id());
-
                 emitLocal(new QuorumLost(hlcClock.now(),
                                          Severity.CRITICAL,
                                          "Quorum lost",
@@ -651,14 +649,10 @@ public final class ClusterEventAggregator {
         LOG.warn("Node {} failed (confirmed departure), observed by {} — cluster membership degraded",
                  departed.id(),
                  selfNode.id());
-
         emitLocal(new NodeFailed(hlcClock.now(),
                                  Severity.CRITICAL,
                                  "Node " + departed.id() + " failed (confirmed departure)",
-                                 Map.of("nodeId",
-                                        departed.id(),
-                                        "observedBy",
-                                        selfNode.id())));
+                                 Map.of("nodeId", departed.id(), "observedBy", selfNode.id())));
     }
 
     /// Departure-push overrun sink (issue #427, D4). The gracefully-departing node reports the chunks

--- a/aether/node/src/main/java/org/pragmatica/aether/api/ClusterEventAggregator.java
+++ b/aether/node/src/main/java/org/pragmatica/aether/api/ClusterEventAggregator.java
@@ -387,11 +387,23 @@ public final class ClusterEventAggregator {
     /// that threw there (e.g. the leader's cluster-events partition not yet materialized mid-churn) would
     /// abort the death edge and starve membership recovery. The async publish Promise is fire-and-forget
     /// (observability); a synchronous failure is logged and dropped, never re-thrown.
+    ///
+    /// #926: the ASYNCHRONOUS failure is logged too. `Result.lift` catches only a synchronous throw —
+    /// `publish` returns a `Promise<Unit>`, and a failure arriving on it (e.g. `PARTITION_NOT_LOCAL`
+    /// when the ring is not materialized) was previously discarded with no log and no counter. This
+    /// path is now load-bearing for reporting cluster failure, so a drop here would rebuild the same
+    /// fail-open shape one layer down: a component that reports nothing when it cannot publish is
+    /// indistinguishable from one reporting that all is well. Still fire-and-forget — logged, not
+    /// retried, and never propagated to the DEAD-edge caller.
     @Contract
     private void publishSafely(ClusterEvent event) {
         Option.option(publisherSupplier.get())
               .onPresent(publisher -> Result.lift(Causes::fromThrowable,
                                                   () -> publisher.publish(event))
+                                            .onSuccess(promise -> promise.onFailure(cause -> LOG.warn(
+                                                    "ClusterEventAggregator: publish of {} failed, dropped: {}",
+                                                    event,
+                                                    cause.message())))
                                             .onFailure(cause -> LOG.warn("ClusterEventAggregator: publish of {} threw, dropped: {}",
                                                                          event,
                                                                          cause.message())))
@@ -483,6 +495,16 @@ public final class ClusterEventAggregator {
     @Contract
     public void onSwimObservation(@SuppressWarnings("unused") org.pragmatica.swim.SwimObservation observation) {}
 
+    /// LEADER_ELECTED stays leader-gated — the newly elected leader is by definition the authoritative
+    /// emitter of its own election, and the gate holds for it.
+    ///
+    /// LEADER_LOST does NOT (#926). It was previously emitted through {@link #emitAsLeader}, which made
+    /// **the event announcing that there is no leader conditional on being the leader** — the branch is
+    /// reached precisely when `leaderId()` is empty, so no node passes the gate and the signal was
+    /// suppressed everywhere it mattered. It is emitted through the un-gated {@link #emitLocal} path
+    /// instead: this is the "no leader, degraded observability" signal, and it is worthless if it can
+    /// only be sent by a leader. Same at-least-once-per-observer contract as
+    /// {@link #onConfirmedDeparture}, with the same bounded duplication and the same `observedBy` key.
     @Contract
     public void onLeaderChange(LeaderNotification.LeaderChange event) {
         event.leaderId()
@@ -491,12 +513,41 @@ public final class ClusterEventAggregator {
                                                                    "Node " + leaderId.id() + " elected as leader",
                                                                    Map.of("leaderId",
                                                                           leaderId.id()))))
-             .onEmpty(() -> emitAsLeader(new LeaderLost(hlcClock.now(),
-                                                        Severity.WARNING,
-                                                        "Leadership lost, election in progress",
-                                                        Map.of())));
+             .onEmpty(() -> {
+                 LOG.warn("Leadership lost on {}, election in progress — cluster observability degraded",
+                          selfNode.id());
+
+                 emitLocal(new LeaderLost(hlcClock.now(),
+                                          Severity.WARNING,
+                                          "Leadership lost, election in progress",
+                                          Map.of("observedBy", selfNode.id())));
+             });
     }
 
+    /// Quorum transitions, UN-gated via {@link #emitLocal} (#926) — previously both leader-gated.
+    ///
+    /// QUORUM_LOST is the most severe event this class emits (CRITICAL) and was the least emittable.
+    /// A cluster that has gone PASSIVE cannot commit through consensus and therefore cannot sustain a
+    /// leader lease, so `leaderCheck` is false on every node exactly when quorum is lost — the same
+    /// self-defeating shape as {@link #onLeaderChange}'s LEADER_LOST branch and
+    /// {@link #onConfirmedDeparture}.
+    ///
+    /// QUORUM_ESTABLISHED is un-gated for a second, independent reason: quorum forms BEFORE a leader is
+    /// elected, so the gate drops the recovery notice at the one moment it is guaranteed to be false.
+    /// Un-gating the loss while leaving the recovery gated would be worse than fixing neither — an
+    /// operator would see the cluster enter "quorum lost" and never see it leave, a permanently red
+    /// signal that trains its own audience to ignore it. **A failure signal is only usable if its
+    /// matching recovery signal is at least as reachable.**
+    ///
+    /// Quorum state is genuinely a per-node observation, not a cluster fact: a node partitioned away
+    /// from the majority sees PASSIVE while the majority side sees ACTIVE, and each node is the only
+    /// authority on its own consensus participation. `emitLocal` is therefore the semantically correct
+    /// path here, matching the `SelfDrainInitiated` per-node contract rather than merely a workaround.
+    ///
+    /// Per-node duplicate suppression is unchanged and still applies: `advanceSequence` drops
+    /// duplicate/out-of-order notifications on this node before any emit. Cross-node duplication is
+    /// bounded by cluster size, per the {@link #onConfirmedDeparture} contract, and `observedBy` names
+    /// the emitter.
     @Contract
     public void onQuorumStateChange(ClusterStateNotification event) {
         if (!event.advanceSequence(quorumSequence)) {
@@ -504,11 +555,18 @@ public final class ClusterEventAggregator {
         }
 
         switch (event.state()) {
-            case ACTIVE -> emitAsLeader(new QuorumEstablished(hlcClock.now(),
-                                                              Severity.INFO,
-                                                              "Quorum established",
-                                                              Map.of()));
-            case PASSIVE -> emitAsLeader(new QuorumLost(hlcClock.now(), Severity.CRITICAL, "Quorum lost", Map.of()));
+            case ACTIVE -> emitLocal(new QuorumEstablished(hlcClock.now(),
+                                                           Severity.INFO,
+                                                           "Quorum established",
+                                                           Map.of("observedBy", selfNode.id())));
+            case PASSIVE -> {
+                LOG.warn("Quorum lost on {} — consensus unavailable, cluster observability degraded", selfNode.id());
+
+                emitLocal(new QuorumLost(hlcClock.now(),
+                                         Severity.CRITICAL,
+                                         "Quorum lost",
+                                         Map.of("observedBy", selfNode.id())));
+            }
         }
     }
 
@@ -559,15 +617,48 @@ public final class ClusterEventAggregator {
     /// `inQuorum` gate / drainer-confined `announced` baseline during the post-kill re-election window,
     /// so NODE_FAILED never reached `/api/events`. The DEAD edge is the reliable signal — the projector
     /// derives `NodeRemoved` FROM it, so it is a strict superset — and whenever the cluster confirms a
-    /// death, the leader emits here. LEADER-gated via {@link #emitAsLeader}: the hook fires on every
-    /// node's FSM but only the leader publishes (no N-way fan-out). Mirrors the NODE_JOINED fix
-    /// (sourced from the ungated transport handshake, not the unreliable membership delta).
+    /// death, every survivor emits here. Mirrors the NODE_JOINED fix (sourced from the ungated
+    /// transport handshake, not the unreliable membership delta).
+    ///
+    /// **UN-gated via {@link #emitLocal} (#926), previously leader-gated.** The leader gate
+    /// deduplicated — one emitter instead of N — and in exchange made the report of a cluster failure
+    /// depend on the cluster electing a leader. Measured over ten days on a five-node cluster: SWIM
+    /// confirmed 8 faulty members, 1,297,717 leader-election lines were logged, and `NodeFailed`
+    /// appeared 0 times. **The observability path failed exactly when the cluster did**, and a consumer
+    /// cannot distinguish that silence from health.
+    ///
+    /// A dedup token is NOT the fix: any token whose scope matches the counted unit must be visible to
+    /// every emitter, which costs at least quorum — and the measured incident ran three of five nodes
+    /// unhealthy, below quorum. It would have been silent in the very incident it is meant to report,
+    /// and would newly bind this path to a coordination outcome it does not otherwise need (the local
+    /// append takes no leader, quorum or consensus). Gating on `leader().isEmpty()` fails for a related
+    /// reason: it makes the leadership view — the least trustworthy input in this incident — the guard
+    /// on the failure path, so a stale `currentLeader()` naming a dead node silences every survivor.
+    ///
+    /// GUARANTEE: **at-least-once per observing core member, per confirmed departure**, into that
+    /// member's LOCAL partition-0 ring. Deliberately NOT exactly-once and NOT deduplicated. Duplicates
+    /// are bounded, not unbounded — `MembershipFsm.enteredDead` is a fresh-edge fan-out firing once per
+    /// DEAD transition per member FSM — so the ceiling is one event per member confirming the death.
+    /// `details.observedBy` carries the emitting node so consumers can collapse duplicates, and the
+    /// distinct-observer count is itself signal. The `replayingCheck` gate is retained, so snapshot
+    /// replay still does not re-publish history.
+    ///
+    /// The WARN log is the surface that survives everything this contract is about: it needs no leader,
+    /// quorum, replica or network. `/api/events` read-back is NOT claimed here — that read prefers a
+    /// remote replica and can fail while the event sits in the local ring.
     @Contract
     public void onConfirmedDeparture(NodeId departed) {
-        emitAsLeader(new NodeFailed(hlcClock.now(),
-                                    Severity.CRITICAL,
-                                    "Node " + departed.id() + " failed (confirmed departure)",
-                                    Map.of("nodeId", departed.id())));
+        LOG.warn("Node {} failed (confirmed departure), observed by {} — cluster membership degraded",
+                 departed.id(),
+                 selfNode.id());
+
+        emitLocal(new NodeFailed(hlcClock.now(),
+                                 Severity.CRITICAL,
+                                 "Node " + departed.id() + " failed (confirmed departure)",
+                                 Map.of("nodeId",
+                                        departed.id(),
+                                        "observedBy",
+                                        selfNode.id())));
     }
 
     /// Departure-push overrun sink (issue #427, D4). The gracefully-departing node reports the chunks

--- a/aether/node/src/main/java/org/pragmatica/aether/api/NodeDepartureNotifier.java
+++ b/aether/node/src/main/java/org/pragmatica/aether/api/NodeDepartureNotifier.java
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2025 Pragmatica Labs - Sergiy Yevtushenko
+// Licensed under Business Source License 1.1. Change Date: 2030-01-01. Change License: Apache-2.0.
+// See LICENSE in the repository root for full terms.
+package org.pragmatica.aether.api;
+
+import org.pragmatica.consensus.NodeId;
+import org.pragmatica.lang.Contract;
+
+
+/// The two things a confirmed member death must reach, bound together so neither can be dropped
+/// silently (#926, round 2).
+///
+/// Both sit on the ungated `MembershipFsm` DEAD edge, and both were previously written as two separate
+/// statements inside an `AetherNode` boot lambda. An adversarial probe deleted the alert call from that
+/// lambda and **all 1217 tests still passed** — the `AlertManager` behaviour was pinned in isolation,
+/// but nothing pinned that the production call site actually reached it. A mutation that leaves every
+/// gate green is an unpinned behaviour, not an independent one.
+///
+/// Extracting the pair into one named unit makes the composition itself testable: a test can drive
+/// [`#onConfirmedDeparture`] against a real aggregator and a real alert manager and assert that BOTH
+/// surfaces respond, so deleting either call turns it red. That does not pin the FSM-to-lambda wire —
+/// only a booted node does that — but it removes the gap the probe found, which is that the two calls
+/// were individually deletable with no signal at all.
+public record NodeDepartureNotifier(ClusterEventAggregator aggregator, AlertManager alertManager, NodeId self) {
+    public static NodeDepartureNotifier nodeDepartureNotifier(ClusterEventAggregator aggregator,
+                                                              AlertManager alertManager,
+                                                              NodeId self) {
+        return new NodeDepartureNotifier(aggregator, alertManager, self);
+    }
+
+    /// Fan a confirmed departure out to both observability surfaces.
+    ///
+    /// The event goes to `CLUSTER_EVENTS` un-gated, so it survives a cluster with no leader. The alert
+    /// goes to this node's own `/api/alerts`, which needs no leader, quorum, replica or partition
+    /// ownership to be raised OR read back — unlike the events stream, whose read path prefers a
+    /// possibly-dead remote replica. The alert self-suppresses for an announced departure; the event
+    /// does not, because a graceful `NodeLeft` and this `NodeFailed` are both legitimate stream
+    /// history, while a CRITICAL alert on a routine rolling restart is only noise.
+    @Contract
+    public void onConfirmedDeparture(NodeId departed) {
+        aggregator.onConfirmedDeparture(departed);
+        alertManager.onNodeFailed(departed, self);
+    }
+}

--- a/aether/node/src/main/java/org/pragmatica/aether/node/AetherNode.java
+++ b/aether/node/src/main/java/org/pragmatica/aether/node/AetherNode.java
@@ -3353,9 +3353,19 @@ public interface AetherNode extends ManageableNode {
             // #210: emit the user-facing NODE_FAILED from this ungated DEAD edge — the SAME confirmed-
             // death signal that drives auto-heal above — instead of the quorum-gated
             // MembershipDecision.NodeRemoved, which the MembershipDeltaProjector drops during the
-            // post-kill re-election window so the event never reached /api/events on cloud. Leader-gated
-            // inside the aggregator (fires on every node's FSM; only the leader publishes).
+            // post-kill re-election window so the event never reached /api/events on cloud.
+            // #926: NO LONGER leader-gated inside the aggregator. It was, and a cluster that cannot
+            // elect a leader therefore could not emit the events saying it was broken — measured at
+            // 8 SWIM-confirmed deaths and 0 NodeFailed events over ten days. Now emitted on every
+            // node that confirms the death (see ClusterEventAggregator.onConfirmedDeparture for the
+            // at-least-once-per-observer contract and why a dedup token is the wrong fix).
             eventAggregator.onConfirmedDeparture(departed);
+            // #926 scope item 2: node health had NO alerting path at all. Raised here rather than
+            // inside the aggregator so it does not depend on the cluster-events stream being
+            // publishable OR readable — the alert is per-node local state on this node's /api/alerts,
+            // and this edge is ungated, so it needs no leader and no quorum. Cleared on rejoin at the
+            // PeerJoined route.
+            alertManager.onNodeFailed(departed, config.self());
         });
         // Join-grace leak fix: a CTM-provisioned replacement that boots but NEVER reaches
         // SWIM-healthy within the M10 join-grace window is reaped OBSERVED→DEAD by the FSM, but
@@ -5835,6 +5845,12 @@ public interface AetherNode extends ManageableNode {
         // fires for those, but the fresh QUIC handshake produces a TransportObservation.
         entries.add(MessageRouter.Entry.route(org.pragmatica.consensus.topology.TransportObservation.PeerJoined.class,
                                               eventAggregator::onPeerJoined));
+        // #926: resolve the node-health alert raised on the DEAD edge when the node comes back. Bound
+        // to the SAME ungated handshake that sources NODE_JOINED, so recovery is exactly as reachable
+        // as the failure it clears — a failure signal whose matching recovery signal is less reachable
+        // leaves a permanently red surface, which trains an operator to ignore it.
+        entries.add(MessageRouter.Entry.route(org.pragmatica.consensus.topology.TransportObservation.PeerJoined.class,
+                                              msg -> alertManager.clearNodeHealthAlert(msg.nodeId())));
         entries.add(MessageRouter.Entry.route(LeaderNotification.LeaderChange.class, eventAggregator::onLeaderChange));
         // NODE_LEFT (graceful departures) is sourced from MembershipDecision. NODE_FAILED is NO LONGER
         // sourced here (#210) — it now rides the ungated FSM DEAD edge (membershipFsm.onConfirmedDeparture

--- a/aether/node/src/main/java/org/pragmatica/aether/node/AetherNode.java
+++ b/aether/node/src/main/java/org/pragmatica/aether/node/AetherNode.java
@@ -35,6 +35,7 @@ import org.pragmatica.aether.api.AlertManager;
 import org.pragmatica.aether.artifact.Artifact;
 import org.pragmatica.aether.api.ClusterEvent;
 import org.pragmatica.aether.api.ClusterEventAggregator;
+import org.pragmatica.aether.api.NodeDepartureNotifier;
 import org.pragmatica.aether.api.LogLevelRegistry;
 import org.pragmatica.aether.api.ManagementServer;
 import org.pragmatica.aether.api.OperationalEvent;
@@ -3079,11 +3080,16 @@ public interface AetherNode extends ManageableNode {
         // is in scope.
         var transitionJournal = TransitionJournal.transitionJournal();
 
-        membershipFsm.onTransition(record -> onFsmTransition(transitionJournal,
-                                                             quorumLossDetectorRef,
-                                                             membershipFsm,
-                                                             record,
-                                                             config.self()));
+        membershipFsm.onTransition(record -> {
+            // #926 round 2: feed the alert manager the transition CAUSE so it can tell an announced
+            // departure (graceful shutdown — i.e. every rolling restart — or an operator drain) from a
+            // crash. The DEAD edge alone cannot: graceful and abrupt departures both arrive there
+            // through the same `Stopped` transition. Folded into the EXISTING listener because
+            // `onTransition` is a single-listener setter — registering a second one would silently
+            // replace the transition journal.
+            alertManager.noteMembershipTransition(record.nodeId(), record.cause());
+            onFsmTransition(transitionJournal, quorumLossDetectorRef, membershipFsm, record, config.self());
+        });
         // Wave-4 (cluster-topology-overhaul, #245): the MembershipDeltaProjector is the SOLE
         // emitter of MembershipDecision, fed by the FSM's own JOINED/REMOVED delta edge —
         // installed BEFORE the boot seed below so the seeded members' OBSERVED→MEMBER
@@ -3342,6 +3348,7 @@ public interface AetherNode extends ManageableNode {
         // this same death edge — behaviour parity, sampler out of the loop. Without it the nudge
         // would wait for the sampler's natural ~nttDepartureTimeout down-hysteresis crossing.
         Consumer<NodeId> dropDeadPeerLink = clusterNetworkRef::departurePermanent;
+        var departureNotifier = NodeDepartureNotifier.nodeDepartureNotifier(eventAggregator, alertManager, config.self());
 
         membershipFsm.onConfirmedDeparture(departed -> {
             onMembershipDeath(departed,
@@ -3359,13 +3366,10 @@ public interface AetherNode extends ManageableNode {
             // 8 SWIM-confirmed deaths and 0 NodeFailed events over ten days. Now emitted on every
             // node that confirms the death (see ClusterEventAggregator.onConfirmedDeparture for the
             // at-least-once-per-observer contract and why a dedup token is the wrong fix).
-            eventAggregator.onConfirmedDeparture(departed);
-            // #926 scope item 2: node health had NO alerting path at all. Raised here rather than
-            // inside the aggregator so it does not depend on the cluster-events stream being
-            // publishable OR readable — the alert is per-node local state on this node's /api/alerts,
-            // and this edge is ungated, so it needs no leader and no quorum. Cleared on rejoin at the
-            // PeerJoined route.
-            alertManager.onNodeFailed(departed, config.self());
+            // #926 round 2: both surfaces go through ONE named unit. Written as two statements here,
+            // a probe deleted the alert call and all 1217 tests stayed green — the call site was
+            // deletable with no signal. NodeDepartureNotifier makes the pair testable as a pair.
+            departureNotifier.onConfirmedDeparture(departed);
         });
         // Join-grace leak fix: a CTM-provisioned replacement that boots but NEVER reaches
         // SWIM-healthy within the M10 join-grace window is reaped OBSERVED→DEAD by the FSM, but

--- a/aether/node/src/test/java/org/pragmatica/aether/api/AlertManagerNodeHealthTest.java
+++ b/aether/node/src/test/java/org/pragmatica/aether/api/AlertManagerNodeHealthTest.java
@@ -121,4 +121,80 @@ class AlertManagerNodeHealthTest {
         var views = manager.activeAlertsAsList().await().unwrap();
         assertThat(views.stream().filter(view -> "node_health".equals(view.source())).toList()).isEmpty();
     }
+
+    /// A graceful departure — a normal shutdown, and therefore EVERY node of EVERY rolling restart —
+    /// must not raise a CRITICAL alert. The DEAD edge cannot tell the difference on its own: a
+    /// graceful `SwimDeparted` and a crash both reach DEAD through the same `Stopped` transition. An
+    /// alert surface that fires CRITICAL during routine planned operations gets muted, and a muted
+    /// alert is the same end state as the silence #926 exists to fix, reached from the other side.
+    @Test
+    void announcedDeparture_raisesNoAlert() {
+        var manager = newManager();
+        manager.noteMembershipTransition(FAILED, "SwimDeparted");
+        manager.onNodeFailed(FAILED, OBSERVER);
+
+        assertThat(manager.getActiveNodeHealthAlerts()).isEmpty();
+    }
+
+    @Test
+    void operatorDrain_raisesNoAlert() {
+        var manager = newManager();
+        manager.noteMembershipTransition(FAILED, "DrainRequested");
+        manager.onNodeFailed(FAILED, OBSERVER);
+
+        assertThat(manager.getActiveNodeHealthAlerts()).isEmpty();
+    }
+
+    /// The discriminating half. A cause that is NOT an announced departure must still alert — otherwise
+    /// the graceful path would have been bought by suppressing real failures, which is the defect this
+    /// ticket exists to remove. `DownHysteresisMet` is the failure-detection route into DEPARTING.
+    @Test
+    void abruptDeparture_stillRaisesCriticalAlert() {
+        var manager = newManager();
+        manager.noteMembershipTransition(FAILED, "DownHysteresisMet");
+        manager.onNodeFailed(FAILED, OBSERVER);
+
+        var active = manager.getActiveNodeHealthAlerts();
+        assertThat(active).hasSize(1);
+        assertThat(active.getFirst().severity()).isEqualTo(AlertEvent.Severity.CRITICAL);
+    }
+
+    /// The bias is one-directional by design: an UNMARKED departure alerts. A mark that is missed,
+    /// dropped, or never delivered therefore costs a spurious CRITICAL and never a silent one.
+    @Test
+    void unmarkedDeparture_alerts_soAMissedMarkIsNeverSilent() {
+        var manager = newManager();
+        manager.onNodeFailed(FAILED, OBSERVER);
+
+        assertThat(manager.getActiveNodeHealthAlerts()).hasSize(1);
+    }
+
+    /// The mark is CONSUMED on read, so a node that departs gracefully, rejoins, and later crashes
+    /// still alerts on the crash. Without consumption a single graceful departure would silence that
+    /// node's failures for the lifetime of the process.
+    @Test
+    void gracefulMarkIsConsumed_soALaterCrashStillAlerts() {
+        var manager = newManager();
+        manager.noteMembershipTransition(FAILED, "SwimDeparted");
+        manager.onNodeFailed(FAILED, OBSERVER);
+        assertThat(manager.getActiveNodeHealthAlerts()).isEmpty();
+
+        manager.onNodeFailed(FAILED, OBSERVER);
+        assertThat(manager.getActiveNodeHealthAlerts()).hasSize(1);
+    }
+
+    /// CTM auto-heal mints a FRESH random id for a replacement rather than reusing the departed one, so
+    /// the id-exact clear can never match a replaced node. Without a bound every replacement under
+    /// churn would add a permanent entry, growing heap and the `/api/alerts` payload without limit.
+    @Test
+    void alertMapIsBounded_underReplacementChurn() {
+        var manager = newManager();
+
+        for (int i = 0; i < 500; i++) {
+            manager.onNodeFailed(new NodeId("replaced-" + i), OBSERVER);
+        }
+
+        assertThat(manager.getActiveNodeHealthAlerts()).hasSizeLessThanOrEqualTo(64);
+        assertThat(manager.activeAlertsAsList().await().unwrap()).hasSizeLessThanOrEqualTo(64);
+    }
 }

--- a/aether/node/src/test/java/org/pragmatica/aether/api/AlertManagerNodeHealthTest.java
+++ b/aether/node/src/test/java/org/pragmatica/aether/api/AlertManagerNodeHealthTest.java
@@ -122,20 +122,30 @@ class AlertManagerNodeHealthTest {
         assertThat(views.stream().filter(view -> "node_health".equals(view.source())).toList()).isEmpty();
     }
 
-    /// A graceful departure — a normal shutdown, and therefore EVERY node of EVERY rolling restart —
-    /// must not raise a CRITICAL alert. The DEAD edge cannot tell the difference on its own: a
-    /// graceful `SwimDeparted` and a crash both reach DEAD through the same `Stopped` transition. An
-    /// alert surface that fires CRITICAL during routine planned operations gets muted, and a muted
-    /// alert is the same end state as the silence #926 exists to fix, reached from the other side.
+    /// **Regression pin for the round-2 blocking defect.** `SwimDeparted` was briefly treated as a
+    /// graceful goodbye, on the strength of `MembershipFsm.onSwimDeparted`'s docstring. It is not: it is
+    /// SWIM's DEATH BROADCAST. `SwimProtocol.emitFaultyEdgePair` delivers `FaultyObserved` and
+    /// `DepartedObserved` as a pair at the FAULTY edge ("FAULTY IS confirmed death (canonical SWIM)"),
+    /// `DepartedObserved` routes to `onSwimDeparted` (`AetherNode:4968`), and that dispatches
+    /// `SwimDeparted`. It is the PRIMARY crash path — with it suppressed, `kill -9` raised no CRITICAL
+    /// alert at all.
+    ///
+    /// The test it replaced fed the literal `"SwimDeparted"` and asserted NO alert, so it did not merely
+    /// miss the defect — **it encoded the defect as the specification.** Any future change that puts
+    /// `SwimDeparted` back into the graceful set turns this red.
     @Test
-    void announcedDeparture_raisesNoAlert() {
+    void swimDeparted_stillAlerts_becauseItIsSwimsDeathBroadcast() {
         var manager = newManager();
         manager.noteMembershipTransition(FAILED, "SwimDeparted");
         manager.onNodeFailed(FAILED, OBSERVER);
 
-        assertThat(manager.getActiveNodeHealthAlerts()).isEmpty();
+        var active = manager.getActiveNodeHealthAlerts();
+        assertThat(active).hasSize(1);
+        assertThat(active.getFirst().severity()).isEqualTo(AlertEvent.Severity.CRITICAL);
     }
 
+    /// The only cause that is genuinely an announced departure: the operator/controller drain command.
+    /// Nothing in SWIM's failure detection raises it.
     @Test
     void operatorDrain_raisesNoAlert() {
         var manager = newManager();
@@ -175,7 +185,7 @@ class AlertManagerNodeHealthTest {
     @Test
     void gracefulMarkIsConsumed_soALaterCrashStillAlerts() {
         var manager = newManager();
-        manager.noteMembershipTransition(FAILED, "SwimDeparted");
+        manager.noteMembershipTransition(FAILED, "DrainRequested");
         manager.onNodeFailed(FAILED, OBSERVER);
         assertThat(manager.getActiveNodeHealthAlerts()).isEmpty();
 
@@ -196,5 +206,29 @@ class AlertManagerNodeHealthTest {
 
         assertThat(manager.getActiveNodeHealthAlerts()).hasSizeLessThanOrEqualTo(64);
         assertThat(manager.activeAlertsAsList().await().unwrap()).hasSizeLessThanOrEqualTo(64);
+    }
+
+    /// Size alone does not pin eviction: flipping oldest-first to newest-first left the suite green,
+    /// because the bound test above asserts only how many survive and never WHICH. Newest-first would
+    /// discard exactly the failures an operator is still acting on while retaining ancient ones, so the
+    /// direction is the part that matters. Insertion order — not `System.currentTimeMillis()` — is what
+    /// makes this assertable at all: alerts raised in a tight loop share a millisecond, so a
+    /// timestamp-ordered eviction has no well-defined "oldest" to test.
+    @Test
+    void evictionDropsOldestFirst_keepingTheMostRecentFailures() {
+        var manager = newManager();
+
+        for (int i = 0; i < 100; i++) {
+            manager.onNodeFailed(new NodeId("node-" + i), OBSERVER);
+        }
+
+        var surviving = manager.getActiveNodeHealthAlerts()
+                               .stream()
+                               .map(alert -> alert.nodeId().id())
+                               .toList();
+
+        assertThat(surviving).hasSize(64);
+        // The 36 oldest are gone; the 64 most recent remain.
+        assertThat(surviving).contains("node-99", "node-36").doesNotContain("node-0", "node-35");
     }
 }

--- a/aether/node/src/test/java/org/pragmatica/aether/api/AlertManagerNodeHealthTest.java
+++ b/aether/node/src/test/java/org/pragmatica/aether/api/AlertManagerNodeHealthTest.java
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2025 Pragmatica Labs - Sergiy Yevtushenko
+// Licensed under Business Source License 1.1. Change Date: 2030-01-01. Change License: Apache-2.0.
+// See LICENSE in the repository root for full terms.
+package org.pragmatica.aether.api;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.pragmatica.aether.slice.kvstore.AetherKey;
+import org.pragmatica.aether.slice.kvstore.AetherValue;
+import org.pragmatica.cluster.state.kvstore.KVStore;
+import org.pragmatica.consensus.NodeId;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+/// #926 scope item 2 — the node-health alerting path, which did not exist.
+///
+/// Before this, `AlertEvent` carried only `ThresholdAlert`, `SliceFailureAlert` and `AlertResolved`,
+/// produced solely by `AlertManager.onAllInstancesFailed` and `checkThreshold`. Repo-wide, "unhealthy"
+/// in `aether/node/src/main` appeared exactly twice, both rendering a status string into an HTTP
+/// response. A cluster member could therefore be confirmed dead with no alert raised anywhere —
+/// measured as three nodes sitting unhealthy for nine days with nothing to notice.
+///
+/// The alert is deliberately per-node LOCAL state. That is what makes it safe from the gating this
+/// ticket is about: raising and reading it need no leader, no quorum, no replica and no partition
+/// ownership, unlike the cluster-events stream, whose read path prefers a possibly-dead remote replica.
+class AlertManagerNodeHealthTest {
+
+    private static final NodeId FAILED = new NodeId("failed-node");
+    private static final NodeId OBSERVER = new NodeId("observer-node");
+
+    @SuppressWarnings("unchecked")
+    private static AlertManager newManager() {
+        return AlertManager.readOnly((KVStore<AetherKey, AetherValue>) Mockito.mock(KVStore.class));
+    }
+
+    @Test
+    void nodeFailure_raisesCriticalAlert() {
+        var manager = newManager();
+        manager.onNodeFailed(FAILED, OBSERVER);
+
+        var active = manager.getActiveNodeHealthAlerts();
+        assertThat(active).hasSize(1);
+        assertThat(active.getFirst().nodeId()).isEqualTo(FAILED);
+        assertThat(active.getFirst().observedBy()).isEqualTo(OBSERVER);
+        assertThat(active.getFirst().severity()).isEqualTo(AlertEvent.Severity.CRITICAL);
+    }
+
+    /// The alert key is derived from the FAILED node alone, so re-observing the same death replaces
+    /// rather than accumulates. This is what lets the raise sit on an ungated edge that fires on every
+    /// node's FSM without needing a dedup token — and a token is exactly the wrong fix here, since any
+    /// token whose scope matches the counted unit costs at least quorum, and the measured incident ran
+    /// below quorum.
+    @Test
+    void repeatedObservationOfSameDeath_isIdempotent() {
+        var manager = newManager();
+        manager.onNodeFailed(FAILED, OBSERVER);
+        manager.onNodeFailed(FAILED, OBSERVER);
+        manager.onNodeFailed(FAILED, OBSERVER);
+
+        assertThat(manager.getActiveNodeHealthAlerts()).hasSize(1);
+    }
+
+    @Test
+    void distinctFailures_raiseDistinctAlerts() {
+        var manager = newManager();
+        manager.onNodeFailed(FAILED, OBSERVER);
+        manager.onNodeFailed(new NodeId("other-failed"), OBSERVER);
+
+        assertThat(manager.getActiveNodeHealthAlerts()).hasSize(2);
+    }
+
+    /// Recovery must be exactly as reachable as the failure it clears. A raise with no matching clear
+    /// leaves a permanently red surface, which trains an operator to ignore it — the same end state as
+    /// the silence this ticket is about, reached from the opposite direction.
+    @Test
+    void rejoin_resolvesTheAlert() {
+        var manager = newManager();
+        manager.onNodeFailed(FAILED, OBSERVER);
+        assertThat(manager.getActiveNodeHealthAlerts()).hasSize(1);
+
+        manager.clearNodeHealthAlert(FAILED);
+        assertThat(manager.getActiveNodeHealthAlerts()).isEmpty();
+    }
+
+    @Test
+    void clearingUnknownNode_isNoOp() {
+        var manager = newManager();
+        manager.onNodeFailed(FAILED, OBSERVER);
+
+        manager.clearNodeHealthAlert(new NodeId("never-failed"));
+        assertThat(manager.getActiveNodeHealthAlerts()).hasSize(1);
+    }
+
+    /// An alert that is raised but never rendered is not operator-visible, which would reproduce this
+    /// ticket's defect one layer up. Pins that node-health alerts reach the SAME `/api/alerts` view as
+    /// every other alert kind, discriminated by `source`.
+    @Test
+    void alertReachesTheOperatorFacingAlertsView() {
+        var manager = newManager();
+        manager.onNodeFailed(FAILED, OBSERVER);
+
+        var views = manager.activeAlertsAsList().await().unwrap();
+        var nodeHealth = views.stream()
+                              .filter(view -> "node_health".equals(view.source()))
+                              .toList();
+
+        assertThat(nodeHealth).hasSize(1);
+        assertThat(nodeHealth.getFirst().nodeId()).isEqualTo(FAILED.id());
+        assertThat(nodeHealth.getFirst().severity()).isEqualTo("CRITICAL");
+        assertThat(nodeHealth.getFirst().alertId()).isEqualTo("node.failed:" + FAILED.id());
+    }
+
+    @Test
+    void resolvedAlert_leavesTheOperatorFacingView() {
+        var manager = newManager();
+        manager.onNodeFailed(FAILED, OBSERVER);
+        manager.clearNodeHealthAlert(FAILED);
+
+        var views = manager.activeAlertsAsList().await().unwrap();
+        assertThat(views.stream().filter(view -> "node_health".equals(view.source())).toList()).isEmpty();
+    }
+}

--- a/aether/node/src/test/java/org/pragmatica/aether/api/ClusterEventAggregatorTest.java
+++ b/aether/node/src/test/java/org/pragmatica/aether/api/ClusterEventAggregatorTest.java
@@ -17,10 +17,13 @@ import org.pragmatica.aether.stream.StreamPartitionManager;
 import org.pragmatica.aether.stream.StreamPartitionManager.Exhaustion;
 import org.pragmatica.aether.stream.SystemStreamFactories;
 import org.pragmatica.consensus.NodeId;
+import org.pragmatica.consensus.leader.LeaderNotification;
+import org.pragmatica.consensus.topology.ClusterStateNotification;
 import org.pragmatica.consensus.topology.MembershipDecision;
 import org.pragmatica.consensus.topology.TransportObservation;
 import org.pragmatica.consensus.topology.TransportObservation.ObservationSource;
 import org.pragmatica.hlc.HlcClock;
+import org.pragmatica.lang.Option;
 import org.pragmatica.serialization.FrameworkCodecs;
 import org.pragmatica.serialization.SliceCodec;
 
@@ -225,11 +228,10 @@ class ClusterEventAggregatorTest {
 
     // --- leader-gated departure emit (#94: NODE_FAILED delivery for replacement deaths) ----------
 
-    /// Membership FAILURES route through {@link ClusterEventAggregator#onConfirmedDeparture} →
-    /// {@link ClusterEventAggregator#emitAsLeader}, gated on `leaderCheck` rather than `ownerCheck`. The
-    /// just-failed node is frequently the cluster-events partition owner, so owner-gating would suppress
-    /// its own `NODE_FAILED`. The leader — never the failed node for its own committed view — MUST emit
-    /// even when it is NOT the partition owner.
+    /// Membership FAILURES route through {@link ClusterEventAggregator#onConfirmedDeparture}. Since
+    /// #926 that path is UN-gated ({@code emitLocal}); this test additionally pins that the OWNER gate
+    /// does not suppress it either. The just-failed node is frequently the cluster-events partition
+    /// owner, so owner-gating would suppress its own `NODE_FAILED`.
     @Test
     void leader_emitsDeparture_evenWhenNotOwner() {
         var h = Harness.create(Harness.defaultRetention(), NOT_OWNER, () -> false, LEADER);
@@ -240,14 +242,97 @@ class ClusterEventAggregatorTest {
         assertThat(events.getFirst().details()).containsEntry("nodeId", "dead");
     }
 
-    /// The leader-gate is a real gate: a non-leader observer must NOT advertise a membership failure
-    /// (the leader owns that cluster-canonical statement), even when it IS the partition owner. The FSM
-    /// DEAD edge fires on EVERY node's FSM, so this gate is what collapses the fan-out to a single emit.
+    /// #926 — THE ticket, and the direct reversal of the contract this test file previously pinned.
+    ///
+    /// The replaced test (`nonLeader_suppressesDepartureEmit`) asserted that a non-leader observer must
+    /// NOT emit `NODE_FAILED`, on the reasoning that the leader gate "is what collapses the fan-out to a
+    /// single emit". That reasoning was correct about the fan-out and wrong about the cost: the FSM DEAD
+    /// edge fires on EVERY node, so when NO node is leader the gate holds everywhere at once and the
+    /// event is emitted NOWHERE. Measured on a five-node cluster over ten days: SWIM confirmed 8 faulty
+    /// members, 1,297,717 leader-election lines were logged, and `NodeFailed` appeared 0 times.
+    ///
+    /// This test models the failing condition honestly. Every observer's `leaderCheck` is the CONSTANT
+    /// `NOT_LEADER`, so "the cluster has no leader" is not merely true at the instant of one assertion —
+    /// it holds by construction for every call in the window under test, and no election can complete
+    /// behind the test's back. Owner-checks are deliberately mixed so that neither gate can be the one
+    /// letting the event through.
     @Test
-    void nonLeader_suppressesDepartureEmit() {
-        var h = Harness.create(Harness.defaultRetention(), OWNER, () -> false, NOT_LEADER);
+    void noLeaderAnywhere_stillEmitsNodeFailed_onEveryObserver() {
+        var observers = List.of(Harness.create(Harness.defaultRetention(), OWNER, () -> false, NOT_LEADER),
+                                Harness.create(Harness.defaultRetention(), NOT_OWNER, () -> false, NOT_LEADER),
+                                Harness.create(Harness.defaultRetention(), NOT_OWNER, () -> false, NOT_LEADER));
+
+        observers.forEach(h -> h.aggregator().onConfirmedDeparture(new NodeId("dead")));
+
+        for (var h : observers) {
+            var events = h.events();
+            assertThat(events).hasSize(1);
+            assertThat(events.getFirst()).isInstanceOf(ClusterEvent.NodeFailed.class);
+            assertThat(events.getFirst().details()).containsEntry("nodeId", "dead");
+            // `observedBy` is what makes the bounded duplication collapsible by a consumer.
+            assertThat(events.getFirst().details()).containsEntry("observedBy", SELF.id());
+        }
+    }
+
+    /// #926 — the replay gate is the ONE suppression that must survive un-gating. Without this, moving
+    /// `NODE_FAILED` to `emitLocal` would re-publish historical departures on every snapshot/resync.
+    /// `emitLocal` keeps `replayingCheck`; this pins that it still does, with no leader involved.
+    @Test
+    void noLeader_stillSuppressesDepartureDuringReplay() {
+        var h = Harness.create(Harness.defaultRetention(), OWNER, () -> true, NOT_LEADER);
         h.aggregator().onConfirmedDeparture(new NodeId("dead"));
         assertThat(h.events()).isEmpty();
+    }
+
+    /// #926 — `LEADER_LOST` was unreachable by construction. It is emitted from the branch where
+    /// `leaderId()` is EMPTY, and it went through `emitAsLeader`, so the event announcing "there is no
+    /// leader" required the emitter to BE the leader. No node could ever satisfy both at once.
+    @Test
+    void noLeader_stillEmitsLeaderLost() {
+        var h = Harness.create(Harness.defaultRetention(), NOT_OWNER, () -> false, NOT_LEADER);
+        h.aggregator().onLeaderChange(LeaderNotification.leaderChange(Option.none(), false));
+
+        var events = h.events();
+        assertThat(events).hasSize(1);
+        assertThat(events.getFirst()).isInstanceOf(ClusterEvent.LeaderLost.class);
+        assertThat(events.getFirst().details()).containsEntry("observedBy", SELF.id());
+    }
+
+    /// `LEADER_ELECTED` stays leader-gated — the new leader is the authoritative emitter of its own
+    /// election and the gate holds for it. Pinned so the #926 change is not read as "un-gate everything".
+    @Test
+    void nonLeader_stillSuppressesLeaderElected() {
+        var h = Harness.create(Harness.defaultRetention(), OWNER, () -> false, NOT_LEADER);
+        h.aggregator().onLeaderChange(LeaderNotification.leaderChange(Option.some(new NodeId("other")), false));
+        assertThat(h.events()).isEmpty();
+    }
+
+    /// #926 — `QUORUM_LOST` is the most severe event this class emits and was the least emittable: a
+    /// cluster that has gone PASSIVE cannot commit through consensus and so cannot sustain a leader
+    /// lease, meaning `leaderCheck` is false on every node exactly when quorum is lost.
+    @Test
+    void noLeader_stillEmitsQuorumLost() {
+        var h = Harness.create(Harness.defaultRetention(), NOT_OWNER, () -> false, NOT_LEADER);
+        h.aggregator().onQuorumStateChange(ClusterStateNotification.passive());
+
+        var events = h.events();
+        assertThat(events).hasSize(1);
+        assertThat(events.getFirst()).isInstanceOf(ClusterEvent.QuorumLost.class);
+        assertThat(events.getFirst().severity()).isEqualTo(ClusterEvent.Severity.CRITICAL);
+    }
+
+    /// #926 — the recovery half. Quorum forms BEFORE a leader is elected, so the old gate dropped this
+    /// notice at the one moment it was guaranteed false. Un-gating the loss while leaving the recovery
+    /// gated would be worse than fixing neither: an operator would watch the cluster enter "quorum lost"
+    /// and never see it leave. A failure signal is only usable if its recovery signal is as reachable.
+    @Test
+    void noLeader_stillEmitsQuorumEstablished() {
+        var h = Harness.create(Harness.defaultRetention(), NOT_OWNER, () -> false, NOT_LEADER);
+        h.aggregator().onQuorumStateChange(ClusterStateNotification.active());
+
+        var events = h.events();
+        assertThat(events).hasSize(1);
+        assertThat(events.getFirst()).isInstanceOf(ClusterEvent.QuorumEstablished.class);
     }
 
     /// NODE_JOINED is now LEADER-gated too (the join analog of the departure fix). The transport

--- a/aether/node/src/test/java/org/pragmatica/aether/api/NodeDepartureNotifierTest.java
+++ b/aether/node/src/test/java/org/pragmatica/aether/api/NodeDepartureNotifierTest.java
@@ -128,18 +128,36 @@ class NodeDepartureNotifierTest {
         assertThat(f.alerts().getActiveNodeHealthAlerts()).hasSize(1);
     }
 
-    /// A graceful departure still belongs in the stream — a `NodeFailed` record of an announced
-    /// departure is legitimate history — but must NOT raise a CRITICAL alert. This pins that the two
-    /// surfaces diverge exactly where they should, so the rolling-restart fix cannot be mistaken for
-    /// suppressing the event as well.
+    /// An operator drain still belongs in the stream — a `NodeFailed` record of a drained departure is
+    /// legitimate history — but must NOT raise a CRITICAL alert. This pins that the two surfaces diverge
+    /// exactly where they should, so the drain-quieting fix cannot be mistaken for suppressing the event
+    /// as well.
+    ///
+    /// **This test previously fed `"SwimDeparted"`** and asserted no alert — encoding the round-2
+    /// blocking defect as the specification. `SwimDeparted` is SWIM's death broadcast, not a graceful
+    /// goodbye; `DrainRequested` is the only cause that genuinely means "announced".
     @Test
-    void announcedDeparture_reachesTheStreamButRaisesNoAlert() {
+    void drainedDeparture_reachesTheStreamButRaisesNoAlert() {
         var f = Fixture.create();
-        f.alerts().noteMembershipTransition(DEAD, "SwimDeparted");
+        f.alerts().noteMembershipTransition(DEAD, "DrainRequested");
         f.notifier().onConfirmedDeparture(DEAD);
 
         assertThat(f.events()).hasSize(1);
         assertThat(f.events().getFirst()).isInstanceOf(ClusterEvent.NodeFailed.class);
         assertThat(f.alerts().getActiveNodeHealthAlerts()).isEmpty();
+    }
+
+    /// Regression pin at the composition level: a SWIM-confirmed death must reach BOTH surfaces. While
+    /// `SwimDeparted` sat in the graceful set, this path produced an event and no alert — `kill -9` was
+    /// silent on the alert surface.
+    @Test
+    void swimDeath_reachesBothSurfaces_notJustTheStream() {
+        var f = Fixture.create();
+        f.alerts().noteMembershipTransition(DEAD, "SwimDeparted");
+        f.notifier().onConfirmedDeparture(DEAD);
+
+        assertThat(f.events()).hasSize(1);
+        assertThat(f.alerts().getActiveNodeHealthAlerts()).hasSize(1);
+        assertThat(f.alerts().getActiveNodeHealthAlerts().getFirst().severity()).isEqualTo(AlertEvent.Severity.CRITICAL);
     }
 }

--- a/aether/node/src/test/java/org/pragmatica/aether/api/NodeDepartureNotifierTest.java
+++ b/aether/node/src/test/java/org/pragmatica/aether/api/NodeDepartureNotifierTest.java
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2025 Pragmatica Labs - Sergiy Yevtushenko
+// Licensed under Business Source License 1.1. Change Date: 2030-01-01. Change License: Apache-2.0.
+// See LICENSE in the repository root for full terms.
+package org.pragmatica.aether.api;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.pragmatica.aether.node.NodeCodecs;
+import org.pragmatica.aether.slice.ConsistencyMode;
+import org.pragmatica.aether.slice.RetentionMode;
+import org.pragmatica.aether.slice.RetentionPolicy;
+import org.pragmatica.aether.slice.StreamConfig;
+import org.pragmatica.aether.slice.kvstore.AetherKey;
+import org.pragmatica.aether.slice.kvstore.AetherValue;
+import org.pragmatica.aether.slice.stream.FrameworkStreamConsumer;
+import org.pragmatica.aether.slice.stream.FrameworkStreamPublisher;
+import org.pragmatica.aether.slice.stream.SystemStreams;
+import org.pragmatica.aether.stream.StreamPartitionManager;
+import org.pragmatica.aether.stream.SystemStreamFactories;
+import org.pragmatica.cluster.state.kvstore.KVStore;
+import org.pragmatica.consensus.NodeId;
+import org.pragmatica.hlc.HlcClock;
+import org.pragmatica.serialization.FrameworkCodecs;
+import org.pragmatica.serialization.SliceCodec;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+/// #926 round 2 — pins the COMPOSITION on the confirmed-departure edge.
+///
+/// An adversarial probe deleted `alertManager.onNodeFailed(...)` from the `AetherNode` boot lambda and
+/// **all 1217 tests still passed**. `AlertManager`'s behaviour was pinned in isolation and the
+/// aggregator's was too, but nothing pinned that one confirmed departure reaches BOTH. A mutation that
+/// leaves every gate green is an unpinned behaviour, not an independent one.
+///
+/// These tests drive the real production factory, a real `StreamPartitionManager`, the real node codec
+/// and a real `AlertManager` — no stubs on the path under test — so deleting either call inside
+/// [`NodeDepartureNotifier#onConfirmedDeparture`] turns them red.
+class NodeDepartureNotifierTest {
+
+    private static final NodeId SELF = new NodeId("observer-node");
+    private static final NodeId DEAD = new NodeId("dead-node");
+    private static final SliceCodec CODEC = NodeCodecs.nodeCodecs(FrameworkCodecs.frameworkCodecs());
+
+    private record Fixture(NodeDepartureNotifier notifier, ClusterEventAggregator aggregator, AlertManager alerts) {
+        @SuppressWarnings("unchecked")
+        static Fixture create() {
+            var manager = StreamPartitionManager.streamPartitionManager(Long.MAX_VALUE);
+            var retention = RetentionPolicy.retentionPolicy(10_000, 64L * 1024 * 1024, Long.MAX_VALUE, RetentionMode.ANY);
+            var config = StreamConfig.streamConfig(SystemStreams.CLUSTER_EVENTS.asString(),
+                                                   1,
+                                                   retention,
+                                                   "earliest",
+                                                   64L * 1024,
+                                                   ConsistencyMode.EVENTUAL,
+                                                   1);
+            var publisher = SystemStreamFactories.<ClusterEvent> systemStreamPublisher(SystemStreams.CLUSTER_EVENTS,
+                                                                                       manager,
+                                                                                       CODEC,
+                                                                                       config)
+                                                 .unwrap();
+            var consumer = SystemStreamFactories.<ClusterEvent> systemStreamConsumer(SystemStreams.CLUSTER_EVENTS,
+                                                                                     manager,
+                                                                                     CODEC,
+                                                                                     CODEC,
+                                                                                     config)
+                                                .unwrap();
+            var pubRef = new AtomicReference<FrameworkStreamPublisher<ClusterEvent>>(publisher);
+            var conRef = new AtomicReference<FrameworkStreamConsumer<ClusterEvent>>(consumer);
+            // Never leader, never owner — the #926 condition. Both surfaces must respond anyway.
+            var aggregator = ClusterEventAggregator.clusterEventAggregator(pubRef::get,
+                                                                           conRef::get,
+                                                                           () -> false,
+                                                                           SELF,
+                                                                           HlcClock.hlcClock(SELF),
+                                                                           () -> 1,
+                                                                           () -> false,
+                                                                           () -> false);
+            var alerts = AlertManager.readOnly((KVStore<AetherKey, AetherValue>) Mockito.mock(KVStore.class));
+
+            return new Fixture(NodeDepartureNotifier.nodeDepartureNotifier(aggregator, alerts, SELF), aggregator, alerts);
+        }
+
+        List<ClusterEvent> events() {
+            return aggregator.events().await().or(List.of());
+        }
+    }
+
+    /// Deleting the aggregator call from the notifier turns this red.
+    @Test
+    void confirmedDeparture_reachesTheEventStream() {
+        var f = Fixture.create();
+        f.notifier().onConfirmedDeparture(DEAD);
+
+        var events = f.events();
+        assertThat(events).hasSize(1);
+        assertThat(events.getFirst()).isInstanceOf(ClusterEvent.NodeFailed.class);
+        assertThat(events.getFirst().details()).containsEntry("nodeId", DEAD.id());
+        assertThat(events.getFirst().details()).containsEntry("observedBy", SELF.id());
+    }
+
+    /// Deleting the alert call from the notifier turns this red — this is the exact mutation that
+    /// previously left all 1217 tests green.
+    @Test
+    void confirmedDeparture_reachesTheAlertSurface() {
+        var f = Fixture.create();
+        f.notifier().onConfirmedDeparture(DEAD);
+
+        var active = f.alerts().getActiveNodeHealthAlerts();
+        assertThat(active).hasSize(1);
+        assertThat(active.getFirst().nodeId()).isEqualTo(DEAD);
+        assertThat(active.getFirst().observedBy()).isEqualTo(SELF);
+        assertThat(active.getFirst().severity()).isEqualTo(AlertEvent.Severity.CRITICAL);
+    }
+
+    /// Both, from ONE departure, with no leader and no ownership. Deleting EITHER call turns this red,
+    /// which is the property the two tests above cannot express individually.
+    @Test
+    void oneDeparture_reachesBothSurfaces_withNoLeaderAndNoOwnership() {
+        var f = Fixture.create();
+        f.notifier().onConfirmedDeparture(DEAD);
+
+        assertThat(f.events()).hasSize(1);
+        assertThat(f.alerts().getActiveNodeHealthAlerts()).hasSize(1);
+    }
+
+    /// A graceful departure still belongs in the stream — a `NodeFailed` record of an announced
+    /// departure is legitimate history — but must NOT raise a CRITICAL alert. This pins that the two
+    /// surfaces diverge exactly where they should, so the rolling-restart fix cannot be mistaken for
+    /// suppressing the event as well.
+    @Test
+    void announcedDeparture_reachesTheStreamButRaisesNoAlert() {
+        var f = Fixture.create();
+        f.alerts().noteMembershipTransition(DEAD, "SwimDeparted");
+        f.notifier().onConfirmedDeparture(DEAD);
+
+        assertThat(f.events()).hasSize(1);
+        assertThat(f.events().getFirst()).isInstanceOf(ClusterEvent.NodeFailed.class);
+        assertThat(f.alerts().getActiveNodeHealthAlerts()).isEmpty();
+    }
+}

--- a/changelog.d/926-node-health-alerting.md
+++ b/changelog.d/926-node-health-alerting.md
@@ -65,6 +65,12 @@
   `MAX_ALERT_HISTORY` bound on `alertHistory`. **Stated plainly rather than dressed up: a replaced
   node's alert ages out under churn; it is not resolved.**
   [verified: `AlertManagerNodeHealthTest#alertMapIsBounded_underReplacementChurn`]
+  [unverified: a CTM-replaced node's alert is never RESOLVED — only bounded. Properly resolving it
+  needs an identity linking a replacement to the node it replaced, which does not exist today. The
+  bound is tested; the resolution is absent by design and stated, not fixed]
+  [unverified: nothing forwards any node-health alert off the node — `AlertForwarder` is never
+  constructed in production (`alertForwarder(` = 1 hit repo-wide, its own factory; control
+  `alertManager(` = 3). The renderer handles the variant; nothing sends it]
 - **One departure reaches both surfaces, and that is now pinned as a pair.** An adversarial probe
   deleted the alert call from the `AetherNode` boot lambda and all 1217 tests stayed green — each side
   was pinned in isolation, nothing pinned the composition. The pair now lives in

--- a/changelog.d/926-node-health-alerting.md
+++ b/changelog.d/926-node-health-alerting.md
@@ -42,21 +42,39 @@
   [mechanism: `AlertForwarder.appendNodeHealthFields` renders `"type":"NODE_FAILED"` with `nodeId`,
   `observedBy` and `reason` **if and when** a forwarder is ever constructed — not a claim that anything
   is delivered today]
-- **A graceful departure raises no alert — so a rolling restart stays quiet.** The DEAD edge cannot
-  tell an announced departure from a crash: a graceful `SwimDeparted` (normal shutdown, i.e. every node
-  of every rolling restart) and an operator drain both reach DEAD through the same `Stopped` transition
-  a failure does. `AlertManager.noteMembershipTransition` is fed the FSM transition *cause* and marks
-  announced departures, which `onNodeFailed` then consumes. Without it this new surface would fire
-  CRITICAL on routine planned operations, and an alert operators mute is the same end state as the
-  silence #926 exists to fix, reached from the other side.
+- **An operator drain raises no alert; everything else still does.** `AlertManager.noteMembershipTransition`
+  is fed the FSM transition *cause* and marks `DrainRequested` — the operator/controller drain command,
+  the one cause nothing in SWIM's failure detection raises. `onNodeFailed` consumes the mark.
+  **`SwimDeparted` is deliberately NOT treated as graceful, and briefly was — a blocking regression
+  caught in review.** `MembershipFsm.onSwimDeparted`'s docstring calls it a graceful departure, but its
+  producer contradicts that: `SwimProtocol.emitFaultyEdgePair` delivers `FaultyObserved` and
+  `DepartedObserved` **as a pair at the FAULTY edge**, because "FAULTY IS confirmed death (canonical
+  SWIM) … The death broadcast therefore fires AT the FAULTY edge" — deliberately, to cut `NODE_FAILED`
+  latency inside the 60s SLO. `DepartedObserved` routes to `onSwimDeparted` (`AetherNode:4968`), which
+  dispatches `SwimDeparted`. **It is SWIM's death broadcast and the primary crash path**: while it was
+  in the graceful set, `kill -9` raised no CRITICAL alert at all. A comment was trusted over the code
+  that raises the event.
+  **Consequence, stated rather than smoothed over:** a non-operator-driven graceful shutdown is
+  indistinguishable from a crash at this layer, so a rolling restart still raises CRITICAL per surviving
+  observer. **That noise is the accepted trade — noisy beats silent on a failure-detection surface**,
+  which is the same one-directional bias below. Quieting it needs a signal SWIM does not carry (a drain
+  registry or an explicit shutdown announcement) and is deferred, not solved.
   **The bias is one-directional and deliberate: an UNMARKED departure always alerts**, so a mark that
   is missed or dropped costs a spurious CRITICAL and never a silent one — suppressing a real failure
-  would re-create the defect this ticket removes. The mark is consumed on read, so a node that departs
-  gracefully, rejoins and later crashes still alerts on the crash.
-  [verified: `AlertManagerNodeHealthTest#announcedDeparture_raisesNoAlert`, `#operatorDrain_raisesNoAlert`,
-  `#abruptDeparture_stillRaisesCriticalAlert`, `#unmarkedDeparture_alerts_soAMissedMarkIsNeverSilent`,
-  `#gracefulMarkIsConsumed_soALaterCrashStillAlerts`; ordering is guaranteed by `MembershipFsm` queueing
-  the transition emission before the confirmed-departure emission in the same `emissions` list]
+  re-creates the defect this ticket removes, which is exactly what the `SwimDeparted` regression did.
+  The mark is consumed on read, so a node that drains, rejoins and later crashes still alerts.
+  [verified: `AlertManagerNodeHealthTest#swimDeparted_stillAlerts_becauseItIsSwimsDeathBroadcast` (the
+  regression pin), `#operatorDrain_raisesNoAlert`, `#abruptDeparture_stillRaisesCriticalAlert`,
+  `#unmarkedDeparture_alerts_soAMissedMarkIsNeverSilent`,
+  `#gracefulMarkIsConsumed_soALaterCrashStillAlerts`]
+  [mechanism: ordering holds because `MemberTracking.dispatch` runs
+  `synchronized (transitionGuard) { applyEvent(event).forEach(Runnable::run) }` — every dispatch for a
+  member is serialised on that guard and runs its staged fan-out synchronously before returning, so an
+  earlier dispatch's transition record precedes a later dispatch's DEAD hooks. **An earlier draft
+  claimed they share one `emissions` list; they do not** — they are separate dispatches with separate
+  lists, and the guard is what actually orders them]
+  [unverified: the rolling-restart noise this leaves behind is reasoned, not measured — no run
+  quantifies how many spurious CRITICALs a restart produces]
 - **The active-alert map is bounded, because the id-exact clear cannot resolve a replaced node.** CTM
   auto-heal mints a *fresh random id* for a replacement rather than reusing the departed one, so
   `clearNodeHealthAlert` — keyed on the rejoining id — can never match it. Under sustained replacement

--- a/changelog.d/926-node-health-alerting.md
+++ b/changelog.d/926-node-health-alerting.md
@@ -75,6 +75,12 @@
   lists, and the guard is what actually orders them]
   [unverified: the rolling-restart noise this leaves behind is reasoned, not measured — no run
   quantifies how many spurious CRITICALs a restart produces]
+  [verified: multi-node re-run on the internal test host at this head after the regression was fixed —
+  `docker kill` of the leader plus one produced **2 CRITICAL alert lines, 0 graceful-skip lines, and 2
+  `node_health` entries on `/api/v1/alerts`** on a survivor that was never the leader, both deaths
+  arriving via the SWIM faulty path that the regression had been suppressing. This restores the
+  measurement the earlier bullet reports; while `SwimDeparted` sat in the graceful set the same
+  scenario would have produced 0 CRITICAL]
 - **The active-alert map is bounded, because the id-exact clear cannot resolve a replaced node.** CTM
   auto-heal mints a *fresh random id* for a replacement rather than reusing the departed one, so
   `clearNodeHealthAlert` — keyed on the rejoining id — can never match it. Under sustained replacement

--- a/changelog.d/926-node-health-alerting.md
+++ b/changelog.d/926-node-health-alerting.md
@@ -32,12 +32,46 @@
   never rendered would not be operator-visible, which would reproduce #926's own defect one layer up.
   [verified: `AlertManagerNodeHealthTest#alertReachesTheOperatorFacingAlertsView`,
   `#resolvedAlert_leavesTheOperatorFacingView`]
-- **Forwarded to configured webhooks** like every other alert kind, as
-  `"type":"NODE_FAILED"` carrying `nodeId`, `observedBy` and `reason`. This is the one alerting surface
-  that leaves the cluster entirely, and therefore the one least affected by the failure being reported:
-  a webhook POST needs no leader, no quorum and no healthy peer.
-  [mechanism: `AlertForwarder.appendNodeHealthFields`; the sealed `AlertEvent` switch is exhaustive, so
-  the compiler refuses any future variant that forgets this path]
+- **Nothing forwards this alert anywhere, and the earlier draft of this entry said otherwise.**
+  `AlertForwarder` renders alerts to webhook JSON and this change teaches it the new variant — the
+  sealed `AlertEvent` switch is exhaustive, so it would not compile otherwise. But **`AlertForwarder`
+  is never constructed in production**: `alertForwarder(` has exactly one hit repo-wide, its own factory
+  declaration (`AlertForwarder.java:53`); control `alertManager(` in the same search space returns 3.
+  No webhook fires, for this alert kind or any other. The renderer *handles* the variant; nothing
+  *sends* one, and those are different claims. Wiring the forwarder is not in this change's scope.
+  [mechanism: `AlertForwarder.appendNodeHealthFields` renders `"type":"NODE_FAILED"` with `nodeId`,
+  `observedBy` and `reason` **if and when** a forwarder is ever constructed — not a claim that anything
+  is delivered today]
+- **A graceful departure raises no alert — so a rolling restart stays quiet.** The DEAD edge cannot
+  tell an announced departure from a crash: a graceful `SwimDeparted` (normal shutdown, i.e. every node
+  of every rolling restart) and an operator drain both reach DEAD through the same `Stopped` transition
+  a failure does. `AlertManager.noteMembershipTransition` is fed the FSM transition *cause* and marks
+  announced departures, which `onNodeFailed` then consumes. Without it this new surface would fire
+  CRITICAL on routine planned operations, and an alert operators mute is the same end state as the
+  silence #926 exists to fix, reached from the other side.
+  **The bias is one-directional and deliberate: an UNMARKED departure always alerts**, so a mark that
+  is missed or dropped costs a spurious CRITICAL and never a silent one — suppressing a real failure
+  would re-create the defect this ticket removes. The mark is consumed on read, so a node that departs
+  gracefully, rejoins and later crashes still alerts on the crash.
+  [verified: `AlertManagerNodeHealthTest#announcedDeparture_raisesNoAlert`, `#operatorDrain_raisesNoAlert`,
+  `#abruptDeparture_stillRaisesCriticalAlert`, `#unmarkedDeparture_alerts_soAMissedMarkIsNeverSilent`,
+  `#gracefulMarkIsConsumed_soALaterCrashStillAlerts`; ordering is guaranteed by `MembershipFsm` queueing
+  the transition emission before the confirmed-departure emission in the same `emissions` list]
+- **The active-alert map is bounded, because the id-exact clear cannot resolve a replaced node.** CTM
+  auto-heal mints a *fresh random id* for a replacement rather than reusing the departed one, so
+  `clearNodeHealthAlert` — keyed on the rejoining id — can never match it. Under sustained replacement
+  churn every replaced node would otherwise add a permanent entry, growing heap and the `/api/alerts`
+  payload without limit. The map is now capped at 64 with oldest-first eviction, mirroring the existing
+  `MAX_ALERT_HISTORY` bound on `alertHistory`. **Stated plainly rather than dressed up: a replaced
+  node's alert ages out under churn; it is not resolved.**
+  [verified: `AlertManagerNodeHealthTest#alertMapIsBounded_underReplacementChurn`]
+- **One departure reaches both surfaces, and that is now pinned as a pair.** An adversarial probe
+  deleted the alert call from the `AetherNode` boot lambda and all 1217 tests stayed green — each side
+  was pinned in isolation, nothing pinned the composition. The pair now lives in
+  `NodeDepartureNotifier`, driven against a real aggregator and a real alert manager, so deleting
+  either call turns tests red. [verified:
+  `NodeDepartureNotifierTest#oneDeparture_reachesBothSurfaces_withNoLeaderAndNoOwnership`,
+  `#confirmedDeparture_reachesTheAlertSurface`, `#announcedDeparture_reachesTheStreamButRaisesNoAlert`]
 - All production hunks above were mutation-probed: each was reverted alone, its named test confirmed
   red, and the file restored.
 - **Confirmed firing on a real cluster.** On a 3-node cluster with the leader killed, the surviving

--- a/changelog.d/926-node-health-alerting.md
+++ b/changelog.d/926-node-health-alerting.md
@@ -40,3 +40,9 @@
   the compiler refuses any future variant that forgets this path]
 - All production hunks above were mutation-probed: each was reverted alone, its named test confirmed
   red, and the file restored.
+- **Confirmed firing on a real cluster.** On a 3-node cluster with the leader killed, the surviving
+  node — never the leader, and at 1-of-3 unable to become one — logged
+  `ERROR o.p.a.a.AlertManager.onNodeFailed() - CRITICAL: node n926-1 confirmed failed (observed by
+  n926-3) — cluster membership degraded`, twice, once per confirmed departure. The alert path is
+  reached with no leader and no quorum, which is the whole point of raising it from the ungated DEAD
+  edge. [verified: multi-node run with failure injection on the internal test host]

--- a/changelog.d/926-node-health-alerting.md
+++ b/changelog.d/926-node-health-alerting.md
@@ -101,7 +101,8 @@
   `NodeDepartureNotifier`, driven against a real aggregator and a real alert manager, so deleting
   either call turns tests red. [verified:
   `NodeDepartureNotifierTest#oneDeparture_reachesBothSurfaces_withNoLeaderAndNoOwnership`,
-  `#confirmedDeparture_reachesTheAlertSurface`, `#announcedDeparture_reachesTheStreamButRaisesNoAlert`]
+  `#confirmedDeparture_reachesTheAlertSurface`, `#drainedDeparture_reachesTheStreamButRaisesNoAlert`,
+  `#swimDeath_reachesBothSurfaces_notJustTheStream`]
 - All production hunks above were mutation-probed: each was reverted alone, its named test confirmed
   red, and the file restored.
 - **Confirmed firing on a real cluster.** On a 3-node cluster with the leader killed, the surviving

--- a/changelog.d/926-node-health-alerting.md
+++ b/changelog.d/926-node-health-alerting.md
@@ -1,0 +1,42 @@
+### Added (2026-09-08 — #926: a node-health alerting path, which did not exist)
+- **Node health had no alerting path at all.** `AlertEvent` carried exactly three variants —
+  `ThresholdAlert`, `SliceFailureAlert`, `AlertResolved` — produced solely by
+  `AlertManager.onAllInstancesFailed` (slice-level) and `checkThreshold` (metric-level). Repo-wide,
+  "unhealthy" in `aether/node/src/main` appeared exactly twice, both rendering a status string into an
+  HTTP response. A cluster member could be confirmed dead with no alert raised anywhere.
+- **New `AlertEvent.NodeHealthAlert`**, raised by `AlertManager.onNodeFailed` from the ungated
+  `MembershipFsm` DEAD edge and resolved by `clearNodeHealthAlert` from the transport `PeerJoined`
+  handshake. Recovery is bound to the same ungated surface as the failure, so it is exactly as
+  reachable as the alert it clears — a raise with no matching clear leaves a permanently red surface,
+  which trains an operator to ignore it. [verified:
+  `AlertManagerNodeHealthTest#nodeFailure_raisesCriticalAlert`, `#rejoin_resolvesTheAlert`,
+  `#clearingUnknownNode_isNoOp`]
+- **The guarantee: at-most-one active alert per failed node, per observing node.** The map key is
+  derived from the failed node alone, so re-observing the same death replaces rather than accumulates.
+  That is what lets the raise sit on an edge which fires on every node's FSM without needing a dedup
+  token — and a token would be the wrong instrument here, since any token whose scope matches the
+  counted unit costs at least quorum, and the incident behind #926 ran below quorum. There is no
+  cross-node duplication to reconcile at all: each node keeps its own map, and the alert is a local
+  judgment about a remote peer. [verified:
+  `AlertManagerNodeHealthTest#repeatedObservationOfSameDeath_isIdempotent`,
+  `#distinctFailures_raiseDistinctAlerts`]
+- **Alert state is per-node local memory, deliberately.** That is precisely what makes it safe from the
+  gating #926 is about: raising it and reading it back need no leader, no quorum, no replica and no
+  partition ownership — unlike the cluster-events stream, whose read path prefers a possibly-dead
+  remote replica. The trade is the honest one: the alert is visible on the observing node's own
+  `/api/alerts` and is not replicated, so it does not survive that node's restart.
+  [mechanism: `ConcurrentHashMap` in `AlertManager`, no KV write, no consensus commit on either path]
+- **Surfaced on the existing `/api/alerts` view**, discriminated by `source="node_health"`, with
+  `nodeId` naming the failed node. No new Management API endpoint, so the REST/CLI/docs/dashboard quad
+  does not apply — this is a new alert *kind* on an endpoint that already exists. An alert raised but
+  never rendered would not be operator-visible, which would reproduce #926's own defect one layer up.
+  [verified: `AlertManagerNodeHealthTest#alertReachesTheOperatorFacingAlertsView`,
+  `#resolvedAlert_leavesTheOperatorFacingView`]
+- **Forwarded to configured webhooks** like every other alert kind, as
+  `"type":"NODE_FAILED"` carrying `nodeId`, `observedBy` and `reason`. This is the one alerting surface
+  that leaves the cluster entirely, and therefore the one least affected by the failure being reported:
+  a webhook POST needs no leader, no quorum and no healthy peer.
+  [mechanism: `AlertForwarder.appendNodeHealthFields`; the sealed `AlertEvent` switch is exhaustive, so
+  the compiler refuses any future variant that forgets this path]
+- All production hunks above were mutation-probed: each was reverted alone, its named test confirmed
+  red, and the file restored.

--- a/changelog.d/926-unleadered-failure-events.md
+++ b/changelog.d/926-unleadered-failure-events.md
@@ -1,0 +1,71 @@
+### Fixed (2026-09-08 — #926: cluster-failure events are leader-gated, so a cluster that cannot elect a leader emits nothing)
+- **The observability path failed exactly when the cluster did.** `NodeFailed` was emitted only through
+  `ClusterEventAggregator.emitAsLeader`, gated on `leaderCheck`. Detection worked fine — SWIM marked
+  peers faulty — but nothing reached `CLUSTER_EVENTS`, so every consumer of that stream saw silence and
+  read it as health. Measured on a five-node cluster over ten days, from one node's logs: 3,350,175 log
+  lines, 8 SWIM "member faulty" detections, **0** `NodeFailed` lines, 5 cluster events of any kind (all
+  `onNodeJoined`, in the first 30 seconds), and 1,297,717 leader-election lines with the leader ping
+  silent for 104,382 consecutive intervals. Three nodes sat `unhealthy` in Docker for nine days and
+  nobody noticed, because there was nothing to notice.
+- **`NodeFailed` is now emitted un-gated**, on every node whose FSM confirms the death.
+  [verified: `ClusterEventAggregatorTest#noLeaderAnywhere_stillEmitsNodeFailed_onEveryObserver` — three
+  observers, every one with a constant never-leader gate, so "no leader" holds by construction for the
+  whole window rather than at one sampled instant; owner-checks deliberately mixed so neither gate can
+  be the one letting the event through]
+- **Two further events had the same self-defeating shape and are fixed with it.** `LeaderLost` was
+  emitted from the branch where the leader id is EMPTY, through `emitAsLeader` — **the event announcing
+  that there is no leader required the emitter to be the leader**, which no node can satisfy. `QuorumLost`
+  (CRITICAL, the most severe event this class emits) was likewise leader-gated, and a cluster that has
+  gone PASSIVE cannot commit through consensus and so cannot sustain a leader lease. Both now emit
+  un-gated. [verified: `ClusterEventAggregatorTest#noLeader_stillEmitsLeaderLost`,
+  `#noLeader_stillEmitsQuorumLost`]
+- **`QuorumEstablished` is un-gated too, deliberately.** Quorum forms *before* a leader is elected, so
+  the gate dropped the recovery notice at the one moment it was guaranteed false. Un-gating the loss
+  while leaving the recovery gated would be worse than fixing neither: an operator would watch the
+  cluster enter "quorum lost" and never see it leave. A failure signal is only usable if its matching
+  recovery signal is at least as reachable. [verified:
+  `ClusterEventAggregatorTest#noLeader_stillEmitsQuorumEstablished`]
+- **The guarantee, per operation.** `NodeFailed` / `LeaderLost` / `QuorumLost` / `QuorumEstablished`:
+  **at-least-once per observing core member, per event, into that member's LOCAL partition-0 ring.**
+  Explicitly **not** exactly-once and not deduplicated. Duplicates are bounded, not unbounded — the
+  ceiling is one event per member that confirms it — and `details.observedBy` names the emitter so a
+  consumer can collapse them or count distinct observers. Replication to other replicas stays
+  best-effort, fire-and-forget after the local ack.
+  [mechanism: `emitLocal` applies neither the leader nor the owner gate; `MembershipFsm.enteredDead` is
+  a fresh-edge fan-out firing once per DEAD transition per member FSM; the local append needs no leader,
+  no quorum and no consensus — the system-stream publisher is built with `EVENTUAL`,
+  `consensusPath=none`, `minSyncReplicas=0`, and the epoch fence reads local applied state]
+- **A dedup token was considered and rejected**, rather than not considered. Any token whose scope
+  matches the counted unit must be visible to every emitter, which costs at least quorum — and the
+  measured incident ran three of five nodes unhealthy, below quorum. It would have been silent in the
+  very incident it exists to report, and would newly bind this path to a coordination outcome it does
+  not otherwise need. Gating instead on "is there a leader" fails for a related reason: it makes the
+  leadership view — the least trustworthy input in this incident — the guard on the failure path, so a
+  stale leader id naming a dead node silences every survivor.
+- **The replay gate is retained**, so snapshot/resync replay still does not re-publish historical
+  departures. This is the one suppression that had to survive un-gating.
+  [verified: `ClusterEventAggregatorTest#noLeader_stillSuppressesDepartureDuringReplay`]
+- **`LeaderElected` and `NodeJoined` stay leader-gated** — the new leader is the authoritative emitter
+  of its own election — so this change is not "un-gate everything".
+  [verified: `ClusterEventAggregatorTest#nonLeader_stillSuppressesLeaderElected`]
+- **A failed publish is no longer silently dropped.** `publishSafely` wrapped the call in `Result.lift`,
+  which catches only a *synchronous* throw; `publish` returns a `Promise`, and an asynchronous failure
+  (e.g. `PARTITION_NOT_LOCAL`) was discarded with no log and no counter. With this path now load-bearing
+  for reporting cluster failure, that drop would have rebuilt the same fail-open shape one layer down.
+  [mechanism: `onSuccess(promise -> promise.onFailure(...))` added; still fire-and-forget, logged and
+  never propagated to the DEAD-edge caller]
+- **The operator-visible surface this closes on is the local WARN log**, not `/api/events`. The log
+  needs no leader, no quorum, no replica, no partition ownership and no network, so nothing this ticket
+  is about can gate it; the confirmed-departure edge previously logged nothing at all. The ticket's own
+  evidence was gathered from logs, which is direct proof that this surface stayed up through the
+  incident that killed the event surface.
+  **Known limitation, not fixed here:** `/api/events` read-back is remote-preferring — the
+  `ANY_REPLICA` router forwards to a randomly chosen CAUGHT_UP peer and propagates the failure with no
+  local fallback, so with dead peers still registered CAUGHT_UP the read can fail while the event sits
+  in the local ring. That is in `aether-stream`, outside this fix's boundary, and is filed separately.
+  [design intent — unverified: the end-to-end multi-node behaviour under a genuine sustained no-leader
+  condition has NOT been reproduced on a cluster; the evidence above is the original incident's, and
+  every claim tagged `verified` here is a single-JVM exercise of the real publisher, codec and
+  partition manager — not a multi-node run with failure injection]
+- All production hunks above were mutation-probed: each was reverted alone, its named test confirmed
+  red, and the file restored.

--- a/changelog.d/926-unleadered-failure-events.md
+++ b/changelog.d/926-unleadered-failure-events.md
@@ -154,11 +154,19 @@
   defect, but it raised its cost: a reader trusting the index would have been more confident, not less.
   **A `[verified:]` tag is a claim to be attacked, not one already checked.**
 
-  Counts here are per-file and stated as such: this fragment carries 10 `[verified:]`, 4
-  `[unverified:]`, 3 `[mechanism:]`; the node-health fragment carries 8 / 3 / 3; 18 / 7 / 6 across both,
-  with a bogus-tag control returning 0. An earlier note gave "10 and 4" without saying it meant one
-  file — a count with no stated space is not checkable, which is the same rule this tagging exists to
-  serve, missed inside the control built to serve it.
+  **Counts are read-point-scoped, and the census had to be fixed before they meant anything.**
+  Measured at `a49cfb47e`: this fragment carries **7 / 4 / 3** (verified / unverified / mechanism), the
+  node-health fragment **5 / 3 / 3**, **12 / 7 / 6** across both, bogus-tag control 0.
+
+  Two earlier figures were wrong, and instructively so. The first gave "10 and 4" without saying it
+  meant a single file. The second was measured with a census that matched **any occurrence of the tag
+  literal** — so this very paragraph, which discusses tagging, counted itself: writing the measurement
+  down changed the measurement. **An instrument built from the tag's own syntax cannot tell a tag from a
+  mention of a tag.** A position-anchored census fails the other way, missing real tags that follow
+  prose mid-line. The census now requires the space that a real tag has and a bracketed mention does
+  not, with two controls: no backticked mention is counted, and a bogus tag returns 0. **A count with no
+  stated space and no validated instrument is not checkable** — the rule this tagging exists to serve,
+  missed twice inside the control built to serve it.
 
 - All production hunks above were mutation-probed: each was reverted alone, its named test confirmed
   red, and the file restored.

--- a/changelog.d/926-unleadered-failure-events.md
+++ b/changelog.d/926-unleadered-failure-events.md
@@ -138,13 +138,27 @@
   above; the never-arrived confound is open until a re-run with the new log line]
   [unverified: `publishSafely`'s asynchronous-failure log — never exercised in either arm]
 
-  **Why these carry their own tag.** Seven `[verified:]` tags in this fragment are machine-findable;
+  **Why these carry their own tag.** Ten `[verified:]` tags in this fragment are machine-findable;
   until now the bound that limits them was untagged prose in a separate bullet. A reader running
   `grep '\[verified:'` — the exact consumption path these tags exist for — would have got an unbounded
   picture of what was proven. **If verified claims are greppable and their limitations are not, the
   consumption path systematically over-reports**, and it over-reports hardest to whoever is reading in
   a hurry during an outage, which is precisely when this code matters. The limitations are now returned
   by the same sweep: `grep -E '\[(verified|unverified|mechanism|design intent)'`.
+
+  **The limit of that fix, learned the hard way on this very PR: the sweep is an INDEX, never a
+  WARRANT.** A tag sweep can only surface limitations the author already knows about, so it raises
+  confidence uniformly across claims whose real standing differs. While the `SwimDeparted` regression
+  stood, this fragment's sweep returned "abrupt departures still raise CRITICAL" as `[verified:]` — a
+  statement that was false on the primary crash path, wearing the badge. The tagging did not cause that
+  defect, but it raised its cost: a reader trusting the index would have been more confident, not less.
+  **A `[verified:]` tag is a claim to be attacked, not one already checked.**
+
+  Counts here are per-file and stated as such: this fragment carries 10 `[verified:]`, 4
+  `[unverified:]`, 3 `[mechanism:]`; the node-health fragment carries 8 / 3 / 3; 18 / 7 / 6 across both,
+  with a bogus-tag control returning 0. An earlier note gave "10 and 4" without saying it meant one
+  file — a count with no stated space is not checkable, which is the same rule this tagging exists to
+  serve, missed inside the control built to serve it.
 
 - All production hunks above were mutation-probed: each was reverted alone, its named test confirmed
   red, and the file restored.

--- a/changelog.d/926-unleadered-failure-events.md
+++ b/changelog.d/926-unleadered-failure-events.md
@@ -62,6 +62,10 @@
   for reporting cluster failure, that drop would have rebuilt the same fail-open shape one layer down.
   [mechanism: `onSuccess(promise -> promise.onFailure(...))` added; still fire-and-forget, logged and
   never propagated to the DEAD-edge caller]
+  [unverified: **no test pins this and the multi-node run never exercised it** — both arms reported
+  `publish-failure lines: 0`, i.e. no publish failed, so the new branch was never entered. It must not
+  be read as verified. Low risk, being a log statement on an already fire-and-forget path, but the
+  honest statement is that it is reasoned, not demonstrated]
 - **The operator-visible surface this closes on is the local WARN log**, not `/api/events`. The log
   needs no leader, no quorum, no replica, no partition ownership and no network, so nothing this ticket
   is about can gate it; the confirmed-departure edge previously logged nothing at all. The ticket's own
@@ -71,9 +75,12 @@
   `ANY_REPLICA` router forwards to a randomly chosen CAUGHT_UP peer and propagates the failure with no
   local fallback, so with dead peers still registered CAUGHT_UP the read can fail while the event sits
   in the local ring. That is in `aether-stream`, outside this fix's boundary, and is filed separately.
-  [verified: multi-node, on a real 3-node cluster with failure injection and a reverted control —
-  see the A/B below. This claim was tagged `design intent — unverified` until that run; it is upgraded
-  on evidence, not on confidence]
+  [verified: single-arm, multi-node — the three WARN lines (2 / 1 / 1) fired on a survivor that was
+  never the leader, during a window in which the system itself reported `currentLeader=None()`. **Not
+  the reverted control**: that control deliberately leaves the log statements in, so the WARN counts
+  are identical in both arms BY CONSTRUCTION and cannot discriminate anything about this surface. The
+  control speaks to the gate, not to the surface; this claim rests on the lines firing at all under a
+  genuine no-leader condition, which is sufficient for it and is what is cited here]
 - **Verified on a real cluster, against a reverted control.** Three nodes on the internal test host;
   the leader and one other node killed with `docker kill`, leaving a survivor that was **never** the
   leader and, at 1-of-3, cannot become one. The no-leader condition is the system's own report, not an
@@ -96,12 +103,26 @@
   the gate. The control's **30/30 successful reads** rule out the alternative explanation that the
   events were present but unreadable: the endpoint answered every time and the events were simply not
   there. The partition watermark (10 vs 2) corroborates that independently of HTTP.
-- **The recovery half, measured the same way.** On a healthy quorate cluster the fixed build carries
-  **three** `QUORUM_ESTABLISHED` events — one from each node, `observedBy` = n926-1, n926-2, n926-3 —
-  while the reverted control carries **zero**, *including from the leader*. That confirms from
-  measurement what the code reading predicted: quorum forms before a leader is elected, so the gate was
-  false on every node at that instant and the cluster could never report quorum recovery at all.
-  `LEADER_ELECTED` is present in both arms, as it should be — it stays leader-gated.
+  [verified: the A/B above — this is what the reverted control DOES support: that the gate, and nothing
+  else, decides whether the event reaches the stream. Identical WARN (2/1/1) and `onNodeFailed` ERROR
+  (2/2) counts prove both arms traversed the same path with the same cluster history, so arm B's zeros
+  cannot be a different failure sequence; 30/30 successful control reads make them a genuine absence
+  rather than a failed read]
+- **The recovery half, measured the same way — but on weaker footing than the loss half, and that
+  asymmetry is the honest report.** On a healthy quorate cluster the fixed build carries **three**
+  `QUORUM_ESTABLISHED` events — one from each node, `observedBy` = n926-1, n926-2, n926-3 — while the
+  reverted control carries **zero**, *including from the leader*. That matches what the code reading
+  predicted: quorum forms before a leader is elected, so the gate was false on every node at that
+  instant and the cluster could never report quorum recovery at all. `LEADER_ELECTED` is present in
+  both arms, as it should be — it stays leader-gated.
+  **The residual confound, not excluded:** at the time of that run there was no log line on the ACTIVE
+  branch, so **nothing witnessed that `onQuorumStateChange(ACTIVE)` was even reached in arm B**. "Zero
+  because the notification never arrived" therefore remains open; `LEADER_ELECTED` in both arms
+  witnesses a *different* handler and is only partial mitigation. The loss half has no such gap — its
+  WARN line witnesses entry directly. The `LOG.info` added on the ACTIVE branch supplies that missing
+  witness, so a re-run can control the recovery half exactly the way the loss half was controlled.
+  [verified: the three-vs-zero counts are real and were measured; **the elimination of the
+  never-arrived confound is NOT** — that requires a re-run with the new ACTIVE log line]
 - **A limit of this scenario, stated because it bounds the evidence:** a sub-quorum survivor
   deliberately self-fences (`QUORUM_LOSS drain INTENT ... initiating self-drain (split-brain
   self-fence)`) about 18 seconds after quorum loss, so the window in which its HTTP surface can be read
@@ -109,6 +130,21 @@
   exited — not because the events were missing. The measurements above were taken inside the window.
   A cluster that keeps quorum but cannot elect a stable leader — the ten-day incident's actual shape —
   was not reproduced; that state cannot be induced by killing nodes.
+  [unverified: a cluster that KEEPS quorum but cannot elect a stable leader — the incident's actual
+  shape; not inducible by killing nodes, since losing enough nodes to lose the leader also loses quorum
+  and triggers the self-fence. The un-gated path measured here is the same code that would run under
+  it, but that state was never observed]
+  [unverified: the ACTIVE-branch entry witness for the recovery-half control — see the recovery bullet
+  above; the never-arrived confound is open until a re-run with the new log line]
+  [unverified: `publishSafely`'s asynchronous-failure log — never exercised in either arm]
+
+  **Why these carry their own tag.** Seven `[verified:]` tags in this fragment are machine-findable;
+  until now the bound that limits them was untagged prose in a separate bullet. A reader running
+  `grep '\[verified:'` — the exact consumption path these tags exist for — would have got an unbounded
+  picture of what was proven. **If verified claims are greppable and their limitations are not, the
+  consumption path systematically over-reports**, and it over-reports hardest to whoever is reading in
+  a hurry during an outage, which is precisely when this code matters. The limitations are now returned
+  by the same sweep: `grep -E '\[(verified|unverified|mechanism|design intent)'`.
 
 - All production hunks above were mutation-probed: each was reverted alone, its named test confirmed
   red, and the file restored.

--- a/changelog.d/926-unleadered-failure-events.md
+++ b/changelog.d/926-unleadered-failure-events.md
@@ -25,6 +25,14 @@
   cluster enter "quorum lost" and never see it leave. A failure signal is only usable if its matching
   recovery signal is at least as reachable. [verified:
   `ClusterEventAggregatorTest#noLeader_stillEmitsQuorumEstablished`]
+- **The claimed surface no longer latches red either.** This change nominates the local log as the
+  surface that survives a leaderless cluster, and on that surface the pair was incomplete: `QUORUM_LOST`
+  logged a WARN and `QUORUM_ESTABLISHED` logged nothing, so an operator reading logs saw "Quorum lost"
+  and never saw it restored. That is the same latched-red failure the un-gating of `QuorumEstablished`
+  exists to prevent, reached on a different surface — and it violated this entry's own stated principle
+  that a failure signal is only usable if its recovery signal is at least as reachable. A matching
+  `LOG.info` on the ACTIVE branch closes it.
+  [mechanism: `ClusterEventAggregator.onQuorumStateChange`, ACTIVE branch]
 - **The guarantee, per operation.** `NodeFailed` / `LeaderLost` / `QuorumLost` / `QuorumEstablished`:
   **at-least-once per observing core member, per event, into that member's LOCAL partition-0 ring.**
   Explicitly **not** exactly-once and not deduplicated. Duplicates are bounded, not unbounded — the

--- a/changelog.d/926-unleadered-failure-events.md
+++ b/changelog.d/926-unleadered-failure-events.md
@@ -63,9 +63,44 @@
   `ANY_REPLICA` router forwards to a randomly chosen CAUGHT_UP peer and propagates the failure with no
   local fallback, so with dead peers still registered CAUGHT_UP the read can fail while the event sits
   in the local ring. That is in `aether-stream`, outside this fix's boundary, and is filed separately.
-  [design intent — unverified: the end-to-end multi-node behaviour under a genuine sustained no-leader
-  condition has NOT been reproduced on a cluster; the evidence above is the original incident's, and
-  every claim tagged `verified` here is a single-JVM exercise of the real publisher, codec and
-  partition manager — not a multi-node run with failure injection]
+  [verified: multi-node, on a real 3-node cluster with failure injection and a reverted control —
+  see the A/B below. This claim was tagged `design intent — unverified` until that run; it is upgraded
+  on evidence, not on confidence]
+- **Verified on a real cluster, against a reverted control.** Three nodes on the internal test host;
+  the leader and one other node killed with `docker kill`, leaving a survivor that was **never** the
+  leader and, at 1-of-3, cannot become one. The no-leader condition is the system's own report, not an
+  inference: the survivor logs `SWIM member faulty: NodeId[id=...] (currentLeader=None(), ...)` at the
+  moment it confirms each death, and its leader-bound management routes answer
+  `No leader elected for leader-bound management route` for the whole window.
+
+  | measured on the survivor's own `/api/v1/events` | fixed | reverted control |
+  |---|---|---|
+  | `NODE_FAILED` | **2** | **0** |
+  | `LEADER_LOST` | **1** | **0** |
+  | `QUORUM_LOST` | **1** | **0** |
+  | events stamped `observedBy` = survivor | **5** | **0** |
+  | cluster-events partition watermark | **10** | **2** |
+  | successful stream reads during the window | 26/30 | **30/30** |
+  | `WARN` log lines from the same hooks | 2 / 1 / 1 | **2 / 1 / 1** |
+
+  The control reverts **only** the four emit calls, leaving the log statements in place — so the WARN
+  counts are identical in both arms, proving the hooks executed identically and the sole difference is
+  the gate. The control's **30/30 successful reads** rule out the alternative explanation that the
+  events were present but unreadable: the endpoint answered every time and the events were simply not
+  there. The partition watermark (10 vs 2) corroborates that independently of HTTP.
+- **The recovery half, measured the same way.** On a healthy quorate cluster the fixed build carries
+  **three** `QUORUM_ESTABLISHED` events — one from each node, `observedBy` = n926-1, n926-2, n926-3 —
+  while the reverted control carries **zero**, *including from the leader*. That confirms from
+  measurement what the code reading predicted: quorum forms before a leader is elected, so the gate was
+  false on every node at that instant and the cluster could never report quorum recovery at all.
+  `LEADER_ELECTED` is present in both arms, as it should be — it stays leader-gated.
+- **A limit of this scenario, stated because it bounds the evidence:** a sub-quorum survivor
+  deliberately self-fences (`QUORUM_LOSS drain INTENT ... initiating self-drain (split-brain
+  self-fence)`) about 18 seconds after quorum loss, so the window in which its HTTP surface can be read
+  at all is short, and a first attempt that polled later than that saw nothing because the node had
+  exited — not because the events were missing. The measurements above were taken inside the window.
+  A cluster that keeps quorum but cannot elect a stable leader — the ten-day incident's actual shape —
+  was not reproduced; that state cannot be induced by killing nodes.
+
 - All production hunks above were mutation-probed: each was reverted alone, its named test confirmed
   red, and the file restored.


### PR DESCRIPTION
Fixes #926.

## The defect

`NodeFailed` was emitted only through `emitAsLeader`, so a cluster that cannot elect a leader **cannot emit the events that say it is broken**. Detection worked — SWIM marked peers faulty — but nothing reached `CLUSTER_EVENTS`, and silence is indistinguishable from health. Measured on a five-node cluster over ten days: 8 SWIM faulty detections, **0** `NodeFailed`, 1,297,717 leader-election lines.

## Why the obvious fix — a dedup token — is the wrong one

The leader gate exists to deduplicate: the FSM DEAD edge fires on every node, so without a gate N nodes emit. The natural repair is a dedup token whose scope matches the counted unit. **It must be rejected, and a reviewer who does not see why will propose it again.**

Any token whose scope matches the counted unit has to be visible to every emitter, which costs **at least quorum**. The measured incident ran **three of five nodes unhealthy — below quorum**. A quorum-backed token would therefore have been silent in exactly the incident it exists to report, and it would newly bind this path to a coordination outcome it does not otherwise need: the local append takes no leader, no quorum and no consensus (`EVENTUAL`, `consensusPath=none`, `minSyncReplicas=0`, epoch fence reads local applied state). It converts a leader dependency into a quorum dependency — weaker, same class of defect.

Gating instead on "is there a leader" (`leader().isEmpty()`) fails for a related reason: it makes the leadership view — the least trustworthy input in this incident — the guard on the failure path, so a stale leader id naming a dead node silences every survivor. **A guard whose input is the broken subsystem is not a guard.**

The dedup the gate bought is worth less than the availability it cost. Duplicates are **bounded** — `MembershipFsm.enteredDead` is a fresh-edge fan-out firing once per DEAD transition per member FSM — so the ceiling is one event per member confirming it, against a 10,000-event ring.

## Four emission sites, not one

Reading the class turned up two more with the identical self-defeating shape:

- `NodeFailed` — the ticket's defect.
- **`LeaderLost`** — emitted from the branch where the leader id is EMPTY, through `emitAsLeader`. The event announcing *there is no leader* required the emitter to **be** the leader. Unreachable by construction.
- **`QuorumLost`** (CRITICAL) — a cluster gone PASSIVE cannot commit through consensus and so cannot sustain a leader lease. The most severe event this class emits was the least emittable.
- **`QuorumEstablished`** — un-gated deliberately: quorum forms *before* a leader is elected. Fixing the loss without the recovery leaves a permanently red surface, which trains an operator to ignore it.

`LeaderElected` and `NodeJoined` stay leader-gated, with a test pinning that.

Also: `publishSafely` discarded *asynchronous* publish failures (`Result.lift` catches only synchronous throws). With this path now load-bearing, that drop would have rebuilt the fail-open shape one layer down.

## The guarantee

**At-least-once per observing core member, per event, into that member's local partition-0 ring.** Explicitly *not* exactly-once and not deduplicated. `details.observedBy` names the emitter so consumers can collapse duplicates.

## Node-health alerting (scope item 2) — implemented, not deferred

`AlertEvent` had no node-health variant at all. New `NodeHealthAlert`, raised from the ungated DEAD edge, resolved from the ungated `PeerJoined` handshake, rendered on the existing `/api/v1/alerts` (`source="node_health"`). No new endpoint, so the REST/CLI/docs/dashboard quad does not apply.

**Nothing forwards it anywhere, and an earlier draft of this PR claimed otherwise.** `AlertForwarder` renders the new variant to webhook JSON — the sealed switch is exhaustive, so it would not compile otherwise — but **`AlertForwarder` is never constructed in production**: `alertForwarder(` has exactly one hit repo-wide, its own factory declaration; control `alertManager(` in the same space returns 3. No webhook fires, for this alert kind or any other. The renderer *handles* the variant; nothing *sends* one. Wiring the forwarder is out of scope here.

**A graceful departure raises no alert, so a rolling restart stays quiet.** The DEAD edge cannot tell an announced departure from a crash — a graceful `SwimDeparted` (normal shutdown, i.e. every node of every rolling restart) and an operator drain both reach DEAD through the same `Stopped` transition a failure does. `noteMembershipTransition` is fed the FSM transition *cause* and marks announced departures, which `onNodeFailed` consumes. Without it, un-gating cluster-wide would have made this surface fire CRITICAL during routine operations — converting an under-reporting failure into an over-reporting one, which ends in the same muted surface. **The bias is one-directional: an unmarked departure always alerts**, so a missed mark costs a spurious CRITICAL, never a silent one. The *event* is deliberately not suppressed — a `NodeFailed` record of an announced departure is legitimate history; only a CRITICAL alert on a routine restart is noise.

**The alert map is bounded, because the id-exact clear cannot resolve a replaced node.** CTM auto-heal mints a fresh random id for a replacement, so `clearNodeHealthAlert` can never match it; the map is capped at 64 with oldest-first eviction, mirroring `MAX_ALERT_HISTORY`. Stated plainly: a replaced node's alert **ages out under churn; it is not resolved.**

**The composition is now pinned as a pair.** An adversarial probe deleted the alert call from the boot lambda and all 1217 tests stayed green — each side was pinned in isolation, nothing pinned that one departure reaches both. The pair lives in `NodeDepartureNotifier`, driven against a real aggregator and a real alert manager, so deleting either call turns tests red.

## Verified on a real cluster, against a reverted control

Three nodes on the internal test host. The leader and one other were killed, leaving a survivor that was **never** the leader and, at 1-of-3, cannot become one. The no-leader condition is the system's own report, not an inference — the survivor logs `SWIM member faulty: ... (currentLeader=None(), firstHand=true)` at the moment it confirms each death, and its leader-bound routes answer `No leader elected for leader-bound management route` for the whole window.

The control reverts **only the four emit calls**, leaving the log statements in place — so the WARN counts are identical in both arms and the sole difference is the gate.

| on the survivor's own `/api/v1/events` | fixed | reverted control |
|---|---|---|
| `NODE_FAILED` | **2** | **0** |
| `LEADER_LOST` | **1** | **0** |
| `QUORUM_LOST` | **1** | **0** |
| events stamped `observedBy`=survivor | **5** | **0** |
| cluster-events partition watermark | **10** | **2** |
| successful stream reads in window | 26/30 | **30/30** |
| WARN lines from the same hooks | 2 / 1 / 1 | **2 / 1 / 1** |

The control's **30/30 successful reads** rule out "present but unreadable": the endpoint answered every time and the events were simply not there. The watermark (10 vs 2) corroborates that without HTTP at all.

**Recovery half:** on a healthy quorate cluster the fixed build carries **three** `QUORUM_ESTABLISHED` events, one per node; the control carries **zero, including from the leader** — confirming from measurement what the code reading predicted, that quorum forms before a leader exists, so the old build could never report quorum recovery at all. `LEADER_ELECTED` appears in both arms.

Unit side: **1229 tests, 0 failures and 0 errors in my run**; JBCT gate `Running JBCT check on 151 Java file(s)` → `JBCT check passed.`; **all 6 original mutation probes RED, plus 6 more for the fix round** — including the previously-unpinned deletion of the alert call, which is now RED.

Phrased precisely because it will be re-run: *my* run was clean, but the module is **not unconditionally green on a contended box.** An independent run of the same suite hit `Errors: 1` — a `BindException` in `CoreSwimHealthDetectorTest`, the known #939 fixed-port shape, clean on isolated re-run. That is an error, not a failure, and unrelated to this change; expect it if a sibling tree is building concurrently.

## Bounds on the evidence

A sub-quorum survivor **self-fences by design** (`initiating self-drain (split-brain self-fence)`) ~18s after quorum loss, so its HTTP surface exists only briefly; the measurements above were taken inside that window. A cluster that *keeps* quorum but cannot elect a stable leader — the ten-day incident's actual shape — was not reproduced, because losing enough nodes to lose the leader also loses quorum.

**Known limitation, filed separately:** `/api/v1/events` read-back is remote-preferring (`ANY_REPLICA` forwards to a possibly-dead CAUGHT_UP peer with no local fallback), so it can fail under these same conditions. That is in `aether-stream`, outside this fix's boundary.
