### PR TITLE
fix(aether): one owner source for the schema gate, and fence the best-effort outcome merge (#805)

### DIFF
--- a/aether/aether-deployment/src/main/java/org/pragmatica/aether/deployment/cluster/BlueprintService.java
+++ b/aether/aether-deployment/src/main/java/org/pragmatica/aether/deployment/cluster/BlueprintService.java
@@ -77,8 +77,10 @@ public interface BlueprintService {
     Option<ExpandedBlueprint> get(BlueprintId id);
     /// Durable terminal outcome of `id`'s last deployment attempt (#759 review, BLOCKING 3). Bounded
     /// to exactly one record per blueprint id: the FSM writes via `KVCommand.Put` at
-    /// `AetherKey.DeploymentOutcomeKey.deploymentOutcomeKey(id)`, and a Put at the same key overwrites
-    /// the prior value, so the store holds only the latest outcome — cardinality is the number of
+    /// `AetherKey.DeploymentOutcomeKey.deploymentOutcomeKey(id)`, and a Put at the same key replaces
+    /// the prior value — subject, since #805 item 2, to the `VersionFenced` successor check, which
+    /// rejects a Put built on a stale read rather than letting it overwrite. The store therefore holds
+    /// only the latest outcome — cardinality is the number of
     /// distinct blueprint ids ever deployed, not the number of attempts. Survives
     /// `unloadBlueprintSlices`'s ALL_OR_NOTHING rollback, which removes only `AppBlueprintKey`, never
     /// this key — the intended read path for the node's blueprint-status route after a rollback

--- a/aether/aether-deployment/src/main/java/org/pragmatica/aether/deployment/cluster/fsm/ClusterDeploymentState.java
+++ b/aether/aether-deployment/src/main/java/org/pragmatica/aether/deployment/cluster/fsm/ClusterDeploymentState.java
@@ -188,6 +188,31 @@ public sealed interface ClusterDeploymentState extends FsmState<ClusterDeploymen
         return resolveDeclaredSchemaRequired(kvStore, blueprintId).or(true);
     }
 
+    /// #805 item 1: the SINGLE slice-owner resolution path for both callers of
+    /// [#blocksSliceActivation] — the activation gate (`Active.blockingSchemaRecords`) and
+    /// `SchemaRoutes.heldSlices` — reading the committed `SliceTargetKey`/`SliceTargetValue` record
+    /// that both already treat as the ownership authority.
+    ///
+    /// #760's first round made the two share this PREDICATE; they still fed it from two different
+    /// sources. The gate resolved the owner from [Active#blueprints], a node-local mirror rebuilt
+    /// from KV notifications and therefore lagging them, and additionally pre-filtered on that
+    /// mirror's `schemaRequired` flag; the route read the KV record directly and pre-filtered on
+    /// nothing. A stale mirror entry naming an owner the committed record no longer names made the
+    /// gate hold a slice the route simultaneously reported as NOT held — the same divergence #760
+    /// closed, running the other way. Sharing a predicate is not sharing a decision while its INPUTS
+    /// disagree.
+    ///
+    /// The dropped `schemaRequired` pre-filter is not a lost check: [#blocksSliceActivation] already
+    /// resolves `schemaRequired` per candidate record from this same [KVStore] via
+    /// [#resolveSchemaRequired(KVStore, BlueprintId)], so the mirror's copy was strictly a second,
+    /// divergent answer to a question the shared predicate was already asking.
+    static Option<BlueprintId> resolveSliceOwner(KVStore<AetherKey, AetherValue> kvStore, Artifact artifact) {
+        return kvStore.get(SliceTargetKey.sliceTargetKey(artifact.base()))
+                      .filter(SliceTargetValue.class::isInstance)
+                      .map(SliceTargetValue.class::cast)
+                      .flatMap(SliceTargetValue::owningBlueprint);
+    }
+
     record Dormant(ClusterDeploymentContext ctx) implements ClusterDeploymentState {
         @Contract
         @Override
@@ -1710,8 +1735,8 @@ public sealed interface ClusterDeploymentState extends FsmState<ClusterDeploymen
         /// permanent failure. The hold now clears only via `/api/schema/{ds}/retry`
         /// (FAILED -> PENDING -> COMPLETED) or a redeploy that republishes the record.
         ///
-        /// A slice whose owning blueprint cannot be resolved — no `Blueprint` entry, or an entry
-        /// carrying no owner — is reported READY. No record can be attributed to it, so blocking
+        /// A slice whose owning blueprint cannot be resolved — no committed `SliceTargetValue`
+        /// record, or one carrying no owner — is reported READY. No record can be attributed to it, so blocking
         /// would be an unclearable hold: nothing that ever completes could match it, and the slice
         /// would sit in LOADED forever. Records only ever exist because some blueprint declared
         /// migrations, and that blueprint's own slices do carry its owner, so the safety property is
@@ -1723,12 +1748,15 @@ public sealed interface ClusterDeploymentState extends FsmState<ClusterDeploymen
         /// Named records rather than a boolean so the hold can be reported with detail (#760) — the
         /// prior `noBlockingSchemaRecords` collapsed the same scan into a single flag, which is all
         /// [#areSchemasReady(SliceNodeKey)] needs but nothing an operator-facing log could name.
+        /// #805 item 1: owner resolution goes through the shared
+        /// [ClusterDeploymentState#resolveSliceOwner(KVStore, Artifact)] — the committed
+        /// `SliceTargetValue` record — instead of the node-local [#blueprints] mirror, and the
+        /// mirror's `schemaRequired` pre-filter is gone. Both were inputs the route did not share,
+        /// so the gate and `SchemaRoutes.heldSlices` could disagree about the same slice even while
+        /// calling one predicate. See that method for why dropping the pre-filter removes no check.
         private List<SchemaVersionValue> blockingSchemaRecords(SliceNodeKey sliceKey) {
-            return Option.option(blueprints.get(sliceKey.artifact()))
-                         .filter(Blueprint::schemaRequired)
-                         .flatMap(Blueprint::owner)
-                         .map(this::collectBlockingSchemaRecords)
-                         .or(List.of());
+            return resolveSliceOwner(ctx.kvStore(), sliceKey.artifact()).map(this::collectBlockingSchemaRecords)
+                                                                       .or(List.of());
         }
 
         private List<SchemaVersionValue> collectBlockingSchemaRecords(BlueprintId owner) {

--- a/aether/aether-deployment/src/main/java/org/pragmatica/aether/deployment/cluster/fsm/ClusterDeploymentState.java
+++ b/aether/aether-deployment/src/main/java/org/pragmatica/aether/deployment/cluster/fsm/ClusterDeploymentState.java
@@ -1659,9 +1659,42 @@ public sealed interface ClusterDeploymentState extends FsmState<ClusterDeploymen
         /// of erasing the first. The merge was a bare read-then-Put until #805 item 2; it is now
         /// fenced and confirmed — see [#submitBestEffortFailureOutcome(BlueprintId, Artifact, String, int)].
         private void recordBestEffortFailureOutcome(Artifact artifact, String failureReason) {
-            Option.option(blueprints.get(artifact))
-                  .flatMap(Blueprint::owner)
-                  .onPresent(blueprintId -> submitBestEffortFailureOutcome(blueprintId, artifact, failureReason, 1));
+            resolveOutcomeOwner(artifact).onPresent(blueprintId -> submitBestEffortFailureOutcome(blueprintId,
+                                                                                                  artifact,
+                                                                                                  failureReason,
+                                                                                                  1));
+        }
+
+        /// #805 follow-up: the owning blueprint for a BEST_EFFORT failure record, resolved from the
+        /// node-local [#blueprints] mirror FIRST and from the committed `SliceTargetValue` only when
+        /// the mirror cannot answer.
+        ///
+        /// An unresolved owner here is not a degraded record, it is NO record: there is no
+        /// `DeploymentOutcomeKey` to write against, so the failure goes unrecorded entirely. #698
+        /// closed one route to that — the autoscaler and A/B writer erasing
+        /// `SliceTargetValue.owningBlueprint`, fixed in #940. This closes the other: the mirror is
+        /// rebuilt from KV notifications and can be stale, or simply absent for an artifact whose
+        /// entry `removeNonTargetVersions` dropped, or during the window after a leader failover
+        /// before `rebuildSliceStateFromKVStoreEntries` has run.
+        ///
+        /// **Mirror FIRST, not committed-record first — the order is load-bearing.**
+        /// [Active#handleAppBlueprintChange] populates the mirror in the same pass that only QUEUES
+        /// the `SliceTargetKey` Put, and that Put applies later, after consensus. Between the two the
+        /// mirror legitimately names an owner the committed store does not yet carry, so resolving
+        /// from the store alone would stop recording failures for the whole deploy window — trading
+        /// one dropped-record bug for another. Consulting both, mirror first, strictly widens what is
+        /// recorded: the worst case is attributing a failure to an owner that is about to change,
+        /// never losing the record. For a ticket about lost records that is the right asymmetry.
+        ///
+        /// Deliberately NOT the shared [ClusterDeploymentState#resolveSliceOwner(KVStore, Artifact)]
+        /// call alone: that method is item 1's single-source rule for the SCHEMA GATE, where
+        /// convergence with `SchemaRoutes.heldSlices` is the whole point and one source is required.
+        /// Here there is no second reader to converge with, and the requirement is the opposite —
+        /// resolve from anything that can answer.
+        private Option<BlueprintId> resolveOutcomeOwner(Artifact artifact) {
+            return Option.option(blueprints.get(artifact))
+                         .flatMap(Blueprint::owner)
+                         .orElse(() -> resolveSliceOwner(ctx.kvStore(), artifact));
         }
 
         /// #805 item 2. This write is a read-modify-write: it merges `artifact` into whatever

--- a/aether/aether-deployment/src/main/java/org/pragmatica/aether/deployment/cluster/fsm/ClusterDeploymentState.java
+++ b/aether/aether-deployment/src/main/java/org/pragmatica/aether/deployment/cluster/fsm/ClusterDeploymentState.java
@@ -260,6 +260,9 @@ public sealed interface ClusterDeploymentState extends FsmState<ClusterDeploymen
                   CancellableTask reconcileTimer) implements ClusterDeploymentState {
         private static final Logger log = LoggerFactory.getLogger(Active.class);
         private static final int MAX_RETRIES = 5;
+        /// Retry budget for the fenced deployment-outcome merge (#805 item 2). Each attempt re-reads
+        /// committed state, so this bounds contention, not transport failure.
+        private static final int MAX_OUTCOME_MERGE_ATTEMPTS = 5;
         private static final long MAX_RETRY_DELAY_SECONDS = 30;
         /// The deterministic, single-community-per-source suffix (worker-membership-spec A10): one
         /// community `<source>-w-0` per source keeps community ids stable across rejoins (no
@@ -1651,35 +1654,123 @@ public sealed interface ClusterDeploymentState extends FsmState<ClusterDeploymen
         /// artifact `permanentlyFailed` and calls here instead of retrying it. A slice with no
         /// owning blueprint (`Blueprint::owner` empty — a standalone deploy, not part of any
         /// blueprint) has no `DeploymentOutcomeKey` to write against and is correctly a no-op
-        /// here. Merges into any existing FAILED record for the same blueprint (read-then-Put,
-        /// not a blind overwrite) so a second independently-failing slice in one partial
-        /// deployment is added to `failingSlices` instead of erasing the first.
+        /// here. Merges into any existing FAILED record for the same blueprint so a second
+        /// independently-failing slice in one partial deployment is added to `failingSlices` instead
+        /// of erasing the first. The merge was a bare read-then-Put until #805 item 2; it is now
+        /// fenced and confirmed — see [#submitBestEffortFailureOutcome(BlueprintId, Artifact, String, int)].
         private void recordBestEffortFailureOutcome(Artifact artifact, String failureReason) {
             Option.option(blueprints.get(artifact))
                   .flatMap(Blueprint::owner)
-                  .onPresent(blueprintId -> submitBatch(List.of(bestEffortFailureCommand(blueprintId,
-                                                                                         artifact,
-                                                                                         failureReason))));
+                  .onPresent(blueprintId -> submitBestEffortFailureOutcome(blueprintId, artifact, failureReason, 1));
+        }
+
+        /// #805 item 2. This write is a read-modify-write: it merges `artifact` into whatever
+        /// `failingSlices` the committed record already carries. The read happens when the command is
+        /// BUILT; the Put applies later, after consensus. Two BEST_EFFORT failures both in flight
+        /// before either applies therefore read the same base, and — because `RabiaEngine` selects
+        /// proposals from a `ConcurrentSkipListMap` keyed by a SHA-256 content hash rather than by
+        /// submission order — which one survives is a coin flip on the happy path, not a rare
+        /// interleaving. The `VersionFenced` fence on [DeploymentOutcomeValue] makes the applier
+        /// REJECT the loser instead of letting it overwrite the winner; rejection alone still drops
+        /// the id, so this method confirms after its own apply resolves and retries the merge against
+        /// the now-current committed value.
+        ///
+        /// Deliberately NOT routed through [#submitBatch(List)]: that helper's `onFailure`-only
+        /// contract has no confirmation step, and a fenced merge is exactly the write whose apply
+        /// succeeding does not mean the change landed. `ClusterNode.apply`'s Promise resolves after
+        /// the local state machine has applied the decision (`RabiaEngine.commitChanges` calls
+        /// `stateMachine.process` before `promise.succeed`), so the re-read below observes this
+        /// batch's own effect.
+        ///
+        /// Bounded at [#MAX_OUTCOME_MERGE_ATTEMPTS] retries: each attempt is a fresh read of
+        /// committed state, so progress needs only that some attempt find no competing writer, and a
+        /// budget keeps a pathological contender from turning a failure record into an unbounded
+        /// resubmission loop. Exhaustion is logged at ERROR naming the slice that was not recorded —
+        /// the record is operator-facing history, so a lost id must not be silent.
+        private void submitBestEffortFailureOutcome(BlueprintId blueprintId,
+                                                    Artifact artifact,
+                                                    String failureReason,
+                                                    int attempt) {
+            var command = List.<KVCommand<AetherKey>> of(bestEffortFailureCommand(blueprintId,
+                                                                                  artifact,
+                                                                                  failureReason));
+
+            ctx.cluster()
+               .apply(command)
+               .onSuccess(_ -> confirmBestEffortFailureOutcome(blueprintId, artifact, failureReason, attempt))
+               .onFailure(cause -> handleBatchFailure(cause, command));
+        }
+
+        private void confirmBestEffortFailureOutcome(BlueprintId blueprintId,
+                                                     Artifact artifact,
+                                                     String failureReason,
+                                                     int attempt) {
+            if (deactivated.get() || bestEffortFailureLanded(blueprintId, artifact)) {
+                return;
+            }
+
+            if (attempt >= MAX_OUTCOME_MERGE_ATTEMPTS) {
+                log.error("BEST_EFFORT failure of {} was NOT recorded in the deployment-outcome record for blueprint {}"
+                          + " after {} merge attempts — the record under-reports this deployment's failing slices",
+                          artifact,
+                          blueprintId.asString(),
+                          attempt);
+
+                return;
+            }
+
+            log.debug("Outcome merge for {} on blueprint {} was fenced out (attempt {}), retrying against current committed value",
+                      artifact,
+                      blueprintId.asString(),
+                      attempt);
+            submitBestEffortFailureOutcome(blueprintId, artifact, failureReason, attempt + 1);
+        }
+
+        private boolean bestEffortFailureLanded(BlueprintId blueprintId, Artifact artifact) {
+            return committedOutcome(DeploymentOutcomeKey.deploymentOutcomeKey(blueprintId)).map(DeploymentOutcomeValue::failingSlices)
+                                                                                          .map(slices -> slices.contains(artifact.asString()))
+                                                                                          .or(false);
         }
 
         private KVCommand<AetherKey> bestEffortFailureCommand(BlueprintId blueprintId,
                                                               Artifact artifact,
                                                               String failureReason) {
             var key = DeploymentOutcomeKey.deploymentOutcomeKey(blueprintId);
-            var existingSlices = ctx.kvStore()
-                                    .get(key)
-                                    .filter(v -> v instanceof DeploymentOutcomeValue)
-                                    .map(v -> ((DeploymentOutcomeValue) v).failingSlices())
-                                    .or(List.of());
-            var slices = new ArrayList<>(existingSlices);
+            var committed = committedOutcome(key);
+            var slices = new ArrayList<>(committed.map(DeploymentOutcomeValue::failingSlices)
+                                                  .or(List.of()));
 
             if (!slices.contains(artifact.asString())) {
                 slices.add(artifact.asString());
             }
 
-            var value = DeploymentOutcomeValue.failed(slices, failureReason, ctx.nowMs());
+            var value = DeploymentOutcomeValue.failed(slices,
+                                                      failureReason,
+                                                      ctx.nowMs(),
+                                                      successorOutcomeVersion(committed));
 
             return new KVCommand.Put<>(key, value);
+        }
+
+        private Option<DeploymentOutcomeValue> committedOutcome(DeploymentOutcomeKey key) {
+            return ctx.kvStore()
+                      .get(key)
+                      .filter(DeploymentOutcomeValue.class::isInstance)
+                      .map(DeploymentOutcomeValue.class::cast);
+        }
+
+        /// The version obligation [DeploymentOutcomeValue#fenceVersion()] imposes on every writer:
+        /// derive from the CURRENT committed value and bump by exactly one, or write
+        /// [DeploymentOutcomeValue#FIRST_VERSION] against an absent key. A write built on anything
+        /// else is a write built on a stale read, and the applier drops it.
+        private long nextOutcomeVersion(DeploymentOutcomeKey key) {
+            return successorOutcomeVersion(committedOutcome(key));
+        }
+
+        private static long successorOutcomeVersion(Option<DeploymentOutcomeValue> committed) {
+            return committed.map(DeploymentOutcomeValue::outcomeVersion)
+                            .map(version -> version + 1)
+                            .or(DeploymentOutcomeValue.FIRST_VERSION);
         }
 
         private void handleTransientFailure(SliceNodeKey sliceKey, String failureReason) {
@@ -2502,7 +2593,7 @@ public sealed interface ClusterDeploymentState extends FsmState<ClusterDeploymen
         /// site's failure needs a targeted WARN instead of `submitBatch`'s generic ERROR.
         private void recordSucceededOutcome(BlueprintId blueprintId) {
             var key = DeploymentOutcomeKey.deploymentOutcomeKey(blueprintId);
-            var value = DeploymentOutcomeValue.succeeded(ctx.nowMs());
+            var value = DeploymentOutcomeValue.succeeded(ctx.nowMs(), nextOutcomeVersion(key));
             var command = List.<KVCommand<AetherKey>> of(new KVCommand.Put<>(key, value));
 
             ctx.cluster()
@@ -2594,7 +2685,7 @@ public sealed interface ClusterDeploymentState extends FsmState<ClusterDeploymen
                                                           String cause) {
             var key = DeploymentOutcomeKey.deploymentOutcomeKey(inflight.id());
             var slices = failingSlices.stream().map(Artifact::asString).toList();
-            var value = DeploymentOutcomeValue.failed(slices, cause, ctx.nowMs());
+            var value = DeploymentOutcomeValue.failed(slices, cause, ctx.nowMs(), nextOutcomeVersion(key));
 
             return new KVCommand.Put<>(key, value);
         }
@@ -2657,7 +2748,7 @@ public sealed interface ClusterDeploymentState extends FsmState<ClusterDeploymen
             allSlices.addAll(inflight.activeSlices());
             var key = DeploymentOutcomeKey.deploymentOutcomeKey(inflight.id());
             var slices = allSlices.stream().map(Artifact::asString).toList();
-            var value = DeploymentOutcomeValue.rolledBack(slices, cause, ctx.nowMs());
+            var value = DeploymentOutcomeValue.rolledBack(slices, cause, ctx.nowMs(), nextOutcomeVersion(key));
 
             return new KVCommand.Put<>(key, value);
         }

--- a/aether/aether-deployment/src/main/java/org/pragmatica/aether/deployment/cluster/fsm/ClusterDeploymentState.java
+++ b/aether/aether-deployment/src/main/java/org/pragmatica/aether/deployment/cluster/fsm/ClusterDeploymentState.java
@@ -1694,7 +1694,8 @@ public sealed interface ClusterDeploymentState extends FsmState<ClusterDeploymen
         private Option<BlueprintId> resolveOutcomeOwner(Artifact artifact) {
             return Option.option(blueprints.get(artifact))
                          .flatMap(Blueprint::owner)
-                         .orElse(() -> resolveSliceOwner(ctx.kvStore(), artifact));
+                         .orElse(() -> resolveSliceOwner(ctx.kvStore(),
+                                                         artifact));
         }
 
         /// #805 item 2. This write is a read-modify-write: it merges `artifact` into whatever

--- a/aether/aether-deployment/src/main/java/org/pragmatica/aether/deployment/cluster/fsm/ClusterDeploymentState.java
+++ b/aether/aether-deployment/src/main/java/org/pragmatica/aether/deployment/cluster/fsm/ClusterDeploymentState.java
@@ -1691,9 +1691,7 @@ public sealed interface ClusterDeploymentState extends FsmState<ClusterDeploymen
                                                     Artifact artifact,
                                                     String failureReason,
                                                     int attempt) {
-            var command = List.<KVCommand<AetherKey>> of(bestEffortFailureCommand(blueprintId,
-                                                                                  artifact,
-                                                                                  failureReason));
+            var command = List.<KVCommand<AetherKey>> of(bestEffortFailureCommand(blueprintId, artifact, failureReason));
 
             ctx.cluster()
                .apply(command)
@@ -1711,7 +1709,7 @@ public sealed interface ClusterDeploymentState extends FsmState<ClusterDeploymen
 
             if (attempt >= MAX_OUTCOME_MERGE_ATTEMPTS) {
                 log.error("BEST_EFFORT failure of {} was NOT recorded in the deployment-outcome record for blueprint {}"
-                          + " after {} merge attempts — the record under-reports this deployment's failing slices",
+                         + " after {} merge attempts — the record under-reports this deployment's failing slices",
                           artifact,
                           blueprintId.asString(),
                           attempt);
@@ -1728,8 +1726,8 @@ public sealed interface ClusterDeploymentState extends FsmState<ClusterDeploymen
 
         private boolean bestEffortFailureLanded(BlueprintId blueprintId, Artifact artifact) {
             return committedOutcome(DeploymentOutcomeKey.deploymentOutcomeKey(blueprintId)).map(DeploymentOutcomeValue::failingSlices)
-                                                                                          .map(slices -> slices.contains(artifact.asString()))
-                                                                                          .or(false);
+                                   .map(slices -> slices.contains(artifact.asString()))
+                                   .or(false);
         }
 
         private KVCommand<AetherKey> bestEffortFailureCommand(BlueprintId blueprintId,
@@ -1737,8 +1735,7 @@ public sealed interface ClusterDeploymentState extends FsmState<ClusterDeploymen
                                                               String failureReason) {
             var key = DeploymentOutcomeKey.deploymentOutcomeKey(blueprintId);
             var committed = committedOutcome(key);
-            var slices = new ArrayList<>(committed.map(DeploymentOutcomeValue::failingSlices)
-                                                  .or(List.of()));
+            var slices = new ArrayList<>(committed.map(DeploymentOutcomeValue::failingSlices).or(List.of()));
 
             if (!slices.contains(artifact.asString())) {
                 slices.add(artifact.asString());
@@ -1846,8 +1843,9 @@ public sealed interface ClusterDeploymentState extends FsmState<ClusterDeploymen
         /// so the gate and `SchemaRoutes.heldSlices` could disagree about the same slice even while
         /// calling one predicate. See that method for why dropping the pre-filter removes no check.
         private List<SchemaVersionValue> blockingSchemaRecords(SliceNodeKey sliceKey) {
-            return resolveSliceOwner(ctx.kvStore(), sliceKey.artifact()).map(this::collectBlockingSchemaRecords)
-                                                                       .or(List.of());
+            return resolveSliceOwner(ctx.kvStore(),
+                                     sliceKey.artifact()).map(this::collectBlockingSchemaRecords)
+                                    .or(List.of());
         }
 
         private List<SchemaVersionValue> collectBlockingSchemaRecords(BlueprintId owner) {

--- a/aether/aether-deployment/src/test/java/org/pragmatica/aether/deployment/cluster/fsm/BestEffortOutcomeMergeTest.java
+++ b/aether/aether-deployment/src/test/java/org/pragmatica/aether/deployment/cluster/fsm/BestEffortOutcomeMergeTest.java
@@ -91,6 +91,11 @@ import static org.pragmatica.lang.io.TimeSpan.timeSpan;
 /// sequential cases below deliberately do NOT await: their promises are pre-resolved, the confirm runs
 /// inline, and asserting directly keeps that distinction visible.
 ///
+/// **What keeps that asynchrony from making these tests flaky** is the `synchronized` on
+/// [InMemoryKvStore#applyBatch], which models production's single applier thread — see
+/// [HoldingClusterNode#releaseHeld] for the five-run measurement behind that statement, and for the
+/// correction of an earlier comment that credited it to the wrong mechanism.
+///
 /// Every test drives the real production path — a `NodeArtifactPutReceived` notification carrying a
 /// fatal FAILED state, exactly what `ClusterDeploymentManager.onNodeArtifactPut` dispatches — and
 /// asserts on committed KV state, never on a recorded command list. A test that inspected proposed
@@ -578,21 +583,31 @@ class BestEffortOutcomeMergeTest {
             return held.size();
         }
 
-        /// Applies the held batches in the given order, and — critically — lets each batch's
-        /// confirm-and-retry run to completion BEFORE releasing the next one.
+        /// Applies the held batches in the given order, letting each batch's confirm-and-retry run to
+        /// completion before releasing the next.
         ///
-        /// That quiescence step is what makes these tests pin the FENCE rather than a lucky
-        /// interleaving. `apply`'s Promise resolution dispatches the confirm asynchronously, so
-        /// without the wait the first batch's confirm races the second batch's apply. When it happens
-        /// to lose that race it observes the SECOND batch's value, notices its own id missing, and
-        /// repairs — which makes the whole suite pass even with the fence removed, because the retry
-        /// alone covered for it. A mutation probe caught exactly that.
+        /// **What the drain is for: fixing the SCENARIO, not detecting the bug.** It makes the release
+        /// sequence the one production reaches — a node applies A's merge, A's confirm sees A present
+        /// and correctly stops, and only then does B's merge land. That is the adversarial ordering,
+        /// and without the drain which ordering a run exercises is left to the scheduler.
         ///
-        /// Draining first is also the adversarial order, and the one production reaches: a node
-        /// applies A's merge, A's confirm sees A present and correctly stops, and only then does B's
-        /// merge land. Without the fence B's write is accepted, A is erased, and NOTHING is left to
-        /// notice — the loser already confirmed. The fence is what guarantees the loser is rejected
-        /// and therefore always observes its own absence.
+        /// **What the drain is NOT for, corrected after review.** An earlier revision of this comment
+        /// claimed the drain is what makes these tests detect a missing fence. That is false, and was
+        /// a misattribution: removing `awaitQuiescence()` alone leaves the fence-removed red set
+        /// byte-identical, message for message. The drain and the `synchronized` on
+        /// [InMemoryKvStore#applyBatch] were added in the same change, and it is the SERIALIZED
+        /// APPLIER that removes the race — it models production's single applier thread, where
+        /// `KVStore.process`'s read-then-write fence never interleaves with another apply.
+        ///
+        /// Measured, not reasoned: with the fence removed AND the drain removed AND `applyBatch`
+        /// unsynchronized, this class goes race-shaped — across five consecutive runs, 0 to 3 of its
+        /// 4 tests failed and one run came up entirely green. Restore the synchronization alone and
+        /// the red set is deterministic again. So the serialized applier is load-bearing; the drain
+        /// is retained for scenario determinism and may be removed without weakening detection.
+        ///
+        /// [ApplierFence] is the timing-independent detector: in that same five-run experiment its
+        /// stale-read and version-skip tests failed on every single run. If you are changing anything
+        /// in this class's concurrency plumbing, that is the nested class to trust.
         void releaseHeld(int... order) {
             for (var index : order) {
                 var batch = held.get(index);
@@ -680,6 +695,11 @@ class BestEffortOutcomeMergeTest {
         /// committed storage followed by a write — not atomic. Serializing here models the applier
         /// faithfully; leaving it unserialized would let the test's release thread and an async retry
         /// interleave inside the fence in a way production cannot produce.
+        ///
+        /// **Load-bearing, and measured rather than assumed:** drop this modifier and
+        /// [ConcurrentFailures] becomes race-shaped — 0 to 3 of its 4 tests failing across five
+        /// consecutive runs, one run entirely green. It is this, not
+        /// [HoldingClusterNode#releaseHeld]'s drain, that makes those tests deterministic.
         synchronized void applyBatch(List<KVCommand<AetherKey>> commands) {
             process(createBatch(List.copyOf(commands)));
         }

--- a/aether/aether-deployment/src/test/java/org/pragmatica/aether/deployment/cluster/fsm/BestEffortOutcomeMergeTest.java
+++ b/aether/aether-deployment/src/test/java/org/pragmatica/aether/deployment/cluster/fsm/BestEffortOutcomeMergeTest.java
@@ -21,6 +21,8 @@ import org.pragmatica.aether.deployment.cluster.fsm.ClusterDeploymentEvents.Node
 import org.pragmatica.aether.deployment.schema.SchemaOrchestratorService;
 import org.pragmatica.aether.slice.SliceState;
 import org.pragmatica.aether.slice.blueprint.BlueprintId;
+import org.pragmatica.aether.slice.blueprint.ExpandedBlueprint;
+import org.pragmatica.aether.slice.blueprint.ResolvedSlice;
 import org.pragmatica.aether.slice.kvstore.AetherKey;
 import org.pragmatica.aether.slice.kvstore.AetherKey.DeploymentOutcomeKey;
 import org.pragmatica.aether.slice.kvstore.AetherKey.NodeArtifactKey;
@@ -102,6 +104,12 @@ class BestEffortOutcomeMergeTest {
 
     @BeforeEach
     void setUp() {
+        buildHarness(DeploymentAtomicity.BEST_EFFORT);
+        registerOwnedSlice(SLICE_A);
+        registerOwnedSlice(SLICE_B);
+    }
+
+    private void buildHarness(DeploymentAtomicity atomicity) {
         var router = MessageRouter.mutable();
 
         kvStore = new InMemoryKvStore(router);
@@ -118,15 +126,13 @@ class BestEffortOutcomeMergeTest {
                                                     () -> Set.of(SELF, NODE_A),
                                                     Set::of,
                                                     Set.of(SELF, NODE_A),
-                                                    DeploymentAtomicity.BEST_EFFORT,
+                                                    atomicity,
                                                     3,
                                                     timeSpan(300).seconds(),
                                                     System::currentTimeMillis).dormant();
 
-        harness = FsmTestHarness.harness("best-effort-outcome-" + System.nanoTime(), factory);
+        harness = FsmTestHarness.harness("outcome-merge-" + System.nanoTime(), factory);
         harness.dispatch(new Activate());
-        registerOwnedSlice(SLICE_A);
-        registerOwnedSlice(SLICE_B);
     }
 
     @Nested
@@ -224,6 +230,66 @@ class BestEffortOutcomeMergeTest {
 
             assertThat(recordedFailingSlices()).containsExactly(SLICE_A.asString());
             assertThat(recordedOutcome().outcomeVersion()).isEqualTo(1L);
+        }
+    }
+
+    /// #805's acceptance clause: "no behaviour change for ALL_OR_NOTHING". Fencing
+    /// [DeploymentOutcomeValue] makes EVERY writer of that record fenceable, not just the BEST_EFFORT
+    /// merge — the three ALL_OR_NOTHING terminal writers (`recordSucceededOutcome`,
+    /// `failedOutcomeCommand`, `rolledBackOutcomeCommand`) included. A writer that kept blindly
+    /// stamping version 1 would now be REJECTED by the applier the moment a record already existed,
+    /// which would be a silent regression of exactly the kind this ticket is about.
+    ///
+    /// These tests therefore assert on COMMITTED state after the batch is applied through the real
+    /// applier. The pre-existing ALL_OR_NOTHING coverage in `ClusterDeploymentStateTransactionalTest`
+    /// cannot speak to this: it inspects the PROPOSED command list from a recording cluster node that
+    /// never applies anything, so it stays green whether the applier accepts the write or drops it.
+    @Nested
+    class AllOrNothingUnaffected {
+        @BeforeEach
+        void useAllOrNothing() {
+            buildHarness(DeploymentAtomicity.ALL_OR_NOTHING);
+            registerOwnedSlice(SLICE_A);
+        }
+
+        /// The terminal FAILED record for a rollback with no previous blueprint still lands.
+        @Test
+        void theTerminalFailedOutcome_isCommitted() {
+            trackInFlight(SLICE_A);
+
+            failSlice(SLICE_A);
+
+            assertThat(recordedOutcome().status()).isEqualTo(DeploymentOutcomeStatus.FAILED);
+            assertThat(recordedFailingSlices()).contains(SLICE_A.asString());
+        }
+
+        /// The load-bearing one. With a record ALREADY committed at version 1, the ALL_OR_NOTHING
+        /// terminal write must derive version 2 and be accepted. A blind `FIRST_VERSION` stamp would
+        /// be fenced out here and the record would still read as the seeded one.
+        @Test
+        void theTerminalOutcome_isAccepted_overAnAlreadyCommittedRecord() {
+            kvStore.applyBatch(List.of(new KVCommand.Put<>(DeploymentOutcomeKey.deploymentOutcomeKey(OWNER),
+                                                           DeploymentOutcomeValue.succeeded(1L))));
+            trackInFlight(SLICE_A);
+
+            failSlice(SLICE_A);
+
+            assertThat(recordedOutcome().status()).as("the terminal write must replace the committed SUCCEEDED record, "
+                                                      + "not be fenced out by it")
+                                                  .isEqualTo(DeploymentOutcomeStatus.FAILED);
+            assertThat(recordedOutcome().outcomeVersion()).as("derived as committed + 1, the only version the applier accepts")
+                                                          .isEqualTo(2L);
+        }
+
+        private void trackInFlight(Artifact artifact) {
+            var slice = ResolvedSlice.resolvedSlice(artifact, 3, false).unwrap();
+            var expanded = ExpandedBlueprint.expandedBlueprint(OWNER, List.of(slice));
+
+            activeState().inFlightBlueprints()
+                         .put(OWNER,
+                              ClusterDeploymentState.Active.InFlightBlueprint.inFlightBlueprint(OWNER,
+                                                                                                expanded,
+                                                                                                Option.none()));
         }
     }
 

--- a/aether/aether-deployment/src/test/java/org/pragmatica/aether/deployment/cluster/fsm/BestEffortOutcomeMergeTest.java
+++ b/aether/aether-deployment/src/test/java/org/pragmatica/aether/deployment/cluster/fsm/BestEffortOutcomeMergeTest.java
@@ -17,6 +17,7 @@ import org.pragmatica.aether.artifact.Artifact;
 import org.pragmatica.aether.deployment.cluster.ClusterDeploymentManager.Blueprint;
 import org.pragmatica.aether.deployment.cluster.ClusterDeploymentManager.DeploymentAtomicity;
 import org.pragmatica.aether.deployment.cluster.fsm.ClusterDeploymentEvents.Activate;
+import org.pragmatica.aether.deployment.cluster.fsm.ClusterDeploymentEvents.AppBlueprintPutReceived;
 import org.pragmatica.aether.deployment.cluster.fsm.ClusterDeploymentEvents.NodeArtifactPutReceived;
 import org.pragmatica.aether.deployment.cluster.fsm.ClusterDeploymentEvents.SliceTargetPutReceived;
 import org.pragmatica.aether.deployment.schema.SchemaOrchestratorService;
@@ -25,10 +26,12 @@ import org.pragmatica.aether.slice.blueprint.BlueprintId;
 import org.pragmatica.aether.slice.blueprint.ExpandedBlueprint;
 import org.pragmatica.aether.slice.blueprint.ResolvedSlice;
 import org.pragmatica.aether.slice.kvstore.AetherKey;
+import org.pragmatica.aether.slice.kvstore.AetherKey.AppBlueprintKey;
 import org.pragmatica.aether.slice.kvstore.AetherKey.DeploymentOutcomeKey;
 import org.pragmatica.aether.slice.kvstore.AetherKey.NodeArtifactKey;
 import org.pragmatica.aether.slice.kvstore.AetherKey.SliceTargetKey;
 import org.pragmatica.aether.slice.kvstore.AetherValue;
+import org.pragmatica.aether.slice.kvstore.AetherValue.AppBlueprintValue;
 import org.pragmatica.aether.slice.kvstore.AetherValue.DeploymentOutcomeStatus;
 import org.pragmatica.aether.slice.kvstore.AetherValue.DeploymentOutcomeValue;
 import org.pragmatica.aether.slice.kvstore.AetherValue.NodeArtifactValue;
@@ -295,6 +298,88 @@ class BestEffortOutcomeMergeTest {
         }
     }
 
+    /// The two sources `resolveOutcomeOwner` consults, each pinned ALONE — because each is the only
+    /// one that can answer in a real situation, and a fix that dropped either would look correct
+    /// against the other's test.
+    ///
+    /// An unresolved owner means NO record, not a degraded one, so both of these are dropped-record
+    /// bugs. #698/#940 closed the erasure route; these close the mirror-availability route.
+    @Nested
+    class OwnerResolutionFallback {
+        @BeforeEach
+        void freshHarness() {
+            buildHarness(DeploymentAtomicity.BEST_EFFORT);
+        }
+
+        /// Mirror cannot answer, committed record can: the artifact has no `blueprints` entry at all
+        /// (dropped by `removeNonTargetVersions`, or not yet rebuilt after a failover) while the
+        /// committed `SliceTargetValue` still names its owner. Before the fallback this failure went
+        /// unrecorded.
+        @Test
+        void theOutcomeRecord_isWritten_whenOnlyTheCommittedRecordNamesTheOwner() {
+            commitSliceTargetWithoutNotifying(SLICE_A, OWNER);
+
+            assertThat(activeState().blueprints()).as("the mirror must be genuinely unable to answer, or this test "
+                                                      + "proves nothing about the fallback")
+                                                  .doesNotContainKey(SLICE_A);
+
+            failSlice(SLICE_A);
+
+            assertThat(recordedFailingSlices()).contains(SLICE_A.asString());
+        }
+
+        /// The non-regression, and the reason the mirror is consulted FIRST.
+        /// `handleAppBlueprintChange` populates the mirror in the same pass that only QUEUES the
+        /// `SliceTargetKey` Put; that Put applies after consensus. In between, the mirror names an
+        /// owner the committed store does not carry. A committed-record-only lookup would stop
+        /// recording failures for that entire deploy window — swapping one dropped-record bug for
+        /// another. Here the slice-target write is dropped outright, which is the adversarial form of
+        /// that window.
+        @Test
+        void theOutcomeRecord_isWritten_whenOnlyTheMirrorNamesTheOwner() {
+            cluster.dropSliceTargetWrites();
+            publishBlueprintDeploy(SLICE_A);
+
+            assertThat(committedSliceTarget(SLICE_A).isEmpty()).as("the committed store must NOT carry the record yet, "
+                                                                   + "or this is not the deploy window")
+                                                              .isTrue();
+            assertThat(activeState().blueprints()).containsKey(SLICE_A);
+
+            failSlice(SLICE_A);
+
+            assertThat(recordedFailingSlices()).as("the mirror leads the store during a deploy — the failure must still "
+                                                   + "be recorded")
+                                               .contains(SLICE_A.asString());
+        }
+
+        /// Writes the committed record WITHOUT dispatching the notification, so the FSM never mirrors
+        /// it — the only way to leave the mirror genuinely empty while the store is authoritative.
+        private void commitSliceTargetWithoutNotifying(Artifact artifact, BlueprintId owner) {
+            kvStore.applyBatch(List.of(new KVCommand.Put<>(SliceTargetKey.sliceTargetKey(artifact.base()),
+                                                           SliceTargetValue.sliceTargetValue(artifact.version(),
+                                                                                             1,
+                                                                                             Option.some(owner)))));
+        }
+
+        /// Drives the real `AppBlueprintPutReceived` notification, so the mirror is populated by
+        /// `handleAppBlueprintChange` itself rather than by hand.
+        private void publishBlueprintDeploy(Artifact artifact) {
+            var slice = ResolvedSlice.resolvedSlice(artifact, 1, false).unwrap();
+            var expanded = ExpandedBlueprint.expandedBlueprint(OWNER, List.of(slice));
+            var key = AppBlueprintKey.appBlueprintKey(OWNER);
+            var value = AppBlueprintValue.appBlueprintValue(expanded);
+
+            harness.dispatch(new AppBlueprintPutReceived(new ValuePut<>(new KVCommand.Put<>(key, value),
+                                                                        Option.none())));
+        }
+
+        private Option<SliceTargetValue> committedSliceTarget(Artifact artifact) {
+            return kvStore.get(SliceTargetKey.sliceTargetKey(artifact.base()))
+                          .filter(SliceTargetValue.class::isInstance)
+                          .map(SliceTargetValue.class::cast);
+        }
+    }
+
     /// #805's acceptance clause: "no behaviour change for ALL_OR_NOTHING". Fencing
     /// [DeploymentOutcomeValue] makes EVERY writer of that record fenceable, not just the BEST_EFFORT
     /// merge — the three ALL_OR_NOTHING terminal writers (`recordSucceededOutcome`,
@@ -469,6 +554,7 @@ class BestEffortOutcomeMergeTest {
         private final List<HeldBatch> held = Collections.synchronizedList(new ArrayList<>());
         private final AtomicLong applies = new AtomicLong();
         private volatile int holdBudget;
+        private volatile boolean dropSliceTargets;
 
         private record HeldBatch(List<KVCommand<AetherKey>> commands, Promise<List<Object>> promise) {}
 
@@ -479,6 +565,13 @@ class BestEffortOutcomeMergeTest {
 
         void holdOutcomeBatches(int count) {
             holdBudget = count;
+        }
+
+        /// Models `handleAppBlueprintChange`'s deploy window: the `SliceTargetKey` Put is queued for
+        /// consensus but has not applied, so the committed store does not carry it while the mirror
+        /// already does. Dropping it outright is the adversarial form of "not yet applied".
+        void dropSliceTargetWrites() {
+            dropSliceTargets = true;
         }
 
         int heldCount() {
@@ -546,10 +639,18 @@ class BestEffortOutcomeMergeTest {
                 return (Promise<List<R>>) (Promise<?>) pending;
             }
 
-            store.applyBatch(batch);
+            store.applyBatch(retained(batch));
             applies.incrementAndGet();
 
             return Promise.success(List.of());
+        }
+
+        private List<KVCommand<AetherKey>> retained(List<KVCommand<AetherKey>> batch) {
+            return dropSliceTargets
+                   ? batch.stream()
+                          .filter(command -> !(command.key() instanceof SliceTargetKey))
+                          .toList()
+                   : batch;
         }
 
         private static boolean touchesOutcomeRecord(List<KVCommand<AetherKey>> batch) {

--- a/aether/aether-deployment/src/test/java/org/pragmatica/aether/deployment/cluster/fsm/BestEffortOutcomeMergeTest.java
+++ b/aether/aether-deployment/src/test/java/org/pragmatica/aether/deployment/cluster/fsm/BestEffortOutcomeMergeTest.java
@@ -91,10 +91,10 @@ import static org.pragmatica.lang.io.TimeSpan.timeSpan;
 /// sequential cases below deliberately do NOT await: their promises are pre-resolved, the confirm runs
 /// inline, and asserting directly keeps that distinction visible.
 ///
-/// **What keeps that asynchrony from making these tests flaky** is the `synchronized` on
-/// [InMemoryKvStore#applyBatch], which models production's single applier thread — see
-/// [HoldingClusterNode#releaseHeld] for the five-run measurement behind that statement, and for the
-/// correction of an earlier comment that credited it to the wrong mechanism.
+/// **What keeps that asynchrony from making these tests flaky is the confirm-drain** in
+/// [HoldingClusterNode#releaseHeld], not the `synchronized` on [InMemoryKvStore#applyBatch]. See that
+/// method for the interleaved measurement establishing it, and for two earlier comments here that got
+/// the attribution wrong in opposite directions.
 ///
 /// Every test drives the real production path — a `NodeArtifactPutReceived` notification carrying a
 /// fatal FAILED state, exactly what `ClusterDeploymentManager.onNodeArtifactPut` dispatches — and
@@ -586,28 +586,41 @@ class BestEffortOutcomeMergeTest {
         /// Applies the held batches in the given order, letting each batch's confirm-and-retry run to
         /// completion before releasing the next.
         ///
-        /// **What the drain is for: fixing the SCENARIO, not detecting the bug.** It makes the release
-        /// sequence the one production reaches — a node applies A's merge, A's confirm sees A present
-        /// and correctly stops, and only then does B's merge land. That is the adversarial ordering,
-        /// and without the drain which ordering a run exercises is left to the scheduler.
+        /// **The drain is what makes detection deterministic. Do not remove it.** With the fence
+        /// removed it is the difference between always catching the regression and sometimes catching
+        /// it. Measured across five rounds with three configurations INTERLEAVED inside each round, so
+        /// load drift could not bias one against another; the numbers are reds out of this class's 4
+        /// tests, one entry per round:
         ///
-        /// **What the drain is NOT for, corrected after review.** An earlier revision of this comment
-        /// claimed the drain is what makes these tests detect a missing fence. That is false, and was
-        /// a misattribution: removing `awaitQuiescence()` alone leaves the fence-removed red set
-        /// byte-identical, message for message. The drain and the `synchronized` on
-        /// [InMemoryKvStore#applyBatch] were added in the same change, and it is the SERIALIZED
-        /// APPLIER that removes the race — it models production's single applier thread, where
-        /// `KVStore.process`'s read-then-write fence never interleaves with another apply.
+        /// | configuration | reds per round |
+        /// |---|---|
+        /// | drain ON, applier synchronized (as shipped) | 4, 4, 4, 4, 4 |
+        /// | drain OFF, applier synchronized | 4, 4, 3, 1, 4 |
+        /// | drain OFF, applier unsynchronized | 1, 4, 2, 2, 3 |
         ///
-        /// Measured, not reasoned: with the fence removed AND the drain removed AND `applyBatch`
-        /// unsynchronized, this class goes race-shaped — across five consecutive runs, 0 to 3 of its
-        /// 4 tests failed and one run came up entirely green. Restore the synchronization alone and
-        /// the red set is deterministic again. So the serialized applier is load-bearing; the drain
-        /// is retained for scenario determinism and may be removed without weakening detection.
+        /// The first two rows differ ONLY in the drain and isolate it: without it, detection falls
+        /// from a deterministic 4/4 to as low as 1/4. The last two rows differ only in the
+        /// `synchronized` on [InMemoryKvStore#applyBatch] and show no measurable effect on the
+        /// distribution.
         ///
-        /// [ApplierFence] is the timing-independent detector: in that same five-run experiment its
-        /// stale-read and version-skip tests failed on every single run. If you are changing anything
-        /// in this class's concurrency plumbing, that is the nested class to trust.
+        /// The mechanism agrees with the numbers, which is why this is stated rather than hedged: the
+        /// drain forces A's confirm to complete before B's apply, so the loss is always observed;
+        /// `synchronized` only orders what happens WITHIN one apply and cannot order a confirm against
+        /// the next apply.
+        ///
+        /// **Two earlier versions of this comment were wrong, in opposite directions.** The history is
+        /// kept because it is the reusable part. The first said removing the drain makes the whole
+        /// suite pass — overstated. Its correction said the drain is optional and the serialized
+        /// applier does the work — inverted, and worse, because "may be removed" is an INSTRUCTION: a
+        /// maintainer following it would have silently degraded this pin from always-catching to
+        /// sometimes-catching. Both were written from small samples of a flaky distribution that
+        /// happened to look clean — one run, and five sequential runs of a single configuration. More
+        /// care at either step would not have caught it; interleaving the configurations did. A claim
+        /// about a flaky mechanism is not reportable without its sample size and its control.
+        ///
+        /// [ApplierFence] is the timing-independent detector: exactly 2 of its 3 tests red in all
+        /// fifteen runs above, never varying. If you are changing this class's concurrency plumbing,
+        /// that is the nested class to trust.
         void releaseHeld(int... order) {
             for (var index : order) {
                 var batch = held.get(index);
@@ -696,10 +709,13 @@ class BestEffortOutcomeMergeTest {
         /// faithfully; leaving it unserialized would let the test's release thread and an async retry
         /// interleave inside the fence in a way production cannot produce.
         ///
-        /// **Load-bearing, and measured rather than assumed:** drop this modifier and
-        /// [ConcurrentFailures] becomes race-shaped — 0 to 3 of its 4 tests failing across five
-        /// consecutive runs, one run entirely green. It is this, not
-        /// [HoldingClusterNode#releaseHeld]'s drain, that makes those tests deterministic.
+        /// **Kept on modelling grounds, NOT because it was measured to matter.** Interleaved against
+        /// an unsynchronized applier across five rounds, it showed no measurable effect on
+        /// [ConcurrentFailures]'s red distribution — both configurations were flaky. It is the drain
+        /// in [HoldingClusterNode#releaseHeld], not this modifier, that makes those tests
+        /// deterministic; see that method for the measurement. Retained because an unsynchronized
+        /// applier admits an interleaving production cannot produce, which would make any future
+        /// failure here ambiguous.
         synchronized void applyBatch(List<KVCommand<AetherKey>> commands) {
             process(createBatch(List.copyOf(commands)));
         }

--- a/aether/aether-deployment/src/test/java/org/pragmatica/aether/deployment/cluster/fsm/BestEffortOutcomeMergeTest.java
+++ b/aether/aether-deployment/src/test/java/org/pragmatica/aether/deployment/cluster/fsm/BestEffortOutcomeMergeTest.java
@@ -18,6 +18,7 @@ import org.pragmatica.aether.deployment.cluster.ClusterDeploymentManager.Bluepri
 import org.pragmatica.aether.deployment.cluster.ClusterDeploymentManager.DeploymentAtomicity;
 import org.pragmatica.aether.deployment.cluster.fsm.ClusterDeploymentEvents.Activate;
 import org.pragmatica.aether.deployment.cluster.fsm.ClusterDeploymentEvents.NodeArtifactPutReceived;
+import org.pragmatica.aether.deployment.cluster.fsm.ClusterDeploymentEvents.SliceTargetPutReceived;
 import org.pragmatica.aether.deployment.schema.SchemaOrchestratorService;
 import org.pragmatica.aether.slice.SliceState;
 import org.pragmatica.aether.slice.blueprint.BlueprintId;
@@ -26,10 +27,12 @@ import org.pragmatica.aether.slice.blueprint.ResolvedSlice;
 import org.pragmatica.aether.slice.kvstore.AetherKey;
 import org.pragmatica.aether.slice.kvstore.AetherKey.DeploymentOutcomeKey;
 import org.pragmatica.aether.slice.kvstore.AetherKey.NodeArtifactKey;
+import org.pragmatica.aether.slice.kvstore.AetherKey.SliceTargetKey;
 import org.pragmatica.aether.slice.kvstore.AetherValue;
 import org.pragmatica.aether.slice.kvstore.AetherValue.DeploymentOutcomeStatus;
 import org.pragmatica.aether.slice.kvstore.AetherValue.DeploymentOutcomeValue;
 import org.pragmatica.aether.slice.kvstore.AetherValue.NodeArtifactValue;
+import org.pragmatica.aether.slice.kvstore.AetherValue.SliceTargetValue;
 import org.pragmatica.cluster.node.ClusterNode;
 import org.pragmatica.cluster.state.kvstore.KVCommand;
 import org.pragmatica.cluster.state.kvstore.KVStore;
@@ -233,6 +236,65 @@ class BestEffortOutcomeMergeTest {
         }
     }
 
+    /// Relayed from `fix-930-922` while #930/#922 were in flight: `recordBestEffortFailureOutcome`
+    /// reaches `DeploymentOutcomeKey` through `Blueprint::owner`, and that owner traces back to
+    /// `SliceTargetValue.owningBlueprint` — the field #698 found the autoscaler and the A/B writer
+    /// erasing. An erased owner does not corrupt the record, it means NO record is written at all, so
+    /// the lost-update fix above would have been correct and irrelevant for every autoscaled or
+    /// A/B-tested slice.
+    ///
+    /// #940 (`a75e6af42`, this branch's base) fixed both producers. These tests are the regression
+    /// sensor for that coupling, driven through the REAL `SliceTargetPutReceived` path — the same
+    /// notification an autoscale write produces — rather than by hand-seeding the mirror, so an owner
+    /// erased anywhere between the KV record and `Blueprint::owner` shows up here.
+    @Nested
+    class OwnerResolutionFromTheSliceTargetRecord {
+        @BeforeEach
+        void freshHarness() {
+            buildHarness(DeploymentAtomicity.BEST_EFFORT);
+        }
+
+        /// The positive case, and the one that would have been red before #940: an autoscale-shaped
+        /// `SliceTargetValue` carrying its owner must still produce a committed outcome record on a
+        /// deterministic failure.
+        @Test
+        void theOutcomeRecord_isWritten_whenTheSliceTargetRecordCarriesItsOwner() {
+            publishSliceTarget(SLICE_A, Option.some(OWNER));
+
+            failSlice(SLICE_A);
+
+            assertThat(recordedFailingSlices()).as("owner preserved on the SliceTargetValue (#698/#940) — the failure "
+                                                   + "record must be attributable and therefore written")
+                                               .contains(SLICE_A.asString());
+        }
+
+        /// The failure mode itself, pinned so it is visible rather than inferred: with no owner on the
+        /// record there is no `DeploymentOutcomeKey` to write against and the failure is silently
+        /// unrecorded. This is what #698's erasure produced for every autoscaled slice, and it is the
+        /// shape a future erasure would take.
+        @Test
+        void noOutcomeRecord_isWritten_whenTheSliceTargetRecordCarriesNoOwner() {
+            publishSliceTarget(SLICE_A, Option.none());
+
+            failSlice(SLICE_A);
+
+            assertThat(committedOutcome().isEmpty()).as("an owner-less slice has no blueprint to record the failure "
+                                                        + "against — the record is dropped entirely, not merely incomplete")
+                                                    .isTrue();
+        }
+
+        /// Drives the real notification `handleSliceTargetChange` consumes, so the owner reaches
+        /// `Active.blueprints` the same way an autoscaler write delivers it.
+        private void publishSliceTarget(Artifact artifact, Option<BlueprintId> owner) {
+            var key = SliceTargetKey.sliceTargetKey(artifact.base());
+            var value = SliceTargetValue.sliceTargetValue(artifact.version(), 1, owner);
+
+            kvStore.applyBatch(List.of(new KVCommand.Put<>(key, value)));
+            harness.dispatch(new SliceTargetPutReceived(new ValuePut<>(new KVCommand.Put<>(key, value),
+                                                                       Option.none())));
+        }
+    }
+
     /// #805's acceptance clause: "no behaviour change for ALL_OR_NOTHING". Fencing
     /// [DeploymentOutcomeValue] makes EVERY writer of that record fenceable, not just the BEST_EFFORT
     /// merge — the three ALL_OR_NOTHING terminal writers (`recordSucceededOutcome`,
@@ -373,6 +435,12 @@ class BestEffortOutcomeMergeTest {
 
     private List<String> recordedFailingSlices() {
         return recordedOutcome().failingSlices();
+    }
+
+    private Option<DeploymentOutcomeValue> committedOutcome() {
+        return kvStore.get(DeploymentOutcomeKey.deploymentOutcomeKey(OWNER))
+                      .filter(DeploymentOutcomeValue.class::isInstance)
+                      .map(DeploymentOutcomeValue.class::cast);
     }
 
     private DeploymentOutcomeValue recordedOutcome() {

--- a/aether/aether-deployment/src/test/java/org/pragmatica/aether/deployment/cluster/fsm/BestEffortOutcomeMergeTest.java
+++ b/aether/aether-deployment/src/test/java/org/pragmatica/aether/deployment/cluster/fsm/BestEffortOutcomeMergeTest.java
@@ -10,6 +10,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Function;
 
 import org.pragmatica.aether.artifact.Artifact;
@@ -226,6 +227,49 @@ class BestEffortOutcomeMergeTest {
         }
     }
 
+    /// The applier-level half of the fix, pinned without the FSM in the picture. These say what the
+    /// `VersionFenced` marker buys on its own: a merge built on a stale read is REJECTED, not applied.
+    ///
+    /// Kept separate from the FSM tests deliberately. The FSM tests show the id is recovered; these
+    /// show WHY it has to be — remove the marker and a stale write silently wins here, which is the
+    /// state in which a confirm that has already run can never notice the loss.
+    @Nested
+    class ApplierFence {
+        @Test
+        void aMergeBuiltOnAStaleRead_isRejected() {
+            applyOutcome(DeploymentOutcomeValue.failed(List.of(SLICE_A.asString()), FAILURE, 1L, 1L));
+            applyOutcome(DeploymentOutcomeValue.failed(List.of(SLICE_B.asString()), FAILURE, 2L, 1L));
+
+            assertThat(recordedFailingSlices()).as("the second writer read the same absent base and computed the same "
+                                                   + "version 1, so the applier must reject it rather than erase SLICE_A")
+                                               .containsExactly(SLICE_A.asString());
+        }
+
+        @Test
+        void aMergeBuiltOnTheCurrentValue_isAccepted() {
+            applyOutcome(DeploymentOutcomeValue.failed(List.of(SLICE_A.asString()), FAILURE, 1L, 1L));
+            applyOutcome(DeploymentOutcomeValue.failed(List.of(SLICE_A.asString(), SLICE_B.asString()), FAILURE, 2L, 2L));
+
+            assertThat(recordedFailingSlices()).as("the successor version is the one legitimate continuation of the chain")
+                                               .containsExactly(SLICE_A.asString(), SLICE_B.asString());
+        }
+
+        /// A version JUMP is a write built on something other than the current committed value, and is
+        /// rejected for the same reason as an equal version — pinning that the fence is a successor
+        /// check, not merely a "greater than" check.
+        @Test
+        void aMergeThatSkipsAVersion_isRejected() {
+            applyOutcome(DeploymentOutcomeValue.failed(List.of(SLICE_A.asString()), FAILURE, 1L, 1L));
+            applyOutcome(DeploymentOutcomeValue.failed(List.of(SLICE_B.asString()), FAILURE, 2L, 3L));
+
+            assertThat(recordedFailingSlices()).containsExactly(SLICE_A.asString());
+        }
+
+        private void applyOutcome(DeploymentOutcomeValue value) {
+            kvStore.applyBatch(List.of(new KVCommand.Put<>(DeploymentOutcomeKey.deploymentOutcomeKey(OWNER), value)));
+        }
+    }
+
     // --- fixture ---
 
     /// Drives the exact notification production dispatches on a fatal slice failure. `fatal = true`
@@ -289,7 +333,8 @@ class BestEffortOutcomeMergeTest {
         private final NodeId self;
         private final InMemoryKvStore store;
         private final List<HeldBatch> held = Collections.synchronizedList(new ArrayList<>());
-        private int holdBudget;
+        private final AtomicLong applies = new AtomicLong();
+        private volatile int holdBudget;
 
         private record HeldBatch(List<KVCommand<AetherKey>> commands, Promise<List<Object>> promise) {}
 
@@ -306,10 +351,21 @@ class BestEffortOutcomeMergeTest {
             return held.size();
         }
 
-        /// Applies the held batches in the given order, resolving each promise as it lands. Resolution
-        /// synchronously runs the FSM's confirm-and-retry for that batch, so a rejected merge is
-        /// recovered before the next held batch is released — the same sequencing the applier thread
-        /// produces in production.
+        /// Applies the held batches in the given order, and — critically — lets each batch's
+        /// confirm-and-retry run to completion BEFORE releasing the next one.
+        ///
+        /// That quiescence step is what makes these tests pin the FENCE rather than a lucky
+        /// interleaving. `apply`'s Promise resolution dispatches the confirm asynchronously, so
+        /// without the wait the first batch's confirm races the second batch's apply. When it happens
+        /// to lose that race it observes the SECOND batch's value, notices its own id missing, and
+        /// repairs — which makes the whole suite pass even with the fence removed, because the retry
+        /// alone covered for it. A mutation probe caught exactly that.
+        ///
+        /// Draining first is also the adversarial order, and the one production reaches: a node
+        /// applies A's merge, A's confirm sees A present and correctly stops, and only then does B's
+        /// merge land. Without the fence B's write is accepted, A is erased, and NOTHING is left to
+        /// notice — the loser already confirmed. The fence is what guarantees the loser is rejected
+        /// and therefore always observes its own absence.
         void releaseHeld(int... order) {
             for (var index : order) {
                 var batch = held.get(index);
@@ -317,6 +373,30 @@ class BestEffortOutcomeMergeTest {
                 store.applyBatch(batch.commands());
                 batch.promise()
                      .succeed(List.of());
+                awaitQuiescence();
+            }
+        }
+
+        /// Waits until no further batch has been applied for a stable window — i.e. the confirm-and-
+        /// retry chain triggered by the last resolution has finished.
+        private void awaitQuiescence() {
+            var deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5);
+            var stableSince = 0L;
+            var lastSeen = applies.get();
+
+            while (System.nanoTime() < deadline) {
+                var current = applies.get();
+
+                if (current != lastSeen) {
+                    lastSeen = current;
+                    stableSince = 0L;
+                } else if (stableSince == 0L) {
+                    stableSince = System.nanoTime();
+                } else if (System.nanoTime() - stableSince > TimeUnit.MILLISECONDS.toNanos(250)) {
+                    return;
+                }
+
+                Thread.onSpinWait();
             }
         }
 
@@ -333,6 +413,7 @@ class BestEffortOutcomeMergeTest {
             }
 
             store.applyBatch(batch);
+            applies.incrementAndGet();
 
             return Promise.success(List.of());
         }

--- a/aether/aether-deployment/src/test/java/org/pragmatica/aether/deployment/cluster/fsm/BestEffortOutcomeMergeTest.java
+++ b/aether/aether-deployment/src/test/java/org/pragmatica/aether/deployment/cluster/fsm/BestEffortOutcomeMergeTest.java
@@ -1,0 +1,445 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2025 Pragmatica Labs - Sergiy Yevtushenko
+// Licensed under Business Source License 1.1. Change Date: 2030-01-01. Change License: Apache-2.0.
+// See LICENSE in the repository root for full terms.
+package org.pragmatica.aether.deployment.cluster.fsm;
+
+import java.net.SocketAddress;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+
+import org.pragmatica.aether.artifact.Artifact;
+import org.pragmatica.aether.deployment.cluster.ClusterDeploymentManager.Blueprint;
+import org.pragmatica.aether.deployment.cluster.ClusterDeploymentManager.DeploymentAtomicity;
+import org.pragmatica.aether.deployment.cluster.fsm.ClusterDeploymentEvents.Activate;
+import org.pragmatica.aether.deployment.cluster.fsm.ClusterDeploymentEvents.NodeArtifactPutReceived;
+import org.pragmatica.aether.deployment.schema.SchemaOrchestratorService;
+import org.pragmatica.aether.slice.SliceState;
+import org.pragmatica.aether.slice.blueprint.BlueprintId;
+import org.pragmatica.aether.slice.kvstore.AetherKey;
+import org.pragmatica.aether.slice.kvstore.AetherKey.DeploymentOutcomeKey;
+import org.pragmatica.aether.slice.kvstore.AetherKey.NodeArtifactKey;
+import org.pragmatica.aether.slice.kvstore.AetherValue;
+import org.pragmatica.aether.slice.kvstore.AetherValue.DeploymentOutcomeStatus;
+import org.pragmatica.aether.slice.kvstore.AetherValue.DeploymentOutcomeValue;
+import org.pragmatica.aether.slice.kvstore.AetherValue.NodeArtifactValue;
+import org.pragmatica.cluster.node.ClusterNode;
+import org.pragmatica.cluster.state.kvstore.KVCommand;
+import org.pragmatica.cluster.state.kvstore.KVStore;
+import org.pragmatica.cluster.state.kvstore.KVStoreNotification.ValuePut;
+import org.pragmatica.consensus.NodeId;
+import org.pragmatica.consensus.fsm.ClusterFsmEvent;
+import org.pragmatica.consensus.net.NodeInfo;
+import org.pragmatica.consensus.topology.NodeState;
+import org.pragmatica.consensus.topology.TopologyManager;
+import org.pragmatica.lang.Option;
+import org.pragmatica.lang.Promise;
+import org.pragmatica.lang.Unit;
+import org.pragmatica.lang.io.TimeSpan;
+import org.pragmatica.messaging.MessageRouter;
+import org.pragmatica.net.tcp.NodeAddress;
+import org.pragmatica.serialization.Deserializer;
+import org.pragmatica.serialization.Serializer;
+import org.pragmatica.statemachine.Fsm;
+import org.pragmatica.statemachine.FsmTestHarness;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import io.netty.buffer.ByteBuf;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.pragmatica.lang.io.TimeSpan.timeSpan;
+
+/// #805 item 2 — the lost-update pin for `recordBestEffortFailureOutcome`.
+///
+/// **The race, stated exactly.** Merging a newly-failed slice into the blueprint's
+/// `DeploymentOutcomeValue` is a read-modify-write. The read happens when the command is BUILT; the
+/// Put applies later, after consensus. Two BEST_EFFORT slice failures that are both in flight before
+/// either applies therefore read the same base and each Put the other's id away.
+///
+/// **Why these tests stage in-flight overlap rather than spawning threads.** The concurrency that
+/// produces the loss is not thread overlap — `ClusterDeploymentState.Active` is a leader-pinned
+/// singleton driven from the applier thread. It is *submission* overlap: two batches pending
+/// simultaneously. And their commit order is NOT their submission order — `RabiaEngine` keeps
+/// `pendingBatches` in a `ConcurrentSkipListMap` keyed by a SHA-256 content hash and every proposal
+/// site takes `firstEntry()`, so which of two pending batches is decided first is a content-hash coin
+/// flip on the happy path, needing no failed consensus round. [HoldingClusterNode] reproduces that
+/// directly and lets each test pick the order, so BOTH orderings are pinned deterministically instead
+/// of one being left to a scheduler that may never produce it.
+///
+/// **Why the concurrent cases await.** `Promise.onResult` runs its action synchronously only when the
+/// promise is ALREADY resolved; on a promise resolved later it is queued as an event processor and
+/// dispatched asynchronously (`PromiseImpl.processActions` — "event processors executed
+/// asynchronously"). A held batch's confirm-and-retry therefore runs off the releasing thread, in the
+/// test and in production alike, so these tests await convergence instead of asserting inline. The
+/// sequential cases below deliberately do NOT await: their promises are pre-resolved, the confirm runs
+/// inline, and asserting directly keeps that distinction visible.
+///
+/// Every test drives the real production path — a `NodeArtifactPutReceived` notification carrying a
+/// fatal FAILED state, exactly what `ClusterDeploymentManager.onNodeArtifactPut` dispatches — and
+/// asserts on committed KV state, never on a recorded command list. A test that inspected proposed
+/// commands would pass against the unfixed code, because the unfixed code proposes both Puts too; the
+/// loss is only visible after they apply.
+class BestEffortOutcomeMergeTest {
+    private static final NodeId SELF = new NodeId("node-self");
+    private static final NodeId NODE_A = new NodeId("node-a");
+    private static final Artifact SLICE_A = Artifact.artifact("org.example:orders-api:1.0.0").unwrap();
+    private static final Artifact SLICE_B = Artifact.artifact("org.example:billing-api:1.0.0").unwrap();
+    private static final BlueprintId OWNER = BlueprintId.blueprintId("org.example:orders-app:1.0.0").unwrap();
+    private static final String FAILURE = "slice class not found";
+
+    private InMemoryKvStore kvStore;
+    private HoldingClusterNode cluster;
+    private FsmTestHarness<ClusterDeploymentState, ClusterFsmEvent> harness;
+
+    @BeforeEach
+    void setUp() {
+        var router = MessageRouter.mutable();
+
+        kvStore = new InMemoryKvStore(router);
+        cluster = new HoldingClusterNode(SELF, kvStore);
+        Function<Fsm<ClusterDeploymentState, ClusterFsmEvent>, ClusterDeploymentState> factory =
+                fsm -> new ClusterDeploymentContext(fsm,
+                                                    SELF,
+                                                    cluster,
+                                                    kvStore,
+                                                    router,
+                                                    stubTopologyManager(SELF),
+                                                    stubSchemaOrchestrator(),
+                                                    () -> Set.of(SELF, NODE_A),
+                                                    () -> Set.of(SELF, NODE_A),
+                                                    Set::of,
+                                                    Set.of(SELF, NODE_A),
+                                                    DeploymentAtomicity.BEST_EFFORT,
+                                                    3,
+                                                    timeSpan(300).seconds(),
+                                                    System::currentTimeMillis).dormant();
+
+        harness = FsmTestHarness.harness("best-effort-outcome-" + System.nanoTime(), factory);
+        harness.dispatch(new Activate());
+        registerOwnedSlice(SLICE_A);
+        registerOwnedSlice(SLICE_B);
+    }
+
+    @Nested
+    class ConcurrentFailures {
+        /// The ticketed race. Both merges are built while the outcome key is still absent, so each
+        /// carries only its own slice id. Before #805 the second to apply overwrote the first and one
+        /// id was gone; the version fence now rejects it and the confirm-and-retry re-merges against
+        /// the value that actually landed.
+        @Test
+        void bothFailingSlices_areRecorded_whenTheSecondMergeAppliesAfterTheFirst() {
+            cluster.holdOutcomeBatches(2);
+
+            failSlice(SLICE_A);
+            failSlice(SLICE_B);
+
+            assertThat(cluster.heldCount()).as("both merges must be pending before either applies — otherwise the "
+                                               + "second reads the first's value and there is no race to pin")
+                                           .isEqualTo(2);
+
+            cluster.releaseHeld(0, 1);
+
+            awaitFailingSlices(SLICE_A, SLICE_B);
+        }
+
+        /// The same two pending merges, decided in the OPPOSITE order. This is not a duplicate: the
+        /// order is chosen by SHA-256 batch-id comparison, so production reaches both, and a fix that
+        /// happened to work only when submission order survives would pass the test above and fail
+        /// this one.
+        @Test
+        void bothFailingSlices_areRecorded_whenTheSecondMergeAppliesBeforeTheFirst() {
+            cluster.holdOutcomeBatches(2);
+
+            failSlice(SLICE_A);
+            failSlice(SLICE_B);
+
+            assertThat(cluster.heldCount()).isEqualTo(2);
+
+            cluster.releaseHeld(1, 0);
+
+            awaitFailingSlices(SLICE_A, SLICE_B);
+        }
+
+        /// The fence must reject the stale merge rather than accept it — otherwise the retry would
+        /// never fire and the test above would be passing for the wrong reason (a merge that happened
+        /// to carry both ids). Pins the version chain the recovery walks: two accepted writes.
+        @Test
+        void theRecoveredMerge_advancesTheVersionChainByExactlyOne() {
+            cluster.holdOutcomeBatches(2);
+
+            failSlice(SLICE_A);
+            failSlice(SLICE_B);
+            cluster.releaseHeld(0, 1);
+
+            await().atMost(5, TimeUnit.SECONDS)
+                   .untilAsserted(() -> assertThat(recordedOutcome().outcomeVersion()).as("first merge lands at version 1; "
+                                                                                          + "the second is fenced out and its retry lands at version 2")
+                                                                                     .isEqualTo(2L));
+        }
+
+        @Test
+        void theRecordStaysFAILED_afterTheRecoveredMerge() {
+            cluster.holdOutcomeBatches(2);
+
+            failSlice(SLICE_A);
+            failSlice(SLICE_B);
+            cluster.releaseHeld(0, 1);
+
+            awaitFailingSlices(SLICE_A, SLICE_B);
+
+            assertThat(recordedOutcome().status()).isEqualTo(DeploymentOutcomeStatus.FAILED);
+        }
+    }
+
+    @Nested
+    class SequentialFailures {
+        /// The uncontended path must be untouched: when the first merge has already applied, the
+        /// second reads it, merges onto it, and is accepted at version 2 with no retry. This is the
+        /// behaviour that existed before #805 and it must survive the fence.
+        @Test
+        void bothFailingSlices_areRecorded_whenTheMergesDoNotOverlap() {
+            failSlice(SLICE_A);
+            failSlice(SLICE_B);
+
+            assertThat(recordedFailingSlices()).containsExactlyInAnyOrder(SLICE_A.asString(), SLICE_B.asString());
+            assertThat(recordedOutcome().outcomeVersion()).as("two uncontended writes, no rejection, no retry")
+                                                          .isEqualTo(2L);
+        }
+
+        /// `handleDeterministicFailure` returns early for an artifact already in `permanentlyFailed`,
+        /// so a repeated notification must not append a duplicate id nor burn a version.
+        @Test
+        void aRepeatedFailure_doesNotDuplicateTheSliceId() {
+            failSlice(SLICE_A);
+            failSlice(SLICE_A);
+
+            assertThat(recordedFailingSlices()).containsExactly(SLICE_A.asString());
+            assertThat(recordedOutcome().outcomeVersion()).isEqualTo(1L);
+        }
+    }
+
+    // --- fixture ---
+
+    /// Drives the exact notification production dispatches on a fatal slice failure. `fatal = true`
+    /// selects `handleDeterministicFailure` over the retry path.
+    private void failSlice(Artifact artifact) {
+        var key = NodeArtifactKey.nodeArtifactKey(NODE_A, artifact);
+        var value = new NodeArtifactValue(SliceState.FAILED, Option.some(FAILURE), true, 0, List.of(), 0L);
+        var put = new KVCommand.Put<NodeArtifactKey, NodeArtifactValue>(key, value);
+
+        harness.dispatch(new NodeArtifactPutReceived(new ValuePut<>(put, Option.none())));
+    }
+
+    /// `recordBestEffortFailureOutcome` resolves the owning blueprint from the FSM's in-memory
+    /// `blueprints` mirror. That lookup is out of #805's scope (item 1 moved the SCHEMA GATE's owner
+    /// resolution, not this one), so the mirror is seeded directly here.
+    private void registerOwnedSlice(Artifact artifact) {
+        activeState().blueprints()
+                     .put(artifact, Blueprint.blueprint(artifact, 1, 1, Option.some(OWNER), true));
+    }
+
+    private ClusterDeploymentState.Active activeState() {
+        return (ClusterDeploymentState.Active) harness.state();
+    }
+
+    /// Waits for the merge chain to converge on exactly `expected`. A timeout here means the retry
+    /// never recovered the fenced-out id — the very loss #805 item 2 fixes.
+    private void awaitFailingSlices(Artifact... expected) {
+        var ids = java.util.Arrays.stream(expected)
+                                  .map(Artifact::asString)
+                                  .toArray(String[]::new);
+
+        await().atMost(5, TimeUnit.SECONDS)
+               .untilAsserted(() -> assertThat(recordedFailingSlices()).containsExactlyInAnyOrder(ids));
+    }
+
+    private List<String> recordedFailingSlices() {
+        return recordedOutcome().failingSlices();
+    }
+
+    private DeploymentOutcomeValue recordedOutcome() {
+        return kvStore.get(DeploymentOutcomeKey.deploymentOutcomeKey(OWNER))
+                      .filter(DeploymentOutcomeValue.class::isInstance)
+                      .map(DeploymentOutcomeValue.class::cast)
+                      .or(() -> org.junit.jupiter.api.Assertions.fail("no deployment-outcome record was committed"));
+    }
+
+    /// A cluster node that APPLIES batches into the real [KVStore] — so the applier's `VersionFenced`
+    /// successor check actually runs — and can hold deployment-outcome batches pending, reproducing
+    /// two merges in flight at once.
+    ///
+    /// Only outcome batches are held; unload/allocation commands issued on the same failure path pass
+    /// straight through, so the hold window contains exactly the writes under test. The hold budget is
+    /// consumed, not standing: once `holdBudget` batches are captured, later outcome batches (the
+    /// retries) apply immediately, which is what lets a released batch's confirm-and-retry run to
+    /// completion inside `releaseHeld`.
+    ///
+    /// `apply`'s Promise resolves only AFTER the batch has been applied to the state machine, matching
+    /// `RabiaEngine.commitChanges`, which calls `stateMachine.process` before `promise.succeed`. The
+    /// retry protocol depends on that ordering: its re-read must observe its own batch's effect.
+    private static final class HoldingClusterNode implements ClusterNode<KVCommand<AetherKey>> {
+        private final NodeId self;
+        private final InMemoryKvStore store;
+        private final List<HeldBatch> held = Collections.synchronizedList(new ArrayList<>());
+        private int holdBudget;
+
+        private record HeldBatch(List<KVCommand<AetherKey>> commands, Promise<List<Object>> promise) {}
+
+        HoldingClusterNode(NodeId self, InMemoryKvStore store) {
+            this.self = self;
+            this.store = store;
+        }
+
+        void holdOutcomeBatches(int count) {
+            holdBudget = count;
+        }
+
+        int heldCount() {
+            return held.size();
+        }
+
+        /// Applies the held batches in the given order, resolving each promise as it lands. Resolution
+        /// synchronously runs the FSM's confirm-and-retry for that batch, so a rejected merge is
+        /// recovered before the next held batch is released — the same sequencing the applier thread
+        /// produces in production.
+        void releaseHeld(int... order) {
+            for (var index : order) {
+                var batch = held.get(index);
+
+                store.applyBatch(batch.commands());
+                batch.promise()
+                     .succeed(List.of());
+            }
+        }
+
+        @SuppressWarnings("unchecked")
+        @Override
+        public <R> Promise<List<R>> apply(List<KVCommand<AetherKey>> batch) {
+            if (holdBudget > 0 && touchesOutcomeRecord(batch)) {
+                holdBudget--;
+                var pending = Promise.<List<Object>> promise();
+
+                held.add(new HeldBatch(List.copyOf(batch), pending));
+
+                return (Promise<List<R>>) (Promise<?>) pending;
+            }
+
+            store.applyBatch(batch);
+
+            return Promise.success(List.of());
+        }
+
+        private static boolean touchesOutcomeRecord(List<KVCommand<AetherKey>> batch) {
+            return batch.stream()
+                        .anyMatch(command -> command.key() instanceof DeploymentOutcomeKey);
+        }
+
+        @Override public NodeId self() {return self;}
+
+        @Override public TopologyManager topologyManager() {return stubTopologyManager(self);}
+
+        @Override public Promise<Unit> start() {return Promise.unitPromise();}
+
+        @Override public Promise<Unit> stop() {return Promise.unitPromise();}
+    }
+
+    /// Extends the real [KVStore], so `applyBatch` goes through `process` and therefore through the
+    /// applier's fences. A double that stored values directly would accept every write and make every
+    /// assertion here vacuous.
+    private static final class InMemoryKvStore extends KVStore<AetherKey, AetherValue> {
+        InMemoryKvStore(MessageRouter router) {
+            super(router, stubSerializer(), stubDeserializer());
+        }
+
+        /// `synchronized` because production applies every decision on ONE thread
+        /// (`RabiaEngine`'s single-thread executor), and `KVStore.process`'s fence is a read of
+        /// committed storage followed by a write — not atomic. Serializing here models the applier
+        /// faithfully; leaving it unserialized would let the test's release thread and an async retry
+        /// interleave inside the fence in a way production cannot produce.
+        synchronized void applyBatch(List<KVCommand<AetherKey>> commands) {
+            process(createBatch(List.copyOf(commands)));
+        }
+    }
+
+    private SchemaOrchestratorService stubSchemaOrchestrator() {
+        return new SchemaOrchestratorService() {
+            @Override public Promise<Unit> migrateIfNeeded(String datasourceName) {
+                return Promise.success(Unit.unit());
+            }
+
+            @Override public Promise<Unit> undoTo(String datasourceName, int targetVersion) {
+                return Promise.success(Unit.unit());
+            }
+
+            @Override public Promise<Unit> baseline(String datasourceName, int version) {
+                return Promise.success(Unit.unit());
+            }
+        };
+    }
+
+    private static Serializer stubSerializer() {
+        return new Serializer() {
+            @Override public <T> void write(ByteBuf byteBuf, T object) {}
+        };
+    }
+
+    private static Deserializer stubDeserializer() {
+        return new Deserializer() {
+            @Override public <T> T read(ByteBuf byteBuf) {
+                return null;
+            }
+        };
+    }
+
+    private static TopologyManager stubTopologyManager(NodeId self) {
+        return new TopologyManager() {
+            @Override public NodeInfo self() {
+                return NodeInfo.nodeInfo(self, new NodeAddress("localhost", 9000));
+            }
+
+            @Override public Option<NodeInfo> get(NodeId id) {
+                return Option.some(NodeInfo.nodeInfo(id, new NodeAddress("localhost", 9000)));
+            }
+
+            @Override public int clusterSize() {
+                return 2;
+            }
+
+            @Override public Option<NodeId> reverseLookup(SocketAddress socketAddress) {
+                return Option.empty();
+            }
+
+            @Override public Promise<Unit> start() {
+                return Promise.unitPromise();
+            }
+
+            @Override public Promise<Unit> stop() {
+                return Promise.unitPromise();
+            }
+
+            @Override public TimeSpan pingInterval() {
+                return timeSpan(5).seconds();
+            }
+
+            @Override public TimeSpan helloTimeout() {
+                return timeSpan(5).seconds();
+            }
+
+            @Override public Option<NodeState> getState(NodeId id) {
+                return Option.empty();
+            }
+
+            @Override public List<NodeId> topology() {
+                return List.of(self);
+            }
+        };
+    }
+}

--- a/aether/aether-deployment/src/test/java/org/pragmatica/aether/deployment/cluster/fsm/SchemaActivationGateTest.java
+++ b/aether/aether-deployment/src/test/java/org/pragmatica/aether/deployment/cluster/fsm/SchemaActivationGateTest.java
@@ -35,12 +35,15 @@ import org.pragmatica.aether.deployment.cluster.fsm.ClusterDeploymentEvents.Node
 import org.pragmatica.aether.deployment.schema.SchemaOrchestratorService;
 import org.pragmatica.aether.slice.SliceState;
 import org.pragmatica.aether.slice.blueprint.BlueprintId;
+import org.pragmatica.aether.slice.blueprint.ExpandedBlueprint;
 import org.pragmatica.aether.slice.kvstore.AetherKey;
+import org.pragmatica.aether.slice.kvstore.AetherKey.AppBlueprintKey;
 import org.pragmatica.aether.slice.kvstore.AetherKey.NodeArtifactKey;
 import org.pragmatica.aether.slice.kvstore.AetherKey.SchemaVersionKey;
 import org.pragmatica.aether.slice.kvstore.AetherKey.SliceNodeKey;
 import org.pragmatica.aether.slice.kvstore.AetherKey.SliceTargetKey;
 import org.pragmatica.aether.slice.kvstore.AetherValue;
+import org.pragmatica.aether.slice.kvstore.AetherValue.AppBlueprintValue;
 import org.pragmatica.aether.slice.kvstore.AetherValue.NodeArtifactValue;
 import org.pragmatica.aether.slice.kvstore.AetherValue.SchemaStatus;
 import org.pragmatica.aether.slice.kvstore.AetherValue.SchemaVersionValue;
@@ -208,30 +211,103 @@ class SchemaActivationGateTest {
 
     @Nested
     class ShortCircuits {
+        /// #805 item 1 moved the source of this answer: `schema_required` is read from the COMMITTED
+        /// blueprint record, never from the node-local mirror's copy of the flag. The outcome is
+        /// unchanged — a `schema_required = false` blueprint's slice is never held — but it is now
+        /// the same source `SchemaRoutes.heldSlices` reads, which is the whole point.
         @Test
         void areSchemasReady_allows_whenSchemaNotRequired() {
             registerSlice(Option.some(OWNER), false);
+            seedOwningBlueprintSchemaRequired(OWNER, false);
             seedSchema(OWNED_DATASOURCE, SchemaStatus.FAILED, OWNER);
 
-            assertThat(schemasReady()).as("schemaRequired=false short-circuits regardless of record status")
+            assertThat(schemasReady()).as("schema_required = false in the committed blueprint means the gate never blocks")
                                       .isTrue();
         }
 
-        /// No `Blueprint` entry means no owner to match records against. Blocking would be an
-        /// unclearable hold — nothing that ever completes could be attributed to this slice.
+        /// No committed `SliceTargetValue` means no owner to match records against. Blocking would be
+        /// an unclearable hold — nothing that ever completes could be attributed to this slice.
         @Test
-        void areSchemasReady_allows_whenSliceHasNoBlueprintEntry() {
+        void areSchemasReady_allows_whenSliceHasNoCommittedTargetRecord() {
             seedSchema(OWNED_DATASOURCE, SchemaStatus.FAILED, OTHER_OWNER);
 
             assertThat(schemasReady()).isTrue();
         }
 
         @Test
-        void areSchemasReady_allows_whenBlueprintCarriesNoOwner() {
+        void areSchemasReady_allows_whenCommittedTargetRecordCarriesNoOwner() {
             registerSlice(Option.none(), true);
             seedSchema(OWNED_DATASOURCE, SchemaStatus.FAILED, OWNER);
 
             assertThat(schemasReady()).isTrue();
+        }
+    }
+
+    /// #805 item 1. The gate and `SchemaRoutes.heldSlices` share [#blocksSliceActivation], but until
+    /// this fix they fed it from two different sources: the gate from the node-local `blueprints`
+    /// mirror (owner AND a `schemaRequired` pre-filter), the route from the committed
+    /// `SliceTargetValue` with no pre-filter. The mirror is rebuilt from KV notifications and
+    /// therefore lags them, so a stale entry made the two disagree about the same slice — the
+    /// divergence #760's first round closed, running the other way.
+    ///
+    /// Each test here plants a mirror entry that CONTRADICTS the committed record and asserts the
+    /// gate follows the committed record. `plantMirrorEntry` deliberately does not seed the target
+    /// record, so the two sources disagree by construction rather than by timing.
+    @Nested
+    class StaleMirrorDivergence {
+        /// The exact shape the ticket names: a stale mirror entry naming an owner the committed
+        /// record does not name makes the gate hold a slice the route reports as NOT held. Before the
+        /// fix the gate read `OWNER` from the mirror, matched the FAILED record, and blocked.
+        @Test
+        void areSchemasReady_allows_whenStaleMirrorNamesAnOwnerTheCommittedRecordDoesNot() {
+            seedSliceTarget(Option.some(OTHER_OWNER));
+            plantMirrorEntry(Option.some(OWNER), true);
+            seedSchema(OWNED_DATASOURCE, SchemaStatus.FAILED, OWNER);
+
+            assertThat(schemasReady()).as("the committed SliceTargetValue owns this slice, and it names OTHER_OWNER — "
+                                          + "a stale mirror must not resurrect a hold the route does not report")
+                                      .isTrue();
+        }
+
+        /// The same divergence with no committed record at all — the mirror is the ONLY thing naming
+        /// an owner. The route reports nothing held (it can resolve no owner); the gate must agree.
+        @Test
+        void areSchemasReady_allows_whenOnlyTheStaleMirrorNamesAnOwner() {
+            plantMirrorEntry(Option.some(OWNER), true);
+            seedSchema(OWNED_DATASOURCE, SchemaStatus.FAILED, OWNER);
+
+            assertThat(schemasReady()).as("no committed SliceTargetValue means no owner to attribute records to")
+                                      .isTrue();
+        }
+
+        /// The pre-filter's OTHER input, and the opposite direction: a stale mirror carrying
+        /// `schemaRequired = false` short-circuited the gate to READY while the committed blueprint
+        /// declared `schema_required = true`, so the route reported the slice held and the gate let it
+        /// activate against an unmigrated schema. Dropping the pre-filter is what closes this; the
+        /// shared predicate resolves `schemaRequired` from the committed record per candidate.
+        @Test
+        void areSchemasReady_blocks_whenStaleMirrorClearsSchemaRequiredButCommittedRecordDeclaresIt() {
+            seedSliceTarget(Option.some(OWNER));
+            plantMirrorEntry(Option.some(OWNER), false);
+            seedOwningBlueprintSchemaRequired(OWNER, true);
+            seedSchema(OWNED_DATASOURCE, SchemaStatus.FAILED, OWNER);
+
+            assertThat(schemasReady()).as("the committed blueprint declares schema_required = true, so a stale mirror "
+                                          + "flag must not let the slice through the gate")
+                                      .isFalse();
+        }
+
+        /// Convergence stated directly: whatever the mirror says, the gate's verdict must equal the
+        /// verdict the route computes from the committed record via the SAME shared inputs. This is
+        /// the property #805 asks for, rather than a restatement of one case's expected boolean.
+        @Test
+        void gateVerdict_matchesRouteVerdict_underAStaleMirror() {
+            seedSliceTarget(Option.some(OTHER_OWNER));
+            plantMirrorEntry(Option.some(OWNER), true);
+            seedSchema(OWNED_DATASOURCE, SchemaStatus.FAILED, OWNER);
+
+            assertThat(schemasReady()).as("gate and route must agree on the same slice")
+                                      .isEqualTo(!routeReportsHeld());
         }
     }
 
@@ -522,9 +598,62 @@ class SchemaActivationGateTest {
         return activeState().areSchemasReady(SLICE_KEY);
     }
 
+    /// `SchemaRoutes.collectIfHeldBySchema`'s body, reproduced against this fixture: the shared
+    /// predicate fed the shared owner resolution, for a LOADED slice (the state the gate itself is
+    /// only ever reached in). Asserting the gate against this pins that `blockingSchemaRecords`
+    /// applies NO filter the route does not — which is the regression #805 names, and the thing a
+    /// reintroduced mirror pre-filter would break.
+    private boolean routeReportsHeld() {
+        return ClusterDeploymentState.blocksSliceActivation(SliceState.LOADED,
+                                                             ClusterDeploymentState.resolveSliceOwner(kvStore, SLICE),
+                                                             schemaRecord(OWNED_DATASOURCE),
+                                                             kvStore);
+    }
+
+    private SchemaVersionValue schemaRecord(String datasource) {
+        return kvStore.get(SchemaVersionKey.schemaVersionKey(datasource))
+                      .filter(SchemaVersionValue.class::isInstance)
+                      .map(SchemaVersionValue.class::cast)
+                      .or(() -> org.junit.jupiter.api.Assertions.fail("no schema record seeded for " + datasource));
+    }
+
+    /// Establishes a CONSISTENT ownership state: the committed `SliceTargetValue` the gate and the
+    /// route both read (#805 item 1), and the node-local `blueprints` mirror that mirrors it. Before
+    /// #805 the gate read only the mirror, so seeding the mirror alone was enough; it no longer is,
+    /// and seeding only one of the two is now precisely how a divergence is STAGED rather than how a
+    /// normal slice is registered — see [StaleMirrorDivergence].
     private void registerSlice(Option<BlueprintId> owner, boolean schemaRequired) {
+        seedSliceTarget(owner);
+        plantMirrorEntry(owner, schemaRequired);
+    }
+
+    /// Writes ONLY the node-local mirror, leaving the committed `SliceTargetValue` untouched. This is
+    /// the stale-map plant #805 asks the gate to become immune to.
+    private void plantMirrorEntry(Option<BlueprintId> owner, boolean schemaRequired) {
         activeState().blueprints()
                      .put(SLICE, Blueprint.blueprint(SLICE, 1, 1, owner, schemaRequired));
+    }
+
+    /// Declares `schema_required` for `owner` in the COMMITTED blueprint record — the only source
+    /// [ClusterDeploymentState#resolveSchemaRequired(KVStore, BlueprintId)] reads. Mirrors
+    /// `SchemaRouteStatusTest.seedOwningBlueprintWithoutSchemaRequirement`: a non-empty `[[slices]]`
+    /// and a `[deployment].strategy` are both required before `schema_required` is read at all.
+    private void seedOwningBlueprintSchemaRequired(BlueprintId owner, boolean schemaRequired) {
+        var resourcesToml = """
+                             id = "%s"
+
+                             [[slices]]
+                             artifact = "org.example:seed-slice:1.0.0"
+
+                             [deployment]
+                             strategy = "rolling"
+                             schema_required = %s
+                             """.formatted(owner.asString(), schemaRequired);
+
+        kvStore.put(AppBlueprintKey.appBlueprintKey(owner),
+                    AppBlueprintValue.appBlueprintValue(ExpandedBlueprint.expandedBlueprint(owner,
+                                                                                            List.of(),
+                                                                                            Option.some(resourcesToml))));
     }
 
     private void seedSchema(String datasource, SchemaStatus status, BlueprintId owner) {

--- a/aether/node/src/main/java/org/pragmatica/aether/api/routes/SchemaRoutes.java
+++ b/aether/node/src/main/java/org/pragmatica/aether/api/routes/SchemaRoutes.java
@@ -22,12 +22,10 @@ import org.pragmatica.aether.slice.blueprint.BlueprintId;
 import org.pragmatica.aether.slice.kvstore.AetherKey;
 import org.pragmatica.aether.slice.kvstore.AetherKey.SchemaVersionKey;
 import org.pragmatica.aether.slice.kvstore.AetherKey.SliceNodeKey;
-import org.pragmatica.aether.slice.kvstore.AetherKey.SliceTargetKey;
 import org.pragmatica.aether.slice.kvstore.AetherValue;
 import org.pragmatica.aether.slice.kvstore.AetherValue.SchemaStatus;
 import org.pragmatica.aether.slice.kvstore.AetherValue.SchemaVersionValue;
 import org.pragmatica.aether.slice.kvstore.AetherValue.SliceNodeValue;
-import org.pragmatica.aether.slice.kvstore.AetherValue.SliceTargetValue;
 import org.pragmatica.cluster.state.kvstore.KVCommand;
 import org.pragmatica.cluster.state.kvstore.KVStore;
 import org.pragmatica.http.routing.QueryParameter;
@@ -190,15 +188,15 @@ public final class SchemaRoutes implements RouteSource {
     /// `SliceNodeValue` carries no ownership — that lives on `SliceTargetKey`/`SliceTargetValue`
     /// (the same desired/ownership record `ClusterDeploymentState.Active.blueprints` mirrors), so
     /// live state and ownership are joined here per slice, one KV read per artifact.
+    ///
+    /// #805 item 1: delegates to [ClusterDeploymentState#resolveSliceOwner(KVStore, Artifact)] — the
+    /// SAME static the activation gate now calls. The route already read the committed record; it
+    /// was the gate that read the node-local `blueprints` mirror, so this delegation is what makes
+    /// the shared source a fact rather than a coincidence of two identical bodies.
     private Option<BlueprintId> sliceOwner(Artifact artifact) {
-        var targetKey = SliceTargetKey.sliceTargetKey(artifact.base());
-
-        return nodeSupplier.get()
-                           .kvStore()
-                           .get(targetKey)
-                           .filter(v -> v instanceof SliceTargetValue)
-                           .map(v -> (SliceTargetValue) v)
-                           .flatMap(SliceTargetValue::owningBlueprint);
+        return ClusterDeploymentState.resolveSliceOwner(nodeSupplier.get()
+                                                                    .kvStore(),
+                                                        artifact);
     }
 
     /// #760 review BLOCKING 1: `/migrate` writing MIGRATING has no orchestrator effect by itself —

--- a/aether/node/src/main/java/org/pragmatica/aether/api/routes/SchemaRoutes.java
+++ b/aether/node/src/main/java/org/pragmatica/aether/api/routes/SchemaRoutes.java
@@ -194,8 +194,7 @@ public final class SchemaRoutes implements RouteSource {
     /// was the gate that read the node-local `blueprints` mirror, so this delegation is what makes
     /// the shared source a fact rather than a coincidence of two identical bodies.
     private Option<BlueprintId> sliceOwner(Artifact artifact) {
-        return ClusterDeploymentState.resolveSliceOwner(nodeSupplier.get()
-                                                                    .kvStore(),
+        return ClusterDeploymentState.resolveSliceOwner(nodeSupplier.get().kvStore(),
                                                         artifact);
     }
 

--- a/aether/slice/src/main/java/org/pragmatica/aether/slice/kvstore/AetherValue.java
+++ b/aether/slice/src/main/java/org/pragmatica/aether/slice/kvstore/AetherValue.java
@@ -305,7 +305,11 @@ public sealed interface AetherValue {
         }
 
         public static DeploymentOutcomeValue succeeded(long timestampMs, long outcomeVersion) {
-            return new DeploymentOutcomeValue(DeploymentOutcomeStatus.SUCCEEDED, List.of(), "", timestampMs, outcomeVersion);
+            return new DeploymentOutcomeValue(DeploymentOutcomeStatus.SUCCEEDED,
+                                              List.of(),
+                                              "",
+                                              timestampMs,
+                                              outcomeVersion);
         }
 
         public static DeploymentOutcomeValue failed(List<String> failingSlices,

--- a/aether/slice/src/main/java/org/pragmatica/aether/slice/kvstore/AetherValue.java
+++ b/aether/slice/src/main/java/org/pragmatica/aether/slice/kvstore/AetherValue.java
@@ -254,23 +254,80 @@ public sealed interface AetherValue {
     record DeploymentOutcomeValue(DeploymentOutcomeStatus status,
                                   List<String> failingSlices,
                                   String cause,
-                                  long timestampMs) implements AetherValue {
+                                  long timestampMs,
+                                  long outcomeVersion) implements AetherValue, VersionFenced {
+        /// The first version of a chain — the value written when no outcome record is committed yet.
+        /// The applier does not fence a first write (there is no chain to fence), so this constant is
+        /// what every write against an absent key carries.
+        public static final long FIRST_VERSION = 1L;
+
+        public DeploymentOutcomeValue {
+            failingSlices = List.copyOf(failingSlices);
+        }
+
+        /// Lost-update fence version (RFC-0018, #570) — added for #805 item 2.
+        ///
+        /// `recordBestEffortFailureOutcome` merges a newly-failed slice into this record by READING
+        /// the committed value and PUTTING a merged one. The read happens when the command is built;
+        /// the Put applies later, after consensus. Two BEST_EFFORT slice failures that are both
+        /// in flight before either applies therefore both read the same base and each Put the other's
+        /// id away — and the loser is decided by SHA-256 batch-id order (`RabiaEngine.pendingBatches`
+        /// is a `ConcurrentSkipListMap` keyed by a content hash and every proposal site takes
+        /// `firstEntry()`), NOT by submission order, so this is a coin flip on the happy path rather
+        /// than a narrow window needing a failed consensus round.
+        ///
+        /// Fencing the record makes the applier reject the second writer instead of letting it
+        /// silently overwrite the first. Rejection alone does not preserve the id — the write is
+        /// simply dropped — so the merge path pairs this with a bounded re-read-and-retry after its
+        /// apply resolves, which is the confirmation protocol [VersionFenced] itself prescribes.
+        ///
+        /// **Every writer of this record must derive its version from the CURRENT committed value and
+        /// bump by exactly one.** `ClusterDeploymentState.Active.nextOutcomeVersion` is that
+        /// derivation; all four production write sites go through it.
+        @Override
+        public long fenceVersion() {
+            return outcomeVersion;
+        }
+
+        /// First-write forms, carrying [#FIRST_VERSION]. Correct only against an absent key — a
+        /// writer that may find a committed record must use the version-carrying overload, because
+        /// the applier rejects any non-successor write.
         public static DeploymentOutcomeValue succeeded(long timestampMs) {
-            return new DeploymentOutcomeValue(DeploymentOutcomeStatus.SUCCEEDED, List.of(), "", timestampMs);
+            return succeeded(timestampMs, FIRST_VERSION);
         }
 
         public static DeploymentOutcomeValue failed(List<String> failingSlices, String cause, long timestampMs) {
-            return new DeploymentOutcomeValue(DeploymentOutcomeStatus.FAILED,
-                                              List.copyOf(failingSlices),
-                                              cause,
-                                              timestampMs);
+            return failed(failingSlices, cause, timestampMs, FIRST_VERSION);
         }
 
         public static DeploymentOutcomeValue rolledBack(List<String> failingSlices, String cause, long timestampMs) {
-            return new DeploymentOutcomeValue(DeploymentOutcomeStatus.ROLLED_BACK,
-                                              List.copyOf(failingSlices),
+            return rolledBack(failingSlices, cause, timestampMs, FIRST_VERSION);
+        }
+
+        public static DeploymentOutcomeValue succeeded(long timestampMs, long outcomeVersion) {
+            return new DeploymentOutcomeValue(DeploymentOutcomeStatus.SUCCEEDED, List.of(), "", timestampMs, outcomeVersion);
+        }
+
+        public static DeploymentOutcomeValue failed(List<String> failingSlices,
+                                                    String cause,
+                                                    long timestampMs,
+                                                    long outcomeVersion) {
+            return new DeploymentOutcomeValue(DeploymentOutcomeStatus.FAILED,
+                                              failingSlices,
                                               cause,
-                                              timestampMs);
+                                              timestampMs,
+                                              outcomeVersion);
+        }
+
+        public static DeploymentOutcomeValue rolledBack(List<String> failingSlices,
+                                                        String cause,
+                                                        long timestampMs,
+                                                        long outcomeVersion) {
+            return new DeploymentOutcomeValue(DeploymentOutcomeStatus.ROLLED_BACK,
+                                              failingSlices,
+                                              cause,
+                                              timestampMs,
+                                              outcomeVersion);
         }
     }
 

--- a/aether/slice/src/main/java/org/pragmatica/aether/slice/kvstore/KVStoreSerializer.java
+++ b/aether/slice/src/main/java/org/pragmatica/aether/slice/kvstore/KVStoreSerializer.java
@@ -318,7 +318,8 @@ public final class KVStoreSerializer {
                       .collect(Collectors.joining(","));
 
         return v.status()
-                .name() + PIPE + slices + PIPE + escapeOutcomeField(v.cause()) + PIPE + v.timestampMs();
+                .name() + PIPE + slices + PIPE + escapeOutcomeField(v.cause()) + PIPE + v.timestampMs() + PIPE
+               + v.outcomeVersion();
     }
 
     /// Backslash-escapes `\`, `|`, and `,` for a single field of the `deployment-outcome` wire form.
@@ -765,8 +766,8 @@ public final class KVStoreSerializer {
     private static Result<Map.Entry<AetherKey, AetherValue>> parseDeploymentOutcomeEntry(String identity, String raw) {
         var parts = splitOutcomeField(raw, '|');
 
-        if (parts.size() != 4) {
-            return parseFailure("deployment-outcome value requires 4 fields, got " + parts.size());
+        if (parts.size() != 5) {
+            return parseFailure("deployment-outcome value requires 5 fields, got " + parts.size());
         }
 
         return DeploymentOutcomeKey.deploymentOutcomeKey("deployment-outcome/" + identity).flatMap(key -> buildDeploymentOutcomeValue(parts).map(value -> entry(key,
@@ -796,7 +797,19 @@ public final class KVStoreSerializer {
             return parseFailure("deployment-outcome value has invalid timestamp: " + parts.get(3));
         }
 
-        return success(new DeploymentOutcomeValue(status, failingSlices, unescapeOutcomeField(parts.get(2)), timestampMs));
+        long outcomeVersion;
+
+        try {
+            outcomeVersion = Long.parseLong(parts.get(4));
+        } catch (NumberFormatException e) {
+            return parseFailure("deployment-outcome value has invalid outcome version: " + parts.get(4));
+        }
+
+        return success(new DeploymentOutcomeValue(status,
+                                                  failingSlices,
+                                                  unescapeOutcomeField(parts.get(2)),
+                                                  timestampMs,
+                                                  outcomeVersion));
     }
 
     private static Result<Map.Entry<AetherKey, AetherValue>> parseEndpointEntry(String identity, String raw) {

--- a/aether/slice/src/main/java/org/pragmatica/aether/slice/kvstore/KVStoreSerializer.java
+++ b/aether/slice/src/main/java/org/pragmatica/aether/slice/kvstore/KVStoreSerializer.java
@@ -318,8 +318,7 @@ public final class KVStoreSerializer {
                       .collect(Collectors.joining(","));
 
         return v.status()
-                .name() + PIPE + slices + PIPE + escapeOutcomeField(v.cause()) + PIPE + v.timestampMs() + PIPE
-               + v.outcomeVersion();
+                .name() + PIPE + slices + PIPE + escapeOutcomeField(v.cause()) + PIPE + v.timestampMs() + PIPE + v.outcomeVersion();
     }
 
     /// Backslash-escapes `\`, `|`, and `,` for a single field of the `deployment-outcome` wire form.

--- a/changelog.d/805-gate-prefilter-and-failure-cas.md
+++ b/changelog.d/805-gate-prefilter-and-failure-cas.md
@@ -70,6 +70,23 @@
   real `SliceTargetPutReceived` notification rather than by seeding the mirror; mutation-probed by
   erasing the owner as it enters the mirror, which turns the positive case red with "no
   deployment-outcome record was committed" while the owner-less negative case stays green]
+- **The owner lookup itself now consults both sources, mirror first.** #698/#940 closed *erasure*;
+  the mirror could still fail to answer for reasons unrelated to it — an artifact whose entry
+  `removeNonTargetVersions` dropped, or the window after a leader failover before
+  `rebuildSliceStateFromKVStoreEntries` runs. Either way the result is not a degraded record but no
+  record at all. `Active.resolveOutcomeOwner` reads the mirror first and falls back to the committed
+  `SliceTargetValue`.
+  **The order is load-bearing, and the obvious fix is the wrong one:** resolving from the committed
+  store alone regresses, because `handleAppBlueprintChange` populates the mirror in the same pass that
+  only *queues* the `SliceTargetKey` Put — between the two the mirror legitimately names an owner the
+  store does not yet carry, so a store-only lookup would stop recording failures for the whole deploy
+  window. Consulting both strictly widens what is recorded: the worst case is attributing a failure to
+  an owner about to change, never losing the record. For a ticket about lost records that is the right
+  asymmetry. [verified: `BestEffortOutcomeMergeTest$OwnerResolutionFallback` — each source pinned
+  alone; mutation-probed in both directions, and the two probes are orthogonal: mirror-only turns
+  `whenOnlyTheCommittedRecordNamesTheOwner` red while the other stays green, and committed-only turns
+  `whenOnlyTheMirrorNamesTheOwner` red — along with 6 further tests, which is the regression the
+  fallback ordering exists to prevent]
 - **Wire format:** the `deployment-outcome` TOML value goes from 4 fields to 5 (`outcomeVersion`
   appended). Consistent with the rc-line posture RFC-0018 O1 already records — rc releases do not
   support mixed-version co-application, and the KV serializer format already diverges between rcs.

--- a/changelog.d/805-gate-prefilter-and-failure-cas.md
+++ b/changelog.d/805-gate-prefilter-and-failure-cas.md
@@ -1,0 +1,60 @@
+### Fixed (2026-09-08 — #805: schema gate pre-filtered a stale in-memory map; best-effort outcome merge was a read-then-Put)
+
+- **The schema activation gate and `SchemaRoutes.heldSlices` shared a predicate but not its inputs.**
+  #760's first round made both call `ClusterDeploymentState.blocksSliceActivation`, which resolves
+  `schemaRequired` from the KV store. The gate still reached that predicate through the node-local
+  `Active.blueprints` mirror — taking the slice's owner from it *and* pre-filtering on its
+  `schemaRequired` flag — while the route read the committed `SliceTargetValue` and pre-filtered on
+  nothing. The mirror is rebuilt from KV notifications and therefore lags them, so a stale entry made
+  the gate hold a slice the route simultaneously reported as not held. Sharing a predicate is not
+  sharing a decision while its inputs disagree.
+  Both call sites now resolve the owner through one new static,
+  `ClusterDeploymentState.resolveSliceOwner(KVStore, Artifact)`, reading the committed
+  `SliceTargetKey`/`SliceTargetValue` record; the mirror pre-filter is gone. Dropping it removes no
+  check — `blocksSliceActivation` already resolves `schemaRequired` per candidate record from the same
+  store, so the mirror's copy was only ever a second, divergent answer to a question already being
+  asked. [verified: `SchemaActivationGateTest$StaleMirrorDivergence` — four tests planting a mirror
+  entry that contradicts the committed record, covering a stale owner, a mirror-only owner, a stale
+  `schemaRequired = false` over a declared `true`, and gate/route agreement; all four confirmed red on
+  a revert of the production hunk alone]
+- **`recordBestEffortFailureOutcome` merged the failing-slice list by read-then-Put, outside any
+  compare-and-set.** The read happens when the command is built, the Put applies after consensus, so
+  two BEST_EFFORT slice failures both in flight before either applies read the same base and each Put
+  the other's slice id away. This is not a narrow window: `RabiaEngine` holds `pendingBatches` in a
+  `ConcurrentSkipListMap` keyed by a SHA-256 content hash and every proposal site takes
+  `firstEntry()`, so the surviving write is chosen by content hash, not by submission order — a coin
+  flip on the happy path, needing no failed consensus round.
+  `AetherValue.DeploymentOutcomeValue` now carries an `outcomeVersion` and implements `VersionFenced`
+  (RFC-0018, #570), so the applier rejects any Put that is not the immediate successor of the
+  committed value. Rejection alone does not preserve the id — the write is simply dropped — so the
+  merge path also confirms after its own apply resolves and retries against the now-current committed
+  value, bounded at 5 attempts, logging at ERROR and naming the slice if the budget is exhausted.
+  [verified: `BestEffortOutcomeMergeTest` — 11 tests; `$ConcurrentFailures` stages two merges pending
+  simultaneously and releases them in BOTH orders, `$ApplierFence` pins the rejection at the applier,
+  `$SequentialFailures` pins the uncontended path. Both halves mutation-probed independently:
+  removing `VersionFenced` turned 6 of 9 red, and removing the confirm-and-retry with the fence intact
+  turned exactly the 4 `$ConcurrentFailures` red while `$ApplierFence` stayed green]
+- **Guarantee, stated per operation.** A BEST_EFFORT deterministic slice failure observed by the
+  leader's `ClusterDeploymentState.Active` adds its artifact id to the committed
+  `DeploymentOutcomeValue.failingSlices`, or logs at ERROR that it did not. This is *not* atomicity:
+  it is the applier's successor-version fence (which makes a merge built on a stale read fail rather
+  than overwrite) plus a bounded read-after-apply retry on the proposer (which is what turns a
+  rejected write back into a recorded one). The re-read is sound because `ClusterNode.apply`'s Promise
+  resolves after the local state machine has applied the decision — `RabiaEngine.commitChanges` calls
+  `stateMachine.process` before `promise.succeed`. Convergence is bounded, not guaranteed: five
+  contended attempts end in a logged, operator-visible gap rather than an unbounded resubmission loop.
+  [mechanism: `KVStore.staleSuccessorWrite` + `submitBestEffortFailureOutcome`'s confirm-and-retry]
+- **No behaviour change for ALL_OR_NOTHING**, and it is pinned rather than assumed. Fencing the record
+  makes every writer of it fenceable, including the three ALL_OR_NOTHING terminal writers, so all four
+  production write sites now derive their version from the committed value via
+  `Active.nextOutcomeVersion`. A writer left stamping a blind first version would be silently rejected
+  the moment a record already existed. The pre-existing ALL_OR_NOTHING coverage in
+  `ClusterDeploymentStateTransactionalTest` cannot speak to this — it inspects the proposed command
+  list from a recording node that never applies anything, so it stays green whether the applier accepts
+  the write or drops it. [verified:
+  `BestEffortOutcomeMergeTest$AllOrNothingUnaffected#theTerminalOutcome_isAccepted_overAnAlreadyCommittedRecord`,
+  which asserts on committed state after a real apply and was confirmed red when
+  `failedOutcomeCommand` was reverted to a blind version stamp]
+- **Wire format:** the `deployment-outcome` TOML value goes from 4 fields to 5 (`outcomeVersion`
+  appended). Consistent with the rc-line posture RFC-0018 O1 already records — rc releases do not
+  support mixed-version co-application, and the KV serializer format already diverges between rcs.

--- a/changelog.d/805-gate-prefilter-and-failure-cas.md
+++ b/changelog.d/805-gate-prefilter-and-failure-cas.md
@@ -55,6 +55,21 @@
   `BestEffortOutcomeMergeTest$AllOrNothingUnaffected#theTerminalOutcome_isAccepted_overAnAlreadyCommittedRecord`,
   which asserts on committed state after a real apply and was confirmed red when
   `failedOutcomeCommand` was reverted to a blind version stamp]
+- **The owner path this record depends on was audited, not assumed.** `recordBestEffortFailureOutcome`
+  reaches `DeploymentOutcomeKey` through `Blueprint::owner`, which traces to
+  `SliceTargetValue.owningBlueprint` — the field #698 found the autoscaler and A/B writer erasing. An
+  erased owner does not corrupt the record, it means no record is written at all, so the lost-update
+  fix above would have been correct and irrelevant for every autoscaled or A/B-tested slice. All five
+  external writers of `SliceTargetValue` were enumerated: the two #698 named are fixed by #940
+  (`a75e6af42`, this branch's base) and verified to carry the owner through; the other three
+  (`DeploymentManagerImpl.addSliceTargetCommand`, `RollbackManager.updateSliceTargetForRollback`,
+  `SliceRoutes.applyDeployCommand`) all follow `existing.map(current -> current.withX(...))
+  .or(<owner-less fallback>)`, and every `withX` helper on the record preserves `owningBlueprint`, so
+  the owner-less fallback fires only for a genuinely absent record. The path is intact at this head.
+  [verified: `BestEffortOutcomeMergeTest$OwnerResolutionFromTheSliceTargetRecord`, driven through the
+  real `SliceTargetPutReceived` notification rather than by seeding the mirror; mutation-probed by
+  erasing the owner as it enters the mirror, which turns the positive case red with "no
+  deployment-outcome record was committed" while the owner-less negative case stays green]
 - **Wire format:** the `deployment-outcome` TOML value goes from 4 fields to 5 (`outcomeVersion`
   appended). Consistent with the rc-line posture RFC-0018 O1 already records — rc releases do not
   support mixed-version co-application, and the KV serializer format already diverges between rcs.


### PR DESCRIPTION
Closes #805 — both residuals from the round-3 review of the #760/#724/#759 branch.

## 1. Gate pre-filtered a stale in-memory map

`blocksSliceActivation` is shared by the activation gate and `SchemaRoutes.heldSlices`, but the two fed it from different sources: the gate took the slice owner from the node-local `Active.blueprints` mirror *and* pre-filtered on that mirror's `schemaRequired` flag; the route read the committed `SliceTargetValue` and pre-filtered on nothing. The mirror lags the KV notifications that rebuild it, so a stale entry made the gate hold a slice the route reported as not held.

Both call sites now go through one new static, `ClusterDeploymentState.resolveSliceOwner(KVStore, Artifact)`, reading the committed record; the mirror pre-filter is gone. It removes no check — `blocksSliceActivation` already resolves `schemaRequired` per candidate record from the same store.

## 2. `bestEffortFailureCommand` read-then-Put

The read happens at command-build time, the Put applies after consensus, so two BEST_EFFORT failures in flight before either applies read the same base and each Put the other's slice id away. Not a narrow window: `RabiaEngine.pendingBatches` is a `ConcurrentSkipListMap` keyed by a SHA-256 content hash (`"batch-" + sha256Hex(...)`, lexicographic `Id.compareTo`) and all three proposal sites take `firstEntry()`, so the survivor is chosen by content hash, not submission order — a coin flip on the happy path, no failed round required.

`DeploymentOutcomeValue` now carries `outcomeVersion` and implements `VersionFenced` (RFC-0018, #570), so the applier rejects a Put that is not the committed value's immediate successor. Rejection alone still drops the id, so the merge path confirms after its own apply resolves and retries against current committed state, bounded at 5 attempts with an ERROR naming the slice on exhaustion. The re-read is sound because `RabiaEngine.commitChanges` calls `stateMachine.process` before `promise.succeed`.

**Guarantee, per operation:** a BEST_EFFORT deterministic slice failure adds its artifact id to the committed `failingSlices`, or logs at ERROR that it did not. Not atomicity — the applier's successor-version fence plus a bounded read-after-apply retry. Convergence is bounded, not guaranteed.

## Verification

- 3946 tests green across `slice`, `aether-deployment`, `node`, `aether-control`, `aether-invoke`, `cli` (counted from surefire XML); 0 failures, 0 errors.
- Gate: `Running JBCT check on 80 / 88 / 150 Java file(s)`, `JBCT check passed.` on all three changed modules.
- **Mutation probes**, each a revert of one production hunk against a committed base:
  - Item 1 hunk reverted → all 4 `StaleMirrorDivergence` tests red, nothing else moved.
  - `VersionFenced` removed → 6 of 9 red.
  - Confirm-and-retry removed, fence intact → exactly the 4 `ConcurrentFailures` red, `ApplierFence` green.
  - `failedOutcomeCommand` reverted to a blind version stamp → the ALL_OR_NOTHING acceptance test red.

An earlier version of the concurrency test passed with the fence removed — the retry happened to cover for it. The test now drains each confirm before releasing the next batch, which is both the adversarial order and the one production reaches.

## No behaviour change for ALL_OR_NOTHING

Fencing the record makes every writer fenceable, so all four production write sites derive their version via `Active.nextOutcomeVersion`. Pinned by `AllOrNothingUnaffected#theTerminalOutcome_isAccepted_overAnAlreadyCommittedRecord`, which asserts on committed state after a real apply — the pre-existing `ClusterDeploymentStateTransactionalTest` coverage cannot speak to this, as it inspects proposed commands from a recording node that never applies anything.

## Wire format

`deployment-outcome` TOML goes 4 fields → 5. Consistent with RFC-0018 O1's rc-line posture: rc releases do not support mixed-version co-application.
