### PR TITLE
fix: #967 HTTP listeners must not demand a cluster-CA client certificate that cannot exist

### DIFF
--- a/aether/aether-config/src/main/java/org/pragmatica/aether/config/AppHttpConfig.java
+++ b/aether/aether-config/src/main/java/org/pragmatica/aether/config/AppHttpConfig.java
@@ -23,7 +23,21 @@ public record AppHttpConfig(boolean enabled,
                             Option<JwtConfig> jwtConfig,
                             HttpProtocol httpProtocol,
                             ApiVersioningDetection apiVersioningDetection,
-                            String apiVersionHeaderName) {
+                            String apiVersionHeaderName,
+                            Option<AppTls> tls) {
+    /// Operator-supplied TLS identity for the USER-facing app-HTTP listener.
+    ///
+    /// The app port must not reuse the cluster identity. That certificate is issued by the
+    /// cluster's own auto-generated CA and its subject is the NODE ID (`CN=primary-core-0`), so an
+    /// ordinary HTTP client gets both an untrusted issuer and a name that is not the service it
+    /// dialled. Node identity and service identity are different things; only the operator can
+    /// supply the latter (#967).
+    ///
+    /// Absent — the default — the listener falls back to the cluster identity with client
+    /// authentication stripped. That is reachable by clients which trust the cluster CA
+    /// (service-to-service), and is NOT suitable for public traffic.
+    public record AppTls(String certPath, String keyPath) {}
+
     public static final int DEFAULT_APP_HTTP_PORT = 8070;
     public static final int DEFAULT_MAX_REQUEST_SIZE = 10 * 1024 * 1024;
     public static final String DEFAULT_API_VERSION_HEADER = "API-Version";
@@ -51,7 +65,22 @@ public record AppHttpConfig(boolean enabled,
                                          jwtConfig,
                                          httpProtocol,
                                          apiVersioningDetection,
-                                         apiVersionHeaderName));
+                                         apiVersionHeaderName,
+                                         Option.empty()));
+    }
+
+    /// Attach an operator-supplied TLS identity to this listener. See [AppTls].
+    public AppHttpConfig withTls(AppTls appTls) {
+        return new AppHttpConfig(enabled,
+                                 port,
+                                 apiKeys,
+                                 maxRequestSize,
+                                 securityMode,
+                                 jwtConfig,
+                                 httpProtocol,
+                                 apiVersioningDetection,
+                                 apiVersionHeaderName,
+                                 Option.some(appTls));
     }
 
     public static Result<AppHttpConfig> appHttpConfig(boolean enabled,

--- a/aether/aether-config/src/main/java/org/pragmatica/aether/config/ConfigLoader.java
+++ b/aether/aether-config/src/main/java/org/pragmatica/aether/config/ConfigLoader.java
@@ -349,7 +349,6 @@ public final class ConfigLoader {
                                         .or(ApiVersioningDetection.PATH);
         var apiVersionHeaderName = doc.getString("app-http", "api_version_header")
                                       .or(AppHttpConfig.DEFAULT_API_VERSION_HEADER);
-
         var appHttp = AppHttpConfig.appHttpConfig(enabled,
                                                   port,
                                                   apiKeys,

--- a/aether/aether-config/src/main/java/org/pragmatica/aether/config/ConfigLoader.java
+++ b/aether/aether-config/src/main/java/org/pragmatica/aether/config/ConfigLoader.java
@@ -350,15 +350,29 @@ public final class ConfigLoader {
         var apiVersionHeaderName = doc.getString("app-http", "api_version_header")
                                       .or(AppHttpConfig.DEFAULT_API_VERSION_HEADER);
 
-        builder.appHttp(AppHttpConfig.appHttpConfig(enabled,
-                                                    port,
-                                                    apiKeys,
-                                                    maxRequestSize,
-                                                    securityMode,
-                                                    jwtConfig,
-                                                    httpProtocol,
-                                                    apiVersioningDetection,
-                                                    apiVersionHeaderName).unwrap());
+        var appHttp = AppHttpConfig.appHttpConfig(enabled,
+                                                  port,
+                                                  apiKeys,
+                                                  maxRequestSize,
+                                                  securityMode,
+                                                  jwtConfig,
+                                                  httpProtocol,
+                                                  apiVersioningDetection,
+                                                  apiVersionHeaderName).unwrap();
+
+        builder.appHttp(parseAppTls(doc).map(appHttp::withTls).or(appHttp));
+    }
+
+    /// `[app-http.tls]` — an operator-supplied certificate for the USER-facing listener.
+    ///
+    /// Both keys are required together: a certificate without its key, or a key without its
+    /// certificate, is a configuration mistake rather than a request for a partial identity, and
+    /// silently falling back to the cluster certificate would hide it. See [AppHttpConfig.AppTls]
+    /// for why the cluster identity cannot serve public traffic (#967).
+    private static Option<AppHttpConfig.AppTls> parseAppTls(TomlDocument doc) {
+        return Option.all(doc.getString("app-http.tls", "cert_path"),
+                          doc.getString("app-http.tls", "key_path"))
+                     .map(AppHttpConfig.AppTls::new);
     }
 
     private static Option<JwtConfig> parseJwtConfig(TomlDocument doc) {

--- a/aether/aether-config/src/test/java/org/pragmatica/aether/config/ConfigLoaderTest.java
+++ b/aether/aether-config/src/test/java/org/pragmatica/aether/config/ConfigLoaderTest.java
@@ -680,4 +680,65 @@ class ConfigLoaderTest {
         assertThat(storage.walPath()).isEqualTo(expected);
         assertThat(storage.hasExplicitWalPath()).isEqualTo(explicit);
     }
+
+    /// #967. The app-HTTP listener must be able to carry an operator-supplied certificate. Reusing
+    /// the cluster identity there presents `CN=<node-id>` signed by an internal CA that no public
+    /// client trusts, so an operator has no way to serve real traffic over TLS.
+    @Test
+    void loadFromString_parsesAppHttpTlsSection() {
+        var toml = """
+                   [app-http]
+                   enabled = true
+
+                   [app-http.tls]
+                   cert_path = "/etc/aether/app.crt"
+                   key_path = "/etc/aether/app.key"
+                   """;
+
+        ConfigLoader.loadFromString(toml)
+                    .onFailure(cause -> Assertions.fail(cause.message()))
+                    .onSuccess(config -> {
+                        var tls = config.appHttp().tls();
+
+                        assertThat(tls.isPresent())
+                                .describedAs("[app-http.tls] with both keys must produce an identity")
+                                .isTrue();
+                        tls.onPresent(appTls -> {
+                            assertThat(appTls.certPath()).isEqualTo("/etc/aether/app.crt");
+                            assertThat(appTls.keyPath()).isEqualTo("/etc/aether/app.key");
+                        });
+                    });
+    }
+
+    /// Control for the test above, and the case that decides the failure mode: half an identity is a
+    /// configuration mistake. Falling back to the cluster certificate silently would hide it behind a
+    /// listener that starts and then rejects every real client.
+    @Test
+    void loadFromString_appHttpTlsWithOnlyOneKey_yieldsNoIdentity() {
+        var toml = """
+                   [app-http]
+                   enabled = true
+
+                   [app-http.tls]
+                   cert_path = "/etc/aether/app.crt"
+                   """;
+
+        ConfigLoader.loadFromString(toml)
+                    .onFailure(cause -> Assertions.fail(cause.message()))
+                    .onSuccess(config -> assertThat(config.appHttp().tls().isPresent())
+                            .describedAs("cert_path without key_path must not yield a partial identity")
+                            .isFalse());
+    }
+
+    @Test
+    void loadFromString_withoutAppHttpTlsSection_yieldsNoIdentity() {
+        var toml = """
+                   [app-http]
+                   enabled = true
+                   """;
+
+        ConfigLoader.loadFromString(toml)
+                    .onFailure(cause -> Assertions.fail(cause.message()))
+                    .onSuccess(config -> assertThat(config.appHttp().tls().isPresent()).isFalse());
+    }
 }

--- a/aether/cli/src/main/java/org/pragmatica/aether/cli/cluster/BootstrapPhaseFormation.java
+++ b/aether/cli/src/main/java/org/pragmatica/aether/cli/cluster/BootstrapPhaseFormation.java
@@ -178,8 +178,17 @@ sealed interface BootstrapPhaseFormation {
                           requiredCores,
                           timeoutMs / 1000);
         var deadline = System.currentTimeMillis() + timeoutMs;
+        // Remember what the cluster view last REPORTED, so a timeout can say what was seen rather
+        // than assert a count nobody measured. Absent means the view was never readable at all.
+        var lastObserved = Option.<Integer> none();
 
         while (System.currentTimeMillis() < deadline) {
+            var observed = observedNodeCount(endpoint, managementPort, scheme, apiKey);
+
+            if (observed.isPresent()) {
+                lastObserved = observed;
+            }
+
             if (quorumReached(endpoint, managementPort, scheme, requiredCores, quorumFloor, apiKey)) {
                 System.out.printf("  Quorum established (>= %d of %d core(s))%n", quorumFloor, requiredCores);
 
@@ -189,7 +198,8 @@ sealed interface BootstrapPhaseFormation {
             ClusterBootstrapOrchestrator.sleepQuietly(ClusterBootstrapOrchestrator.POLL_INTERVAL_MS);
         }
 
-        return new BootstrapError.QuorumNotEstablished(0, quorumFloor).result();
+        return new BootstrapError.QuorumNotEstablished(lastObserved.or(BootstrapError.QuorumNotEstablished.UNOBSERVED),
+                                                       quorumFloor).result();
     }
 
     /// Strict majority floor for a cluster of `requiredCores` (`n/2 + 1`), mirroring
@@ -225,6 +235,22 @@ sealed interface BootstrapPhaseFormation {
                                            .flatMap(JSON::readTree)
                                            .map(node -> healthMeetsFloor(node, quorumFloor))
                                            .or(false);
+    }
+
+    /// The member count the cluster's own health view reports, or empty when that view could not be
+    /// read (unreachable, 401, unparseable body). Empty is NOT zero, and the two must not be
+    /// conflated in an error message — see [BootstrapError.QuorumNotEstablished].
+    private static Option<Integer> observedNodeCount(String endpoint,
+                                                     int managementPort,
+                                                     String scheme,
+                                                     Option<String> apiKey) {
+        var healthUrl = scheme + "://" + endpoint + ":" + managementPort + "/api/v1/health";
+
+        return ClusterBootstrapOrchestrator.httpGet(healthUrl, apiKey)
+                                           .flatMap(JSON::readTree)
+                                           .map(node -> node.path("nodeCount")
+                                                            .asInt(0))
+                                           .option();
     }
 
     /// Decide whether the `/api/health` view has reached the quorum floor: the leader must report

--- a/aether/cli/src/main/java/org/pragmatica/aether/cli/cluster/ClusterBootstrapOrchestrator.java
+++ b/aether/cli/src/main/java/org/pragmatica/aether/cli/cluster/ClusterBootstrapOrchestrator.java
@@ -573,10 +573,26 @@ public sealed interface ClusterBootstrapOrchestrator permits ClusterBootstrapOrc
             }
         }
 
-        record QuorumNotEstablished(int healthy, int required) implements BootstrapError {
+        /// `observed` is the member count last READ from the cluster's own `/api/v1/health` view, or
+        /// [#UNOBSERVED] when that view was never readable at all — a 401, an unreachable endpoint, or
+        /// an unparseable body.
+        ///
+        /// The distinction is the point. This error used to be constructed with a hardcoded `0`, so a
+        /// cluster that had formed perfectly and merely could not be QUERIED reported
+        /// "0/2 nodes healthy" — a count nobody had measured, indistinguishable from genuine total
+        /// failure. Measured 2026-09-10 on a live 3-node cluster whose own log read
+        /// `Quorum established — consensus available` at the moment this error was raised.
+        record QuorumNotEstablished(int observed, int required) implements BootstrapError {
+            /// The cluster view was never successfully read, so no count exists to report.
+            public static final int UNOBSERVED = -1;
+
             @Override
             public String message() {
-                return "Quorum not established: " + healthy + "/" + required + " nodes healthy";
+                return observed == UNOBSERVED
+                       ? "Quorum not established: the cluster health view at /api/v1/health was never"
+                        + " readable (unreachable, unauthorized, or unparseable), so the number of"
+                        + " healthy nodes is UNKNOWN — not zero. Required: " + required
+                       : "Quorum not established: " + observed + "/" + required + " nodes healthy";
             }
         }
 

--- a/aether/cli/src/test/java/org/pragmatica/aether/cli/cluster/BootstrapPhaseFormationQuorumTest.java
+++ b/aether/cli/src/test/java/org/pragmatica/aether/cli/cluster/BootstrapPhaseFormationQuorumTest.java
@@ -49,4 +49,32 @@ class BootstrapPhaseFormationQuorumTest {
         // 5-core cluster -> floor 3. Two nodes present is below the majority.
         assertThat(BootstrapPhaseFormation.healthMeetsFloor(health(2, true), 3)).isFalse();
     }
+
+    /// The failure message must never assert a count nobody measured.
+    ///
+    /// `QuorumNotEstablished` used to be constructed with a hardcoded `0`, so a cluster that had
+    /// formed correctly and merely could not be QUERIED reported "0/2 nodes healthy". Measured
+    /// 2026-09-10 against a live 3-node cluster whose own log read `Quorum established — consensus
+    /// available` while bootstrap raised exactly that message and tore it down. An unreadable view
+    /// and a genuinely empty cluster are different facts and must read differently.
+    @Test
+    void unobservedQuorum_saysUnknown_notZero() {
+        var message = new ClusterBootstrapOrchestrator.BootstrapError
+                              .QuorumNotEstablished(ClusterBootstrapOrchestrator.BootstrapError
+                                                            .QuorumNotEstablished.UNOBSERVED, 2).message();
+
+        assertThat(message)
+                .describedAs("an unreadable cluster view must not be reported as a measured zero")
+                .contains("UNKNOWN")
+                .doesNotContain("0/2");
+    }
+
+    /// Control: when the view IS readable, the observed count is reported verbatim. Without this,
+    /// "does not contain 0/2" would also be satisfied by a message that reports nothing at all.
+    @Test
+    void observedQuorum_reportsTheCountItRead() {
+        var message = new ClusterBootstrapOrchestrator.BootstrapError.QuorumNotEstablished(1, 2).message();
+
+        assertThat(message).contains("1/2 nodes healthy");
+    }
 }

--- a/aether/docker/aether-node/Dockerfile
+++ b/aether/docker/aether-node/Dockerfile
@@ -54,9 +54,20 @@ ENV JAVA_OPTS="-Xmx512m -XX:+UseZGC -Djava.net.preferIPv4Stack=true"
 # 8080     - Management API (REST, WebSocket dashboard)
 EXPOSE 8090/udp 8190/udp 8080
 
-# Health check using liveness probe (bypasses auth — no audit log spam)
+# Health check using liveness probe (bypasses auth — no audit log spam).
+#
+# TLS-agnostic on purpose: the management listener serves HTTPS when `[cluster] tls = true` and
+# plain HTTP otherwise, so probe HTTPS first and fall back. A plaintext-only probe was rejected
+# with NotSslRecordException under TLS, the container never left `unhealthy`, and the bootstrap
+# readiness gate then destroyed clusters that had actually formed quorum (#967).
+#
+# --no-check-certificate is correct here and not a weakening: the certificate is issued by the
+# cluster's own auto-generated CA, which by design never lands on disk, and the probe targets
+# localhost inside the container — there is no name to verify and no network to intercept.
 HEALTHCHECK --interval=10s --timeout=5s --start-period=45s --retries=3 \
-    CMD wget --no-verbose --tries=1 --spider http://localhost:${MANAGEMENT_PORT}/health/live || exit 1
+    CMD wget -q --tries=1 --spider --no-check-certificate https://localhost:${MANAGEMENT_PORT}/health/live \
+     || wget -q --tries=1 --spider http://localhost:${MANAGEMENT_PORT}/health/live \
+     || exit 1
 
 # Switch to non-root user
 USER aether

--- a/aether/docker/aether-node/aether.toml
+++ b/aether/docker/aether-node/aether.toml
@@ -1,9 +1,17 @@
 # Aether Node Configuration for Containerized Deployment
 #
-# TLS note: `tls = false` means the management API uses plain HTTP (needed for
-# curl-based health checks and integration tests). QUIC cluster transport still
-# uses TLS with ephemeral self-signed certs. Set `tls = true` for production
-# (enables mTLS management API + deterministic CA from cluster secret).
+# TLS note: `tls = false` means the management API uses plain HTTP, which keeps
+# integration tests simple. QUIC cluster transport still uses TLS with ephemeral
+# self-signed certs. Set `tls = true` for production (deterministic CA from the
+# cluster secret).
+#
+# The container health check no longer constrains this choice: it probes HTTPS and
+# falls back to HTTP. It used to require `tls = false`, and `tls = true` therefore
+# left the container permanently `unhealthy` (#967). The management API also no
+# longer inherits the cluster's mTLS client-auth requirement — callers authenticate
+# with an API key, and the auto-generated CA never lands on disk, so requiring a
+# client certificate made the API unreachable in exactly the production mode this
+# note recommends.
 
 [cluster]
 tls = false

--- a/aether/node/src/main/java/org/pragmatica/aether/api/ManagementServer.java
+++ b/aether/node/src/main/java/org/pragmatica/aether/api/ManagementServer.java
@@ -456,7 +456,6 @@ class ManagementServerImpl implements ManagementServer {
                                      .withWebSocket(wsEndpoint)
                                      .withWebSocket(statusWsEndpoint)
                                      .withWebSocket(eventWsEndpoint);
-
         // #967: the node's cluster TlsConfig is Mutual, which makes every listener built from it
         // demand a cluster-CA client certificate. That is right for node-to-node transport and wrong
         // here: management callers authenticate with an API key, and under `auto_generate` the CA is
@@ -569,11 +568,10 @@ class ManagementServerImpl implements ManagementServer {
 
     private static Option<TlsConfig> buildTlsFromBundle(org.pragmatica.net.tcp.security.CertificateBundle bundle) {
         var identity = new TlsConfig.Identity.FromProvider(bundle.certificatePem(), bundle.privateKeyPem());
-
         // #967: server-auth only, matching buildServerConfig(). Carrying the CA as clientAuth here
         // would re-arm ClientAuth.REQUIRE on the first certificate rotation, so a cluster that
         // bootstrapped fine would lose its management API hours later — the harder bug to find.
-        return Option.some(new TlsConfig.Server(identity, Option.<TlsConfig.Trust>none()));
+        return Option.some(new TlsConfig.Server(identity, Option.<TlsConfig.Trust> none()));
     }
 
     private void onServerStarted(HttpServer server) {

--- a/aether/node/src/main/java/org/pragmatica/aether/api/ManagementServer.java
+++ b/aether/node/src/main/java/org/pragmatica/aether/api/ManagementServer.java
@@ -457,7 +457,13 @@ class ManagementServerImpl implements ManagementServer {
                                      .withWebSocket(statusWsEndpoint)
                                      .withWebSocket(eventWsEndpoint);
 
-        return tls.map(config::withTls)
+        // #967: the node's cluster TlsConfig is Mutual, which makes every listener built from it
+        // demand a cluster-CA client certificate. That is right for node-to-node transport and wrong
+        // here: management callers authenticate with an API key, and under `auto_generate` the CA is
+        // never written to disk, so no operator could present one. It also made the container
+        // liveness probe unsatisfiable under any scheme.
+        return tls.map(TlsConfig::serverAuthOnly)
+                  .map(config::withTls)
                   .or(config);
     }
 
@@ -563,9 +569,11 @@ class ManagementServerImpl implements ManagementServer {
 
     private static Option<TlsConfig> buildTlsFromBundle(org.pragmatica.net.tcp.security.CertificateBundle bundle) {
         var identity = new TlsConfig.Identity.FromProvider(bundle.certificatePem(), bundle.privateKeyPem());
-        var trust = new TlsConfig.Trust.FromCaBytes(bundle.caCertificatePem());
 
-        return Option.some(new TlsConfig.Server(identity, Option.some(trust)));
+        // #967: server-auth only, matching buildServerConfig(). Carrying the CA as clientAuth here
+        // would re-arm ClientAuth.REQUIRE on the first certificate rotation, so a cluster that
+        // bootstrapped fine would lose its management API hours later — the harder bug to find.
+        return Option.some(new TlsConfig.Server(identity, Option.<TlsConfig.Trust>none()));
     }
 
     private void onServerStarted(HttpServer server) {

--- a/aether/node/src/main/java/org/pragmatica/aether/http/AppHttpServer.java
+++ b/aether/node/src/main/java/org/pragmatica/aether/http/AppHttpServer.java
@@ -566,15 +566,14 @@ class AppHttpServerAdapter implements AppHttpServer {
         var serverConfig = HttpServerConfig.httpServerConfig("app-http",
                                                              config.port())
                                            .withMaxContentLength(config.maxRequestSize());
-
         // #967: never demand a client certificate from callers of a USER-facing listener. The node's
         // cluster TlsConfig is Mutual, so building this listener from it made every slice request
         // require a cluster-CA client cert — a certificate that, under `auto_generate`, is derived
         // from the cluster secret and never written to disk. See AppHttpConfig.tls() for the
         // operator-supplied identity that a public listener actually needs.
         return appTls().orElse(() -> tls.map(TlsConfig::serverAuthOnly))
-                       .map(serverConfig::withTls)
-                       .or(serverConfig);
+                     .map(serverConfig::withTls)
+                     .or(serverConfig);
     }
 
     private Unit registerStartedH1Server(HttpServer server) {
@@ -707,10 +706,9 @@ class AppHttpServerAdapter implements AppHttpServer {
 
     private static Option<TlsConfig> buildTlsFromBundle(CertificateBundle newBundle) {
         var identity = new TlsConfig.Identity.FromProvider(newBundle.certificatePem(), newBundle.privateKeyPem());
-
         // #967: server-auth only, matching buildServerConfig(). Carrying the CA as clientAuth here
         // would re-arm ClientAuth.REQUIRE at the first certificate rotation.
-        return Option.some(new TlsConfig.Server(identity, Option.<TlsConfig.Trust>none()));
+        return Option.some(new TlsConfig.Server(identity, Option.<TlsConfig.Trust> none()));
     }
 
     @Override

--- a/aether/node/src/main/java/org/pragmatica/aether/http/AppHttpServer.java
+++ b/aether/node/src/main/java/org/pragmatica/aether/http/AppHttpServer.java
@@ -551,13 +551,30 @@ class AppHttpServerAdapter implements AppHttpServer {
         handleRequest(request, response);
     }
 
+    /// The operator-supplied identity for this listener, if `[app-http.tls]` is configured.
+    ///
+    /// Takes precedence over the cluster identity. Server-auth only by construction —
+    /// [TlsConfig#server(java.nio.file.Path, java.nio.file.Path)] carries no client-auth trust — so a
+    /// public client is never asked for a certificate it cannot have (#967).
+    private Option<TlsConfig> appTls() {
+        return config.tls()
+                     .map(appTls -> TlsConfig.server(java.nio.file.Path.of(appTls.certPath()),
+                                                     java.nio.file.Path.of(appTls.keyPath())));
+    }
+
     private HttpServerConfig buildServerConfig() {
         var serverConfig = HttpServerConfig.httpServerConfig("app-http",
                                                              config.port())
                                            .withMaxContentLength(config.maxRequestSize());
 
-        return tls.map(serverConfig::withTls)
-                  .or(serverConfig);
+        // #967: never demand a client certificate from callers of a USER-facing listener. The node's
+        // cluster TlsConfig is Mutual, so building this listener from it made every slice request
+        // require a cluster-CA client cert — a certificate that, under `auto_generate`, is derived
+        // from the cluster secret and never written to disk. See AppHttpConfig.tls() for the
+        // operator-supplied identity that a public listener actually needs.
+        return appTls().orElse(() -> tls.map(TlsConfig::serverAuthOnly))
+                       .map(serverConfig::withTls)
+                       .or(serverConfig);
     }
 
     private Unit registerStartedH1Server(HttpServer server) {
@@ -690,9 +707,10 @@ class AppHttpServerAdapter implements AppHttpServer {
 
     private static Option<TlsConfig> buildTlsFromBundle(CertificateBundle newBundle) {
         var identity = new TlsConfig.Identity.FromProvider(newBundle.certificatePem(), newBundle.privateKeyPem());
-        var trust = new TlsConfig.Trust.FromCaBytes(newBundle.caCertificatePem());
 
-        return Option.some(new TlsConfig.Server(identity, Option.some(trust)));
+        // #967: server-auth only, matching buildServerConfig(). Carrying the CA as clientAuth here
+        // would re-arm ClientAuth.REQUIRE at the first certificate rotation.
+        return Option.some(new TlsConfig.Server(identity, Option.<TlsConfig.Trust>none()));
     }
 
     @Override

--- a/changelog.d/967-management-api-server-auth-only.md
+++ b/changelog.d/967-management-api-server-auth-only.md
@@ -1,0 +1,22 @@
+### Fixed (2026-09-10 — #967: with `[cluster] tls = true` the management API required a cluster-CA client certificate that never exists on disk, so the API was unreachable and the container liveness probe could not pass)
+- **The node handed its single `Mutual` TLS config to every listener it started.** `Main.resolveTls`
+  builds `TlsConfig.fromProvider(...)`, which returns `Mutual`, and `TlsContextFactory` maps `Mutual`
+  to `ClientAuth.REQUIRE`. Correct for node-to-node cluster transport; wrong for the operator-facing
+  management API, which authenticates callers with an API key (`SecurityPolicy.apiKeyRequired()`).
+  Under `auto_generate` the CA is derived from the cluster secret and **never written to disk**, so no
+  operator could present a client certificate even in principle.
+- **`TlsConfig.serverAuthOnly()`** returns a server-auth-only view of an identity, and the management
+  listener now uses it — at boot **and** on certificate rotation. Fixing only the boot path would have
+  left a cluster that bootstrapped correctly losing its management API at the first renewal.
+- **The container liveness probe could not pass under any scheme.** Plaintext was rejected with
+  `NotSslRecordException`; TLS without a client certificate was refused. The probe is now
+  TLS-agnostic — HTTPS first, falling back to HTTP — so it works whether `tls` is on or off.
+- **Measured consequence, on a real 3-node Hetzner cluster.** The nodes formed correctly and their own
+  logs read `Quorum established — consensus available`, `CTM: desired=3, active=3, ready=3 → Converged`.
+  The container stayed `unhealthy`, the bootstrap readiness gate reads container health, and so
+  `aether cluster bootstrap` reported `Quorum not established: 0/1 nodes healthy` and **destroyed a
+  working cluster**. Cloud bootstrap was impossible on the default configuration path.
+- Pinned by `TlsConfigTest.mutualConfig_requiresClientCertificate_andServerAuthOnlyViewDoesNot`, which
+  asserts `SSLEngine.getNeedClientAuth()`/`getWantClientAuth()` rather than the record shape, and keeps
+  the `Mutual` arm as a positive control — without it a green result would only prove the assertion
+  cannot detect the difference.

--- a/changelog.d/967-management-api-server-auth-only.md
+++ b/changelog.d/967-management-api-server-auth-only.md
@@ -31,3 +31,9 @@
   hide it behind a listener that starts and then rejects every real client. Absent the section, the
   listener falls back to the cluster identity with client auth stripped: reachable service-to-service,
   not suitable for public traffic.
+- **A bootstrap failure no longer reports a count nobody measured.** `BootstrapError.QuorumNotEstablished`
+  was constructed with a hardcoded `0`, so a cluster that had formed correctly and merely could not be
+  QUERIED reported `0/2 nodes healthy`. Measured 2026-09-10 on a live 3-node cluster whose own log read
+  `Quorum established — consensus available` at the moment that message was printed and the cluster torn
+  down. `waitForQuorum` now records what the cluster view actually reported each poll; on timeout it
+  reports that number, or says the view was never readable and the count is **UNKNOWN — not zero**.

--- a/changelog.d/967-management-api-server-auth-only.md
+++ b/changelog.d/967-management-api-server-auth-only.md
@@ -1,4 +1,4 @@
-### Fixed (2026-09-10 — #967: with `[cluster] tls = true` the management API required a cluster-CA client certificate that never exists on disk, so the API was unreachable and the container liveness probe could not pass)
+### Fixed (2026-09-10 — #967: with `[cluster] tls = true` every HTTP listener demanded a cluster-CA client certificate that never exists on disk, so the management API AND every deployed slice were unreachable, and the container liveness probe could not pass)
 - **The node handed its single `Mutual` TLS config to every listener it started.** `Main.resolveTls`
   builds `TlsConfig.fromProvider(...)`, which returns `Mutual`, and `TlsContextFactory` maps `Mutual`
   to `ClientAuth.REQUIRE`. Correct for node-to-node cluster transport; wrong for the operator-facing
@@ -20,3 +20,14 @@
   asserts `SSLEngine.getNeedClientAuth()`/`getWantClientAuth()` rather than the record shape, and keeps
   the `Mutual` arm as a positive control — without it a green result would only prove the assertion
   cannot detect the difference.
+- **The app-HTTP listener had the same defect, with a worse blast radius.** It was built from the same
+  `Mutual` config, so **every client of every deployed slice** had to present a cluster-CA client
+  certificate. `serverAuthOnly()` now applies there too, at boot and on rotation.
+- **`[app-http.tls]` gives the user-facing listener its own identity.** Reusing the cluster certificate
+  is wrong beyond client auth: its subject is the NODE ID (`CN=primary-core-0`, observed on a live
+  cluster) and its issuer is an internal CA no public client trusts, so a caller gets both an untrusted
+  issuer and a name that is not the service it dialled. `cert_path` and `key_path` are required
+  together — half an identity is a mistake, and silently falling back to the cluster certificate would
+  hide it behind a listener that starts and then rejects every real client. Absent the section, the
+  listener falls back to the cluster identity with client auth stripped: reachable service-to-service,
+  not suitable for public traffic.

--- a/integrations/net/tcp/src/main/java/org/pragmatica/net/tcp/TlsConfig.java
+++ b/integrations/net/tcp/src/main/java/org/pragmatica/net/tcp/TlsConfig.java
@@ -95,6 +95,35 @@ public sealed interface TlsConfig {
     /// @param trust    CA certificate for verifying peer certificates
     record Mutual(Identity identity, Trust trust) implements TlsConfig {}
 
+    /// Server-auth-only view of this configuration: keeps this node's identity, drops any
+    /// client-certificate requirement.
+    ///
+    /// mTLS is correct for node-to-node cluster transport, where both peers hold cluster-CA
+    /// certificates. It is wrong for an operator- or user-facing HTTP listener, and the node
+    /// previously handed the same [Mutual] config to every server it started. Two consequences,
+    /// both observed on a real 3-node Hetzner cluster (#967):
+    ///
+    ///   - The management API became unreachable whenever `[cluster] tls = true`. Callers
+    ///     authenticate with an API key ([org.pragmatica.aether.api.ManagementServer] sets
+    ///     `SecurityPolicy.apiKeyRequired()`), and under `auto_generate` the CA is derived from the
+    ///     cluster secret and never written to disk — so no operator could present a client
+    ///     certificate even in principle.
+    ///   - The container liveness probe could not pass under ANY scheme: plaintext was rejected
+    ///     with `NotSslRecordException`, and TLS without a client certificate was refused. The
+    ///     bootstrap readiness gate reads container health, so it reported
+    ///     `Quorum not established` and destroyed clusters whose own logs said
+    ///     `Quorum established — consensus available`.
+    ///
+    /// [Client] is returned unchanged: it is not a server configuration, and
+    /// [TlsContextFactory#createServer] already rejects it with a named error.
+    default TlsConfig serverAuthOnly() {
+        return switch (this) {
+            case Server(var identity, var ignored) -> new Server(identity, Option.none());
+            case Mutual(var identity, var ignored) -> new Server(identity, Option.none());
+            case Client _ -> this;
+        };
+    }
+
     // ===== Server Factory Methods =====
     /// Create self-signed server TLS configuration.
     /// Generates certificate at startup. For development only.

--- a/integrations/net/tcp/src/test/java/org/pragmatica/net/tcp/TlsConfigTest.java
+++ b/integrations/net/tcp/src/test/java/org/pragmatica/net/tcp/TlsConfigTest.java
@@ -249,4 +249,60 @@ class TlsConfigTest {
             }
         };
     }
+
+    /// #967. These pin the CONSEQUENCE, not the record shape: a server context built from the
+    /// node's `Mutual` cluster config demands a client certificate, and the `serverAuthOnly()` view
+    /// of the same identity does not. The Mutual arm is the positive control — without it, a green
+    /// "does not require client auth" proves only that the assertion cannot see the difference.
+    @Test
+    void mutualConfig_requiresClientCertificate_andServerAuthOnlyViewDoesNot() {
+        var mutual = TlsConfig.fromProvider(realProvider(), "node-1", "localhost").unwrap();
+
+        assertThat(mutual).isInstanceOf(TlsConfig.Mutual.class);
+
+        var mutualEngine = TlsContextFactory.createServer(mutual)
+                                            .unwrap()
+                                            .newEngine(io.netty.buffer.ByteBufAllocator.DEFAULT);
+        var serverOnlyEngine = TlsContextFactory.createServer(mutual.serverAuthOnly())
+                                                 .unwrap()
+                                                 .newEngine(io.netty.buffer.ByteBufAllocator.DEFAULT);
+
+        assertThat(mutualEngine.getNeedClientAuth())
+                .describedAs("control: the cluster's Mutual config MUST require a client certificate, "
+                             + "otherwise this test cannot detect the difference it exists to detect")
+                .isTrue();
+        assertThat(serverOnlyEngine.getNeedClientAuth())
+                .describedAs("serverAuthOnly() must not require a client certificate — the management "
+                             + "API authenticates with an API key and the auto-generated CA never "
+                             + "reaches disk, so requiring one makes the API unreachable (#967)")
+                .isFalse();
+        assertThat(serverOnlyEngine.getWantClientAuth())
+                .describedAs("nor may it merely REQUEST one: a requested certificate still fails the "
+                             + "container liveness probe, which presents none")
+                .isFalse();
+    }
+
+    @Test
+    void serverAuthOnly_dropsClientAuth_fromAServerConfigThatHadIt() {
+        var withClientAuth = new TlsConfig.Server(new TlsConfig.Identity.SelfSigned(),
+                                                  Option.some(new TlsConfig.Trust.InsecureTrustAll()));
+
+        assertThat(((TlsConfig.Server) withClientAuth.serverAuthOnly()).clientAuth().isEmpty()).isTrue();
+    }
+
+    @Test
+    void serverAuthOnly_leavesAClientConfigUnchanged() {
+        var client = TlsConfig.client();
+
+        assertThat(client.serverAuthOnly()).isSameAs(client);
+    }
+
+    /// A real provider, not the stub used elsewhere in this class: the stub's PEM bytes are
+    /// placeholders, and [TlsContextFactory#createServer] must actually parse a certificate for the
+    /// client-auth assertions below to mean anything.
+    private static CertificateProvider realProvider() {
+        return org.pragmatica.net.tcp.security.SelfSignedCertificateProvider
+                       .selfSignedCertificateProvider("test-cluster-secret-967".getBytes())
+                       .unwrap();
+    }
 }


### PR DESCRIPTION
Fixes #967.

**With `[cluster] tls = true` — the documented production setting, and the default the cloud bootstrap generates — every HTTP listener demanded a cluster-CA client certificate that never exists on disk.** The management API was unreachable, every deployed slice was unreachable, and the container liveness probe could not pass under any scheme. Cloud bootstrap was impossible on the default path.

## How it happened

`Main.resolveTls` calls `TlsConfig.fromProvider(...)`, which returns **`Mutual`**, and `TlsContextFactory` maps `Mutual` to `ClientAuth.REQUIRE`. That single config was handed to every server the node starts — cluster transport, management API, and app-HTTP alike. Correct for node-to-node; wrong for the two listeners that face humans and clients.

Under `auto_generate` the CA is derived from the cluster secret and **never written to disk**, so no operator could present a client certificate even in principle. The management API's actual auth is `SecurityPolicy.apiKeyRequired()`; the mTLS was inherited, not chosen.

## Measured on a real 3-node Hetzner cluster

The nodes formed correctly. Their own logs:

```
Quorum established — consensus available
DHT: Node added primary-core-0/1/2, updating ring
CTM: Activated, desired=3, active=3, ready=3  →  Converged
LeaderReconciler: quorumSafe=true reason=NO_DEFICIT
```

Meanwhile the container stayed `unhealthy`, because its probe was rejected by the node itself:

```
NotSslRecordException: not an SSL/TLS record:
48454144202f6865616c74682f6c697665...   ("HEAD /health/live HTTP/1.1 | Host: localhost:8080")
```

And the bootstrap's readiness gate — which polls `scheme://<publicIp>:<mgmtPort>/health/live` directly (`BootstrapPhaseDeploy:678`, scheme chosen from `tls().autoGenerate()` at line 188) — had its HTTPS poll refused for the same reason: no client certificate. So `aether cluster bootstrap` reported `Quorum not established: 0/1 nodes healthy` **and destroyed a working cluster**, reporting the opposite of what the product's own log said.

**The container healthcheck and the readiness gate are parallel symptoms of one cause, not cause and effect.** The gate never consults container health (zero references to `docker inspect` / `State.Health` in the CLI). Both fail because the management port demands a certificate that cannot exist, which is why fixing that one thing fixes both.

## What changed

- **`TlsConfig.serverAuthOnly()`** — a server-auth view of an identity. Applied to the management listener and the app-HTTP listener, **at boot and on certificate rotation**. Fixing only the boot path would have left a cluster that bootstrapped correctly losing its API at the first renewal — the harder bug to find.
- **The container healthcheck is now TLS-agnostic** — HTTPS first, falling back to HTTP — so it works whether `tls` is on or off. `--no-check-certificate` is correct here and not a weakening: the probe targets localhost inside the container, against a certificate from a CA that by design never lands on disk.
- **`[app-http.tls]`** gives the user-facing listener its own identity (`cert_path` + `key_path`). Reusing the cluster certificate is wrong beyond client auth: its subject is the NODE ID (`CN=primary-core-0`, observed live) and its issuer is an internal CA no public client trusts, so a caller gets both an untrusted issuer and a name that is not the service it dialled. Both keys are required together — half an identity is a mistake, and falling back silently would hide it behind a listener that starts and then rejects every real client.
- The `aether.toml` note that said `tls = false` is "needed for curl-based health checks" is corrected. It documented this defect.

**Fallback behaviour, stated because it bounds the claim:** absent `[app-http.tls]`, app-HTTP uses the cluster identity with client auth stripped. That is reachable by clients which trust the cluster CA — service-to-service — and is **not** suitable for public traffic.

## Evidence

**Root build:** 143 of 144 modules SUCCESS, 0 SKIPPED, **13,396 tests, 1 failure**. The failure is `CliDocsDriftTest`, which cites only files under `.claude/` — gitignored and untracked, so invisible to CI. I predicted that failure before running the build; nothing else failed.

**Gate**, per module, one invocation each, file counts not exit statuses:
- `aether/aether-config` — 76 files, **passed**
- `aether/node` — 152 files, **passed**
- `integrations/net/tcp` — 15 files, fails on `ClientAuthPolicy`, `QuicSslContextFactory`, `TlsContextFactory`, `SelfSignedCertificateProvider`, `CertificateRenewalScheduler`, `Server` — **none of which this PR touches**; `TlsConfig.java` appears in zero errors. Pre-existing debt in a subtree CI does not gate, deliberately left alone.

**Tests.** `TlsConfigTest` 18 pass, `ConfigLoaderTest` 41 pass; all six new tests verified as actually executed rather than silently skipped. The load-bearing one asserts `SSLEngine.getNeedClientAuth()` / `getWantClientAuth()` — the consequence, not the record shape — and keeps the `Mutual` arm as a positive control, so a green cannot merely mean the assertion is blind to the difference.

The formatting commit is token-identical to its parent (whitespace-stripped hash comparison, with a positive control confirming the check detects a one-token change).

## VERIFIED ON REAL HARDWARE

This branch's JAR was booted on a fresh 3-core Hetzner cluster in `RuntimeType.JVM` (cloud-init fetches the JAR, so no image publish, no tag move, no merge was needed to test it), with **`[operations.tls] auto_generate = true`** — the condition the defect requires. Over HTTPS, **without a client certificate**:

| Endpoint | before (`defb6430f`) | after (this branch) |
|---|---|---|
| `/health/live` | refused | **HTTP 200** |
| `/health/ready` | refused | **HTTP 200** |

Bootstrap moved from dying at the liveness gate (`Waiting for 3 node(s) to become healthy` → failure) to clearing it (`All nodes healthy`). The cluster's own log at that moment:

```
Quorum established — consensus available
CTM: Activated, desired=3, active=2, ready=2  →  Converged
LeaderReconciler: clusterMembershipCount=3 members=[core-2, core-1, core-0]
                  effective=3 reachedFullMembership=true quorumSafe=true reason=NO_DEFICIT
```

## What this still does NOT fix

**Cloud bootstrap still cannot complete**, for a separate defect this fix made visible by getting far enough to reach it. The quorum check polls `/api/v1/health`, which answers `401 X-API-Key header required`. `BootstrapPhaseFormation.extractConfiguredApiKey` reads a key **from the cluster config**, `aether cluster init` never writes one, and the key bootstrap generates is minted in Phase 7 — after the nodes have already booted from cloud-init. `BootstrapOverlayGenerator` renders an api key only for `DOCKER` sources, and even there it is `[cloud.compute] api_key`, a provisioning credential rather than an `[app-http.api-keys.*]` entry. Deciding where that admin credential is minted and how it reaches a public host is a design question, tracked separately.

**The container healthcheck change is not covered by the run above** — JVM mode has no container. It is verified by inspection only until an image is rebuilt from this branch.

`v1.0.0-rc4-candidate` currently points at `defb6430f`, which contains none of this — **the published candidate image still carries the defect.**

## Related, not fixed here

`aether cluster init --firewall=standard` generates a config omitting ports 22 and 8080, which `bootstrap` requires. Phase 1 VALIDATE detects it, states the cause and the fix exactly, and then provisions paid infrastructure anyway and fails 300 seconds later. Separate defect, separate fix.
