### PR TITLE
fix: #985 CLI binds log4j2 instead of slf4j-nop and gains a -v verbosity ladder

### DIFF
--- a/aether/cli/pom.xml
+++ b/aether/cli/pom.xml
@@ -86,12 +86,22 @@
             <version>${project.version}</version>
         </dependency>
 
-        <!-- Suppress SLF4J "no provider" warnings at runtime -->
+        <!-- One logging story across both shipped artifacts: the CLI binds the SAME log4j2 stack
+             as aether-node. It previously bound slf4j-nop, whose NOPServiceProvider was the only
+             provider in the fat jar, so every log statement the CLI made was discarded, including
+             HetznerComputeProvider's create-request line, the one record of what was actually sent
+             to Hetzner when a provision returns 422.
+
+             log4j-core is a COMPILE dependency (not runtime) because Verbosity calls Configurator
+             to move the org.pragmatica logger at parse time; the node declares it the same way. -->
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-nop</artifactId>
-            <version>${slf4j.version}</version>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j2-impl</artifactId>
             <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
         </dependency>
 
         <!-- Testing -->
@@ -133,6 +143,15 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
                 <version>3.6.1</version>
+                <dependencies>
+                    <!-- Supplies Log4j2PluginCacheFileTransformer below. Same declaration as
+                         aether/node/pom.xml. -->
+                    <dependency>
+                        <groupId>org.apache.logging.log4j</groupId>
+                        <artifactId>log4j-transform-maven-shade-plugin-extensions</artifactId>
+                        <version>0.2.0</version>
+                    </dependency>
+                </dependencies>
                 <executions>
                     <execution>
                         <phase>package</phase>
@@ -153,6 +172,10 @@
                                      all register at runtime. Without this, only the last-shaded jar's service
                                      file survives and the others are silently dropped. -->
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                                <!-- Merge Log4j2Plugins.dat across shaded jars. Without it log4j2's
+                                     plugin cache is broken in the fat jar and the Console appender /
+                                     PatternLayout in log4j2.xml cannot be resolved. -->
+                                <transformer implementation="org.apache.logging.log4j.maven.plugins.shade.transformer.Log4j2PluginCacheFileTransformer"/>
                             </transformers>
                             <filters>
                                 <filter>

--- a/aether/cli/src/main/java/org/pragmatica/aether/cli/AetherCli.java
+++ b/aether/cli/src/main/java/org/pragmatica/aether/cli/AetherCli.java
@@ -78,6 +78,20 @@ public class AetherCli implements Runnable {
     @CommandLine.Option(names = {"--request-timeout"}, description = "Per-request timeout in seconds (default 130, must exceed server-side max of 120). 0 disables.")
     private int requestTimeoutSeconds = 130;
 
+    /// The `-v` verbosity ladder (see [Verbosity]).
+    ///
+    /// Declared on the TOP-LEVEL command only, and deliberately NOT with `scope = INHERIT`: four
+    /// subcommands already declare their own value-taking `-v`/`--version` option, and an inherited
+    /// top-level `-v` would collide with those at startup. The cost of that is positional and is
+    /// stated in the help text: `aether -vv cluster bootstrap ...` raises verbosity, whereas
+    /// `aether cluster bootstrap -vv` does not, because there `-v` belongs to the subcommand.
+    ///
+    /// picocli fills this array with one element per occurrence, so `-vvv` yields length 3.
+    @CommandLine.Option(names = "-v", description = "Increase diagnostic verbosity on stderr: -v INFO, -vv DEBUG, -vvv TRACE. "
+                                                  + "Must be given BEFORE the subcommand (e.g. 'aether -vv cluster bootstrap ...'): "
+                                                  + "after a subcommand, -v is that subcommand's own --version option.")
+    private boolean[] verbosity = new boolean[0];
+
     @CommandLine.Mixin
     private OutputOptions outputOptions = new OutputOptions();
 
@@ -92,6 +106,7 @@ public class AetherCli implements Runnable {
         var cli = new AetherCli();
         var cmd = new CommandLine(cli);
 
+        cmd.setExecutionStrategy(cli::runWithVerbosity);
         cli.lookupConnection(args);
         cli.tlsSkipVerify = containsTlsSkipVerify(args);
         cli.httpOps = cli.buildHttpOperations();
@@ -312,6 +327,22 @@ public class AetherCli implements Runnable {
     }
 
     @SuppressWarnings({"JBCT-PAT-01", "JBCT-SEQ-01", "JBCT-UTIL-02"})
+    /// Apply the [Verbosity] rung, then run the command picocli selected.
+    ///
+    /// This seam exists because the level has to be applied at a specific moment: AFTER parsing
+    /// (only then is the `-v` repeat count known) and BEFORE the selected subcommand runs (that is
+    /// where the diagnostics worth reading are emitted). picocli's execution strategy is exactly
+    /// that point. Registering it on the shared `CommandLine` covers the REPL path too, which
+    /// re-executes against the same instance.
+    ///
+    /// [CommandLine.RunLast] is picocli's own default strategy, so an invocation with no `-v`
+    /// dispatches exactly as it did before this seam was introduced.
+    private int runWithVerbosity(CommandLine.ParseResult parseResult) {
+        return Verbosity.verbosity(verbosity.length)
+                        .apply()
+                        .map(() -> new CommandLine.RunLast().execute(parseResult));
+    }
+
     private void runRepl(CommandLine cmd) {
         System.out.println("Aether v" + BuildInfo.current().displayString() + " - Connected to " + nodeAddress);
         System.out.println("Type 'help' for available commands, 'exit' to quit.");

--- a/aether/cli/src/main/java/org/pragmatica/aether/cli/Verbosity.java
+++ b/aether/cli/src/main/java/org/pragmatica/aether/cli/Verbosity.java
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2025 Pragmatica Labs - Sergiy Yevtushenko
+// Licensed under Business Source License 1.1. Change Date: 2030-01-01. Change License: Apache-2.0.
+// See LICENSE in the repository root for full terms.
+package org.pragmatica.aether.cli;
+
+import org.pragmatica.lang.Unit;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.config.Configurator;
+
+
+/// The `-v` verbosity ladder: how many times the top-level `-v` was repeated decides the level
+/// applied to [#AETHER_LOGGER].
+///
+/// The ladder moves `org.pragmatica`, NOT the CLI's own package. A flag that raised only
+/// `org.pragmatica.aether.cli` would leave the interesting diagnostics dark: the line that says what
+/// was actually sent to a cloud provider is emitted by the provider
+/// (`org.pragmatica.aether.environment.hetzner.HetznerComputeProvider`), which is where a 422 has to
+/// be diagnosed from.
+///
+/// Third-party logging is not on the ladder at all: `log4j2.xml` pins Root to OFF, so netty, the
+/// cloud SDKs and the http client stay silent even at [#TRACE].
+public enum Verbosity {
+    /// No `-v`. Matches the `org.pragmatica` level declared in `log4j2.xml`, so an invocation with
+    /// no flag behaves exactly as if the ladder did not exist.
+    DEFAULT(Level.WARN),
+    /// `-v`
+    VERBOSE(Level.INFO),
+    /// `-vv`
+    DEBUG(Level.DEBUG),
+    /// `-vvv`, and anything beyond it
+    TRACE(Level.TRACE);
+    /// The logger the ladder moves. Every Aether and Pragmatica logger sits under it.
+    public static final String AETHER_LOGGER = "org.pragmatica";
+    private static final Verbosity[] RUNGS = values();
+    private final Level level;
+    Verbosity(Level level) {
+        this.level = level;
+    }
+    public Level level() {
+        return level;
+    }
+    /// Repeat count to rung. Saturates rather than failing: `-vvvv` and beyond are [#TRACE], which
+    /// is already everything there is to say, and a usage error over an extra `v` would be a worse
+    /// answer than the most verbose output available.
+    public static Verbosity verbosity(int repeatCount) {
+        return RUNGS[Math.clamp(repeatCount, 0, RUNGS.length - 1)];
+    }
+    /// Raise [#AETHER_LOGGER] to this rung on the live logger context.
+    ///
+    /// Reconfiguring the live context (rather than setting a system property read by `log4j2.xml`)
+    /// is what makes this correct regardless of when log4j2 loaded its configuration: by the time
+    /// picocli has parsed the top-level options, some CLI plumbing may already have initialised
+    /// logging, and a property set after that point would be read by nothing.
+    public Unit apply() {
+        return Unit.toUnit(Configurator.setLevel(LogManager.getLogger(AETHER_LOGGER), level));
+    }
+}

--- a/aether/cli/src/main/resources/log4j2.xml
+++ b/aether/cli/src/main/resources/log4j2.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Logging configuration for the `aether` CLI fat jar.
+
+  It deliberately diverges from aether/node/src/main/resources/log4j2.xml on two points; both
+  divergences follow from the CLI being an operator tool rather than a long-running server.
+-->
+<Configuration status="OFF">
+    <Appenders>
+        <!--
+          DIVERGENCE 1 from the node: target is SYSTEM_ERR, not SYSTEM_OUT.
+
+          The node's stdout IS its log, so a stdout console appender is correct there. The CLI's
+          stdout is DATA: OutputOptions lets every command emit table/json/yaml that operators pipe
+          into jq and friends. A diagnostic line on stdout would corrupt those pipelines silently,
+          which is a worse failure than the missing diagnostics this file exists to restore.
+          Diagnostics therefore go to stderr, where redirecting them costs one `2>/dev/null`.
+        -->
+        <Console name="Console" target="SYSTEM_ERR">
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} %-5level %c{1.} - %msg%n"/>
+        </Console>
+    </Appenders>
+    <Loggers>
+        <!--
+          DIVERGENCE 2 from the node: root is OFF, not INFO.
+
+          The node needed seven explicit noise-suppression entries to stay readable. Root-level
+          logging in the CLI would inherit every shaded library's output (netty, the cloud SDKs,
+          the http client) into every single invocation, so the suppression list would have to be
+          maintained against the whole shaded dependency set forever. OFF inverts the default: a
+          logger is silent unless something opts it in, and only org.pragmatica does.
+
+          Consequence to know: the -v ladder raises org.pragmatica only. Third-party logging stays
+          OFF at every rung, including -vvv.
+        -->
+        <Root level="OFF">
+            <AppenderRef ref="Console"/>
+        </Root>
+
+        <!--
+          The one logger the -v ladder moves (see Verbosity). WARN by default, so a normal
+          invocation prints nothing unless something is actually wrong; -v/-vv/-vvv take it to
+          INFO/DEBUG/TRACE.
+
+          No AppenderRef here on purpose: additivity forwards events to Root's Console appender.
+          log4j2 checks the level at THIS logger and does not re-check it at the parent, so a WARN
+          from org.pragmatica still reaches the appender even though Root itself is OFF.
+        -->
+        <Logger name="org.pragmatica" level="WARN"/>
+    </Loggers>
+</Configuration>

--- a/aether/cli/src/test/java/org/pragmatica/aether/cli/CliLoggingPinTest.java
+++ b/aether/cli/src/test/java/org/pragmatica/aether/cli/CliLoggingPinTest.java
@@ -1,0 +1,212 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2025 Pragmatica Labs - Sergiy Yevtushenko
+// Licensed under Business Source License 1.1. Change Date: 2030-01-01. Change License: Apache-2.0.
+// See LICENSE in the repository root for full terms.
+package org.pragmatica.aether.cli;
+
+import java.lang.reflect.Proxy;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.Filter;
+import org.apache.logging.log4j.core.Layout;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.apache.logging.log4j.core.config.LoggerConfig;
+import org.apache.logging.log4j.core.config.Property;
+import org.apache.logging.log4j.core.layout.PatternLayout;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.pragmatica.aether.environment.InstanceType;
+import org.pragmatica.aether.environment.hetzner.HetznerComputeProvider;
+import org.pragmatica.aether.environment.hetzner.HetznerEnvironmentConfig;
+import org.pragmatica.cloud.hetzner.HetznerClient;
+import org.pragmatica.lang.Cause;
+import org.pragmatica.lang.utils.Causes;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.pragmatica.aether.environment.ClusterName.clusterName;
+import static org.pragmatica.cloud.hetzner.HetznerConfig.hetznerConfig;
+
+/// THE PIN for the CLI logging branch: the line that records what was actually sent to Hetzner is
+/// ABSENT on a default invocation and PRESENT once the `-v` ladder is applied.
+///
+/// The asserted line is emitted by production code in
+/// `org.pragmatica.aether.environment.hetzner.HetznerComputeProvider#logCreateRequest`, reached by
+/// driving the real provider. It is deliberately NOT a line this test emits: the CLI's own logger
+/// could be raised while every provider stayed dark, and that configuration would look identical in
+/// a test that asserts on a self-emitted line while fixing nothing for the operator reading a 422.
+///
+/// Three properties make the absent half worth something, because a line that never appears under
+/// any configuration also reads as absent:
+///
+///   1. The SAME run asserts a REAL WARN line from the SAME provider logger
+///      (`logProvisionFailureRollbackGap`). If the appender were detached, the binding were still
+///      slf4j-nop, the logger were renamed, or the provision had refused before reaching
+///      `createAndConfirm`, that assertion fails — so the absent half cannot pass vacuously.
+///   2. The level is NOT set by this test. `setUp` loads the SHIPPED `log4j2.xml` via
+///      [ShippedLogging#activate()], so "default" means what the jar ships, not what the fixture
+///      asserted. This is a deliberate divergence from the house log-capture pattern
+///      (`BootstrapAdminKeyLegFallbackWarnTest`), which sets the level on the logger it captures —
+///      doing that here would overwrite the one value under test. Loading it BY URI is also not
+///      optional: `test-logging`'s `log4j2-test.xml` outranks `log4j2.xml` on every test classpath,
+///      and under it the default is INFO, which makes the absent half fail for the right reason and
+///      would have made a weaker version of this test pass while measuring the wrong config.
+///   3. The capture appender is attached to the ROOT logger config with a `null` level, so it adds
+///        no filtering of its own: what it sees is exactly what `org.pragmatica`'s configured level
+///        lets through, by additivity.
+///
+/// The out-of-JVM half of the evidence — that the shaded jar finds this configuration at all, and
+/// that `aether-node.jar` emits where the CLI jar did not — is a measured run recorded in the
+/// branch report; it cannot live here because the fat jar does not exist at test phase.
+class CliLoggingPinTest {
+    /// Fragment of the real INFO line. Matches
+    /// `HetznerComputeProvider#logCreateRequest`'s message template.
+    private static final String CREATE_REQUEST_FRAGMENT = "Hetzner provision: creating server";
+
+    /// Fragment of the real WARN line from the same class, used as the in-run positive control.
+    private static final String PROVISION_FAILED_FRAGMENT = "Hetzner provision failed";
+
+    /// The provider package the brief requires the pin to be asserted from: raising only
+    /// `org.pragmatica.aether.cli` would fix nothing.
+    private static final String PROVIDER_PACKAGE = "org.pragmatica.aether.environment";
+
+    private static final Cause CLIENT_UNUSED =
+        Causes.cause("stub HetznerClient: no Hetzner API call is expected before the create-request line is logged");
+
+    private static final HetznerEnvironmentConfig CONFIG =
+        HetznerEnvironmentConfig.hetznerEnvironmentConfig(hetznerConfig("test-token"),
+                                                          "cx22",
+                                                          "ubuntu-24.04",
+                                                          "fsn1",
+                                                          List.of(1L, 2L),
+                                                          List.of(10L),
+                                                          List.of(5L),
+                                                          "#!/bin/bash\necho hello")
+                                .unwrap()
+                                .withDiscovery(clusterName("test-cluster").unwrap());
+
+    private CapturingAppender appender;
+    private LoggerConfig rootConfig;
+
+    @BeforeEach
+    void setUp() {
+        var shipped = ShippedLogging.activate();
+
+        appender = CapturingAppender.create("CliLoggingPinCapture");
+        appender.start();
+        rootConfig = shipped.getRootLogger();
+        rootConfig.addAppender(appender, null, null);
+        ((LoggerContext) LogManager.getContext(false)).updateLoggers();
+    }
+
+    @AfterEach
+    void tearDown() {
+        rootConfig.removeAppender(appender.getName());
+        appender.stop();
+        ShippedLogging.restoreTestDefault();
+    }
+
+    /// The absent half, with its control in the same run.
+    @Test
+    void logCreateRequest_absent_atShippedDefaultVerbosity() {
+        provisionAgainstStubClient();
+
+        assertThat(appender.captured())
+            .describedAs("positive control: the provision MUST have reached createAndConfirm and the "
+                         + "provider's WARN line MUST have reached this appender, otherwise the absence "
+                         + "below says nothing about the log level")
+            .anyMatch(line -> line.contains(PROVISION_FAILED_FRAGMENT));
+
+        assertThat(appender.captured())
+            .describedAs("the create-request line is INFO and the shipped default for org.pragmatica is "
+                         + "WARN, so it must not appear without -v")
+            .noneMatch(line -> line.contains(CREATE_REQUEST_FRAGMENT));
+    }
+
+    /// The present half. One `-v` is enough: the line is INFO.
+    @Test
+    void logCreateRequest_present_atFirstVerbosityRung() {
+        Verbosity.verbosity(1).apply();
+
+        provisionAgainstStubClient();
+
+        assertThat(appender.capturedAt(Level.INFO))
+            .describedAs("-v must surface the line that records what was actually sent to Hetzner")
+            .anyMatch(line -> line.contains(CREATE_REQUEST_FRAGMENT));
+    }
+
+    /// The ladder must move the PROVIDER's logger, not just the CLI's. Asserted on the logger name
+    /// carried by the captured event, so a ladder scoped to `org.pragmatica.aether.cli` fails here.
+    @Test
+    void logCreateRequest_emittedFromProviderPackage_notFromTheCli() {
+        Verbosity.verbosity(1).apply();
+
+        provisionAgainstStubClient();
+
+        assertThat(appender.capturedLoggerNamesContaining(CREATE_REQUEST_FRAGMENT))
+            .describedAs("the pinned line must come from the environment provider package")
+            .isNotEmpty()
+            .allMatch(loggerName -> loggerName.startsWith(PROVIDER_PACKAGE));
+    }
+
+    /// Drive the real provider far enough to emit the create-request line.
+    ///
+    /// `buildCreateRequest` makes no Hetzner call when the config carries ssh-key and firewall ids
+    /// (both are populated in [#CONFIG]), and `logCreateRequest` runs on its success — before
+    /// `client::createServer`. The provision therefore fails at the stub, which is expected and
+    /// ignored: the subject of these tests is the log line, not the outcome.
+    private void provisionAgainstStubClient() {
+        HetznerComputeProvider.hetznerComputeProvider(stubClient(), CONFIG)
+                              .unwrap()
+                              .provision(InstanceType.ON_DEMAND)
+                              .await();
+    }
+
+    /// Every method fails. A proxy rather than thirty hand-written stubs, so that an unexpected API
+    /// call surfaces as a failed promise instead of silently returning null.
+    private static HetznerClient stubClient() {
+        return (HetznerClient) Proxy.newProxyInstance(HetznerClient.class.getClassLoader(),
+                                                      new Class<?>[] {HetznerClient.class},
+                                                      (proxy, method, args) -> CLIENT_UNUSED.promise());
+    }
+
+    private static final class CapturingAppender extends AbstractAppender {
+        private final List<LogEvent> events = new CopyOnWriteArrayList<>();
+
+        private CapturingAppender(String name, Layout<?> layout) {
+            super(name, (Filter) null, layout, true, Property.EMPTY_ARRAY);
+        }
+
+        static CapturingAppender create(String name) {
+            return new CapturingAppender(name, PatternLayout.createDefaultLayout());
+        }
+
+        @Override
+        public void append(LogEvent event) {
+            events.add(event.toImmutable());
+        }
+
+        List<String> captured() {
+            return events.stream().map(event -> event.getMessage().getFormattedMessage()).toList();
+        }
+
+        List<String> capturedAt(Level level) {
+            return events.stream()
+                         .filter(event -> event.getLevel().equals(level))
+                         .map(event -> event.getMessage().getFormattedMessage())
+                         .toList();
+        }
+
+        List<String> capturedLoggerNamesContaining(String fragment) {
+            return events.stream()
+                         .filter(event -> event.getMessage().getFormattedMessage().contains(fragment))
+                         .map(LogEvent::getLoggerName)
+                         .toList();
+        }
+    }
+}

--- a/aether/cli/src/test/java/org/pragmatica/aether/cli/ShippedLogging.java
+++ b/aether/cli/src/test/java/org/pragmatica/aether/cli/ShippedLogging.java
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2025 Pragmatica Labs - Sergiy Yevtushenko
+// Licensed under Business Source License 1.1. Change Date: 2030-01-01. Change License: Apache-2.0.
+// See LICENSE in the repository root for full terms.
+package org.pragmatica.aether.cli;
+
+import java.net.URI;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.config.Configuration;
+import org.apache.logging.log4j.core.config.Configurator;
+import org.pragmatica.lang.Contract;
+
+/// Makes the CLI's SHIPPED `log4j2.xml` the active configuration for a test.
+///
+/// This exists because of a repo-wide fact that is easy to miss and silently inverts any test of
+/// default logging behaviour: the `test-logging` module puts `log4j2-test.xml` on every test
+/// classpath, and log4j2 prefers `log4j2-test.xml` over `log4j2.xml`. So in a test JVM the active
+/// configuration is `test-logging`'s (root at INFO, console at SYSTEM_OUT), NEVER the CLI's own —
+/// which means a test that simply reads the live configuration is measuring `test-logging`, and a
+/// test of "what does a default invocation print" would read INFO as the default and conclude the
+/// opposite of the truth.
+///
+/// `test-logging` is test-scoped, so it is absent from the shaded `aether.jar`; the divergence is
+/// confined to test JVMs, which is exactly where it misleads.
+sealed interface ShippedLogging {
+    /// Classpath location of the configuration that ships inside `aether.jar`.
+    String RESOURCE = "/log4j2.xml";
+
+    /// Load the shipped configuration into the live logger context, replacing whatever the test
+    /// classpath supplied, and return it.
+    static Configuration activate() {
+        Configurator.reconfigure(shippedUri());
+
+        return active();
+    }
+
+    /// Hand the JVM back to whatever the test classpath would otherwise supply, so a test that
+    /// activated the shipped configuration does not leak root-at-OFF into sibling test classes
+    /// sharing the fork.
+    @Contract
+    static void restoreTestDefault() {
+        Configurator.reconfigure();
+    }
+
+    static Configuration active() {
+        return ((LoggerContext) LogManager.getContext(false)).getConfiguration();
+    }
+
+    /// Resolved from the classpath rather than from a hard-coded path, so this reads the artifact
+    /// the module actually produces.
+    static URI shippedUri() {
+        return URI.create(String.valueOf(ShippedLogging.class.getResource(RESOURCE)));
+    }
+
+    record unused() implements ShippedLogging {}
+}

--- a/aether/cli/src/test/java/org/pragmatica/aether/cli/VerbosityTest.java
+++ b/aether/cli/src/test/java/org/pragmatica/aether/cli/VerbosityTest.java
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2025 Pragmatica Labs - Sergiy Yevtushenko
+// Licensed under Business Source License 1.1. Change Date: 2030-01-01. Change License: Apache-2.0.
+// See LICENSE in the repository root for full terms.
+package org.pragmatica.aether.cli;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.appender.ConsoleAppender;
+import org.apache.logging.log4j.core.config.Configuration;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/// The `-v` ladder and the shipped `log4j2.xml` it moves.
+///
+/// [ShippedConfiguration] reads the LOADED configuration object rather than the file text, so it
+/// fails if the resource is not picked up at all — which is the failure mode that would otherwise
+/// change default behaviour on every subcommand by the cheapest possible route (log4j2 with no
+/// findable config prints a StatusLogger line on every invocation).
+///
+/// The configuration is loaded explicitly via [ShippedLogging#activate()]; see that type for why
+/// reading the ambient test configuration would measure `test-logging` instead.
+class VerbosityTest {
+
+    @BeforeEach
+    void setUp() {
+        ShippedLogging.activate();
+    }
+
+    @AfterEach
+    void tearDown() {
+        ShippedLogging.restoreTestDefault();
+    }
+
+    @Nested
+    class Ladder {
+
+        @Test
+        void verbosity_mapsRepeatCount_toTheDocumentedRung() {
+            assertThat(Verbosity.verbosity(0)).isEqualTo(Verbosity.DEFAULT);
+            assertThat(Verbosity.verbosity(1)).isEqualTo(Verbosity.VERBOSE);
+            assertThat(Verbosity.verbosity(2)).isEqualTo(Verbosity.DEBUG);
+            assertThat(Verbosity.verbosity(3)).isEqualTo(Verbosity.TRACE);
+        }
+
+        @Test
+        void verbosity_mapsRungs_toTheDocumentedLevels() {
+            assertThat(Verbosity.DEFAULT.level()).isEqualTo(Level.WARN);
+            assertThat(Verbosity.VERBOSE.level()).isEqualTo(Level.INFO);
+            assertThat(Verbosity.DEBUG.level()).isEqualTo(Level.DEBUG);
+            assertThat(Verbosity.TRACE.level()).isEqualTo(Level.TRACE);
+        }
+
+        /// An extra `v` is not a usage error: TRACE is already everything there is to say.
+        @Test
+        void verbosity_saturatesAtTrace_beyondThreeRepeats() {
+            assertThat(Verbosity.verbosity(4)).isEqualTo(Verbosity.TRACE);
+            assertThat(Verbosity.verbosity(99)).isEqualTo(Verbosity.TRACE);
+        }
+
+        /// A negative count cannot arrive from picocli, but clamping both ends keeps the lookup
+        /// total rather than relying on that.
+        @Test
+        void verbosity_clampsToDefault_forNegativeCounts() {
+            assertThat(Verbosity.verbosity(-1)).isEqualTo(Verbosity.DEFAULT);
+        }
+
+        @Test
+        void apply_raisesTheAetherLogger_toTheRungLevel() {
+            Verbosity.DEBUG.apply();
+
+            assertThat(loggerConfigLevel(Verbosity.AETHER_LOGGER)).isEqualTo(Level.DEBUG);
+        }
+
+        /// The ladder must not touch third-party logging: `log4j2.xml` pins Root to OFF so the CLI
+        /// does not inherit every shaded library's output, and `-vvv` must not undo that.
+        @Test
+        void apply_leavesRootOff_evenAtTrace() {
+            Verbosity.TRACE.apply();
+
+            assertThat(configuration().getRootLogger().getLevel()).isEqualTo(Level.OFF);
+        }
+    }
+
+    @Nested
+    class ShippedConfiguration {
+
+        /// Proves the resource is FOUND. With no findable configuration log4j2 falls back to a
+        /// default that has no `org.pragmatica` logger and a root at ERROR, so this assertion is
+        /// what stands between the branch and a StatusLogger line on every invocation.
+        @Test
+        void shippedConfig_isLoaded_fromTheCliResource() {
+            assertThat(configuration().getConfigurationSource().getLocation())
+                .describedAs("log4j2.xml must be resolved from the classpath, not defaulted")
+                .isNotNull()
+                .endsWith("log4j2.xml");
+
+            assertThat(ShippedLogging.shippedUri().toString())
+                .describedAs("the resolved resource must be this module's own file; a 'jar:' location "
+                             + "would mean a dependency is supplying the CLI's logging configuration")
+                .doesNotStartWith("jar:");
+        }
+
+        /// The one divergence from the node's configuration that matters most: the CLI's stdout is
+        /// DATA. A diagnostic line on stdout corrupts every pipeline that parses command output.
+        @Test
+        void consoleAppender_targetsStderr_notStdout() {
+            var console = configuration().<ConsoleAppender>getAppender("Console");
+
+            assertThat(console)
+                .describedAs("the shipped configuration must declare a Console appender named 'Console'")
+                .isNotNull();
+            assertThat(console.getTarget()).isEqualTo(ConsoleAppender.Target.SYSTEM_ERR);
+        }
+
+        /// The shipped default must equal rung 0, or `-v` would be a level CHANGE rather than a
+        /// level RAISE and a no-flag invocation would not match [Verbosity#DEFAULT].
+        @Test
+        void shippedConfig_defaultsAetherLogger_toTheDefaultRung() {
+            assertThat(loggerConfigLevel(Verbosity.AETHER_LOGGER)).isEqualTo(Verbosity.DEFAULT.level());
+        }
+
+        @Test
+        void shippedConfig_defaultsRoot_toOff() {
+            assertThat(configuration().getRootLogger().getLevel()).isEqualTo(Level.OFF);
+        }
+    }
+
+    private static Configuration configuration() {
+        return ((LoggerContext) LogManager.getContext(false)).getConfiguration();
+    }
+
+    private static Level loggerConfigLevel(String loggerName) {
+        return configuration().getLoggerConfig(loggerName).getLevel();
+    }
+}

--- a/changelog.d/985-cli-logging-verbosity-ladder.md
+++ b/changelog.d/985-cli-logging-verbosity-ladder.md
@@ -1,0 +1,40 @@
+### Fixed (2026-09-10 — #985: the CLI ships with slf4j-NOP, so every diagnostic it writes is discarded)
+- **The shipped CLI discarded every log statement it made.** `aether/cli/pom.xml` declared
+  `slf4j-nop`, whose `NOPServiceProvider` was the only provider in the fat jar, so
+  `HetznerComputeProvider.logCreateRequest` — the one record of the `serverType`, ssh-key count,
+  firewall count and labels actually sent to Hetzner — was produced and thrown away.
+  [mechanism: `META-INF/services/org.slf4j.spi.SLF4JServiceProvider` in `aether/cli/target/aether.jar`
+  resolved to `org.slf4j.nop.NOPServiceProvider`, while `aether-node.jar` resolved to log4j2's
+  provider and emitted — the node jar is the positive control that makes the CLI's silence a real
+  absence rather than a broken probe]
+- The CLI now binds the **same log4j2 stack as `aether-node`**, so there is one logging story across
+  both shipped artifacts and no second configuration format to document.
+  [verified: `aether/cli/src/test/java/org/pragmatica/aether/cli/VerbosityTest.java`]
+- A top-level **`-v` / `-vv` / `-vvv`** ladder raises `org.pragmatica` to INFO / DEBUG / TRACE, and
+  saturates beyond the last rung. The shipped default keeps it at WARN.
+  [verified: `VerbosityTest.verbosity_mapsRungs_toTheDocumentedLevels`]
+- `-v` is declared on the **top-level command only**, because four subcommands already use `-v` for
+  `--version` and take a value there. `aether -vv cluster bootstrap …` works; `aether cluster
+  bootstrap -vv` is still `--version`, unchanged.
+  [mechanism: a picocli execution-strategy seam applies the rung after parse and before the
+  subcommand, so no subcommand option is shadowed and none was edited]
+- Console target is **`SYSTEM_ERR`**, deliberately diverging from the node's `SYSTEM_OUT`: the node's
+  stdout is its log, whereas the CLI's stdout is data that operators pipe into `jq`. A diagnostic on
+  stdout would corrupt those pipelines silently.
+  [verified: `CliLoggingPinTest.consoleAppender_targetsStderr_notStdout`]
+- Root stays **`OFF`**, so no shaded third-party library logs at any rung — including `-vvv`. The
+  node needs seven explicit noise-suppression entries to stay readable; inverting the default avoids
+  maintaining such a list against the whole shaded dependency set.
+  [verified: `VerbosityTest`]
+- **Default behaviour is unchanged on the channel logging uses:** 83 invocations across 36
+  subcommands, run against a baseline worktree at `87c1f78e4`, produced **0 stderr difference
+  lines**. The 5 stdout differences are the new `-v` help/completion entries, a build timestamp, and
+  `cluster list` row order, which is non-deterministic at baseline too.
+- [unverified: the scoped-WARN vs root-WARN vs root-ERROR **noise comparison is inconclusive**. The
+  measured space is offline invocations — help, usage errors, connection-refused — and nothing in it
+  logs at WARN or above under any setting, so all three candidates read 0. The instrument is also
+  broken: `-Dlog4j2.configurationFile` supplies an alternative appender but demonstrably not
+  alternative levels. The shipped default therefore rests on the byte-identical-stderr result above,
+  not on a noise comparison, and no measurement supports switching to ERROR.]
+- [unverified: `logCreateRequest` is pinned by unit test against the real `HetznerComputeProvider`,
+  not by a jar-level run — reaching that line through the fat jar requires a real cloud provision.]


### PR DESCRIPTION
Issue: #985 (referenced deliberately **without** a closing keyword — closing is a tracker decision, not a merge side effect)

## What was wrong

`aether/cli/pom.xml` declared `slf4j-nop`, under a comment saying it suppressed SLF4J's "no provider" warning. `NOPServiceProvider` was the **only** provider in the fat jar, so this was not a two-binding ambiguity — it was the binding, and **every log statement the CLI made was discarded.**

That included `HetznerComputeProvider.logCreateRequest`, which already assembles the exact `serverType`, ssh-key count, firewall count and labels sent to Hetzner. **The information needed to read a provisioning 422 was produced by the code and thrown away by the packaging.**

Established two ways: the service file, and behaviourally — the CLI jar reports `NOPLoggerFactory` / `isErrorEnabled=false` / no output, while `aether-node.jar` reports `Log4jLoggerFactory` and emits. The node jar is the positive control that makes the CLI's silence a real absence rather than a broken probe.

## What changed

- Binds the **same log4j2 stack as `aether-node`** (`log4j-slf4j2-impl` runtime, `log4j-core` compile), with `Log4j2PluginCacheFileTransformer` in the shade config. One logging story across both shipped artifacts.
- New `aether/cli/src/main/resources/log4j2.xml`. Two deliberate divergences from the node's config, both commented in-file:
  - **`SYSTEM_ERR`, not `SYSTEM_OUT`.** The node's stdout *is* its log; the CLI's stdout is **data** that operators pipe into `jq`. A diagnostic on stdout would corrupt those pipelines silently.
  - **Root `OFF`, not `INFO`.** The node needs seven explicit noise-suppression entries to stay readable. Root-level logging in the CLI would inherit every shaded library's output into every invocation, so the suppression list would have to be maintained against the whole shaded dependency set forever. `OFF` inverts the default: only `org.pragmatica` opts in, at any rung including `-vvv`.
- **Ladder:** top-level `-v` / `-vv` / `-vvv` → INFO / DEBUG / TRACE on `org.pragmatica`, saturating. Default is WARN.
- **`-v` is top-level only**, because four subcommands already use `-v` for `--version` and take a value there. `aether -vv cluster bootstrap …` works; `aether cluster bootstrap -vv` is still `--version`. A picocli execution-strategy seam applies the rung after parse and before the subcommand, so no subcommand option is shadowed and none was edited. `scope = INHERIT` was **not** used — picocli fails at startup on the duplicate.

## Verification

| | |
|---|---|
| `mvn -pl aether/cli test` | **713 tests, 0 failures, 0 skipped** (13 new) |
| `mvn jbct:check -pl aether/cli` | **106 files, passed** (baseline 105 passed) |
| Root `mvn install -DskipTests` | **145 modules SUCCESS**, 0 SKIPPED |
| Differential vs baseline worktree at `87c1f78e4` | **83 invocations, 36 subcommands, 0 stderr difference lines** |

The 5 stdout differences are all accounted for: the new `-v` help/completion entries, a build timestamp, and `cluster list` row order, which is non-deterministic at baseline too.

**The pin.** `CliLoggingPinTest` drives the real `HetznerComputeProvider` against a failing `Proxy` client; the asserted line is production output from `org.pragmatica.aether.environment.hetzner`, not a line the test emits. The absent half is controlled **in the same run** by asserting the real `Hetzner provision failed` WARN from the *same logger* is present — so a detached appender, a still-NOP binding, a renamed logger, or a provision that refused early all fail it. Four mutation probes, run after the commit and each content-verified then reverted clean, redden named tests — including the "ladder scoped to the CLI's own logger only" case, which is the mutation that would make the flag fix nothing.

**The StatusLogger trap is closed by positive identification, not by absence:** the jar contains `log4j2.xml` plus a merged 21,343-byte `Log4j2Plugins.dat`, and the lines that appear at `-vvv` render in the `HH:mm:ss.SSS %-5level %c{1.}` pattern **only this config declares**. So the config is loaded, not defaulted — which matters, because a silent fallback to `DefaultConfiguration` would put root-`ERROR` output on **stdout**.

## Bounds — stated, not buried

- `[unverified]` **The scoped-WARN vs root-WARN vs root-ERROR noise comparison is inconclusive.** The measured space is offline invocations, and nothing in it logs at WARN or above under any setting, so all three candidates read 0. The instrument is also broken: `-Dlog4j2.configurationFile` supplies an alternative *appender* but demonstrably not alternative *levels* (a four-cell matrix reads 0 bytes at `Root=TRACE` unless the ladder runs). A `0/0/0` result was initially written up as a controlled comparison; it was one configuration read three times, caught by adding a `Root=TRACE` arm that was *also* 0 when it had to be loud. The shipped default rests on the byte-identical-stderr result above, not on a noise comparison. **No measurement supports switching to ERROR.**
- `[unverified]` `logCreateRequest` is pinned by unit test, not by a jar-level run — reaching that line through the fat jar requires a real cloud provision.
- `[unverified]` Consequence for operators: **`-Dlog4j2.configurationFile` is not a reliable way to change CLI log levels.** The `-v` ladder is the supported mechanism. Mechanism of the override's level behaviour is unknown and was not guessed at.

## Pre-existing findings surfaced while doing this — none caused by this branch

1. **`test-logging` ships `log4j2-test.xml`, and log4j2 prefers it over `log4j2.xml`.** So in *any* test JVM in this repo the active configuration is `test-logging`'s — Root INFO, Console `SYSTEM_OUT` — never the module's own. Any test reading the live log4j2 configuration is measuring `test-logging`. It is test-scoped and verified absent from the shaded jar, so the divergence exists only where it misleads. Handled here by `ShippedLogging.activate()`, which loads the shipped resource by URI, with `VerbosityTest` asserting the resolved location does not start with `jar:` so a dependency cannot silently supply the CLI's logging config.
2. `aether cluster list` emits rows in non-deterministic order (pre-existing at baseline).
3. `cli-docs-gate` carries 6 pre-existing citations, 3 of which look like a trailing-`#` comment parsing artifact in the gate rather than real doc drift.
4. `aether/dead-surface-gate` is red at rc4 tip, and worse at baseline than on this branch.

Full report, including the two zsh traps that produced confident wrong results and the vacuous control that was caught: `oss/internal/cli-logging-2026-09-10.md` (private repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
