### PR TITLE
chore: move every GitHub Actions pin off deprecated Node 16/20 runtimes

### DIFF
--- a/.github/workflows/catalog.yml
+++ b/.github/workflows/catalog.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Check the generated Statistics table
         run: scripts/catalog-stats.sh --check

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Java 25
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '25'
           distribution: 'zulu'
@@ -46,7 +46,7 @@ jobs:
         timeout-minutes: 15
 
       - name: Upload test results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: always()
         with:
           name: test-results
@@ -61,10 +61,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Java 25
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '25'
           distribution: 'zulu'
@@ -83,7 +83,7 @@ jobs:
         timeout-minutes: 30
 
       - name: Upload Forge test results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: always()
         with:
           name: forge-test-results

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,10 +14,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Java 25
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '25'
           distribution: 'zulu'
@@ -61,7 +61,7 @@ jobs:
             > SHA256SUMS
 
       - name: Create Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v3
         with:
           name: Pragmatica ${{ steps.version.outputs.VERSION }}
           draft: false
@@ -85,10 +85,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Java 25
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '25'
           distribution: 'zulu'
@@ -122,7 +122,7 @@ jobs:
           aether/dist/build-dist.sh --version ${{ steps.version.outputs.VERSION }}
 
       - name: Upload macOS archives to release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v3
         with:
           files: |
             aether/dist/output/*.tar.gz
@@ -137,10 +137,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Java 25
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '25'
           distribution: 'zulu'
@@ -174,7 +174,7 @@ jobs:
           aether/dist/build-dist.sh --version ${{ steps.version.outputs.VERSION }}
 
       - name: Upload arm64 archives to release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v3
         with:
           files: |
             aether/dist/output/*.tar.gz
@@ -191,13 +191,13 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Extract version from tag
         id: version
@@ -216,14 +216,14 @@ jobs:
           fi
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Java 25
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '25'
           distribution: 'zulu'
@@ -235,7 +235,7 @@ jobs:
           mvn package -B -DskipTests
 
       - name: Build and push aether-node
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: aether
           file: aether/docker/aether-node/Dockerfile
@@ -247,7 +247,7 @@ jobs:
             ${{ steps.version.outputs.IS_CANDIDATE == 'false' && format('ghcr.io/{0}/aether-node:latest', github.repository_owner) || '' }}
 
       - name: Build and push aether-forge
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: aether
           file: aether/docker/aether-forge/Dockerfile
@@ -265,10 +265,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Java 25
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '25'
           distribution: 'zulu'
@@ -286,7 +286,7 @@ jobs:
         timeout-minutes: 15
 
       - name: Upload E2E test results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: always()
         with:
           name: e2e-test-results


### PR DESCRIPTION
Every GitHub Actions pin in this repository targets a **deprecated Node runtime**. Today they warn; when GitHub stops force-upgrading them they will fail, and it will land as a CI break with no code change to blame.

## The finding, and why the deprecation warnings understate it

PR annotations flagged **three** actions. The real count is **eight of eight** — because `release.yml` never runs on a pull request, so five of its pins have never appeared in any annotation.

Runtimes read from each action's own `action.yml` at the pinned tag (`runs.using`), not from release notes or the deprecation notice:

| action | was | runtime | now | runtime |
|---|---|---|---|---|
| `actions/checkout` | v4 | node20 | **v5** | node24 |
| `actions/setup-java` | v4 | node20 | **v5** | node24 |
| `actions/upload-artifact` | v4 | node20 | **v6** | node24 |
| `softprops/action-gh-release` | v1 | **node16** | **v3** | node24 |
| `docker/setup-qemu-action` | v3 | node20 | **v4** | node24 |
| `docker/setup-buildx-action` | v3 | node20 | **v4** | node24 |
| `docker/login-action` | v3 | node20 | **v4** | node24 |
| `docker/build-push-action` | v6 | node20 | **v7** | node24 |

**Two things here would have been got wrong by following the guidance rather than reading the source:**

1. **`actions/upload-artifact@v5` is still node20.** Bumping one major — the obvious fix, and the pattern the annotation suggests for `setup-java` — leaves it deprecated. `v6` is the first node24 release. The v5.0.0 release note says *"BREAKING CHANGE: this update supports Node `v24.x`"* while `action.yml` at both `v5` and `v5.0.0` (commit `330a01c49`) declares `using: node20`.
2. **`softprops/action-gh-release@v1` was on node16**, a generation worse than node20 and long past end of life. No annotation ever showed it, because it only appears in `release.yml`.

## Why minimum-node24 majors and not latest

Several actions are further ahead than the version pinned here (`checkout` v7, `setup-java` v6, `upload-artifact` v7). This PR deliberately moves to the **lowest major with a supported runtime** rather than the newest:

- It fully fixes the stated defect — no pin is on a deprecated runtime afterwards.
- It minimises unexamined breaking-change surface on a **release branch**.
- Most importantly, **`release.yml` cannot be verified by a pull request** — it only runs on a release. Seventeen of the 27 pins live there. Minimising the change in a file no CI run will exercise is the conservative choice.

Moving to latest majors is a reasonable follow-up, better done on `main` outside a release window.

## Verification

- **27 pins changed, 4 files.** Counts verified against a pre-edit baseline per action: 9 / 7 / 3 / 3 / 1 / 1 / 1 / 2, which sums to 27 — the total number of `uses:` pins in the repository. No pin sits outside the replacement set, and zero old pins remain.
- **All 54 changed lines (27 added, 27 removed) contain `uses:`** — the change is provably confined to version strings, so workflow structure is untouched. (`pyyaml` was unavailable locally, so no YAML parse was run; this confinement check is offered in its place rather than an unverified claim of validity.)
- `scripts/changelog-check.sh` returns `ok (0 fragment(s), needs_fragment=false)` — correct, since `.github/*` is exempt under the gate's own `is_exempt()`. No changelog fragment is required for a CI-config-only change.
- All runners are GitHub-hosted (`ubuntu-latest`, `macos-latest`, `ubuntu-24.04-arm`), so the **runner floor of v2.327.1** that `setup-java@v5` and `upload-artifact@v6` require is satisfied automatically. It would matter on self-hosted runners.

## What this PR cannot establish

**The 17 pins in `release.yml` are not exercised by any PR check** — `release.yml` triggers on a release, not a pull request. That includes the `action-gh-release` v1→v3 jump (two majors) and all four `docker/*` bumps. Their release notes describe the node bump as the change, and `action-gh-release` v3.0.0's notes describe only a runtime move, but **no run in this PR proves it.** The first real exercise will be the next release, and that is worth knowing in advance rather than discovering mid-release.

`catalog.yml` is likewise only partly exercised, depending on its path filter.

The pins this PR *does* verify are those in `ci.yml` and `changelog.yml`: `checkout@v5`, `setup-java@v5`, `upload-artifact@v6` — which this PR's own `build-and-test`, `forge-tests` and `fragment` checks run.

## Note

`main` carries its own copy of these workflows and will need the same change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
