### PR TITLE
fix: #994 #995 make the cleanup ledger durable and give destroy an honest voice

### DIFF
--- a/aether/cli/src/main/java/org/pragmatica/aether/cli/cluster/BootstrapCleanup.java
+++ b/aether/cli/src/main/java/org/pragmatica/aether/cli/cluster/BootstrapCleanup.java
@@ -37,6 +37,12 @@ sealed interface BootstrapCleanup {
     /// Provider identity for Hetzner cloud (matches `SourceCleanupHandle.provider()` and `CreatedResource.provider()`).
     String HETZNER_PROVIDER = "hetzner";
 
+    /// #994 verification finding SF-4 — the `role` component of a label-swept VM's synthesized
+    /// [CreatedResource.ProvisionedVm]. A swept VM is by definition one the ledger never recorded, so its
+    /// role is genuinely unknown; this marks the absence instead of guessing a plausible value that an
+    /// operator would read as recorded fact.
+    String SWEPT_ROLE = "label-swept";
+
     /// RFC-0016 W4 (#439) — the injectable seams cleanup uses to resolve teardown credentials, so a
     /// timeout-triggered cleanup reaps VMs *and* ssh keys with the SAME credential the operator used to
     /// provision (re-derived from the persisted `SourceCleanupHandle`), never a hard-coded `HCLOUD_TOKEN`.
@@ -213,17 +219,20 @@ sealed interface BootstrapCleanup {
                           + "' (prefix '" + prefix
                           + "')...");
 
-        return hetznerClientFromHandle(handle, resolvers).flatMap(client -> sweepWithClient(client, prefix));
+        return hetznerClientFromHandle(handle, resolvers).flatMap(client -> sweepWithClient(client, prefix, clusterName));
     }
 
     @SuppressWarnings("JBCT-EX-01")
-    private static Result<Unit> sweepWithClient(HetznerClient client, String prefix) {
+    private static Result<Unit> sweepWithClient(HetznerClient client, String prefix, ClusterName clusterName) {
         return client.listSshKeys()
                      .await()
-                     .flatMap(keys -> deleteMatchingKeys(client, keys, prefix));
+                     .flatMap(keys -> deleteMatchingKeys(client, keys, prefix, clusterName));
     }
 
-    private static Result<Unit> deleteMatchingKeys(HetznerClient client, List<SshKey> keys, String prefix) {
+    private static Result<Unit> deleteMatchingKeys(HetznerClient client,
+                                                   List<SshKey> keys,
+                                                   String prefix,
+                                                   ClusterName clusterName) {
         var matches = keys.stream().filter(key -> keyNameMatches(key, prefix)).toList();
 
         if (matches.isEmpty()) {
@@ -234,7 +243,7 @@ sealed interface BootstrapCleanup {
 
         var failures = collectSweepFailures(client, matches);
 
-        return finishSweep(matches.size(), failures);
+        return finishSweep(clusterName, matches.size(), failures);
     }
 
     private static boolean keyNameMatches(SshKey key, String prefix) {
@@ -242,15 +251,23 @@ sealed interface BootstrapCleanup {
                                         .startsWith(prefix);
     }
 
-    private static List<String> collectSweepFailures(HetznerClient client, List<SshKey> matches) {
-        var failures = new ArrayList<String>();
+    /// #994 verification finding SF-4 — failures are [ReapFailure]s over a real [CreatedResource], not
+    /// joined strings, so the key sweep enumerates what it left behind exactly as the ledger-driven cleanup
+    /// does. [CreatedResource.SshKeyResource] is an exact fit for a swept key: provider, id and name are all
+    /// known, so nothing here is synthesized or approximated.
+    private static List<ReapFailure> collectSweepFailures(HetznerClient client, List<SshKey> matches) {
+        var failures = new ArrayList<ReapFailure>();
 
         for (var key : matches) {
             var result = deleteSweptKey(client, key);
-            var _ = result.onFailure(cause -> failures.add(key.name() + " (id=" + key.id() + "): " + cause.message()));
+            var _ = result.onFailure(cause -> failures.add(new ReapFailure(sweptKeyResource(key), cause)));
         }
 
         return List.copyOf(failures);
+    }
+
+    private static CreatedResource sweptKeyResource(SshKey key) {
+        return CreatedResource.SshKeyResource.sshKeyResource(HETZNER_PROVIDER, key.id(), key.name());
     }
 
     @SuppressWarnings("JBCT-EX-01")
@@ -355,17 +372,21 @@ sealed interface BootstrapCleanup {
 
         System.out.println("Sweeping cluster-labelled VMs (selector '" + selector + "')...");
 
-        return hetznerClientFromHandle(handle, resolvers).flatMap(client -> sweepVmsWithClient(client, selector));
+        return hetznerClientFromHandle(handle, resolvers).flatMap(client -> sweepVmsWithClient(client, selector, clusterName));
     }
 
     @SuppressWarnings("JBCT-EX-01")
-    private static Result<Unit> sweepVmsWithClient(HetznerClient client, String selector) {
+    private static Result<Unit> sweepVmsWithClient(HetznerClient client, String selector, ClusterName clusterName) {
         return client.listServers(selector)
                      .await()
-                     .flatMap(servers -> deleteSweptServers(client, servers));
+                     .flatMap(servers -> deleteSweptServers(client, servers, clusterName));
     }
 
-    private static Result<Unit> deleteSweptServers(HetznerClient client, List<Server> servers) {
+    /// #994 verification finding SF-4 — failures are [ReapFailure]s, so the VM sweep's leftovers are
+    /// enumerated by type and id like the ledger-driven cleanup's. This is the sharper half of that finding:
+    /// the sweep exists precisely to catch **billable VMs the ledger never recorded**, which is #994's whole
+    /// theme, and its failure message used to be a joined string with no type and no id.
+    private static Result<Unit> deleteSweptServers(HetznerClient client, List<Server> servers, ClusterName clusterName) {
         if (servers.isEmpty()) {
             System.out.println("  No cluster-labelled VMs found to sweep.");
 
@@ -373,17 +394,29 @@ sealed interface BootstrapCleanup {
         }
 
         printVmInventory(servers);
-        var failures = new ArrayList<String>();
+        var failures = new ArrayList<ReapFailure>();
 
         for (var server : servers) {
             var result = deleteSweptServer(client, server);
-            var _ = result.onFailure(cause -> failures.add(server.name()
-                                                          + " (id=" + server.id()
-                                                          + "): " + cause.message()));
+            var _ = result.onFailure(cause -> failures.add(new ReapFailure(sweptVmResource(server, clusterName), cause)));
         }
 
-        return finishVmSweep(servers.size(), List.copyOf(failures));
+        return finishVmSweep(clusterName, servers.size(), List.copyOf(failures));
     }
+
+    /// A label-swept VM is a [CreatedResource.ProvisionedVm] the ledger never held, so two of the record's
+    /// four components have no recorded value: the role is literally unknown here (that absence is WHY this
+    /// sweep exists) and is marked [#SWEPT_ROLE] rather than guessed, and the source slot carries the cluster
+    /// the selector scoped to. The id is the component that matters — it is what `hcloud server delete` and
+    /// `tools/cloud-reaper.sh` act on — and the server's NAME is already on the adjacent per-server WARN line
+    /// plus the sweep inventory, so nothing an operator needs is only in one place.
+    private static CreatedResource sweptVmResource(Server server, ClusterName clusterName) {
+        return CreatedResource.ProvisionedVm.provisionedVm(HETZNER_PROVIDER,
+                                                           String.valueOf(server.id()),
+                                                           clusterName.value(),
+                                                           SWEPT_ROLE);
+    }
+
 
     /// The inventory print is part of the contract, not decoration: an operator reading the destroy
     /// transcript must be able to see EXACTLY what the sweep deleted — #572's lesson is that a
@@ -422,11 +455,12 @@ sealed interface BootstrapCleanup {
         return cause.result();
     }
 
-    private static Result<Unit> finishVmSweep(int matchCount, List<String> failures) {
+    private static Result<Unit> finishVmSweep(ClusterName clusterName, int matchCount, List<ReapFailure> failures) {
         if (!failures.isEmpty()) {
             System.err.printf("  VM sweep: %d of %d deletion(s) failed.%n", failures.size(), matchCount);
+            printLeftBehind(clusterName, "VM sweep", failures);
 
-            return Causes.cause("VM sweep failed for: " + String.join("; ", failures)).result();
+            return new VmSweepFailed(joinDescriptions(failures), joinEnumeration(failures)).result();
         }
 
         System.out.printf("  VM sweep complete (%d swept).%n", matchCount);
@@ -434,11 +468,12 @@ sealed interface BootstrapCleanup {
         return Result.unitResult();
     }
 
-    private static Result<Unit> finishSweep(int matchCount, List<String> failures) {
+    private static Result<Unit> finishSweep(ClusterName clusterName, int matchCount, List<ReapFailure> failures) {
         if (!failures.isEmpty()) {
             System.err.printf("  SSH-key sweep: %d of %d deletion(s) failed.%n", failures.size(), matchCount);
+            printLeftBehind(clusterName, "SSH-key sweep", failures);
 
-            return new SshKeySweepFailed(String.join("; ", failures)).result();
+            return new SshKeySweepFailed(joinDescriptions(failures), joinEnumeration(failures)).result();
         }
 
         System.out.printf("  SSH-key sweep: %d cluster-scoped key(s) removed.%n", matchCount);
@@ -525,7 +560,7 @@ sealed interface BootstrapCleanup {
 
     private static Result<Unit> finishCleanup(BootstrapState state, CleanupOutcome outcome) {
         if (!outcome.failures().isEmpty()) {
-            printLeftBehind(state, outcome.failures());
+            printLeftBehind(state.clusterName(), "cleanup", outcome.failures());
 
             return new CleanupError(joinDescriptions(outcome.failures()), joinEnumeration(outcome.failures())).result();
         }
@@ -538,16 +573,24 @@ sealed interface BootstrapCleanup {
     /// that something may be billing without telling them what to delete; on 2026-09-11 the something was
     /// two running `ccx23` servers and a firewall, and the list had to be reconstructed by hand from
     /// `hcloud server list`.
+    ///
+    /// #994 verification finding SF-4 — `actor` exists because this block is shared by all THREE teardown
+    /// paths now. The enumeration was scoped to the ledger-driven `cleanupWith` only, which made the
+    /// unqualified claim "every unreaped resource is enumerated" false of the command as a whole — and the
+    /// paths it missed (the label-scoped VM sweep, the ssh-key sweep) are exactly where **unrecorded
+    /// billable VMs** live, which is #994's own theme.
     @Contract
-    private static void printLeftBehind(BootstrapState state, List<ReapFailure> failures) {
-        System.err.printf("  NOT REAPED — %d resource(s) this cleanup could not delete, which may still be billing:%n",
-                          failures.size());
+    private static void printLeftBehind(ClusterName clusterName, String actor, List<ReapFailure> failures) {
+        System.err.printf("  NOT REAPED — %d resource(s) this %s could not delete, which may still be billing:%n",
+                          failures.size(),
+                          actor);
         for (var failure : failures) {
             System.err.println("    - " + failure.enumerate());
         }
 
-        System.err.printf("  Finish teardown with: tools/cloud-reaper.sh --cluster %s --destroy%n", state.clusterName());
+        System.err.printf("  Finish teardown with: tools/cloud-reaper.sh --cluster %s --destroy%n", clusterName);
     }
+
 
     private static String joinDescriptions(List<ReapFailure> failures) {
         return String.join("; ",
@@ -933,10 +976,28 @@ sealed interface BootstrapCleanup {
         }
     }
 
-    record SshKeySweepFailed(String detail) implements Cause {
+    /// #994 verification finding SF-4 — two fields for the same reason [CleanupError] has two: `detail` is
+    /// the transcript, `notReaped` is the machine-shaped enumeration (type + id per resource) that survives
+    /// into `ClusterDestroyCommand`'s exit message after the transcript has scrolled away. A swept key that
+    /// could not be deleted is an orphaned credential on the account, not merely a failed call.
+    record SshKeySweepFailed(String detail, String notReaped) implements Cause {
         @Override
         public String message() {
-            return "SSH-key sweep completed with failures: " + detail;
+            return notReaped.isEmpty()
+                   ? "SSH-key sweep completed with failures: " + detail
+                   : "SSH-key sweep completed with failures: " + detail + " | NOT REAPED: " + notReaped;
+        }
+    }
+
+    /// #994 verification finding SF-4 — the VM sweep's failure used to be a bare `Causes.cause` holding a
+    /// joined string with no type and no id, on the one teardown path whose whole purpose is **billable VMs
+    /// the ledger never recorded.** Named, and carrying the enumeration, like every other reap failure.
+    record VmSweepFailed(String detail, String notReaped) implements Cause {
+        @Override
+        public String message() {
+            return notReaped.isEmpty()
+                   ? "VM sweep completed with failures: " + detail
+                   : "VM sweep completed with failures: " + detail + " | NOT REAPED: " + notReaped;
         }
     }
 

--- a/aether/cli/src/main/java/org/pragmatica/aether/cli/cluster/BootstrapCleanup.java
+++ b/aether/cli/src/main/java/org/pragmatica/aether/cli/cluster/BootstrapCleanup.java
@@ -665,6 +665,12 @@ sealed interface BootstrapCleanup {
     /// delete had been issued and nothing was detaching; the message sent an operator to look at server
     /// shutdown while the actual problem was an incomplete ledger. A diagnostic may report what it has
     /// observed. It may not narrate a mechanism it never started.
+    /// #994 verification NOTE-5 — `deleted` counts what entered `reapedSoFar`, and `tolerateAlreadyGone`
+    /// puts an ALREADY-ABSENT VM there too, so the full-count branch below says **"accounted for"** rather
+    /// than "deleted": this cleanup may have issued a delete that returned `InstanceNotFound` for a server
+    /// somebody else had already removed. Saying "deleted all N" of a server it never deleted is small, but
+    /// it is the same class as #994's "servers are still detaching" — a diagnostic asserting an action
+    /// instead of reporting an observation — and this record exists to end that class.
     record VmAccounting(String sourceName, int recorded, int deleted) {
         String describe() {
             if (recorded == 0) {
@@ -682,9 +688,10 @@ sealed interface BootstrapCleanup {
                      + " recorded VM(s) were NOT deleted (their own failures are reported above)";
             }
 
-            return "this cleanup deleted all " + recorded
+            return "this cleanup accounted for all " + recorded
                  + " VM(s) the bootstrap ledger records for source '" + sourceName
-                 + "', and the provider still reports the firewall in use";
+                 + "' (deleted, or already gone and reported as such above), and the provider still reports"
+                 + " the firewall in use";
         }
     }
 

--- a/aether/cli/src/main/java/org/pragmatica/aether/cli/cluster/BootstrapCleanup.java
+++ b/aether/cli/src/main/java/org/pragmatica/aether/cli/cluster/BootstrapCleanup.java
@@ -36,7 +36,6 @@ sealed interface BootstrapCleanup {
     String API_TOKEN_KEY = "api_token";
     /// Provider identity for Hetzner cloud (matches `SourceCleanupHandle.provider()` and `CreatedResource.provider()`).
     String HETZNER_PROVIDER = "hetzner";
-
     /// #994 verification finding SF-4 — the `role` component of a label-swept VM's synthesized
     /// [CreatedResource.ProvisionedVm]. A swept VM is by definition one the ledger never recorded, so its
     /// role is genuinely unknown; this marks the absence instead of guessing a plausible value that an
@@ -372,7 +371,9 @@ sealed interface BootstrapCleanup {
 
         System.out.println("Sweeping cluster-labelled VMs (selector '" + selector + "')...");
 
-        return hetznerClientFromHandle(handle, resolvers).flatMap(client -> sweepVmsWithClient(client, selector, clusterName));
+        return hetznerClientFromHandle(handle, resolvers).flatMap(client -> sweepVmsWithClient(client,
+                                                                                               selector,
+                                                                                               clusterName));
     }
 
     @SuppressWarnings("JBCT-EX-01")
@@ -386,7 +387,9 @@ sealed interface BootstrapCleanup {
     /// enumerated by type and id like the ledger-driven cleanup's. This is the sharper half of that finding:
     /// the sweep exists precisely to catch **billable VMs the ledger never recorded**, which is #994's whole
     /// theme, and its failure message used to be a joined string with no type and no id.
-    private static Result<Unit> deleteSweptServers(HetznerClient client, List<Server> servers, ClusterName clusterName) {
+    private static Result<Unit> deleteSweptServers(HetznerClient client,
+                                                   List<Server> servers,
+                                                   ClusterName clusterName) {
         if (servers.isEmpty()) {
             System.out.println("  No cluster-labelled VMs found to sweep.");
 
@@ -416,7 +419,6 @@ sealed interface BootstrapCleanup {
                                                            clusterName.value(),
                                                            SWEPT_ROLE);
     }
-
 
     /// The inventory print is part of the contract, not decoration: an operator reading the destroy
     /// transcript must be able to see EXACTLY what the sweep deleted — #572's lesson is that a
@@ -590,7 +592,6 @@ sealed interface BootstrapCleanup {
 
         System.err.printf("  Finish teardown with: tools/cloud-reaper.sh --cluster %s --destroy%n", clusterName);
     }
-
 
     private static String joinDescriptions(List<ReapFailure> failures) {
         return String.join("; ",

--- a/aether/cli/src/main/java/org/pragmatica/aether/cli/cluster/BootstrapCleanup.java
+++ b/aether/cli/src/main/java/org/pragmatica/aether/cli/cluster/BootstrapCleanup.java
@@ -159,9 +159,9 @@ sealed interface BootstrapCleanup {
         var resources = new ArrayList<>(state.createdResources());
 
         Collections.reverse(resources);
-        var failures = collectCleanupFailures(state, resources, resolvers);
+        var outcome = collectCleanupFailures(state, resources, resolvers);
 
-        return finishCleanup(state, failures);
+        return finishCleanup(state, outcome);
     }
 
     /// #481 — defensive cluster-scoped ssh-key sweep. `cleanup` above deletes only keys the state recorded
@@ -446,19 +446,44 @@ sealed interface BootstrapCleanup {
         return Result.unitResult();
     }
 
-    private static List<String> collectCleanupFailures(BootstrapState state,
-                                                       List<CreatedResource> resources,
-                                                       CleanupResolvers resolvers) {
-        var failures = new ArrayList<String>();
-
-        for (var resource : inDestructionOrder(resources)) {
-            var result = destroyResource(state, resource, resolvers);
-
-            logResourceResult(result, resource);
-            var _ = result.onFailure(cause -> failures.add(resource.description() + ": " + cause.message()));
+    /// #994 — one reap attempt that did not succeed, kept as the RESOURCE plus its cause rather than as a
+    /// flattened string, because a partially-failed cleanup has to enumerate what it left behind by type
+    /// and id. "orphan resources may remain" is not actionable; the thing an operator needs is the list.
+    record ReapFailure(CreatedResource resource, Cause cause) {
+        String describe() {
+            return resource.description() + ": " + cause.message();
         }
 
-        return List.copyOf(failures);
+        String enumerate() {
+            return "[" + resource.getClass()
+                                 .getSimpleName()
+                 + "] id=" + resource.resourceId()
+                 + " provider=" + resource.provider()
+                 + " (" + resource.description()
+                 + ")";
+        }
+    }
+
+    /// The cleanup run's observed result: what failed (with the resource, for enumeration) and what was
+    /// actually reaped. `reaped` is load-bearing rather than decorative — the firewall arm reads it to
+    /// state how many of the ledger's VMs this run really deleted, instead of asserting a cause.
+    record CleanupOutcome(List<ReapFailure> failures, List<CreatedResource> reaped) {}
+
+    private static CleanupOutcome collectCleanupFailures(BootstrapState state,
+                                                         List<CreatedResource> resources,
+                                                         CleanupResolvers resolvers) {
+        var failures = new ArrayList<ReapFailure>();
+        var reaped = new ArrayList<CreatedResource>();
+
+        for (var resource : inDestructionOrder(resources)) {
+            var result = destroyResource(state, resource, resolvers, List.copyOf(reaped));
+
+            logResourceResult(result, resource);
+            var _ = result.onSuccess(_ -> reaped.add(resource))
+                          .onFailure(cause -> failures.add(new ReapFailure(resource, cause)));
+        }
+
+        return new CleanupOutcome(List.copyOf(failures), List.copyOf(reaped));
     }
 
     /// Hetzner refuses to delete a firewall still applied to a live server, so VMs must go first.
@@ -467,6 +492,12 @@ sealed interface BootstrapCleanup {
     /// a consequence of phase ordering, so a later producer that records a firewall AFTER provisioning
     /// (e.g. applying a rule change once #578 lands) cannot silently break teardown. The sort is
     /// stable, so equal-rank resources keep the reversed order they arrived in.
+    ///
+    /// #994 — the rank sort is pinned by `BootstrapCleanupTest#cleanup_deletesVmBeforeFirewall_...`
+    /// against a ledger that records the VM FIRST, so reverse-of-creation alone would issue the firewall
+    /// delete first: remove or invert the sort and that test reddens. The pin matters because the 422
+    /// `resource_in_use` failure this order prevents is indistinguishable, from the cleanup's side, from
+    /// the ledger simply not knowing about the servers — which is the defect #994 actually was.
     private static List<CreatedResource> inDestructionOrder(List<CreatedResource> resources) {
         return resources.stream()
                         .sorted(Comparator.comparingInt(BootstrapCleanup::destructionRank))
@@ -492,21 +523,50 @@ sealed interface BootstrapCleanup {
                                                             + ": " + cause.message()));
     }
 
-    private static Result<Unit> finishCleanup(BootstrapState state, List<String> failures) {
-        if (!failures.isEmpty()) {
-            return new CleanupError(String.join("; ", failures)).result();
+    private static Result<Unit> finishCleanup(BootstrapState state, CleanupOutcome outcome) {
+        if (!outcome.failures().isEmpty()) {
+            printLeftBehind(state, outcome.failures());
+
+            return new CleanupError(joinDescriptions(outcome.failures()), joinEnumeration(outcome.failures())).result();
         }
 
         return BootstrapStatePersistence.delete(state.clusterName());
     }
 
+    /// #994 — a cleanup that cannot fully reap names EVERY resource it is leaving behind, with its type
+    /// and id. The previous top-level message was "orphan resources may remain", which tells an operator
+    /// that something may be billing without telling them what to delete; on 2026-09-11 the something was
+    /// two running `ccx23` servers and a firewall, and the list had to be reconstructed by hand from
+    /// `hcloud server list`.
+    @Contract
+    private static void printLeftBehind(BootstrapState state, List<ReapFailure> failures) {
+        System.err.printf("  NOT REAPED — %d resource(s) this cleanup could not delete, which may still be billing:%n",
+                          failures.size());
+        for (var failure : failures) {
+            System.err.println("    - " + failure.enumerate());
+        }
+
+        System.err.printf("  Finish teardown with: tools/cloud-reaper.sh --cluster %s --destroy%n", state.clusterName());
+    }
+
+    private static String joinDescriptions(List<ReapFailure> failures) {
+        return String.join("; ",
+                           failures.stream().map(ReapFailure::describe).toList());
+    }
+
+    private static String joinEnumeration(List<ReapFailure> failures) {
+        return String.join("; ",
+                           failures.stream().map(ReapFailure::enumerate).toList());
+    }
+
     @SuppressWarnings("JBCT-PAT-01")
     private static Result<Unit> destroyResource(BootstrapState state,
                                                 CreatedResource resource,
-                                                CleanupResolvers resolvers) {
+                                                CleanupResolvers resolvers,
+                                                List<CreatedResource> reapedSoFar) {
         return switch (resource) {
             case CreatedResource.ProvisionedVm vm -> destroyVm(state, vm, resolvers);
-            case CreatedResource.CloudFirewall firewall -> deleteCloudFirewall(state, firewall, resolvers);
+            case CreatedResource.CloudFirewall firewall -> deleteCloudFirewall(state, firewall, resolvers, reapedSoFar);
             case CreatedResource.FloatingIpAssignment ip -> detachFloatingIp(ip);
             case CreatedResource.DockerContainer container -> removeContainer(container);
             case CreatedResource.SshDeployedConfig config -> removeRemoteConfig(config);
@@ -539,12 +599,68 @@ sealed interface BootstrapCleanup {
     @SuppressWarnings("JBCT-EX-01")
     private static Result<Unit> deleteCloudFirewall(BootstrapState state,
                                                     CreatedResource.CloudFirewall firewall,
-                                                    CleanupResolvers resolvers) {
+                                                    CleanupResolvers resolvers,
+                                                    List<CreatedResource> reapedSoFar) {
         System.out.printf("  Deleting firewall %s (id=%s)...%n", firewall.name(), firewall.firewallId());
 
         return resolveComputeFor(state, firewall, resolvers).flatMap(compute -> disposeWithRetry(compute,
                                                                                                  firewall,
-                                                                                                 resolvers));
+                                                                                                 resolvers,
+                                                                                                 vmAccounting(state,
+                                                                                                              firewall,
+                                                                                                              reapedSoFar)));
+    }
+
+    /// #994 — the OBSERVED state behind a firewall that will not delete, assembled only from facts this
+    /// cleanup already holds: how many VMs the bootstrap ledger records for the firewall's own source,
+    /// and how many of those this run actually deleted before reaching the firewall. Destruction order
+    /// makes the second number meaningful — every VM attempt precedes the firewall (see
+    /// [#destructionRank]), so at this point the VM outcomes are final, not pending.
+    ///
+    /// This exists to replace the retry line *"servers are still detaching; retrying..."*, which
+    /// asserted a process that was NOT running. On 2026-09-11 the ledger held ZERO VMs, so no server
+    /// delete had been issued and nothing was detaching; the message sent an operator to look at server
+    /// shutdown while the actual problem was an incomplete ledger. A diagnostic may report what it has
+    /// observed. It may not narrate a mechanism it never started.
+    record VmAccounting(String sourceName, int recorded, int deleted) {
+        String describe() {
+            if (recorded == 0) {
+                return "the bootstrap ledger records NO VMs for source '" + sourceName
+                     + "', so this cleanup has issued no server delete for it — whatever still holds the"
+                     + " firewall is a server this cleanup cannot name. Check for unrecorded VMs with"
+                     + " 'hcloud server list -l aether-cluster=<cluster>'";
+            }
+
+            if (deleted < recorded) {
+                return "the bootstrap ledger records " + recorded
+                     + " VM(s) for source '" + sourceName
+                     + "' and this cleanup deleted " + deleted
+                     + " of them, so " + (recorded - deleted)
+                     + " recorded VM(s) were NOT deleted (their own failures are reported above)";
+            }
+
+            return "this cleanup deleted all " + recorded
+                 + " VM(s) the bootstrap ledger records for source '" + sourceName
+                 + "', and the provider still reports the firewall in use";
+        }
+    }
+
+    private static VmAccounting vmAccounting(BootstrapState state,
+                                             CreatedResource.CloudFirewall firewall,
+                                             List<CreatedResource> reapedSoFar) {
+        var sourceName = firewall.sourceName().value();
+
+        return new VmAccounting(sourceName,
+                                countVmsFor(state.createdResources(), sourceName),
+                                countVmsFor(reapedSoFar, sourceName));
+    }
+
+    @SuppressWarnings("JBCT-PAT-01")
+    private static int countVmsFor(List<CreatedResource> resources, String sourceName) {
+        return (int) resources.stream()
+                              .filter(resource -> resource instanceof CreatedResource.ProvisionedVm vm && vm.sourceName()
+                                                                                                            .equals(sourceName))
+                              .count();
     }
 
     /// Attempts bounded by [#FIREWALL_DELETE_ATTEMPTS]; the LAST failure is what surfaces, so a
@@ -559,7 +675,8 @@ sealed interface BootstrapCleanup {
     @SuppressWarnings("JBCT-PAT-01")
     private static Result<Unit> disposeWithRetry(ComputeProvider compute,
                                                  CreatedResource.CloudFirewall firewall,
-                                                 CleanupResolvers resolvers) {
+                                                 CleanupResolvers resolvers,
+                                                 VmAccounting accounting) {
         var attempt = 1;
 
         while (true) {
@@ -569,13 +686,26 @@ sealed interface BootstrapCleanup {
                 return result;
             }
 
-            System.out.printf("  Firewall %s still attached (attempt %d/%d) — servers are still detaching; retrying...%n",
-                              firewall.firewallId(),
-                              attempt,
-                              FIREWALL_DELETE_ATTEMPTS);
+            logFirewallRefusal(firewall, attempt, accounting, result);
             resolvers.sleeper().accept(FIREWALL_DELETE_RETRY_MILLIS);
             attempt++;
         }
+    }
+
+    /// #994 — reports the provider's OWN refusal verbatim plus [VmAccounting]'s observed counts, and
+    /// asserts nothing about why. The line it replaces claimed "servers are still detaching" on every
+    /// attempt, including the observed run where no server delete had been issued at all.
+    @Contract
+    private static void logFirewallRefusal(CreatedResource.CloudFirewall firewall,
+                                           int attempt,
+                                           VmAccounting accounting,
+                                           Result<Unit> result) {
+        System.out.printf("  Firewall %s NOT deleted (attempt %d/%d) — provider refused: %s%n",
+                          firewall.firewallId(),
+                          attempt,
+                          FIREWALL_DELETE_ATTEMPTS,
+                          result.fold(Cause::message, _ -> ""));
+        System.out.printf("    observed: %s. Retrying in %dms.%n", accounting.describe(), FIREWALL_DELETE_RETRY_MILLIS);
     }
 
     /// Teardown-only pause between firewall delete attempts. Interruption is restored and treated as
@@ -791,10 +921,15 @@ sealed interface BootstrapCleanup {
         return Result.unitResult();
     }
 
-    record CleanupError(String detail) implements Cause {
+    /// #994 — `notReaped` is the enumeration, not a restatement of `detail`: it carries type + id for every
+    /// resource left behind, so `BootstrapError.BootstrapFailedWithOrphans`'s top-level message names what
+    /// is still billing instead of saying "orphan resources may remain".
+    record CleanupError(String detail, String notReaped) implements Cause {
         @Override
         public String message() {
-            return "Cleanup completed with failures: " + detail;
+            return notReaped.isEmpty()
+                   ? "Cleanup completed with failures: " + detail
+                   : "Cleanup completed with failures: " + detail + " | NOT REAPED: " + notReaped;
         }
     }
 

--- a/aether/cli/src/main/java/org/pragmatica/aether/cli/cluster/BootstrapPhaseProvision.java
+++ b/aether/cli/src/main/java/org/pragmatica/aether/cli/cluster/BootstrapPhaseProvision.java
@@ -124,18 +124,49 @@ sealed interface BootstrapPhaseProvision {
     /// Takes the cluster name rather than the whole context so the persist is exercisable on its own:
     /// the context carries nothing else this needs, and a seam that demands a full `BootstrapContext`
     /// is a seam no test drives.
+    ///
+    /// #994 verification finding SF-1 — reads through [BootstrapStatePersistence#read] and CONSUMES the
+    /// save, because every step here used to fail silently. The real incident artifact recorded
+    /// `sources: []`, which is precisely this handle missing, and teardown without it cannot re-derive the
+    /// provisioning token at all. A silent no-op costs the operator that credential mapping with nothing
+    /// in the transcript to say so.
     @Contract
     static void persistCleanupHandle(ClusterName clusterName,
                                      String rawToml,
                                      SourceName sourceName,
                                      SourceProfile source) {
-        BootstrapStatePersistence.load(clusterName)
-                                 .map(state -> withSourceHandle(state,
-                                                                rawToml,
-                                                                sourceName,
-                                                                source,
-                                                                resolveProviderName(source)))
-                                 .onPresent(BootstrapStatePersistence::save);
+        var _ = BootstrapStatePersistence.read(clusterName)
+                                         .onFailure(cause -> warnHandleNotPersisted(clusterName,
+                                                                                    sourceName,
+                                                                                    "the persisted ledger is unreadable: " + cause.message()))
+                                         .or(Option.empty())
+                                         .onEmpty(() -> warnHandleNotPersisted(clusterName,
+                                                                               sourceName,
+                                                                               "no bootstrap state is persisted yet"))
+                                         .map(state -> withSourceHandle(state,
+                                                                        rawToml,
+                                                                        sourceName,
+                                                                        source,
+                                                                        resolveProviderName(source)))
+                                         .onPresent(state -> saveOrWarnHandle(state, clusterName, sourceName));
+    }
+
+    @Contract
+    private static void saveOrWarnHandle(BootstrapState state, ClusterName clusterName, SourceName sourceName) {
+        var _ = BootstrapStatePersistence.save(state)
+                                         .onFailure(cause -> warnHandleNotPersisted(clusterName,
+                                                                                    sourceName,
+                                                                                    "the ledger write failed: " + cause.message()));
+    }
+
+    @Contract
+    private static void warnHandleNotPersisted(ClusterName clusterName, SourceName sourceName, String reason) {
+        System.err.printf("  WARN: the cleanup handle for source '%s' was NOT persisted — %s.%n", sourceName, reason);
+        System.err.printf("  Teardown of cluster '%s' will have no credential mapping for this source and may fall"
+                         + " back to a raw provider env var naming a different account. Reap with"
+                         + " 'tools/cloud-reaper.sh --cluster %s --destroy' if bootstrap fails.%n",
+                          clusterName,
+                          clusterName);
     }
 
     /// #994 — appends the VM to the persisted cleanup ledger as soon as the provider reports it created,
@@ -146,18 +177,56 @@ sealed interface BootstrapPhaseProvision {
     /// Duplicate-free on the success path: [#buildUpdatedState] rebuilds the resource list from the
     /// pre-phase in-memory state and [ClusterBootstrapOrchestrator] saves THAT, replacing these
     /// incremental records with an equal set rather than appending to them.
+    ///
+    /// #994 verification finding SF-1 — **every way this can fail to record is now printed WITH the server
+    /// id.** It was a silent no-op when the ledger was absent (which is what an unchecked pre-phase save
+    /// leaves behind), a silent no-op when the file was torn, and it discarded the save's `Result`. Each
+    /// of those drops a server that is already billing, and the recovery an operator needs is exactly the
+    /// id — so the id goes to stderr even though the ledger cannot hold it. It does NOT fail the
+    /// provisioning: the VM exists either way, aborting does not un-bill it, and a hard failure here would
+    /// turn a full disk into a dead bootstrap.
     @Contract
     static void recordProvisionedVm(ClusterName clusterName,
                                     String providerName,
                                     SourceName sourceName,
                                     NodeRole role,
                                     ProvisionedNode node) {
-        BootstrapStatePersistence.load(clusterName)
-                                 .map(state -> state.withResource(CreatedResource.ProvisionedVm.provisionedVm(providerName,
-                                                                                                              node.serverId(),
-                                                                                                              sourceName.value(),
-                                                                                                              role.value())))
-                                 .onPresent(BootstrapStatePersistence::save);
+        var _ = BootstrapStatePersistence.read(clusterName)
+                                         .onFailure(cause -> warnVmNotRecorded(node,
+                                                                               clusterName,
+                                                                               "the persisted ledger is unreadable: " + cause.message()))
+                                         .or(Option.empty())
+                                         .onEmpty(() -> warnVmNotRecorded(node,
+                                                                          clusterName,
+                                                                          "no bootstrap state is persisted for this cluster"))
+                                         .map(state -> state.withResource(CreatedResource.ProvisionedVm.provisionedVm(providerName,
+                                                                                                                     node.serverId(),
+                                                                                                                     sourceName.value(),
+                                                                                                                     role.value())))
+                                         .onPresent(state -> saveOrWarnVm(state, node, clusterName));
+    }
+
+    @Contract
+    private static void saveOrWarnVm(BootstrapState state, ProvisionedNode node, ClusterName clusterName) {
+        var _ = BootstrapStatePersistence.save(state)
+                                         .onFailure(cause -> warnVmNotRecorded(node,
+                                                                               clusterName,
+                                                                               "the ledger write failed: " + cause.message()));
+    }
+
+    /// The id is the whole point of this message. With the ledger broken it is the only place the server
+    /// is named at all, so it has to be printed rather than logged at a level nobody reads — #994's cost
+    /// was two `ccx23` servers whose ids had to be reconstructed by hand from `hcloud server list`.
+    @Contract
+    private static void warnVmNotRecorded(ProvisionedNode node, ClusterName clusterName, String reason) {
+        System.err.printf("  WARN: VM %s (node %s) was NOT recorded in the cleanup ledger — %s.%n",
+                          node.serverId(),
+                          node.nodeId(),
+                          reason);
+        System.err.printf("  This server IS PAID and 'aether cluster destroy' will not find it. Remove it with"
+                         + " 'tools/cloud-reaper.sh --cluster %s --destroy', or directly by id %s.%n",
+                          clusterName,
+                          node.serverId());
     }
 
     /// #994 — Aspects: wraps a per-node provisioner so every node it creates is recorded BEFORE the
@@ -433,8 +502,16 @@ sealed interface BootstrapPhaseProvision {
         return CloudProviderSupport.provisionVia(compute, group).await();
     }
 
+    /// #994 verification finding SF-2 — package-visible so a test can drive **the real call site**, not
+    /// merely the composition it calls. The restructure into [#provisionAndRecordRoleGroup] closed the
+    /// original gap one level down and opened it again here: with only that function pinned, replacing the
+    /// call below with a direct [#rotateZonesForRoleGroup] — i.e. deleting the entire recording behaviour —
+    /// left all 724 `aether/cli` tests green (measured, probe V1). #994 **was** an unwired mechanism:
+    /// `buildUpdatedState` existed and worked and simply never ran on the failure path. A regression that
+    /// re-unwires recording is the same defect class, so the wiring itself needs a pin rather than an
+    /// argument that the delegation "carries no logic".
     @SuppressWarnings("JBCT-EX-01")
-    private static Result<List<ProvisionedNode>> provisionCloudRoleGroup(ComputeProvider compute,
+    static Result<List<ProvisionedNode>> provisionCloudRoleGroup(ComputeProvider compute,
                                                                          BootstrapContext ctx,
                                                                          SourceName sourceName,
                                                                          NodeRole role,

--- a/aether/cli/src/main/java/org/pragmatica/aether/cli/cluster/BootstrapPhaseProvision.java
+++ b/aether/cli/src/main/java/org/pragmatica/aether/cli/cluster/BootstrapPhaseProvision.java
@@ -8,6 +8,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Consumer;
 import java.util.regex.Pattern;
 
 import org.pragmatica.aether.cli.cluster.ClusterBootstrapOrchestrator.BootstrapContext;
@@ -55,6 +56,8 @@ sealed interface BootstrapPhaseProvision {
         for (var entry : ctx.config().sources().entrySet()) {
             var sourceName = sourceNameOrDefault(entry.getKey());
             var source = entry.getValue();
+
+            persistCleanupHandle(ctx, sourceName, source);
             var result = provisionSource(ctx, sourceName, source, mgmtPort, clusterName);
 
             if (result.isFailure()) {
@@ -94,6 +97,79 @@ sealed interface BootstrapPhaseProvision {
         return state;
     }
 
+    /// #994 — the cleanup ledger must be able to NAME a paid VM the moment that VM exists, and the
+    /// credential that reaps it must already be resolvable when the first server is created. Both used
+    /// to be written only by [#buildUpdatedState], which runs ONLY after every source provisioned
+    /// successfully — so a failure part-way through PROVISION (observed 2026-09-11: a dedicated-core
+    /// quota refusal on the third of three servers) left the ledger holding the firewall and NO VMs.
+    /// Cleanup then had nothing to delete but the firewall, which the two surviving servers still held;
+    /// it retried `422 resource_in_use` six times, gave up, and never issued a single server delete.
+    ///
+    /// Records go to the PERSISTED state, not to the in-memory context: a failed phase returns a
+    /// `Result` failure, which carries no context, and
+    /// [ClusterBootstrapOrchestrator#cleanupOnFailure] re-loads the state FILE. The file is therefore
+    /// the only channel that survives the failure, which makes it the authority for created resources.
+    @Contract
+    private static void persistCleanupHandle(BootstrapContext ctx, SourceName sourceName, SourceProfile source) {
+        if (source.type() != SourceType.CLOUD) {
+            return;
+        }
+
+        persistCleanupHandle(ctx.state().clusterName(),
+                             ctx.rawTomlContent(),
+                             sourceName,
+                             source);
+    }
+
+    /// Takes the cluster name rather than the whole context so the persist is exercisable on its own:
+    /// the context carries nothing else this needs, and a seam that demands a full `BootstrapContext`
+    /// is a seam no test drives.
+    @Contract
+    static void persistCleanupHandle(ClusterName clusterName,
+                                     String rawToml,
+                                     SourceName sourceName,
+                                     SourceProfile source) {
+        BootstrapStatePersistence.load(clusterName)
+                                 .map(state -> withSourceHandle(state,
+                                                                rawToml,
+                                                                sourceName,
+                                                                source,
+                                                                resolveProviderName(source)))
+                                 .onPresent(BootstrapStatePersistence::save);
+    }
+
+    /// #994 — appends the VM to the persisted cleanup ledger as soon as the provider reports it created,
+    /// so a refusal on a LATER node of the same role group still leaves every already-paid server
+    /// nameable by teardown. The role is passed in rather than parsed back out of the node id by
+    /// [#extractRole], because here it is known exactly.
+    ///
+    /// Duplicate-free on the success path: [#buildUpdatedState] rebuilds the resource list from the
+    /// pre-phase in-memory state and [ClusterBootstrapOrchestrator] saves THAT, replacing these
+    /// incremental records with an equal set rather than appending to them.
+    @Contract
+    static void recordProvisionedVm(ClusterName clusterName,
+                                    String providerName,
+                                    SourceName sourceName,
+                                    NodeRole role,
+                                    ProvisionedNode node) {
+        BootstrapStatePersistence.load(clusterName)
+                                 .map(state -> state.withResource(CreatedResource.ProvisionedVm.provisionedVm(providerName,
+                                                                                                              node.serverId(),
+                                                                                                              sourceName.value(),
+                                                                                                              role.value())))
+                                 .onPresent(BootstrapStatePersistence::save);
+    }
+
+    /// #994 — Aspects: wraps a per-node provisioner so every node it creates is recorded BEFORE the
+    /// group's overall outcome is known, and records nothing for an attempt that failed. Composed in
+    /// [#provisionAndRecordRoleGroup], which is what production calls and what
+    /// `BootstrapPhaseProvisionLedgerTest` drives — so the line wiring this aspect to the recorder is
+    /// itself covered, not merely each half of it.
+    static ZoneProvisioner recordingProvisioner(ZoneProvisioner seam, Consumer<ProvisionedNode> recorder) {
+        return (nodeId, globalIndex, zone) -> seam.provisionInZone(nodeId, globalIndex, zone)
+                                                  .onSuccess(recorder);
+    }
+
     static BootstrapState stampSourceHandle(BootstrapState state,
                                             String rawToml,
                                             SourceName sourceName,
@@ -103,9 +179,24 @@ sealed interface BootstrapPhaseProvision {
             return state;
         }
 
-        var envVars = extractEnvVarNames(rawToml, sourceName.value());
+        warnOnUnmappedCredentials(sourceName, providerName, extractEnvVarNames(rawToml, sourceName.value()));
 
-        warnOnUnmappedCredentials(sourceName, providerName, envVars);
+        return withSourceHandle(state, rawToml, sourceName, source, providerName);
+    }
+
+    /// The handle stamp WITHOUT the unmapped-credential warning, so #994's pre-provision persist and the
+    /// success-path stamp can both write the handle while the operator still reads the warning exactly
+    /// once — from [#stampSourceHandle], which is the only caller that warns.
+    static BootstrapState withSourceHandle(BootstrapState state,
+                                           String rawToml,
+                                           SourceName sourceName,
+                                           SourceProfile source,
+                                           String providerName) {
+        if (source.type() != SourceType.CLOUD) {
+            return state;
+        }
+
+        var envVars = extractEnvVarNames(rawToml, sourceName.value());
         var handle = SourceCleanupHandle.sourceCleanupHandle(providerName, source.region(), envVars);
 
         return state.withSource(sourceName.value(), handle);
@@ -352,17 +443,47 @@ sealed interface BootstrapPhaseProvision {
                                                                          ClusterName clusterName,
                                                                          int nodeIndexBase) {
         logProvisionRole(sourceName, source.type(), role, Option.some(count));
-        ZoneProvisioner seam = (nodeId, globalIndex, zone) -> provisionOneInZone(compute,
-                                                                                 ctx,
-                                                                                 sourceName,
-                                                                                 source,
-                                                                                 role,
-                                                                                 clusterName,
-                                                                                 nodeId,
-                                                                                 globalIndex,
-                                                                                 zone);
+        ZoneProvisioner provisionOne = (nodeId, globalIndex, zone) -> provisionOneInZone(compute,
+                                                                                         ctx,
+                                                                                         sourceName,
+                                                                                         source,
+                                                                                         role,
+                                                                                         clusterName,
+                                                                                         nodeId,
+                                                                                         globalIndex,
+                                                                                         zone);
 
-        return rotateZonesForRoleGroup(sourceName, role, count, nodeIndexBase, source.effectiveZones(), seam);
+        return provisionAndRecordRoleGroup(ctx.state().clusterName(),
+                                           resolveProviderName(source),
+                                           sourceName,
+                                           role,
+                                           count,
+                                           nodeIndexBase,
+                                           source.effectiveZones(),
+                                           provisionOne);
+    }
+
+    /// #994 — the whole composition that must hold for a mid-group refusal to be survivable: zone rotation
+    /// over `count` nodes, each attempt wrapped by [#recordingProvisioner] so a created VM reaches the
+    /// persisted ledger before the group's outcome is known.
+    ///
+    /// It is one package-visible function rather than three lines inside [#provisionCloudRoleGroup] because
+    /// of what that cost: with the composition assembled inline, a test could exercise the aspect and the
+    /// recorder separately while the LINE THAT WIRES THEM TOGETHER stayed uncovered — measured, not assumed,
+    /// by deleting the wrapper at the old call site and watching all 724 `aether/cli` tests pass. Driving
+    /// this function instead leaves only an argument-passing delegation untested.
+    static Result<List<ProvisionedNode>> provisionAndRecordRoleGroup(ClusterName clusterName,
+                                                                     String providerName,
+                                                                     SourceName sourceName,
+                                                                     NodeRole role,
+                                                                     int count,
+                                                                     int nodeIndexBase,
+                                                                     List<String> zones,
+                                                                     ZoneProvisioner provisionOne) {
+        var seam = recordingProvisioner(provisionOne,
+                                        node -> recordProvisionedVm(clusterName, providerName, sourceName, role, node));
+
+        return rotateZonesForRoleGroup(sourceName, role, count, nodeIndexBase, zones, seam);
     }
 
     /// Provisions one node into a SPECIFIC zone: builds the spec without placement, applies

--- a/aether/cli/src/main/java/org/pragmatica/aether/cli/cluster/BootstrapPhaseProvision.java
+++ b/aether/cli/src/main/java/org/pragmatica/aether/cli/cluster/BootstrapPhaseProvision.java
@@ -153,10 +153,9 @@ sealed interface BootstrapPhaseProvision {
 
     @Contract
     private static void saveOrWarnHandle(BootstrapState state, ClusterName clusterName, SourceName sourceName) {
-        var _ = BootstrapStatePersistence.save(state)
-                                         .onFailure(cause -> warnHandleNotPersisted(clusterName,
-                                                                                    sourceName,
-                                                                                    "the ledger write failed: " + cause.message()));
+        var _ = BootstrapStatePersistence.save(state).onFailure(cause -> warnHandleNotPersisted(clusterName,
+                                                                                                sourceName,
+                                                                                                "the ledger write failed: " + cause.message()));
     }
 
     @Contract
@@ -200,18 +199,17 @@ sealed interface BootstrapPhaseProvision {
                                                                           clusterName,
                                                                           "no bootstrap state is persisted for this cluster"))
                                          .map(state -> state.withResource(CreatedResource.ProvisionedVm.provisionedVm(providerName,
-                                                                                                                     node.serverId(),
-                                                                                                                     sourceName.value(),
-                                                                                                                     role.value())))
+                                                                                                                      node.serverId(),
+                                                                                                                      sourceName.value(),
+                                                                                                                      role.value())))
                                          .onPresent(state -> saveOrWarnVm(state, node, clusterName));
     }
 
     @Contract
     private static void saveOrWarnVm(BootstrapState state, ProvisionedNode node, ClusterName clusterName) {
-        var _ = BootstrapStatePersistence.save(state)
-                                         .onFailure(cause -> warnVmNotRecorded(node,
-                                                                               clusterName,
-                                                                               "the ledger write failed: " + cause.message()));
+        var _ = BootstrapStatePersistence.save(state).onFailure(cause -> warnVmNotRecorded(node,
+                                                                                           clusterName,
+                                                                                           "the ledger write failed: " + cause.message()));
     }
 
     /// The id is the whole point of this message. With the ledger broken it is the only place the server
@@ -512,13 +510,13 @@ sealed interface BootstrapPhaseProvision {
     /// argument that the delegation "carries no logic".
     @SuppressWarnings("JBCT-EX-01")
     static Result<List<ProvisionedNode>> provisionCloudRoleGroup(ComputeProvider compute,
-                                                                         BootstrapContext ctx,
-                                                                         SourceName sourceName,
-                                                                         NodeRole role,
-                                                                         int count,
-                                                                         SourceProfile source,
-                                                                         ClusterName clusterName,
-                                                                         int nodeIndexBase) {
+                                                                 BootstrapContext ctx,
+                                                                 SourceName sourceName,
+                                                                 NodeRole role,
+                                                                 int count,
+                                                                 SourceProfile source,
+                                                                 ClusterName clusterName,
+                                                                 int nodeIndexBase) {
         logProvisionRole(sourceName, source.type(), role, Option.some(count));
         ZoneProvisioner provisionOne = (nodeId, globalIndex, zone) -> provisionOneInZone(compute,
                                                                                          ctx,

--- a/aether/cli/src/main/java/org/pragmatica/aether/cli/cluster/BootstrapStatePersistence.java
+++ b/aether/cli/src/main/java/org/pragmatica/aether/cli/cluster/BootstrapStatePersistence.java
@@ -43,9 +43,8 @@ sealed interface BootstrapStatePersistence {
     }
 
     static Option<BootstrapState> load(ClusterName clusterName) {
-        return read(clusterName).onFailure(cause -> System.err.println("Warning: failed to load bootstrap state: "
-                                                                     + cause.message()))
-                                .or(none());
+        return read(clusterName).onFailure(cause -> System.err.println("Warning: failed to load bootstrap state: " + cause.message()))
+                   .or(none());
     }
 
     /// #994 verification finding SF-1 — **ABSENT and UNREADABLE are different facts, and [#load] cannot

--- a/aether/cli/src/main/java/org/pragmatica/aether/cli/cluster/BootstrapStatePersistence.java
+++ b/aether/cli/src/main/java/org/pragmatica/aether/cli/cluster/BootstrapStatePersistence.java
@@ -43,17 +43,39 @@ sealed interface BootstrapStatePersistence {
     }
 
     static Option<BootstrapState> load(ClusterName clusterName) {
+        return read(clusterName).onFailure(cause -> System.err.println("Warning: failed to load bootstrap state: "
+                                                                     + cause.message()))
+                                .or(none());
+    }
+
+    /// #994 verification finding SF-1 — **ABSENT and UNREADABLE are different facts, and [#load] cannot
+    /// tell a caller which it got.** Both arrive as `none()`, which is correct for a caller that only
+    /// wants a state if there is one, and dangerous for the two callers whose decisions are
+    /// money-bearing:
+    ///
+    ///   - `ClusterBootstrapOrchestrator.markPhaseFailed` falls back to the PRE-phase snapshot and saves
+    ///     it. Over an absent file that is right — there is nothing to lose. Over a torn file it
+    ///     **overwrites the only record of paid VMs with a VM-less one, and the result is valid JSON, so
+    ///     nothing downstream can tell.** That is #994's exact outcome reached by a different route, and
+    ///     it was measured rather than argued (verification report §4b).
+    ///   - `ClusterDestroyCommand.cleanupCloudResources` reads an unreadable ledger as "no bootstrap
+    ///     state", reports cleanup OK, removes the registry entry and exits 0 — while every server the
+    ///     ledger named keeps billing and the operator's last handle on them is gone.
+    ///
+    /// So: absent is `success(none())`, present-and-parsed is `success(some(state))`, and present-but-
+    /// unparseable is a FAILURE carrying the parse cause. A caller that must not act on a guess can now
+    /// refuse instead.
+    static Result<Option<BootstrapState>> read(ClusterName clusterName) {
         var path = stateFilePath(clusterName);
 
         if (!Files.exists(path)) {
-            return none();
+            return Result.success(none());
         }
 
         return Result.lift(PersistenceError::new,
                            () -> Files.readString(path))
                      .flatMap(BootstrapState::fromJson)
-                     .onFailure(cause -> System.err.println("Warning: failed to load bootstrap state: " + cause.message()))
-                     .option();
+                     .map(Option::some);
     }
 
     static Result<Unit> delete(ClusterName clusterName) {

--- a/aether/cli/src/main/java/org/pragmatica/aether/cli/cluster/ClusterBootstrapOrchestrator.java
+++ b/aether/cli/src/main/java/org/pragmatica/aether/cli/cluster/ClusterBootstrapOrchestrator.java
@@ -228,8 +228,9 @@ public sealed interface ClusterBootstrapOrchestrator permits ClusterBootstrapOrc
     /// could not record — so the ids reach the transcript even when the ledger cannot hold them.
     @Contract
     private static void saveState(BootstrapState state, BootstrapPhase phase) {
-        var _ = BootstrapStatePersistence.save(state)
-                                         .onFailure(cause -> warnStateNotPersisted(state.clusterName(), phase, cause));
+        var _ = BootstrapStatePersistence.save(state).onFailure(cause -> warnStateNotPersisted(state.clusterName(),
+                                                                                               phase,
+                                                                                               cause));
     }
 
     @Contract
@@ -270,8 +271,9 @@ public sealed interface ClusterBootstrapOrchestrator permits ClusterBootstrapOrc
                                                                                                phase,
                                                                                                cause))
                                          .onSuccess(persisted -> saveState(persisted.or(preSnapshot)
-                                                                                    .withPhaseStatus(phase, PhaseStatus.FAILED),
-                                                                            phase));
+                                                                                    .withPhaseStatus(phase,
+                                                                                                     PhaseStatus.FAILED),
+                                                                           phase));
     }
 
     @Contract
@@ -315,7 +317,7 @@ public sealed interface ClusterBootstrapOrchestrator permits ClusterBootstrapOrc
 
     private static Result<Unit> cleanupRecordedResources(Option<BootstrapState> state) {
         return state.filter(persisted -> !persisted.createdResources()
-                                                  .isEmpty())
+                                                   .isEmpty())
                     .map(persisted -> cleanupHook().apply(persisted))
                     .or(Result.unitResult());
     }
@@ -326,8 +328,8 @@ public sealed interface ClusterBootstrapOrchestrator permits ClusterBootstrapOrc
     /// absent-vs-unreadable conflation).
     @Contract
     private static void warnKeepOnFailure(ClusterName clusterName, Cause cause) {
-        var read = BootstrapStatePersistence.read(clusterName)
-                                            .onFailure(parseCause -> warnLedgerUnreadableOnKeep(clusterName, parseCause));
+        var read = BootstrapStatePersistence.read(clusterName).onFailure(parseCause -> warnLedgerUnreadableOnKeep(clusterName,
+                                                                                                                  parseCause));
         var state = read.or(none());
         var resources = state.map(BootstrapState::createdResources).or(List.of());
         var vmCount = resources.stream().filter(r -> r instanceof CreatedResource.ProvisionedVm).count();

--- a/aether/cli/src/main/java/org/pragmatica/aether/cli/cluster/ClusterBootstrapOrchestrator.java
+++ b/aether/cli/src/main/java/org/pragmatica/aether/cli/cluster/ClusterBootstrapOrchestrator.java
@@ -203,7 +203,8 @@ public sealed interface ClusterBootstrapOrchestrator permits ClusterBootstrapOrc
 
         return phaseFunc.apply(inProgress)
                         .map(result -> markPhaseCompleted(result, phase))
-                        .onFailure(cause -> markPhaseFailed(inProgress, phase));
+                        .onFailure(cause -> markPhaseFailed(inProgress.state(),
+                                                            phase));
     }
 
     private static BootstrapContext markPhaseCompleted(BootstrapContext result, BootstrapPhase phase) {
@@ -214,11 +215,20 @@ public sealed interface ClusterBootstrapOrchestrator permits ClusterBootstrapOrc
         return completed;
     }
 
+    /// #994 — the FAILED marker must not ERASE what the failing phase already recorded. `preSnapshot` is
+    /// the state as it was BEFORE the phase ran, and PROVISION now appends each paid VM to the persisted
+    /// ledger as the provider reports it created (see `BootstrapPhaseProvision.recordProvisionedVm`), so
+    /// saving the snapshot would discard exactly the records teardown needs — which is how a
+    /// mid-PROVISION quota refusal stranded two running `ccx23` servers on 2026-09-11.
+    ///
+    /// The state FILE is the authority for created resources, so re-load it and mark the phase FAILED on
+    /// THAT, falling back to the snapshot only when nothing is persisted. Takes a `BootstrapState` rather
+    /// than a `BootstrapContext` so the preservation property is testable without a full config fixture.
     @Contract
-    private static void markPhaseFailed(BootstrapContext ctx, BootstrapPhase phase) {
-        var failed = ctx.withState(ctx.state().withPhaseStatus(phase, PhaseStatus.FAILED));
+    static void markPhaseFailed(BootstrapState preSnapshot, BootstrapPhase phase) {
+        var persisted = BootstrapStatePersistence.load(preSnapshot.clusterName()).or(preSnapshot);
 
-        BootstrapStatePersistence.save(failed.state());
+        BootstrapStatePersistence.save(persisted.withPhaseStatus(phase, PhaseStatus.FAILED));
     }
 
     static Cause decorateAfterCleanup(ClusterName clusterName, Cause cause, boolean keepOnFailure) {
@@ -606,10 +616,13 @@ public sealed interface ClusterBootstrapOrchestrator permits ClusterBootstrapOrc
             }
         }
 
+        /// #994 — `cleanupDetail` now carries `BootstrapCleanup.CleanupError`'s enumeration (type + id per
+        /// resource), so this message names what was left behind rather than saying "orphan resources may
+        /// remain" and leaving the operator to reconstruct the list from `hcloud server list`.
         record BootstrapFailedWithOrphans(Cause originalCause, String cleanupDetail) implements BootstrapError {
             @Override
             public String message() {
-                return originalCause.message() + " — cleanup failed, orphan resources may remain: " + cleanupDetail;
+                return originalCause.message() + " — cleanup failed, resources were left behind: " + cleanupDetail;
             }
         }
     }

--- a/aether/cli/src/main/java/org/pragmatica/aether/cli/cluster/ClusterBootstrapOrchestrator.java
+++ b/aether/cli/src/main/java/org/pragmatica/aether/cli/cluster/ClusterBootstrapOrchestrator.java
@@ -121,9 +121,9 @@ public sealed interface ClusterBootstrapOrchestrator permits ClusterBootstrapOrc
                                                            String rawTomlContent) {
         var clusterName = config.cluster().name();
 
-        return BootstrapStatePersistence.load(clusterName)
-                                        .toResult(new BootstrapError.ProvisionFailed(clusterName.value(),
-                                                                                     "No bootstrap state found for resume"))
+        return BootstrapStatePersistence.read(clusterName)
+                                        .flatMap(state -> state.toResult(new BootstrapError.ProvisionFailed(clusterName.value(),
+                                                                                                            "No bootstrap state found for resume")))
                                         .flatMap(state -> validateResumeState(state, config))
                                         .flatMap(state -> resumeFromState(config, state, sshPublicKeys, rawTomlContent))
                                         .fold(cause -> Result.<BootstrapResult> failure(decorateAfterCleanup(clusterName,
@@ -199,7 +199,7 @@ public sealed interface ClusterBootstrapOrchestrator permits ClusterBootstrapOrc
                                                                 Function<BootstrapContext, Result<BootstrapContext>> phaseFunc) {
         var inProgress = ctx.withState(ctx.state().withPhaseStatus(phase, PhaseStatus.IN_PROGRESS));
 
-        BootstrapStatePersistence.save(inProgress.state());
+        saveState(inProgress.state(), phase);
 
         return phaseFunc.apply(inProgress)
                         .map(result -> markPhaseCompleted(result, phase))
@@ -210,9 +210,39 @@ public sealed interface ClusterBootstrapOrchestrator permits ClusterBootstrapOrc
     private static BootstrapContext markPhaseCompleted(BootstrapContext result, BootstrapPhase phase) {
         var completed = result.withState(result.state().withPhaseStatus(phase, PhaseStatus.COMPLETED));
 
-        BootstrapStatePersistence.save(completed.state());
+        saveState(completed.state(), phase);
 
         return completed;
+    }
+
+    /// #994 verification finding SF-1 — **the whole ledger mechanism rests on this write, and its `Result`
+    /// used to be discarded.** `BootstrapPhaseProvision.recordProvisionedVm` loads the state FILE, appends
+    /// the VM and saves; when the file is absent the load is empty and the append is a silent no-op. What
+    /// guarantees it is not absent is exactly this pre-phase save. If it fails and nobody says so, every
+    /// paid VM of the PROVISION phase is dropped from the ledger and #994 recurs with no diagnostic at all.
+    ///
+    /// It WARNS rather than aborting, deliberately. Aborting would fail closed at the wrong moment: a
+    /// bootstrap that could have succeeded is turned into a hard failure by a full disk in `~/.aether`,
+    /// and the phase has created nothing yet, so there is no money at stake to protect. What the operator
+    /// needs instead is to learn now, and `recordProvisionedVm` additionally prints every server id it
+    /// could not record — so the ids reach the transcript even when the ledger cannot hold them.
+    @Contract
+    private static void saveState(BootstrapState state, BootstrapPhase phase) {
+        var _ = BootstrapStatePersistence.save(state)
+                                         .onFailure(cause -> warnStateNotPersisted(state.clusterName(), phase, cause));
+    }
+
+    @Contract
+    private static void warnStateNotPersisted(ClusterName clusterName, BootstrapPhase phase, Cause cause) {
+        System.err.printf("  WARN: could not persist bootstrap state for cluster '%s' at phase %s: %s%n",
+                          clusterName,
+                          phase,
+                          cause.message());
+        System.err.printf("  The state file (%s) is teardown's ONLY record of created cloud resources. While it"
+                         + " cannot be written, resources this run creates will not be reapable by"
+                         + " 'aether cluster destroy' — every server id is printed as it is created so it can be"
+                         + " removed with tools/cloud-reaper.sh.%n",
+                          BootstrapStatePersistence.statePath(clusterName));
     }
 
     /// #994 — the FAILED marker must not ERASE what the failing phase already recorded. `preSnapshot` is
@@ -224,11 +254,39 @@ public sealed interface ClusterBootstrapOrchestrator permits ClusterBootstrapOrc
     /// The state FILE is the authority for created resources, so re-load it and mark the phase FAILED on
     /// THAT, falling back to the snapshot only when nothing is persisted. Takes a `BootstrapState` rather
     /// than a `BootstrapContext` so the preservation property is testable without a full config fixture.
+    ///
+    /// #994 verification finding SF-1 — **the fallback reads through
+    /// [BootstrapStatePersistence#read], not `load`, because "nothing persisted" and "unreadable" are
+    /// different facts and only one of them is safe to overwrite.** `load` collapses both to empty, and
+    /// over a TORN file the snapshot save then replaces the only record of paid VMs with a VM-less one
+    /// that is valid JSON — undetectable afterwards, and #994's outcome by another route. On an unreadable
+    /// ledger this now refuses to write at all: the bytes stay on disk for recovery and the operator is
+    /// told. There is no trade to weigh on this path — it runs only after the bootstrap has ALREADY
+    /// failed, so failing closed here cannot cost a run that would otherwise have succeeded.
     @Contract
     static void markPhaseFailed(BootstrapState preSnapshot, BootstrapPhase phase) {
-        var persisted = BootstrapStatePersistence.load(preSnapshot.clusterName()).or(preSnapshot);
+        var _ = BootstrapStatePersistence.read(preSnapshot.clusterName())
+                                         .onFailure(cause -> refuseToOverwriteUnreadableLedger(preSnapshot.clusterName(),
+                                                                                               phase,
+                                                                                               cause))
+                                         .onSuccess(persisted -> saveState(persisted.or(preSnapshot)
+                                                                                    .withPhaseStatus(phase, PhaseStatus.FAILED),
+                                                                            phase));
+    }
 
-        BootstrapStatePersistence.save(persisted.withPhaseStatus(phase, PhaseStatus.FAILED));
+    @Contract
+    private static void refuseToOverwriteUnreadableLedger(ClusterName clusterName, BootstrapPhase phase, Cause cause) {
+        System.err.printf("  WARN: the bootstrap state file for cluster '%s' exists but cannot be read: %s%n",
+                          clusterName,
+                          cause.message());
+        System.err.printf("  REFUSING to mark %s as FAILED, because writing would replace the only record of this"
+                         + " run's created resources with a pre-phase snapshot that has none — and the result would"
+                         + " be valid JSON, so nothing afterwards could tell. The unreadable file is left at %s for"
+                         + " recovery.%n",
+                          phase,
+                          BootstrapStatePersistence.statePath(clusterName));
+        System.err.printf("  Reap whatever this run created with: tools/cloud-reaper.sh --cluster %s --destroy%n",
+                          clusterName);
     }
 
     static Cause decorateAfterCleanup(ClusterName clusterName, Cause cause, boolean keepOnFailure) {
@@ -245,17 +303,32 @@ public sealed interface ClusterBootstrapOrchestrator permits ClusterBootstrapOrc
         return new BootstrapError.BootstrapFailedWithOrphans(originalCause, cleanupCause.message());
     }
 
+    /// #994 verification finding SF-1 — reads through [BootstrapStatePersistence#read] so an UNPARSEABLE
+    /// ledger fails the cleanup instead of reading as "no resources were created". Under `load` the two
+    /// were the same empty `Option`, and a torn file therefore produced a silent, successful, zero-delete
+    /// teardown over resources that are still billing.
     private static Result<Unit> cleanupOnFailure(ClusterName clusterName) {
-        return BootstrapStatePersistence.load(clusterName)
-                                        .filter(state -> !state.createdResources()
-                                                               .isEmpty())
-                                        .map(state -> cleanupHook().apply(state))
-                                        .or(Result.unitResult());
+        return BootstrapStatePersistence.read(clusterName)
+                                        .mapError(cause -> new BootstrapError.LedgerUnreadable(clusterName, cause))
+                                        .flatMap(ClusterBootstrapOrchestrator::cleanupRecordedResources);
     }
 
+    private static Result<Unit> cleanupRecordedResources(Option<BootstrapState> state) {
+        return state.filter(persisted -> !persisted.createdResources()
+                                                  .isEmpty())
+                    .map(persisted -> cleanupHook().apply(persisted))
+                    .or(Result.unitResult());
+    }
+
+    /// `--keep-on-failure` reports from the ledger, so an unreadable ledger must be reported AS unreadable:
+    /// the counts it would otherwise print are zeros nobody measured, and this text is the operator's whole
+    /// basis for deciding what is still running (#994 verification finding SF-1, the same
+    /// absent-vs-unreadable conflation).
     @Contract
     private static void warnKeepOnFailure(ClusterName clusterName, Cause cause) {
-        var state = BootstrapStatePersistence.load(clusterName);
+        var read = BootstrapStatePersistence.read(clusterName)
+                                            .onFailure(parseCause -> warnLedgerUnreadableOnKeep(clusterName, parseCause));
+        var state = read.or(none());
         var resources = state.map(BootstrapState::createdResources).or(List.of());
         var vmCount = resources.stream().filter(r -> r instanceof CreatedResource.ProvisionedVm).count();
         var keyCount = resources.stream().filter(r -> r instanceof CreatedResource.SshKeyResource).count();
@@ -272,6 +345,16 @@ public sealed interface ClusterBootstrapOrchestrator permits ClusterBootstrapOrc
         System.err.println("[--keep-on-failure] To inspect: ssh aether@<vm-ip> (or root@). "
                           + "To clean up later: aether cluster destroy --cluster " + clusterName
                           + " --yes.");
+    }
+
+    @Contract
+    private static void warnLedgerUnreadableOnKeep(ClusterName clusterName, Cause cause) {
+        System.err.printf("[--keep-on-failure] WARNING: the state file is present but unreadable (%s), so the"
+                         + " counts below are NOT measured — they are what an empty ledger reports. Resources may"
+                         + " exist that nothing here can name; finish teardown with 'tools/cloud-reaper.sh"
+                         + " --cluster %s --destroy'.%n",
+                          cause.message(),
+                          clusterName);
     }
 
     private static String resolveFailedPhase(BootstrapState state) {
@@ -623,6 +706,22 @@ public sealed interface ClusterBootstrapOrchestrator permits ClusterBootstrapOrc
             @Override
             public String message() {
                 return originalCause.message() + " — cleanup failed, resources were left behind: " + cleanupDetail;
+            }
+        }
+
+        /// #994 verification finding SF-1 — the failure-path cleanup could not run because the state file
+        /// is present but unparseable. Distinct from "no state file", which is a success: there, nothing
+        /// was created that needs reaping. Here, resources may exist and their ids are in bytes nothing can
+        /// read, so this must surface as a cleanup FAILURE and reach the operator through
+        /// [BootstrapFailedWithOrphans] rather than letting a torn file read as a clean teardown.
+        record LedgerUnreadable(ClusterName clusterName, Cause origin) implements BootstrapError, Cause.Wrapped {
+            @Override
+            public String message() {
+                return "the bootstrap state file for cluster '" + clusterName
+                     + "' could not be read (" + origin.message()
+                     + "), so cleanup could not name a single resource to reap — run"
+                     + " 'tools/cloud-reaper.sh --cluster " + clusterName
+                     + " --destroy' to finish teardown";
             }
         }
     }

--- a/aether/cli/src/main/java/org/pragmatica/aether/cli/cluster/ClusterDestroyCommand.java
+++ b/aether/cli/src/main/java/org/pragmatica/aether/cli/cluster/ClusterDestroyCommand.java
@@ -34,11 +34,25 @@ import static org.pragmatica.lang.Option.option;
 @Command(name = "destroy", description = "Destroy the active cluster (drain + shutdown all nodes)")
 @SuppressWarnings({"JBCT-RET-01", "JBCT-PAT-01", "JBCT-SEQ-01"})
 class ClusterDestroyCommand implements Callable<Integer> {
-    private static final int DRAIN_POLL_INTERVAL_MS = 2000;
-    private static final int DRAIN_TIMEOUT_SECONDS = 120;
+    /// Package-visible so a test asserts the announced ceiling against **the constant that enforces it**
+    /// rather than against a restated literal — the same arrangement as
+    /// [BootstrapCleanup#FIREWALL_DELETE_ATTEMPTS], and the reason #994's "servers are still detaching" is
+    /// the cautionary case: an announcement that can drift from the code is a false diagnostic waiting to
+    /// happen.
+    static final int DRAIN_POLL_INTERVAL_MS = 2000;
+    static final int DRAIN_TIMEOUT_SECONDS = 120;
     private static final JsonMapper MAPPER = JsonMapper.defaultJsonMapper();
 
-    static Function<ClusterName, org.pragmatica.lang.Option<BootstrapState>> stateLoader = BootstrapStatePersistence::load;
+    /// #994 verification finding SF-1 — carries `Result<Option<…>>` rather than `Option<…>`, so
+    /// **an UNREADABLE ledger is distinguishable from an ABSENT one.** Under the old `Option` seam a torn
+    /// `bootstrap-state.json` arrived as empty, which `cleanupCloudResources` read as "no bootstrap state
+    /// — skipping resource cleanup", returned `true` for, and then removed the registry entry and exited 0
+    /// over servers that were still billing. That is reachable by exactly the failure the incidents ended
+    /// in: the operator killing bootstrap mid-write.
+    ///
+    /// `org.pragmatica.lang.Option` is spelled out because the simple name `Option` in this file is
+    /// picocli's `@Option` annotation — the same reason the previous declaration was fully qualified.
+    static Function<ClusterName, Result<org.pragmatica.lang.Option<BootstrapState>>> stateLoader = BootstrapStatePersistence::read;
 
     static Function<BootstrapState, Result<Unit>> resourceCleaner = BootstrapCleanup::cleanup;
 
@@ -167,7 +181,15 @@ class ClusterDestroyCommand implements Callable<Integer> {
     /// Every phase now announces itself BEFORE it blocks, names the ceiling it may wait for, and reports
     /// its own failure. Silence is what invited the intervention that produced a half-destroyed cluster;
     /// an operator must be able to tell "working" from "wedged" without reading this file.
-    private Result<Integer> performDestruction(ClusterRegistry registry, ClusterName clusterName) {
+    ///
+    /// #994 verification finding SF-3 — package-visible because **no test reached this method at all.**
+    /// The three phase methods were each driven individually and every test entering through `call()`
+    /// returned early (invalid `--cluster`, or an aborted confirmation), so deleting
+    /// `announceDestroyPlan(clusterName)` from here — #995's entire "say so before the wait begins"
+    /// deliverable — left all 724 tests green (measured, probe V3). The PHASE SEQUENCE was unpinned for the
+    /// same reason: the order these five run in is the property the announcement describes, and nothing
+    /// checked it.
+    Result<Integer> performDestruction(ClusterRegistry registry, ClusterName clusterName) {
         announceDestroyPlan(clusterName);
         var nodeIds = fetchNodeIds();
         var drainResults = drainAllNodes(nodeIds);
@@ -257,8 +279,25 @@ class ClusterDestroyCommand implements Callable<Integer> {
         }
 
         return stateLoader.apply(clusterName)
-                          .fold(() -> warnNoState(clusterName),
-                                this::runCleanup);
+                          .map(state -> state.fold(() -> warnNoState(clusterName), this::runCleanup))
+                          .onFailure(cause -> warnUnreadableState(clusterName, cause))
+                          .or(false);
+    }
+
+    /// #994 verification finding SF-1 — an unreadable ledger is a cleanup FAILURE, not an empty cluster.
+    /// Returning `false` is what keeps the registry entry (#521's property: the entry is the operator's
+    /// remaining handle on resources that may still be billing) and exits non-zero, so `destroy` can be
+    /// re-run once the file is repaired or the reaper has finished the job. The alternative — the previous
+    /// behaviour — was "destroyed successfully", exit 0, entry gone, servers running.
+    @Contract
+    private static void warnUnreadableState(ClusterName clusterName, Cause cause) {
+        System.err.printf("  WARN: the bootstrap state file for cluster '%s' exists but cannot be read: %s%n",
+                          clusterName,
+                          cause.message());
+        System.err.printf("  REFUSING to report cleanup as done: an unreadable ledger is NOT an empty one, and every"
+                         + " resource it recorded may still be billing. The registry entry is kept so this can be"
+                         + " retried. Finish teardown with: tools/cloud-reaper.sh --cluster %s --destroy%n",
+                          clusterName);
     }
 
     private static boolean warnNoState(ClusterName clusterName) {

--- a/aether/cli/src/main/java/org/pragmatica/aether/cli/cluster/ClusterDestroyCommand.java
+++ b/aether/cli/src/main/java/org/pragmatica/aether/cli/cluster/ClusterDestroyCommand.java
@@ -4,6 +4,7 @@
 // See LICENSE in the repository root for full terms.
 package org.pragmatica.aether.cli.cluster;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Callable;
@@ -27,6 +28,7 @@ import static org.pragmatica.aether.management.route.ManagementRoute.NODE_DRAIN;
 import static org.pragmatica.aether.management.route.ManagementRoute.NODE_LIFECYCLE_GET;
 import static org.pragmatica.aether.management.route.ManagementRoute.NODE_LIFECYCLE_LIST;
 import static org.pragmatica.aether.management.route.ManagementRoute.NODE_SHUTDOWN;
+import static org.pragmatica.lang.Option.option;
 
 
 @Command(name = "destroy", description = "Destroy the active cluster (drain + shutdown all nodes)")
@@ -155,13 +157,65 @@ class ClusterDestroyCommand implements Callable<Integer> {
         ClusterHttpClient.setEndpointOverride(entry.endpoint());
     }
 
+    /// #995 — against a healthy 3-node cloud cluster this emitted NOTHING for ~2.5 minutes and deleted
+    /// nothing, and the operator killed it with three paid servers still running. Nothing here was
+    /// announced: the first statement is a node-list HTTP request that can block for the whole
+    /// [ClusterHttpClient#REQUEST_TIMEOUT] (130s by default) and whose failure was discarded by
+    /// `.or(List.of())`; with an empty node list the drain and shutdown loops then print nothing either.
+    /// So the command's entire observable output could begin more than two minutes in.
+    ///
+    /// Every phase now announces itself BEFORE it blocks, names the ceiling it may wait for, and reports
+    /// its own failure. Silence is what invited the intervention that produced a half-destroyed cluster;
+    /// an operator must be able to tell "working" from "wedged" without reading this file.
     private Result<Integer> performDestruction(ClusterRegistry registry, ClusterName clusterName) {
+        announceDestroyPlan(clusterName);
         var nodeIds = fetchNodeIds();
         var drainResults = drainAllNodes(nodeIds);
         var shutdownResults = shutdownAllNodes(nodeIds);
         var cleanupOk = cleanupCloudResources(clusterName);
 
         return finalizeDestruction(registry, clusterName, cleanupOk, nodeIds, drainResults, shutdownResults);
+    }
+
+    /// #995 expectation 3 — "if it can take minutes, say so before the wait begins". The figures are read
+    /// from the constants that actually bound the waits, so the estimate cannot drift away from the code.
+    @Contract
+    private void announceDestroyPlan(ClusterName clusterName) {
+        System.out.printf("Destroying cluster '%s' in %d phases. This can take minutes: node enumeration"
+                         + " waits up to %ds, each node's drain up to %ds, and cloud resource deletion is"
+                         + " paced by the provider.%n",
+                          clusterName,
+                          DestroyPhase.values().length,
+                          requestTimeoutSeconds(),
+                          DRAIN_TIMEOUT_SECONDS);
+    }
+
+    /// #995 — the destroy pipeline's phases, printed in the same `[Phase n/m: NAME]` shape
+    /// [ClusterBootstrapOrchestrator#logPhase] uses for bootstrap, so an operator reading a bootstrap
+    /// transcript and a destroy transcript reads one format rather than two.
+    enum DestroyPhase {
+        ENUMERATE_NODES,
+        DRAIN_NODES,
+        SHUTDOWN_NODES,
+        CLOUD_CLEANUP,
+        REGISTRY
+    }
+
+    @Contract
+    static void logPhase(DestroyPhase phase, String message) {
+        System.out.printf("[Phase %d/%d: %s] %s%n",
+                          phase.ordinal() + 1,
+                          DestroyPhase.values().length,
+                          phase.name(),
+                          message);
+    }
+
+    /// The real ceiling on a single management request, read from [ClusterHttpClient#REQUEST_TIMEOUT]
+    /// rather than restated: an announced timeout that does not match the one in force is the same class
+    /// of false diagnostic as #994's "servers are still detaching".
+    private static long requestTimeoutSeconds() {
+        return option(ClusterHttpClient.REQUEST_TIMEOUT.get()).map(Duration::toSeconds)
+                     .or(0L);
     }
 
     /// #521 — registry honesty. The registry entry is the operator's only handle on a cluster whose VMs may
@@ -176,14 +230,26 @@ class ClusterDestroyCommand implements Callable<Integer> {
                                                List<NodeResult> drainResults,
                                                List<NodeResult> shutdownResults) {
         if (!cleanupOk) {
+            logPhase(DestroyPhase.REGISTRY,
+                     "Keeping the registry entry — cloud cleanup failed, and the entry is the operator's"
+                    + " remaining handle on resources that may still be billing");
+
             return Result.success(printSummary(clusterName, nodeIds, drainResults, shutdownResults, false, false));
         }
+
+        logPhase(DestroyPhase.REGISTRY, "Removing the registry entry for '" + clusterName + "'");
 
         return registryRemover.apply(registry, clusterName)
                               .map(_ -> printSummary(clusterName, nodeIds, drainResults, shutdownResults, true, true));
     }
 
     boolean cleanupCloudResources(ClusterName clusterName) {
+        logPhase(DestroyPhase.CLOUD_CLEANUP,
+                 "Deleting cloud resources recorded at bootstrap, then sweeping cluster-labelled VMs and"
+                + " SSH keys. Each delete is reported as it is issued; a firewall still in use is retried"
+                + " up to " + BootstrapCleanup.FIREWALL_DELETE_ATTEMPTS
+                + " times, " + (BootstrapCleanup.FIREWALL_DELETE_RETRY_MILLIS / 1000)
+                + "s apart");
         if (keepResources) {
             System.out.println("--keep-resources: skipping cloud resource termination.");
 
@@ -255,11 +321,39 @@ class ClusterDestroyCommand implements Callable<Integer> {
                           .equals(input);
     }
 
-    private List<String> fetchNodeIds() {
+    /// #995 — this is the call that produced the observed silence: one management request, up to
+    /// [#requestTimeoutSeconds] before it gives up, and its failure was swallowed by `.or(List.of())`
+    /// with no message at all. It now says what it is about to wait for and for how long, and reports a
+    /// failure instead of continuing as if the cluster had no nodes.
+    List<String> fetchNodeIds() {
+        logPhase(DestroyPhase.ENUMERATE_NODES,
+                 String.format("Listing cluster nodes from %s (one request, timeout %ds)",
+                               ClusterHttpClient.resolveEndpoint().or("<no endpoint resolved>"),
+                               requestTimeoutSeconds()));
+
         return ClusterHttpClient.fetch(NODE_LIFECYCLE_LIST)
                                 .flatMap(MAPPER::readTree)
                                 .map(ClusterDestroyCommand::extractNodeIds)
+                                .onFailure(ClusterDestroyCommand::warnNodeEnumerationFailed)
+                                .onSuccess(ClusterDestroyCommand::reportNodesFound)
                                 .or(List.of());
+    }
+
+    @Contract
+    private static void reportNodesFound(List<String> nodeIds) {
+        System.out.printf("  %d node(s) reported by the cluster.%n", nodeIds.size());
+    }
+
+    /// Names the consequence, not just the error: with no node list the drain and shutdown phases have
+    /// nothing to act on, so the nodes are destroyed WITHOUT a graceful drain. That is a different
+    /// outcome from a successful destroy and the operator has to be told, because cloud cleanup still
+    /// proceeds from the bootstrap ledger and the command can still exit 0.
+    @Contract
+    private static void warnNodeEnumerationFailed(Cause cause) {
+        System.err.println("  WARN: could not list cluster nodes: " + cause.message());
+        System.err.println("  Proceeding to cloud resource cleanup with an EMPTY node list — drain and"
+                          + " shutdown are skipped, so nodes are deleted without a graceful drain."
+                          + " Resources recorded at bootstrap are still reaped.");
     }
 
     private static List<String> extractNodeIds(JsonNode root) {
@@ -280,17 +374,30 @@ class ClusterDestroyCommand implements Callable<Integer> {
         return List.copyOf(result);
     }
 
-    private List<NodeResult> drainAllNodes(List<String> nodeIds) {
+    List<NodeResult> drainAllNodes(List<String> nodeIds) {
+        logPhase(DestroyPhase.DRAIN_NODES, drainAnnouncement(nodeIds.size()));
         var results = new ArrayList<NodeResult>();
 
         for (var nodeId : nodeIds) {
-            System.out.printf("Draining node %s...%n", nodeId);
+            System.out.printf("Draining node %s (waiting up to %ds for DECOMMISSIONED, polling every %dms)...%n",
+                              nodeId,
+                              DRAIN_TIMEOUT_SECONDS,
+                              DRAIN_POLL_INTERVAL_MS);
             var result = drainSingleNode(nodeId);
 
             results.add(result);
         }
 
         return List.copyOf(results);
+    }
+
+    private static String drainAnnouncement(int nodeCount) {
+        return nodeCount == 0
+               ? "Nothing to drain — the node list is empty"
+               : String.format("Draining %d node(s), up to %ds each (worst case %ds total)",
+                               nodeCount,
+                               DRAIN_TIMEOUT_SECONDS,
+                               (long) nodeCount * DRAIN_TIMEOUT_SECONDS);
     }
 
     private NodeResult drainSingleNode(String nodeId) {
@@ -334,7 +441,11 @@ class ClusterDestroyCommand implements Callable<Integer> {
         return false;
     }
 
-    private List<NodeResult> shutdownAllNodes(List<String> nodeIds) {
+    List<NodeResult> shutdownAllNodes(List<String> nodeIds) {
+        logPhase(DestroyPhase.SHUTDOWN_NODES,
+                 nodeIds.isEmpty()
+                 ? "Nothing to shut down — the node list is empty"
+                 : String.format("Shutting down %d node(s)", nodeIds.size()));
         var results = new ArrayList<NodeResult>();
 
         for (var nodeId : nodeIds) {

--- a/aether/cli/src/main/java/org/pragmatica/aether/cli/cluster/ClusterDestroyCommand.java
+++ b/aether/cli/src/main/java/org/pragmatica/aether/cli/cluster/ClusterDestroyCommand.java
@@ -41,6 +41,7 @@ class ClusterDestroyCommand implements Callable<Integer> {
     /// happen.
     static final int DRAIN_POLL_INTERVAL_MS = 2000;
     static final int DRAIN_TIMEOUT_SECONDS = 120;
+
     private static final JsonMapper MAPPER = JsonMapper.defaultJsonMapper();
 
     /// #994 verification finding SF-1 — carries `Result<Option<…>>` rather than `Option<…>`, so
@@ -279,7 +280,8 @@ class ClusterDestroyCommand implements Callable<Integer> {
         }
 
         return stateLoader.apply(clusterName)
-                          .map(state -> state.fold(() -> warnNoState(clusterName), this::runCleanup))
+                          .map(state -> state.fold(() -> warnNoState(clusterName),
+                                                   this::runCleanup))
                           .onFailure(cause -> warnUnreadableState(clusterName, cause))
                           .or(false);
     }

--- a/aether/cli/src/main/java/org/pragmatica/aether/cli/cluster/SecureFiles.java
+++ b/aether/cli/src/main/java/org/pragmatica/aether/cli/cluster/SecureFiles.java
@@ -6,11 +6,14 @@ package org.pragmatica.aether.cli.cluster;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.nio.file.StandardOpenOption;
+import java.nio.file.attribute.FileAttribute;
 import java.nio.file.attribute.PosixFilePermission;
 import java.nio.file.attribute.PosixFilePermissions;
 import java.util.Set;
@@ -45,6 +48,22 @@ public sealed interface SecureFiles {
     ///     an older release never holds the *new* secret at `0644`.
     ///
     /// Non-POSIX filesystems (Windows) keep the plain write: best-effort, as before.
+    ///
+    /// #994 verification finding SF-1 — **the write is also all-or-nothing.** It used to open `path`
+    /// itself with `TRUNCATE_EXISTING`, so a process that died part-way through left a zero-byte or
+    /// half-written file: `Files.exists` true, `fromJson` failing, and `BootstrapStatePersistence.load`
+    /// reporting EMPTY — indistinguishable from "nothing was ever persisted". That mattered because
+    /// `bootstrap-state.json` is the only record of money-bearing resources and **both the #994 and #995
+    /// incidents ended with the operator KILLING the process mid-run.** Content now lands in a sibling
+    /// temp file and arrives at `path` by [StandardCopyOption#ATOMIC_MOVE], so a reader sees either the
+    /// whole previous file or the whole new one.
+    ///
+    /// Precise guarantee, because "atomic" alone overclaims: the rename is atomic **with respect to
+    /// process death** — `rename(2)` within one directory either completed or did not, and the page
+    /// cache survives the process. The temp file's bytes are `force`d before the rename, so the content
+    /// a completed rename publishes is on the device. The DIRECTORY entry is not fsync'd, so a host
+    /// power loss in the window can still lose the last write; process death, the observed failure mode,
+    /// cannot.
     static Result<Unit> writeSecure(Path path, String content) {
         return Result.lift(Causes::fromThrowable, () -> writeOwnerOnly(path, content));
     }
@@ -52,24 +71,45 @@ public sealed interface SecureFiles {
     /// `throws IOException` is deliberate and lifted exactly once, by [#writeSecure]'s `Result.lift`
     /// — the sanctioned adapter boundary. Threading `Result` through the two creation paths here would
     /// obscure the ordering property the whole method exists to establish.
+    ///
+    /// The pre-tightening of an EXISTING file is kept even though the atomic move replaces the inode
+    /// (and with it the mode) on its own: without it, a file an older release left `0644` keeps holding
+    /// its OLD secret world-readable for the duration of the temp write. That window is pre-existing
+    /// rather than new, but it is one syscall to close and #980's property is stated over instants.
     @SuppressWarnings({"JBCT-SEQ-01", "JBCT-EX-01"})
     private static Unit writeOwnerOnly(Path path, String content) throws IOException {
         if (!posixSupported()) {
-            Files.writeString(path, content);
-
-            return Unit.unit();
+            return writeViaTempFile(path, content);
         }
 
         if (Files.exists(path)) {
             Files.setPosixFilePermissions(path, OWNER_ONLY);
         }
 
-        try (var channel = Files.newByteChannel(path,
-                                                Set.of(StandardOpenOption.CREATE,
-                                                       StandardOpenOption.WRITE,
-                                                       StandardOpenOption.TRUNCATE_EXISTING),
-                                                PosixFilePermissions.asFileAttribute(OWNER_ONLY))) {
-            channel.write(ByteBuffer.wrap(content.getBytes(StandardCharsets.UTF_8)));
+        return writeViaTempFile(path, content, PosixFilePermissions.asFileAttribute(OWNER_ONLY));
+    }
+
+    /// The temp file is created in `path`'s OWN directory, which is what makes the move a same-filesystem
+    /// rename and therefore atomic; a temp in `/tmp` would be a copy-and-delete and would reintroduce the
+    /// torn-file window this method exists to remove. Created with the same mode attribute as the target,
+    /// so the new secret is never loose even while it is still called something else. A failed write
+    /// removes the temp rather than leaving litter beside the real file.
+    @SuppressWarnings({"JBCT-SEQ-01", "JBCT-EX-01"})
+    private static Unit writeViaTempFile(Path path, String content, FileAttribute<?>... attributes) throws IOException {
+        var directory = path.toAbsolutePath().getParent();
+        var temp = Files.createTempFile(directory, path.getFileName() + ".", ".tmp", attributes);
+
+        try {
+            try (var channel = FileChannel.open(temp, StandardOpenOption.WRITE)) {
+                channel.write(ByteBuffer.wrap(content.getBytes(StandardCharsets.UTF_8)));
+                channel.force(true);
+            }
+
+            Files.move(temp, path, StandardCopyOption.ATOMIC_MOVE);
+        } catch (IOException | RuntimeException e) {
+            Files.deleteIfExists(temp);
+
+            throw e;
         }
 
         return Unit.unit();

--- a/aether/cli/src/test/java/org/pragmatica/aether/cli/cluster/BootstrapCleanupTest.java
+++ b/aether/cli/src/test/java/org/pragmatica/aether/cli/cluster/BootstrapCleanupTest.java
@@ -14,6 +14,7 @@ import org.pragmatica.aether.cli.cluster.BootstrapState.PhaseStatus;
 import org.pragmatica.aether.cli.cluster.CreatedResource.ProvisionedVm;
 import org.pragmatica.aether.cli.cluster.CreatedResource.SshKeyResource;
 import org.pragmatica.aether.environment.ComputeProvider;
+import org.pragmatica.aether.environment.EnvironmentError;
 import org.pragmatica.aether.environment.FirewallId;
 import org.pragmatica.aether.environment.InstanceId;
 import org.pragmatica.aether.environment.InstanceInfo;
@@ -1084,15 +1085,39 @@ class BootstrapCleanupTest {
     /// left-behind enumeration.
     static final class OrderRecordingComputeProvider implements ComputeProvider {
         private final List<String> calls;
+        private final Set<String> refusedTerminations;
+        private final Set<String> alreadyGoneInstances;
         private int firewallRefusals;
 
         OrderRecordingComputeProvider(List<String> calls, int firewallRefusals) {
+            this(calls, firewallRefusals, Set.of(), Set.of());
+        }
+
+        /// #994 verification NOTE-5 — `refusedTerminations` fail for a reason that is NOT
+        /// `InstanceNotFound`, so `tolerateAlreadyGone` does not absorb them and the VM stays unreaped:
+        /// the only way to reach `VmAccounting`'s middle branch, which had no test at all.
+        /// `alreadyGoneInstances` fail WITH `InstanceNotFound`, which IS absorbed — the case where the
+        /// count says "accounted for" about a server this cleanup never deleted.
+        OrderRecordingComputeProvider(List<String> calls,
+                                      int firewallRefusals,
+                                      Set<String> refusedTerminations,
+                                      Set<String> alreadyGoneInstances) {
             this.calls = calls;
             this.firewallRefusals = firewallRefusals;
+            this.refusedTerminations = refusedTerminations;
+            this.alreadyGoneInstances = alreadyGoneInstances;
         }
 
         @Override public Promise<Unit> terminate(InstanceId instanceId) {
             calls.add("terminate:" + instanceId.value());
+
+            if (alreadyGoneInstances.contains(instanceId.value())) {
+                return EnvironmentError.InstanceNotFound.instanceNotFound(instanceId).unwrap().promise();
+            }
+
+            if (refusedTerminations.contains(instanceId.value())) {
+                return new TestCause("provider refused to terminate " + instanceId.value()).promise();
+            }
 
             return Promise.success(Unit.unit());
         }
@@ -1132,6 +1157,27 @@ class BootstrapCleanupTest {
         var phases = new EnumMap<BootstrapPhase, PhaseStatus>(BootstrapPhase.class);
         for (var phase : BootstrapPhase.values()) {phases.put(phase, PhaseStatus.COMPLETED);}
         var resources = List.<CreatedResource>of(new ProvisionedVm("hetzner", "vm-1", "hetzner-eu", "core"),
+                                                 CreatedResource.CloudFirewall.cloudFirewall("hetzner",
+                                                                                             FirewallId.firewallId("77").unwrap(),
+                                                                                             sourceNameOrDefault("hetzner-eu"),
+                                                                                             firewallName("aether-test-hetzner-eu").unwrap()));
+        return BootstrapState.bootstrapState(CLUSTER_NAME,
+                                             "hash-1",
+                                             "2026-05-01T00:00:00Z",
+                                             phases,
+                                             resources,
+                                             List.of(),
+                                             List.of());
+    }
+
+    /// #994 verification NOTE-5 — TWO recorded VMs, so `deleted < recorded` is reachable. With one VM this
+    /// branch cannot be entered at all, which is why the two existing diagnostic fixtures only ever produced
+    /// 0/0 and 1/1.
+    private static BootstrapState stateWithTwoVmsThenFirewall() {
+        var phases = new EnumMap<BootstrapPhase, PhaseStatus>(BootstrapPhase.class);
+        for (var phase : BootstrapPhase.values()) {phases.put(phase, PhaseStatus.COMPLETED);}
+        var resources = List.<CreatedResource>of(new ProvisionedVm("hetzner", "vm-1", "hetzner-eu", "core"),
+                                                 new ProvisionedVm("hetzner", "vm-2", "hetzner-eu", "core"),
                                                  CreatedResource.CloudFirewall.cloudFirewall("hetzner",
                                                                                              FirewallId.firewallId("77").unwrap(),
                                                                                              sourceNameOrDefault("hetzner-eu"),
@@ -1235,9 +1281,12 @@ class BootstrapCleanupTest {
                                              new OrderRecordingComputeProvider(new ArrayList<>(), 99));
 
             assertTrue(result.isFailure(), "an undeletable firewall must still fail loudly");
-            assertTrue(stdout().contains("this cleanup deleted all 1 VM(s)"),
-                       () -> "with the ledger's VMs deleted, the observed state is exactly that — and only "
+            assertTrue(stdout().contains("this cleanup accounted for all 1 VM(s)"),
+                       () -> "with the ledger's VMs reaped, the observed state is exactly that — and only "
                              + "then is a provider-side release pending a legitimate reading; got:\n" + stdout());
+            assertFalse(stdout().contains("deleted all 1 VM(s)"),
+                        () -> "NOTE-5: 'deleted' overstates it — an already-gone VM also enters the reaped "
+                              + "set, so the honest word is 'accounted for'; got:\n" + stdout());
             assertFalse(stdout().contains("records NO VMs"),
                         () -> "the zero-VM wording must not appear when the ledger DID record one — that "
                               + "would make the message a constant rather than a reading; got:\n" + stdout());
@@ -1269,6 +1318,44 @@ class BootstrapCleanupTest {
             result.onSuccess(_ -> fail("precondition: cleanup must fail"))
                   .onFailure(cause -> assertTrue(cause.message().contains("NOT REAPED: [CloudFirewall] id=77"),
                                                  () -> "the cause must enumerate what was left behind: " + cause.message()));
+        }
+
+        /// #994 verification NOTE-5 — **the middle branch had NO test.** The two existing diagnostic
+        /// fixtures produce only 0/0 and 1/1, so `deleted < recorded` — the reading that tells an operator
+        /// exactly how many recorded VMs are still alive — was never executed, and a mutation that stops
+        /// `deleted` being an observation was undetectable (verifier probe V5, GREEN).
+        @Test
+        void cleanup_firewallRefusal_reportsThePartialCount_whenARecordedVmCouldNotBeDeleted() {
+            var result = cleanupWithProvider(stateWithTwoVmsThenFirewall(),
+                                             new OrderRecordingComputeProvider(new ArrayList<>(), 99, Set.of("vm-2"), Set.of()));
+
+            assertTrue(result.isFailure(), "precondition: one VM and the firewall could not be reaped");
+            assertTrue(stdout().contains("records 2 VM(s) for source 'hetzner-eu' and this cleanup deleted 1 of them"),
+                       () -> "the count must be READ from what cleanup observed, not asserted; got:\n" + stdout());
+            assertTrue(stdout().contains("1 recorded VM(s) were NOT deleted"),
+                       () -> "and the operator needs the remainder stated, because those are the ones still "
+                             + "billing; got:\n" + stdout());
+            assertFalse(stdout().contains("accounted for all"),
+                        () -> "the all-reaped wording must not appear when one VM survived; got:\n" + stdout());
+        }
+
+        /// #994 verification NOTE-5, the other half: an already-gone VM enters the reaped set through
+        /// `tolerateAlreadyGone`, so the full-count branch fires for a server this cleanup did NOT delete.
+        /// That is why the wording is "accounted for" — the adjacent line says which of the two it was.
+        @Test
+        void cleanup_firewallRefusal_doesNotClaimToHaveDeleted_aVmThatWasAlreadyGone() {
+            var result = cleanupWithProvider(stateWithVmThenFirewall(),
+                                             new OrderRecordingComputeProvider(new ArrayList<>(), 99, Set.of(), Set.of("vm-1")));
+
+            assertTrue(result.isFailure(), "precondition: the firewall could not be reaped");
+            assertTrue(stdout().contains("already gone — treating as destroyed"),
+                       () -> "precondition: the VM was absent, not deleted by this run; got:\n" + stdout());
+            assertTrue(stdout().contains("accounted for all 1 VM(s)"),
+                       () -> "it is still accounted for — the ledger's VM is not holding the firewall; "
+                             + "got:\n" + stdout());
+            assertFalse(stdout().contains("cleanup deleted all"),
+                        () -> "but this cleanup deleted nothing, and saying otherwise is the same class as "
+                              + "'servers are still detaching'; got:\n" + stdout());
         }
 
         /// A fully successful cleanup must print no leftover block at all — otherwise the block becomes noise

--- a/aether/cli/src/test/java/org/pragmatica/aether/cli/cluster/BootstrapCleanupTest.java
+++ b/aether/cli/src/test/java/org/pragmatica/aether/cli/cluster/BootstrapCleanupTest.java
@@ -5,6 +5,9 @@
 
 package org.pragmatica.aether.cli.cluster;
 
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.pragmatica.aether.environment.ClusterName;
 import org.pragmatica.aether.cli.cluster.BootstrapState.PhaseStatus;
@@ -31,6 +34,9 @@ import org.pragmatica.lang.Promise;
 import org.pragmatica.lang.Result;
 import org.pragmatica.lang.Unit;
 
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.EnumMap;
 import java.util.List;
@@ -1050,6 +1056,215 @@ class BootstrapCleanupTest {
 
         private static AssertionError fail(String name) {
             return new AssertionError("Test stub: '" + name + "' must not be called by SSH-key cleanup");
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // #994 — delete ORDER, the honest refusal diagnostic, and the enumeration of what was left behind.
+    // ---------------------------------------------------------------------------------------------
+
+    /// Records VM terminations and firewall disposals into ONE ordered list, so a test can assert the
+    /// ORDER of provider calls rather than merely that both happened. `firewallRefusals` scripts a firewall
+    /// the provider will not release, which is the only way to reach the retry diagnostic and the
+    /// left-behind enumeration.
+    static final class OrderRecordingComputeProvider implements ComputeProvider {
+        private final List<String> calls;
+        private int firewallRefusals;
+
+        OrderRecordingComputeProvider(List<String> calls, int firewallRefusals) {
+            this.calls = calls;
+            this.firewallRefusals = firewallRefusals;
+        }
+
+        @Override public Promise<Unit> terminate(InstanceId instanceId) {
+            calls.add("terminate:" + instanceId.value());
+
+            return Promise.success(Unit.unit());
+        }
+
+        @Override public Promise<Unit> disposeIngress(FirewallId ingressId) {
+            calls.add("disposeIngress:" + ingressId.value());
+
+            if (firewallRefusals > 0) {
+                firewallRefusals--;
+
+                return new HetznerError.ApiError(422,
+                                                 "resource_in_use",
+                                                 "firewall with ID " + ingressId.value() + " is still in use").promise();
+            }
+
+            return Promise.success(Unit.unit());
+        }
+
+        @Override public Promise<InstanceInfo> createFrom(ProvisionRequest request) {
+            return new TestCause("provision not used").promise();
+        }
+
+        @Override public Promise<List<InstanceInfo>> listInstances() {
+            return Promise.success(List.of());
+        }
+
+        @Override public Promise<InstanceInfo> instanceStatus(InstanceId instanceId) {
+            return new TestCause("instanceStatus not used").promise();
+        }
+    }
+
+    /// A ledger that records the VM FIRST and the firewall SECOND. This ordering is what makes the rank
+    /// sort load-bearing: `cleanupWith` reverses creation order, so reverse-of-creation ALONE would issue
+    /// the firewall delete first — exactly the 422 sequence #994 reports. Only `destructionRank` puts the
+    /// VM back in front, so removing or inverting that sort reddens the test below.
+    private static BootstrapState stateWithVmThenFirewall() {
+        var phases = new EnumMap<BootstrapPhase, PhaseStatus>(BootstrapPhase.class);
+        for (var phase : BootstrapPhase.values()) {phases.put(phase, PhaseStatus.COMPLETED);}
+        var resources = List.<CreatedResource>of(new ProvisionedVm("hetzner", "vm-1", "hetzner-eu", "core"),
+                                                 CreatedResource.CloudFirewall.cloudFirewall("hetzner",
+                                                                                             FirewallId.firewallId("77").unwrap(),
+                                                                                             sourceNameOrDefault("hetzner-eu"),
+                                                                                             firewallName("aether-test-hetzner-eu").unwrap()));
+        return BootstrapState.bootstrapState(CLUSTER_NAME,
+                                             "hash-1",
+                                             "2026-05-01T00:00:00Z",
+                                             phases,
+                                             resources,
+                                             List.of(),
+                                             List.of());
+    }
+
+    private static Result<Unit> cleanupWithProvider(BootstrapState state, ComputeProvider compute) {
+        return BootstrapCleanup.cleanupWith(state,
+                                            BootstrapCleanup.CleanupResolvers.cleanupResolvers()
+                                                    .withCloudComputeFallback(_ -> Result.success(compute))
+                                                    .withSleeper(_ -> {}));
+    }
+
+    @Nested
+    class DestructionOrder {
+
+        /// #994 expectation 1. Hetzner refuses to delete a firewall still applied to a live server, so every
+        /// server must be deleted BEFORE the thing it references. Asserted on the ORDER of provider calls,
+        /// against a ledger whose record order is the opposite — so the guarantee comes from the rank sort
+        /// and not from an accident of which phase recorded first.
+        @Test
+        void cleanup_deletesVmBeforeFirewall_whenLedgerRecordsVmFirst() {
+            var calls = new ArrayList<String>();
+
+            var result = cleanupWithProvider(stateWithVmThenFirewall(), new OrderRecordingComputeProvider(calls, 0));
+
+            assertTrue(result.isSuccess(), () -> "both deletes must succeed: " + result);
+            assertEquals(List.of("terminate:vm-1", "disposeIngress:77"),
+                         calls,
+                         "VMs must be deleted BEFORE the firewall they hold; the reverse order is the 422 "
+                         + "resource_in_use sequence that stranded two paid servers on 2026-09-11");
+        }
+    }
+
+    @Nested
+    class FirewallRefusalDiagnostic {
+
+        private final ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+        private final ByteArrayOutputStream err = new ByteArrayOutputStream();
+
+        private PrintStream originalOut;
+
+        private PrintStream originalErr;
+
+        @BeforeEach
+        void captureStreams() {
+            originalOut = System.out;
+            originalErr = System.err;
+            System.setOut(new PrintStream(out, true, StandardCharsets.UTF_8));
+            System.setErr(new PrintStream(err, true, StandardCharsets.UTF_8));
+        }
+
+        @AfterEach
+        void restoreStreams() {
+            System.setOut(originalOut);
+            System.setErr(originalErr);
+        }
+
+        private String stdout() {
+            return out.toString(StandardCharsets.UTF_8);
+        }
+
+        private String stderr() {
+            return err.toString(StandardCharsets.UTF_8);
+        }
+
+        /// #994 expectation 2 — the retry line used to read "servers are still detaching; retrying...", which
+        /// asserted a mechanism that was NOT running: the ledger held no VMs, so no server delete had been
+        /// issued and nothing was detaching. That sent an operator to look at server shutdown while the real
+        /// problem was the ledger. The replacement states only what was observed.
+        @Test
+        void cleanup_firewallRefusal_statesObservedState_neverADetachingProcess() {
+            var result = cleanupWithProvider(stateWithFirewall(77L),
+                                             new OrderRecordingComputeProvider(new ArrayList<>(), 99));
+
+            assertTrue(result.isFailure(), "an undeletable firewall must still fail loudly");
+            assertFalse(stdout().contains("detaching"),
+                        () -> "the diagnostic must not claim servers are detaching when no server delete was "
+                              + "issued; got:\n" + stdout());
+            assertTrue(stdout().contains("the bootstrap ledger records NO VMs for source 'hetzner-eu'"),
+                       () -> "it must state the OBSERVED ledger state — zero VM records is the fact that "
+                             + "explains the refusal; got:\n" + stdout());
+            assertTrue(stdout().contains("resource_in_use"),
+                       () -> "the provider's own refusal must be quoted verbatim, not paraphrased; got:\n" + stdout());
+        }
+
+        /// Positive control for the assertion above: the SAME diagnostic, with VMs in the ledger that this
+        /// cleanup deleted. Without this case, "does not contain 'detaching'" is also satisfied by a
+        /// diagnostic that says nothing at all, and "records NO VMs" could be a hard-coded string.
+        @Test
+        void cleanup_firewallRefusal_reportsVmsItDeleted_whenLedgerRecordsThem() {
+            var result = cleanupWithProvider(stateWithVmThenFirewall(),
+                                             new OrderRecordingComputeProvider(new ArrayList<>(), 99));
+
+            assertTrue(result.isFailure(), "an undeletable firewall must still fail loudly");
+            assertTrue(stdout().contains("this cleanup deleted all 1 VM(s)"),
+                       () -> "with the ledger's VMs deleted, the observed state is exactly that — and only "
+                             + "then is a provider-side release pending a legitimate reading; got:\n" + stdout());
+            assertFalse(stdout().contains("records NO VMs"),
+                        () -> "the zero-VM wording must not appear when the ledger DID record one — that "
+                              + "would make the message a constant rather than a reading; got:\n" + stdout());
+        }
+
+        /// #994 expectation 3. "orphan resources may remain" tells an operator that something may be billing
+        /// without telling them what to delete; the list had to be rebuilt by hand from `hcloud server list`.
+        @Test
+        void cleanup_enumeratesEveryResourceLeftBehind_withTypeAndId() {
+            var result = cleanupWithProvider(stateWithFirewall(77L),
+                                             new OrderRecordingComputeProvider(new ArrayList<>(), 99));
+
+            assertTrue(result.isFailure(), "precondition: the firewall could not be reaped");
+            assertTrue(stderr().contains("NOT REAPED"), () -> "the leftover block must be printed; got:\n" + stderr());
+            assertTrue(stderr().contains("[CloudFirewall] id=77"),
+                       () -> "every unreaped resource must be named by TYPE and ID; got:\n" + stderr());
+            assertTrue(stderr().contains("cloud-reaper.sh"),
+                       () -> "and the operator must be told what finishes the job; got:\n" + stderr());
+        }
+
+        /// The enumeration has to survive into the CAUSE, not only stdout: the bootstrap failure path wraps
+        /// this message into `BootstrapFailedWithOrphans`, which is what an operator sees on a non-zero exit
+        /// after the transcript has scrolled away.
+        @Test
+        void cleanup_failureCause_carriesTheEnumeration_notJustTheTranscript() {
+            var result = cleanupWithProvider(stateWithFirewall(77L),
+                                             new OrderRecordingComputeProvider(new ArrayList<>(), 99));
+
+            result.onSuccess(_ -> fail("precondition: cleanup must fail"))
+                  .onFailure(cause -> assertTrue(cause.message().contains("NOT REAPED: [CloudFirewall] id=77"),
+                                                 () -> "the cause must enumerate what was left behind: " + cause.message()));
+        }
+
+        /// A fully successful cleanup must print no leftover block at all — otherwise the block becomes noise
+        /// an operator learns to skip, which is how #994's honest-but-useless message got ignored.
+        @Test
+        void cleanup_printsNoLeftBehindBlock_whenEverythingWasReaped() {
+            var result = cleanupWithProvider(stateWithVmThenFirewall(), new OrderRecordingComputeProvider(new ArrayList<>(), 0));
+
+            assertTrue(result.isSuccess(), () -> "precondition: everything reaped: " + result);
+            assertFalse(stderr().contains("NOT REAPED"),
+                        () -> "nothing was left behind, so nothing must be enumerated; got:\n" + stderr());
         }
     }
 }

--- a/aether/cli/src/test/java/org/pragmatica/aether/cli/cluster/BootstrapCleanupTest.java
+++ b/aether/cli/src/test/java/org/pragmatica/aether/cli/cluster/BootstrapCleanupTest.java
@@ -658,7 +658,7 @@ class BootstrapCleanupTest {
                            new SshKey(99L, "aether-bootstrap-production-op", "fp-99", "pk-99"),
                            new SshKey(43L, "aether-bootstrap-other-op", "fp-43", "pk-43"),
                            new SshKey(44L, "someones-laptop", "fp-44", "pk-44"));
-        var client = new SweepingHetznerClient(keys, deleteCalls, Set.of());
+        var client = new SweepingHetznerClient(keys, deleteCalls, Set.of(), Set.of());
         var state = stateWithHetznerHandle();
         var env = Map.of(NON_DEFAULT_TOKEN_ENV, PROD_TOKEN_VALUE);
 
@@ -682,7 +682,7 @@ class BootstrapCleanupTest {
     void destroy_sshKeyAlreadyGone_toleratedNoFailure() {
         var deleteCalls = new ArrayList<Long>();
         var keys = List.of(new SshKey(42L, "aether-bootstrap-prod-op", "fp-42", "pk-42"));
-        var client = new SweepingHetznerClient(keys, deleteCalls, Set.of(42L));
+        var client = new SweepingHetznerClient(keys, deleteCalls, Set.of(42L), Set.of());
         var state = stateWithHetznerHandle();
         var env = Map.of(NON_DEFAULT_TOKEN_ENV, PROD_TOKEN_VALUE);
 
@@ -712,7 +712,7 @@ class BootstrapCleanupTest {
         var envReads = new ArrayList<String>();
         var factoryTokens = new ArrayList<String>();
         var servers = List.of(vmServer(101L, "prod-worker-r123-0"), vmServer(102L, "prod-worker-r123-1"));
-        var client = new VmSweepingHetznerClient(servers, deleteCalls, Set.of(), selectors);
+        var client = new VmSweepingHetznerClient(servers, deleteCalls, Set.of(), selectors, Set.of());
         var state = stateWithHetznerHandle();
         var env = Map.of(NON_DEFAULT_TOKEN_ENV, PROD_TOKEN_VALUE);
 
@@ -737,7 +737,7 @@ class BootstrapCleanupTest {
     @Test
     void destroy_vmSweep_protectedCluster_refusedBeforeAnyProviderCall() {
         var factoryTokens = new ArrayList<String>();
-        var client = new VmSweepingHetznerClient(List.of(), new ArrayList<>(), Set.of(), new ArrayList<>());
+        var client = new VmSweepingHetznerClient(List.of(), new ArrayList<>(), Set.of(), new ArrayList<>(), Set.of());
         var state = stateWithHetznerHandle();
         var env = Map.of(NON_DEFAULT_TOKEN_ENV, PROD_TOKEN_VALUE);
 
@@ -759,7 +759,7 @@ class BootstrapCleanupTest {
     void destroy_vmSweep_alreadyGoneVm_tolerated() {
         var deleteCalls = new ArrayList<Long>();
         var servers = List.of(vmServer(101L, "prod-core-0"), vmServer(102L, "prod-worker-r1-0"));
-        var client = new VmSweepingHetznerClient(servers, deleteCalls, Set.of(101L), new ArrayList<>());
+        var client = new VmSweepingHetznerClient(servers, deleteCalls, Set.of(101L), new ArrayList<>(), Set.of());
         var state = stateWithHetznerHandle();
         var env = Map.of(NON_DEFAULT_TOKEN_ENV, PROD_TOKEN_VALUE);
 
@@ -892,7 +892,7 @@ class BootstrapCleanupTest {
         var keys = List.of(new SshKey(42L, "aether-bootstrap-prod-op", "fp-42", "pk-42"));
         var unmappedHandle = SourceCleanupHandle.sourceCleanupHandle("hetzner", Option.some("fsn1"), Map.of());
         var state = stateWithSshKeyAndHandle(unmappedHandle);
-        var sweepingClient = new SweepingHetznerClient(keys, deleteCalls, Set.of());
+        var sweepingClient = new SweepingHetznerClient(keys, deleteCalls, Set.of(), Set.of());
 
         var result = BootstrapCleanup.sweepClusterSshKeys(state,
                                                           clusterName("prod").unwrap(),
@@ -918,10 +918,14 @@ class BootstrapCleanupTest {
     /// surface as a Hetzner 404 `not_found` `ApiError` (already-gone). All other operations throw.
     /// VM-sweep stub: only the label-scoped listing and server deletion are legal; everything else
     /// is a stub failure so the sweep cannot silently widen its surface.
+    /// `failIds` surface as a Hetzner 422 `resource_in_use` — NOT a 404, so `tolerateServerAlreadyGone`
+    /// does not absorb it and the sweep genuinely fails. That is the arm #994 verification finding SF-4
+    /// needs: a swept, billable VM the sweep could not delete.
     record VmSweepingHetznerClient(List<Server> servers,
                                    List<Long> deleteCalls,
                                    Set<Long> goneIds,
-                                   List<String> selectors) implements HetznerClient {
+                                   List<String> selectors,
+                                   Set<Long> failIds) implements HetznerClient {
         @Override public Promise<List<Server>> listServers(String labelSelector) {
             selectors.add(labelSelector);
             return Promise.success(servers);
@@ -931,6 +935,9 @@ class BootstrapCleanupTest {
             deleteCalls.add(serverId);
             if (goneIds.contains(serverId)) {
                 return new HetznerError.ApiError(404, "not_found", "server not found").promise();
+            }
+            if (failIds.contains(serverId)) {
+                return new HetznerError.ApiError(422, "resource_in_use", "server is still in use").promise();
             }
             return Promise.success(Unit.unit());
         }
@@ -969,7 +976,12 @@ class BootstrapCleanupTest {
         }
     }
 
-    record SweepingHetznerClient(List<SshKey> keys, List<Long> deleteCalls, Set<Long> goneIds) implements HetznerClient {
+    /// `failIds` surface as a Hetzner 403 — not a 404 — so `tolerateAlreadyGone` does not absorb it and the
+    /// key sweep genuinely fails (#994 verification finding SF-4: an orphaned credential left on the account).
+    record SweepingHetznerClient(List<SshKey> keys,
+                                 List<Long> deleteCalls,
+                                 Set<Long> goneIds,
+                                 Set<Long> failIds) implements HetznerClient {
         @Override public Promise<List<SshKey>> listSshKeys() {
             return Promise.success(keys);
         }
@@ -978,6 +990,9 @@ class BootstrapCleanupTest {
             deleteCalls.add(sshKeyId);
             if (goneIds.contains(sshKeyId)) {
                 return new HetznerError.ApiError(404, "not_found", "ssh key not found").promise();
+            }
+            if (failIds.contains(sshKeyId)) {
+                return new HetznerError.ApiError(403, "forbidden", "ssh key is protected").promise();
             }
             return Promise.success(Unit.unit());
         }
@@ -1265,6 +1280,128 @@ class BootstrapCleanupTest {
             assertTrue(result.isSuccess(), () -> "precondition: everything reaped: " + result);
             assertFalse(stderr().contains("NOT REAPED"),
                         () -> "nothing was left behind, so nothing must be enumerated; got:\n" + stderr());
+        }
+    }
+
+    /// #994 verification finding SF-4 — `destroy` has THREE teardown paths and the `NOT REAPED` enumeration
+    /// covered one. The claim "a partial cleanup enumerates every resource it left behind, by type and id"
+    /// was therefore true of `cleanupWith` and **false of the command**, and the paths it missed are the
+    /// label-scoped VM sweep and the ssh-key sweep — where the UNRECORDED billable VMs that are #994's whole
+    /// theme actually live. Both now route their failures through `ReapFailure`.
+    @Nested
+    class SweepEnumeration {
+
+        private final ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+        private final ByteArrayOutputStream err = new ByteArrayOutputStream();
+
+        private PrintStream originalOut;
+
+        private PrintStream originalErr;
+
+        @BeforeEach
+        void captureStreams() {
+            originalOut = System.out;
+            originalErr = System.err;
+            System.setOut(new PrintStream(out, true, StandardCharsets.UTF_8));
+            System.setErr(new PrintStream(err, true, StandardCharsets.UTF_8));
+        }
+
+        @AfterEach
+        void restoreStreams() {
+            System.setOut(originalOut);
+            System.setErr(originalErr);
+        }
+
+        private String stderr() {
+            return err.toString(StandardCharsets.UTF_8);
+        }
+
+        private Result<Unit> sweepVms(Set<Long> failIds) {
+            var servers = List.of(vmServer(101L, "prod-worker-r123-0"), vmServer(102L, "prod-worker-r123-1"));
+            var client = new VmSweepingHetznerClient(servers, new ArrayList<>(), Set.of(), new ArrayList<>(), failIds);
+
+            return BootstrapCleanup.sweepClusterVms(stateWithHetznerHandle(),
+                                                    clusterName("prod").unwrap(),
+                                                    recordingGetenv(Map.of(NON_DEFAULT_TOKEN_ENV, PROD_TOKEN_VALUE),
+                                                                    new ArrayList<>()),
+                                                    sweepingClientFactory(client, new ArrayList<>()));
+        }
+
+        private Result<Unit> sweepKeys(Set<Long> failIds) {
+            var keys = List.of(new SshKey(42L, "aether-bootstrap-prod-op", "fp-42", "pk-42"));
+            var client = new SweepingHetznerClient(keys, new ArrayList<>(), Set.of(), failIds);
+
+            return BootstrapCleanup.sweepClusterSshKeys(stateWithHetznerHandle(),
+                                                        clusterName("prod").unwrap(),
+                                                        recordingGetenv(Map.of(NON_DEFAULT_TOKEN_ENV, PROD_TOKEN_VALUE),
+                                                                        new ArrayList<>()),
+                                                        sweepingClientFactory(client, new ArrayList<>()));
+        }
+
+        /// The sweep reaps VMs the LEDGER NEVER RECORDED, so when it cannot delete one there is no other
+        /// record of that server anywhere — which makes the id the only thing standing between the operator
+        /// and a server that bills indefinitely. `"VM sweep failed: <message>"` carried neither type nor id.
+        ///
+        /// Both failing ids are asserted, because "every" is the word the claim uses and a block printing
+        /// only the first satisfies a single-resource test exactly as well.
+        @Test
+        void vmSweep_enumeratesEverySweptVmItCouldNotDelete_withTypeAndId() {
+            var result = sweepVms(Set.of(101L, 102L));
+
+            assertTrue(result.isFailure(), "precondition: the 422 refusals are not tolerated");
+            assertTrue(stderr().contains("NOT REAPED"),
+                       () -> "the sweep must print the leftover block, not just a joined string; got:\n" + stderr());
+            assertTrue(stderr().contains("[ProvisionedVm] id=101"),
+                       () -> "by type and id; got:\n" + stderr());
+            assertTrue(stderr().contains("[ProvisionedVm] id=102"),
+                       () -> "EVERY one of them, not only the first; got:\n" + stderr());
+            assertTrue(stderr().contains("cloud-reaper.sh"),
+                       () -> "and what finishes the job; got:\n" + stderr());
+        }
+
+        /// The enumeration has to survive into the CAUSE as well: `ClusterDestroyCommand.runVmSweep` prints
+        /// `cause.message()`, and that line is what an operator still has after the transcript scrolls.
+        @Test
+        void vmSweep_failureCause_carriesTheEnumeration_notJustTheTranscript() {
+            sweepVms(Set.of(101L)).onSuccess(_ -> fail("precondition: the sweep must fail"))
+                                  .onFailure(cause -> assertTrue(cause.message().contains("NOT REAPED: [ProvisionedVm] id=101"),
+                                                                 () -> "the cause must enumerate: " + cause.message()));
+        }
+
+        /// Positive control for both assertions above. Without it, "stderr contains NOT REAPED" proves only
+        /// that some failure path printed something, and the block could be an always-on line.
+        @Test
+        void vmSweep_printsNoLeftBehindBlock_whenEverySweptVmWasDeleted() {
+            var result = sweepVms(Set.of());
+
+            assertTrue(result.isSuccess(), () -> "precondition: both deletes succeed: " + result);
+            assertFalse(stderr().contains("NOT REAPED"),
+                        () -> "a complete sweep leaves nothing behind, so it must enumerate nothing; got:\n" + stderr());
+        }
+
+        /// An undeleted cluster-scoped key is an orphaned credential on the account, and `SshKeyResource`
+        /// carries its name as well as its id — so this is the one synthesized-free case: every component of
+        /// the enumerated resource is a value the sweep actually observed.
+        @Test
+        void sshKeySweep_enumeratesEveryKeyItCouldNotDelete_withTypeAndId() {
+            var result = sweepKeys(Set.of(42L));
+
+            assertTrue(result.isFailure(), "precondition: a 403 is not an already-gone 404");
+            assertTrue(stderr().contains("NOT REAPED"), () -> "got:\n" + stderr());
+            assertTrue(stderr().contains("[SshKeyResource] id=42"),
+                       () -> "by type and id; got:\n" + stderr());
+            assertTrue(stderr().contains("aether-bootstrap-prod-op"),
+                       () -> "and by the name the operator sees in 'hcloud ssh-key list'; got:\n" + stderr());
+        }
+
+        @Test
+        void sshKeySweep_printsNoLeftBehindBlock_whenEveryKeyWasDeleted() {
+            var result = sweepKeys(Set.of());
+
+            assertTrue(result.isSuccess(), () -> "precondition: the delete succeeds: " + result);
+            assertFalse(stderr().contains("NOT REAPED"),
+                        () -> "positive control for the case above; got:\n" + stderr());
         }
     }
 }

--- a/aether/cli/src/test/java/org/pragmatica/aether/cli/cluster/BootstrapPhaseProvisionLedgerTest.java
+++ b/aether/cli/src/test/java/org/pragmatica/aether/cli/cluster/BootstrapPhaseProvisionLedgerTest.java
@@ -10,28 +10,53 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.pragmatica.aether.cli.cluster.BootstrapPhaseProvision.ZoneProvisioner;
+import org.pragmatica.aether.cli.cluster.ClusterBootstrapOrchestrator.BootstrapContext;
 import org.pragmatica.aether.config.cluster.CloudProviderName;
+import org.pragmatica.aether.config.cluster.ClusterBootstrapConfig;
 import org.pragmatica.aether.config.cluster.ClusterBootstrapConfigParser;
+import org.pragmatica.aether.config.cluster.ClusterIdentity;
+import org.pragmatica.aether.config.cluster.CoreTopology;
+import org.pragmatica.aether.config.cluster.InfrastructureConfig;
 import org.pragmatica.aether.config.cluster.LoadBalancerMode;
+import org.pragmatica.aether.config.cluster.NetworkingType;
 import org.pragmatica.aether.config.cluster.NodeRole;
+import org.pragmatica.aether.config.cluster.OperationsConfig;
 import org.pragmatica.aether.config.cluster.RoleSubTable;
 import org.pragmatica.aether.config.cluster.SourceProfile;
 import org.pragmatica.aether.config.cluster.SourceType;
 import org.pragmatica.aether.environment.ClusterName;
+import org.pragmatica.aether.environment.ComputeProvider;
 import org.pragmatica.aether.environment.EnvironmentError;
 import org.pragmatica.aether.environment.FirewallId;
+import org.pragmatica.aether.environment.InstanceId;
+import org.pragmatica.aether.environment.InstanceInfo;
+import org.pragmatica.aether.environment.InstanceStatus;
+import org.pragmatica.aether.environment.InstanceType;
+import org.pragmatica.aether.environment.ProvisionRequest;
+import org.pragmatica.aether.environment.ProvisionSpec;
 import org.pragmatica.aether.environment.ProvisionedNode;
 import org.pragmatica.aether.environment.SourceName;
 import org.pragmatica.lang.Option;
+import org.pragmatica.lang.Promise;
 import org.pragmatica.lang.Result;
+import org.pragmatica.lang.Unit;
 
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.DirectoryNotEmptyException;
+import java.nio.file.Files;
+import java.security.SecureRandom;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HexFormat;
 import java.util.List;
 import java.util.Map;
 
 import static org.pragmatica.aether.environment.ClusterName.clusterName;
 import static org.pragmatica.aether.environment.FirewallName.firewallName;
 import static org.pragmatica.aether.environment.SourceName.sourceNameOrDefault;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -53,7 +78,13 @@ import static org.pragmatica.lang.Result.success;
 /// a cluster name owned by this test, deleted before and after each case.
 class BootstrapPhaseProvisionLedgerTest {
 
-    private static final ClusterName CLUSTER_NAME = clusterName("ledger-994-test").unwrap();
+    /// #994 verification NOTE-7 — the cluster name carries a per-JVM random suffix, and `@AfterEach`
+    /// removes the DIRECTORY as well as the state file. `AETHER_DIR` is an interface constant resolved from
+    /// `user.home`, so these tests genuinely write the owner's home; with a fixed name, two concurrent
+    /// `aether/cli` reactors — the normal arrangement in this workspace, with nine working trees — share one
+    /// path and one test's `@BeforeEach` delete races the other's write. Same class as #939's fixed port.
+    /// Mirrors `BootstrapStatePersistencePermissionsTest`, which already had this shape.
+    private static final ClusterName CLUSTER_NAME = uniqueClusterName();
 
     private static final SourceName SOURCE = sourceNameOrDefault("hetzner-eu");
 
@@ -61,23 +92,41 @@ class BootstrapPhaseProvisionLedgerTest {
 
     private static final String RAW_TOML = """
         [cluster]
-        name = "ledger-994-test"
+        name = "%s"
 
         %s
         type = "cloud"
         provider = "hetzner"
         credentials = "${env:HCLOUD_TOKEN}"
         region = "eu-central"
-        """.formatted("[" + ClusterBootstrapConfigParser.SOURCE_PREFIX + "hetzner-eu]");
+        """.formatted(CLUSTER_NAME.value(),
+                      "[" + ClusterBootstrapConfigParser.SOURCE_PREFIX + "hetzner-eu]");
+
+    private static ClusterName uniqueClusterName() {
+        var suffix = new byte[6];
+
+        new SecureRandom().nextBytes(suffix);
+
+        return clusterName("ledger-994-test-" + HexFormat.of().formatHex(suffix)).unwrap();
+    }
 
     @BeforeEach
     void clearState() {
         var _ = BootstrapStatePersistence.delete(CLUSTER_NAME);
     }
 
+    /// `deleteIfExists` on a directory refuses when it is not empty, and that refusal is the safety
+    /// property here: anything unexpected in the cluster directory is left alone rather than swept.
     @AfterEach
-    void removeState() {
+    @SuppressWarnings("JBCT-EX-01")
+    void removeState() throws Exception {
         var _ = BootstrapStatePersistence.delete(CLUSTER_NAME);
+
+        try {
+            Files.deleteIfExists(BootstrapStatePersistence.AETHER_DIR.resolve(CLUSTER_NAME.value()));
+        } catch (DirectoryNotEmptyException _) {
+            // Something else is in there — not this test's to remove.
+        }
     }
 
     /// The ledger exactly as Phase 3 (CREATE_FIREWALL) leaves it: a firewall and nothing else. This is the
@@ -365,6 +414,295 @@ class BootstrapPhaseProvisionLedgerTest {
                                      .onEmpty(() -> fail("the snapshot fallback must still write a state file"))
                                      .onPresent(state -> assertEquals(BootstrapState.PhaseStatus.FAILED,
                                                                       state.phases().get(BootstrapPhase.PROVISION)));
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // #994 verification finding SF-2 — the RECORDING IS WIRED INTO PRODUCTION, pinned at the real call
+    // site rather than one level below it.
+    // ---------------------------------------------------------------------------------------------
+
+    private static ClusterBootstrapConfig configWith(SourceProfile source) {
+        return ClusterBootstrapConfig.clusterBootstrapConfig("1.0.0",
+                                                            ClusterIdentity.clusterIdentity(CLUSTER_NAME.value(), "1.0.0").unwrap(),
+                                                            CoreTopology.defaultCoreTopology(),
+                                                            Map.of(SOURCE.value(), source),
+                                                            Map.of(),
+                                                            InfrastructureConfig.infrastructureConfig(NetworkingType.MANUAL),
+                                                            OperationsConfig.defaultOperationsConfig());
+    }
+
+    private static BootstrapContext contextFor(SourceProfile source) {
+        var state = BootstrapState.initialState(CLUSTER_NAME, "hash-1", "2026-09-11T00:00:00Z")
+                                  .withClusterSecret("test-secret-xyz");
+
+        return BootstrapContext.bootstrapContext(configWith(source), state, List.of(), List.of())
+                               .withClusterSecret("test-secret-xyz")
+                               .withRawTomlContent(RAW_TOML);
+    }
+
+    /// The same scripted shape as [QuotaLimitedProvisioner], one layer lower: a real [ComputeProvider], so
+    /// the test enters through `provisionCloudRoleGroup` — the function `provisionCloudWithCompute` actually
+    /// calls — and everything between it and the ledger is production code.
+    private static final class QuotaLimitedCompute implements ComputeProvider {
+        private final int successes;
+        private final List<ProvisionSpec> provisioned = new ArrayList<>();
+
+        private QuotaLimitedCompute(int successes) {
+            this.successes = successes;
+        }
+
+        @Override
+        public Promise<InstanceInfo> provision(ProvisionSpec spec) {
+            provisioned.add(spec);
+
+            return provisioned.size() <= successes
+                   ? Promise.success(info(provisioned.size() - 1))
+                   : EnvironmentError.provisionFailed(new RuntimeException("Hetzner API error 403 "
+                                                                        + "(resource_limit_exceeded): dedicated core limit exceeded"))
+                                     .promise();
+        }
+
+        private static InstanceInfo info(int index) {
+            return new InstanceInfo(new InstanceId("server-" + index),
+                                    InstanceStatus.RUNNING,
+                                    List.of("203.0.113." + index),
+                                    InstanceType.ON_DEMAND,
+                                    Map.of());
+        }
+
+        @Override public Promise<InstanceInfo> createFrom(ProvisionRequest request) {return Promise.success(info(0));}
+
+        @Override public Promise<Unit> terminate(InstanceId instanceId) {return Promise.success(Unit.unit());}
+
+        @Override public Promise<List<InstanceInfo>> listInstances() {return Promise.success(List.of());}
+
+        @Override public Promise<InstanceInfo> instanceStatus(InstanceId instanceId) {return Promise.success(info(0));}
+    }
+
+    @Nested
+    class ProductionWiresTheRecorder {
+
+        /// #994 verification finding SF-2. `provisionAndRecordRoleGroup` being pinned says nothing about
+        /// whether production still CALLS it: replacing the call in `provisionCloudRoleGroup` with a direct
+        /// `rotateZonesForRoleGroup` — deleting the whole recording behaviour — left all 724 tests green.
+        /// That is the same defect class as #994 itself, which was a correct mechanism that never ran.
+        ///
+        /// So this drives `provisionCloudRoleGroup`, the function `provisionCloudWithCompute` calls, through
+        /// a real `ComputeProvider`. Every layer between the provider's "created" and the state file is
+        /// production code.
+        @Test
+        void provisionCloudRoleGroup_recordsEveryVmCreated_whenALaterNodeIsRefused() {
+            seedFirewallOnlyLedger();
+            var source = cloudSource();
+            var compute = new QuotaLimitedCompute(2);
+
+            var result = BootstrapPhaseProvision.provisionCloudRoleGroup(compute,
+                                                                         contextFor(source),
+                                                                         SOURCE,
+                                                                         NodeRole.CORE,
+                                                                         3,
+                                                                         source,
+                                                                         CLUSTER_NAME,
+                                                                         0);
+
+            assertTrue(result.isFailure(), "the group must still fail — recording is not a recovery");
+            assertEquals(3, compute.provisioned.size(), "all three nodes must be attempted, the third refused");
+            assertEquals(List.of("server-0", "server-1"),
+                         persistedVms().stream().map(CreatedResource.ProvisionedVm::resourceId).toList(),
+                         "the VMs must reach the PERSISTED ledger through production's OWN call into "
+                         + "provisionAndRecordRoleGroup — bypassing it here is exactly the regression #994 was");
+        }
+
+        /// Positive control: the assertion above is about records APPEARING, so it cannot be satisfied by a
+        /// provisioner that never ran. All three succeed, all three are recorded with the role and source
+        /// teardown resolves credentials by.
+        @Test
+        void provisionCloudRoleGroup_recordsTheWholeGroup_whenEveryNodeSucceeds() {
+            seedFirewallOnlyLedger();
+            var source = cloudSource();
+            var compute = new QuotaLimitedCompute(3);
+
+            var result = BootstrapPhaseProvision.provisionCloudRoleGroup(compute,
+                                                                         contextFor(source),
+                                                                         SOURCE,
+                                                                         NodeRole.CORE,
+                                                                         3,
+                                                                         source,
+                                                                         CLUSTER_NAME,
+                                                                         0);
+
+            assertTrue(result.isSuccess(), () -> "precondition: every node is created: " + result);
+            assertEquals(List.of("server-0", "server-1", "server-2"),
+                         persistedVms().stream().map(CreatedResource.ProvisionedVm::resourceId).toList());
+            assertEquals(List.of("core", "core", "core"),
+                         persistedVms().stream().map(CreatedResource.ProvisionedVm::role).toList(),
+                         "the role reaches the ledger from the call site's own argument, not from parsing a node id");
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // #994 verification finding SF-1 — the ledger is the only record of money-bearing resources, so every
+    // way a write or a read can fail has to be AUDIBLE, and an unreadable ledger must never be overwritten.
+    // ---------------------------------------------------------------------------------------------
+
+    @Nested
+    class LedgerFailuresAreLoudAndNonDestructive {
+
+        private final ByteArrayOutputStream err = new ByteArrayOutputStream();
+
+        private PrintStream originalErr;
+
+        @BeforeEach
+        void captureErr() {
+            originalErr = System.err;
+            System.setErr(new PrintStream(err, true, StandardCharsets.UTF_8));
+        }
+
+        @AfterEach
+        void restoreErr() {
+            System.setErr(originalErr);
+        }
+
+        private String stderr() {
+            return err.toString(StandardCharsets.UTF_8);
+        }
+
+        /// Writes a HALF of a real, valid state file — the shape `TRUNCATE_EXISTING` used to leave behind
+        /// when the process died mid-write, and the shape the verifier measured loads as EMPTY.
+        @SuppressWarnings("JBCT-EX-01")
+        private byte[] tearTheLedger() throws Exception {
+            seedFirewallOnlyLedger();
+            BootstrapPhaseProvision.recordProvisionedVm(CLUSTER_NAME, PROVIDER, SOURCE, NodeRole.CORE, node("n-0", "server-1"));
+            var path = BootstrapStatePersistence.statePath(CLUSTER_NAME);
+            var whole = Files.readAllBytes(path);
+            var torn = Arrays.copyOf(whole, whole.length / 2);
+
+            Files.write(path, torn);
+
+            assertTrue(BootstrapStatePersistence.read(CLUSTER_NAME).isFailure(),
+                       "precondition: a half-written file must read as a FAILURE, not as empty");
+
+            return torn;
+        }
+
+        /// **The measured torn-write chain (verification §4b), now refused.** `markPhaseFailed` fell back to
+        /// the pre-phase snapshot whenever `load` came back empty — and `load` returns empty for an
+        /// UNREADABLE file just as it does for an absent one. Saving the snapshot over a torn ledger replaces
+        /// the only record of paid VMs with a VM-less one that is **valid JSON**, so nothing downstream can
+        /// tell it ever held anything. This asserts the bytes are untouched, which is the only observation
+        /// that distinguishes "refused" from "rewrote it with the same intent".
+        @Test
+        @SuppressWarnings("JBCT-EX-01")
+        void markPhaseFailed_leavesTheTornLedgerByteForByte_ratherThanOverwritingIt() throws Exception {
+            var torn = tearTheLedger();
+            var preSnapshot = BootstrapState.initialState(CLUSTER_NAME, "hash-1", "2026-09-11T00:00:00Z");
+
+            ClusterBootstrapOrchestrator.markPhaseFailed(preSnapshot, BootstrapPhase.PROVISION);
+
+            assertArrayEquals(torn,
+                              Files.readAllBytes(BootstrapStatePersistence.statePath(CLUSTER_NAME)),
+                              "the unreadable bytes are the only surviving trace of the paid VMs — overwriting "
+                              + "them with a VM-less snapshot is #994's outcome reached by a different route");
+            assertTrue(stderr().contains("REFUSING"),
+                       () -> "and the refusal must be said out loud, or a silent no-op is indistinguishable "
+                             + "from a successful marker; got:\n" + stderr());
+            assertTrue(stderr().contains("cloud-reaper.sh"),
+                       () -> "with the recovery action beside it; got:\n" + stderr());
+        }
+
+        /// Positive control for the assertion above: over a READABLE ledger `markPhaseFailed` still writes.
+        /// Without it, "the bytes did not change" is also satisfied by a `markPhaseFailed` that never writes
+        /// at all, and the #994 fix would be silently undone.
+        @Test
+        @SuppressWarnings("JBCT-EX-01")
+        void markPhaseFailed_stillWritesTheMarker_whenTheLedgerIsReadable() throws Exception {
+            seedFirewallOnlyLedger();
+            var before = Files.readAllBytes(BootstrapStatePersistence.statePath(CLUSTER_NAME));
+            var preSnapshot = BootstrapState.initialState(CLUSTER_NAME, "hash-1", "2026-09-11T00:00:00Z");
+
+            ClusterBootstrapOrchestrator.markPhaseFailed(preSnapshot, BootstrapPhase.PROVISION);
+
+            assertFalse(Arrays.equals(before, Files.readAllBytes(BootstrapStatePersistence.statePath(CLUSTER_NAME))),
+                        "a readable ledger MUST be updated — this is what proves the refusal above is "
+                        + "conditional rather than a method that stopped writing");
+            assertFalse(stderr().contains("REFUSING"),
+                        () -> "and nothing is refused on the normal path; got:\n" + stderr());
+        }
+
+        /// `recordProvisionedVm` was a silent no-op whenever the ledger was absent — which is exactly what an
+        /// unchecked pre-phase save leaves behind. The server is already created and already billing at that
+        /// point, so the id is the only thing that can still save the operator money; it goes to stderr even
+        /// though the ledger cannot hold it. The VM is NOT a phantom: the provider reported it created.
+        @Test
+        void recordProvisionedVm_printsTheServerId_whenThereIsNoLedgerToRecordItIn() {
+            BootstrapPhaseProvision.recordProvisionedVm(CLUSTER_NAME, PROVIDER, SOURCE, NodeRole.CORE, node("n-0", "server-77"));
+
+            assertTrue(stderr().contains("server-77"),
+                       () -> "the id is the whole recovery: without it the server cannot be named at all; "
+                             + "got:\n" + stderr());
+            assertTrue(stderr().contains("PAID"),
+                       () -> "and the operator must be told it costs money; got:\n" + stderr());
+            assertTrue(stderr().contains("cloud-reaper.sh"),
+                       () -> "with what removes it; got:\n" + stderr());
+        }
+
+        /// Positive control: the same call with a ledger present records and says NOTHING. Without it,
+        /// "stderr names the server" could be an always-on line printed on the happy path too, which would
+        /// train an operator to ignore it.
+        @Test
+        void recordProvisionedVm_warnsAboutNothing_whenTheLedgerAcceptsTheRecord() {
+            seedFirewallOnlyLedger();
+
+            BootstrapPhaseProvision.recordProvisionedVm(CLUSTER_NAME, PROVIDER, SOURCE, NodeRole.CORE, node("n-0", "server-77"));
+
+            assertEquals(List.of("server-77"),
+                         persistedVms().stream().map(CreatedResource.ProvisionedVm::resourceId).toList(),
+                         "precondition: the record landed");
+            assertFalse(stderr().contains("NOT recorded"),
+                        () -> "a successful record must be silent; got:\n" + stderr());
+        }
+
+        /// The other silent no-op: the per-source cleanup handle. The real incident artifact recorded
+        /// `sources: []`, so teardown had no credential mapping at all — and nothing in the transcript said
+        /// the handle had not been written.
+        @Test
+        void persistCleanupHandle_saysSo_whenThereIsNoLedgerToWriteInto() {
+            BootstrapPhaseProvision.persistCleanupHandle(CLUSTER_NAME, RAW_TOML, SOURCE, cloudSource());
+
+            assertTrue(stderr().contains("cleanup handle"),
+                       () -> "the missing handle must be reported; got:\n" + stderr());
+            assertTrue(stderr().contains(SOURCE.value()),
+                       () -> "naming the source teardown would have resolved credentials for; got:\n" + stderr());
+        }
+
+        @Test
+        void persistCleanupHandle_warnsAboutNothing_whenTheLedgerAcceptsTheHandle() {
+            seedFirewallOnlyLedger();
+
+            BootstrapPhaseProvision.persistCleanupHandle(CLUSTER_NAME, RAW_TOML, SOURCE, cloudSource());
+
+            assertFalse(stderr().contains("NOT persisted"),
+                        () -> "positive control for the case above; got:\n" + stderr());
+        }
+
+        /// SF-1's atomic-write half, observed from the reader's side: a save OVER a torn file must leave a
+        /// file that parses. Under the old in-place `TRUNCATE_EXISTING` write this held only if the write
+        /// completed; the point of the temp-and-rename is that the reader never sees the intermediate state.
+        @Test
+        @SuppressWarnings("JBCT-EX-01")
+        void save_replacesATornLedgerWholesale_soTheNextReadParses() throws Exception {
+            var _ = tearTheLedger();
+
+            assertTrue(BootstrapStatePersistence.save(BootstrapState.initialState(CLUSTER_NAME, "hash-2", "2026-09-11T01:00:00Z"))
+                                                .isSuccess(),
+                       "the save itself must succeed over an unparseable file");
+            assertTrue(BootstrapStatePersistence.read(CLUSTER_NAME).isSuccess(),
+                       "and the result must parse — a partial overwrite would leave the tail of the old file");
+            try (var entries = Files.list(BootstrapStatePersistence.AETHER_DIR.resolve(CLUSTER_NAME.value()))) {
+                assertTrue(entries.noneMatch(entry -> entry.getFileName().toString().endsWith(".tmp")),
+                           "and the temp file must not be left beside the real one");
+            }
         }
     }
 }

--- a/aether/cli/src/test/java/org/pragmatica/aether/cli/cluster/BootstrapPhaseProvisionLedgerTest.java
+++ b/aether/cli/src/test/java/org/pragmatica/aether/cli/cluster/BootstrapPhaseProvisionLedgerTest.java
@@ -1,0 +1,370 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2025 Pragmatica Labs - Sergiy Yevtushenko
+// Licensed under Business Source License 1.1. Change Date: 2030-01-01. Change License: Apache-2.0.
+// See LICENSE in the repository root for full terms.
+
+package org.pragmatica.aether.cli.cluster;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.pragmatica.aether.cli.cluster.BootstrapPhaseProvision.ZoneProvisioner;
+import org.pragmatica.aether.config.cluster.CloudProviderName;
+import org.pragmatica.aether.config.cluster.ClusterBootstrapConfigParser;
+import org.pragmatica.aether.config.cluster.LoadBalancerMode;
+import org.pragmatica.aether.config.cluster.NodeRole;
+import org.pragmatica.aether.config.cluster.RoleSubTable;
+import org.pragmatica.aether.config.cluster.SourceProfile;
+import org.pragmatica.aether.config.cluster.SourceType;
+import org.pragmatica.aether.environment.ClusterName;
+import org.pragmatica.aether.environment.EnvironmentError;
+import org.pragmatica.aether.environment.FirewallId;
+import org.pragmatica.aether.environment.ProvisionedNode;
+import org.pragmatica.aether.environment.SourceName;
+import org.pragmatica.lang.Option;
+import org.pragmatica.lang.Result;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.pragmatica.aether.environment.ClusterName.clusterName;
+import static org.pragmatica.aether.environment.FirewallName.firewallName;
+import static org.pragmatica.aether.environment.SourceName.sourceNameOrDefault;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.pragmatica.lang.Result.success;
+
+/// #994 — the money path's central property: **a paid VM must be in the persisted cleanup ledger before
+/// anything can go wrong with the NEXT one.**
+///
+/// The defect these tests pin was not a bad delete order. `BootstrapCleanup.inDestructionOrder` already
+/// ranked VMs ahead of firewalls. It was that the ledger was written ONLY by
+/// `BootstrapPhaseProvision.buildUpdatedState`, which runs after every source has provisioned
+/// successfully — so when a dedicated-core quota refused the third of three `ccx23` servers on
+/// 2026-09-11, the failing phase returned the pre-phase context, the ledger held the firewall and no VMs,
+/// and teardown issued zero server deletes while two servers kept billing.
+///
+/// These tests use the REAL persistence path (`BootstrapStatePersistence`, whose directory is an
+/// interface constant resolved from `user.home` at class load, so a temp dir cannot be substituted) under
+/// a cluster name owned by this test, deleted before and after each case.
+class BootstrapPhaseProvisionLedgerTest {
+
+    private static final ClusterName CLUSTER_NAME = clusterName("ledger-994-test").unwrap();
+
+    private static final SourceName SOURCE = sourceNameOrDefault("hetzner-eu");
+
+    private static final String PROVIDER = "hetzner";
+
+    private static final String RAW_TOML = """
+        [cluster]
+        name = "ledger-994-test"
+
+        %s
+        type = "cloud"
+        provider = "hetzner"
+        credentials = "${env:HCLOUD_TOKEN}"
+        region = "eu-central"
+        """.formatted("[" + ClusterBootstrapConfigParser.SOURCE_PREFIX + "hetzner-eu]");
+
+    @BeforeEach
+    void clearState() {
+        var _ = BootstrapStatePersistence.delete(CLUSTER_NAME);
+    }
+
+    @AfterEach
+    void removeState() {
+        var _ = BootstrapStatePersistence.delete(CLUSTER_NAME);
+    }
+
+    /// The ledger exactly as Phase 3 (CREATE_FIREWALL) leaves it: a firewall and nothing else. This is the
+    /// state the observed run's cleanup actually read.
+    private static void seedFirewallOnlyLedger() {
+        var seeded = BootstrapState.initialState(CLUSTER_NAME, "hash-1", "2026-09-11T00:00:00Z")
+                                  .withResource(CreatedResource.CloudFirewall.cloudFirewall(PROVIDER,
+                                                                                            FirewallId.firewallId("11605223").unwrap(),
+                                                                                            SOURCE,
+                                                                                            firewallName("aether-ledger-994-primary").unwrap()));
+
+        assertTrue(BootstrapStatePersistence.save(seeded).isSuccess(), "test seed must persist");
+    }
+
+    private static List<CreatedResource.ProvisionedVm> persistedVms() {
+        return BootstrapStatePersistence.load(CLUSTER_NAME)
+                                        .map(BootstrapState::createdResources)
+                                        .or(List.of())
+                                        .stream()
+                                        .filter(resource -> resource instanceof CreatedResource.ProvisionedVm)
+                                        .map(resource -> (CreatedResource.ProvisionedVm) resource)
+                                        .toList();
+    }
+
+    private static ProvisionedNode node(String nodeId, String serverId) {
+        return ProvisionedNode.provisionedNode(nodeId, serverId, "10.0.0.1");
+    }
+
+    /// Scripts the observed shape: the first `successes` nodes are created, the next attempt is refused the
+    /// way Hetzner refused it — `403 resource_limit_exceeded`, which is NOT capacity-unavailable, so zone
+    /// rotation does not retry it and the group fails immediately.
+    private static final class QuotaLimitedProvisioner implements ZoneProvisioner {
+        private final int successes;
+        private final List<String> attempted = new ArrayList<>();
+
+        private QuotaLimitedProvisioner(int successes) {
+            this.successes = successes;
+        }
+
+        @Override
+        public Result<ProvisionedNode> provisionInZone(String nodeId, int globalIndex, String zone) {
+            attempted.add(nodeId);
+
+            return attempted.size() <= successes
+                   ? success(node(nodeId, "server-" + globalIndex))
+                   : EnvironmentError.provisionFailed(new RuntimeException("Hetzner API error 403 "
+                                                                         + "(resource_limit_exceeded): dedicated core limit exceeded"))
+                                     .result();
+        }
+    }
+
+    private static SourceProfile cloudSource() {
+        return SourceProfile.sourceProfile(SOURCE,
+                                           SourceType.CLOUD,
+                                           Option.some(CloudProviderName.HETZNER),
+                                           Option.some("resolved-token-value"),
+                                           Option.some("eu-central"),
+                                           Option.empty(),
+                                           Option.empty(),
+                                           Option.empty(),
+                                           Option.empty(),
+                                           LoadBalancerMode.NONE,
+                                           List.of(),
+                                           Option.empty(),
+                                           Map.of(),
+                                           Map.of(NodeRole.CORE,
+                                                  RoleSubTable.roleSubTable(NodeRole.CORE,
+                                                                            Option.some(3),
+                                                                            Option.empty(),
+                                                                            Option.empty(),
+                                                                            "default")),
+                                           List.of());
+    }
+
+    /// The recording aspect wrapped around a scripted provisioner, for the two attempt-level controls below.
+    /// The group-level regression test does NOT use this: it calls
+    /// `BootstrapPhaseProvision.provisionAndRecordRoleGroup`, the function production itself calls, so the
+    /// line that wires the aspect to the recorder is covered rather than re-assembled here.
+    private static ZoneProvisioner productionSeam(ZoneProvisioner provisionOne) {
+        return BootstrapPhaseProvision.recordingProvisioner(provisionOne,
+                                                            node -> BootstrapPhaseProvision.recordProvisionedVm(CLUSTER_NAME,
+                                                                                                                PROVIDER,
+                                                                                                                SOURCE,
+                                                                                                                NodeRole.CORE,
+                                                                                                                node));
+    }
+
+    @Nested
+    class LedgerSurvivesMidGroupRefusal {
+
+        /// THE #994 REGRESSION. Three cores requested, the provider creates two and refuses the third.
+        /// Before the fix the ledger still held only the firewall and the two servers billed until a human
+        /// found them; after it, both are nameable by id.
+        @Test
+        void provisionAndRecordRoleGroup_persistsEveryVmCreated_whenALaterNodeIsRefused() {
+            seedFirewallOnlyLedger();
+            var provisioner = new QuotaLimitedProvisioner(2);
+
+            var result = BootstrapPhaseProvision.provisionAndRecordRoleGroup(CLUSTER_NAME,
+                                                                             PROVIDER,
+                                                                             SOURCE,
+                                                                             NodeRole.CORE,
+                                                                             3,
+                                                                             0,
+                                                                             List.of(),
+                                                                             provisioner);
+
+            assertTrue(result.isFailure(), "the group must still fail — recording is not a recovery");
+            assertEquals(List.of("hetzner-eu-core-0", "hetzner-eu-core-1", "hetzner-eu-core-2"),
+                         provisioner.attempted,
+                         "all three nodes must be attempted, the third refused");
+            assertEquals(List.of("server-0", "server-1"),
+                         persistedVms().stream().map(CreatedResource.ProvisionedVm::resourceId).toList(),
+                         "both created servers must be in the PERSISTED ledger: the failing phase returns no "
+                         + "context, so the state file is teardown's only source of their ids");
+        }
+
+        /// Scope guard on the same record: teardown resolves credentials per SOURCE and terminates by
+        /// provider, so a record with the wrong source or provider is a record cleanup cannot act on.
+        @Test
+        void recordProvisionedVm_recordsProviderSourceAndRole_soTeardownCanResolveCredentials() {
+            seedFirewallOnlyLedger();
+
+            BootstrapPhaseProvision.recordProvisionedVm(CLUSTER_NAME, PROVIDER, SOURCE, NodeRole.CORE, node("n-0", "server-77"));
+
+            var vms = persistedVms();
+
+            assertEquals(1, vms.size(), "exactly one VM record");
+            assertEquals(PROVIDER, vms.getFirst().provider());
+            assertEquals("server-77", vms.getFirst().resourceId());
+            assertEquals("hetzner-eu", vms.getFirst().sourceName());
+            assertEquals("core", vms.getFirst().role());
+        }
+
+        /// The firewall must survive the VM appends — cleanup needs BOTH, and in that order.
+        @Test
+        void recordProvisionedVm_keepsResourcesAlreadyInTheLedger() {
+            seedFirewallOnlyLedger();
+
+            BootstrapPhaseProvision.recordProvisionedVm(CLUSTER_NAME, PROVIDER, SOURCE, NodeRole.CORE, node("n-0", "server-1"));
+
+            var resources = BootstrapStatePersistence.load(CLUSTER_NAME)
+                                                     .map(BootstrapState::createdResources)
+                                                     .or(List.of());
+
+            assertEquals(2, resources.size(), "the firewall recorded by Phase 3 must still be there");
+            assertEquals(1,
+                         resources.stream().filter(r -> r instanceof CreatedResource.CloudFirewall).count(),
+                         "firewall record preserved");
+        }
+
+        /// NEGATIVE CONTROL, and it is not symmetry for its own sake: recording a VM that was never created
+        /// would make teardown issue a delete for a phantom id, and a 404 on a phantom is indistinguishable
+        /// from a 404 on a server someone else already removed.
+        @Test
+        void recordingProvisioner_recordsNothing_whenTheAttemptFailed() {
+            seedFirewallOnlyLedger();
+            var provisioner = new QuotaLimitedProvisioner(0);
+
+            var result = productionSeam(provisioner).provisionInZone("hetzner-eu-core-0", 0, "fsn1");
+
+            assertTrue(result.isFailure(), "the scripted attempt fails");
+            assertTrue(persistedVms().isEmpty(),
+                       "a refused attempt created no server, so it must add no record — a phantom id makes "
+                       + "teardown delete nothing and report success");
+        }
+
+        /// Positive control for the assertion above: the same seam, the same ledger, a SUCCEEDING attempt.
+        /// Without it, `persistedVms().isEmpty()` is also satisfied by a recorder that never runs at all.
+        @Test
+        void recordingProvisioner_recordsTheNode_whenTheAttemptSucceeded() {
+            seedFirewallOnlyLedger();
+            var provisioner = new QuotaLimitedProvisioner(1);
+
+            var result = productionSeam(provisioner).provisionInZone("hetzner-eu-core-0", 0, "fsn1");
+
+            assertTrue(result.isSuccess(), "the scripted attempt succeeds");
+            assertEquals(List.of("server-0"),
+                         persistedVms().stream().map(CreatedResource.ProvisionedVm::resourceId).toList(),
+                         "the control proves the recorder CAN write, so the negative case above is a real absence");
+        }
+    }
+
+    @Nested
+    class CleanupHandleAvailableBeforeProvisioning {
+
+        /// Recording the VM is not enough on its own: `BootstrapCleanup.resolveComputeForVm` reads the
+        /// per-source handle to re-derive the provisioning token, and that handle was ALSO written only by
+        /// `buildUpdatedState`. With no handle, teardown of a mid-provision failure falls back to a raw
+        /// env var that may name a different account — or, under the scoped-credential mechanism, nothing
+        /// at all.
+        @Test
+        void persistCleanupHandle_writesTheSourceHandle_beforeAnyVmExists() {
+            seedFirewallOnlyLedger();
+
+            BootstrapPhaseProvision.persistCleanupHandle(CLUSTER_NAME, RAW_TOML, SOURCE, cloudSource());
+
+            var handle = BootstrapStatePersistence.load(CLUSTER_NAME)
+                                                 .map(BootstrapState::sources)
+                                                 .or(Map.of())
+                                                 .get("hetzner-eu");
+
+            assertTrue(handle != null, "a cloud source must have its cleanup handle persisted before provisioning");
+            assertEquals("hetzner", handle.provider());
+            assertEquals("HCLOUD_TOKEN",
+                         handle.credentialEnvVars().get("api_token"),
+                         "the env-var NAME teardown needs to re-derive the token");
+        }
+
+        @Test
+        void persistCleanupHandle_leavesStateUntouched_forNonCloudSource() {
+            seedFirewallOnlyLedger();
+            var docker = SourceProfile.sourceProfile(SOURCE,
+                                                     SourceType.DOCKER,
+                                                     Option.empty(),
+                                                     Option.empty(),
+                                                     Option.empty(),
+                                                     Option.empty(),
+                                                     Option.empty(),
+                                                     Option.empty(),
+                                                     Option.empty(),
+                                                     LoadBalancerMode.NONE,
+                                                     List.of(),
+                                                     Option.empty(),
+                                                     Map.of(),
+                                                     Map.of(),
+                                                     List.of());
+
+            BootstrapPhaseProvision.persistCleanupHandle(CLUSTER_NAME, RAW_TOML, SOURCE, docker);
+
+            assertTrue(BootstrapStatePersistence.load(CLUSTER_NAME)
+                                                .map(BootstrapState::sources)
+                                                .or(Map.of())
+                                                .isEmpty(),
+                       "a docker source has no cloud credential to re-derive — no handle should be stamped");
+        }
+    }
+
+    @Nested
+    class FailedPhaseMarkerPreservesLedger {
+
+        /// The other half of the fix, and on its own the whole defect would persist: the orchestrator marks
+        /// the phase FAILED from the PRE-phase snapshot, so a save of that snapshot erases everything the
+        /// phase appended to the file while it ran.
+        @Test
+        void markPhaseFailed_preservesResourcesTheFailingPhaseRecorded() {
+            seedFirewallOnlyLedger();
+            var preSnapshot = BootstrapStatePersistence.load(CLUSTER_NAME).or(BootstrapState.initialState(CLUSTER_NAME, "h", "t"));
+
+            BootstrapPhaseProvision.recordProvisionedVm(CLUSTER_NAME, PROVIDER, SOURCE, NodeRole.CORE, node("n-0", "server-1"));
+            BootstrapPhaseProvision.recordProvisionedVm(CLUSTER_NAME, PROVIDER, SOURCE, NodeRole.CORE, node("n-1", "server-2"));
+
+            ClusterBootstrapOrchestrator.markPhaseFailed(preSnapshot, BootstrapPhase.PROVISION);
+
+            assertEquals(List.of("server-1", "server-2"),
+                         persistedVms().stream().map(CreatedResource.ProvisionedVm::resourceId).toList(),
+                         "marking PROVISION as FAILED must not roll the ledger back to the pre-phase snapshot");
+        }
+
+        @Test
+        void markPhaseFailed_stillRecordsTheFailedPhaseStatus() {
+            seedFirewallOnlyLedger();
+            var preSnapshot = BootstrapStatePersistence.load(CLUSTER_NAME).or(BootstrapState.initialState(CLUSTER_NAME, "h", "t"));
+
+            ClusterBootstrapOrchestrator.markPhaseFailed(preSnapshot, BootstrapPhase.PROVISION);
+
+            BootstrapStatePersistence.load(CLUSTER_NAME)
+                                     .onEmpty(() -> fail("state must still be persisted"))
+                                     .onPresent(state -> assertEquals(BootstrapState.PhaseStatus.FAILED,
+                                                                      state.phases().get(BootstrapPhase.PROVISION),
+                                                                      "resume logic reads this status — preserving the ledger must not cost it"));
+        }
+
+        /// A phase that fails with nothing persisted must still produce a state file, or `cleanupOnFailure`
+        /// has nothing to load and `--keep-on-failure` can report no phase at all.
+        @Test
+        void markPhaseFailed_fallsBackToTheSnapshot_whenNothingIsPersisted() {
+            var snapshot = BootstrapState.initialState(CLUSTER_NAME, "hash-1", "2026-09-11T00:00:00Z");
+
+            assertFalse(BootstrapStatePersistence.load(CLUSTER_NAME).isPresent(), "precondition: no state on disk");
+
+            ClusterBootstrapOrchestrator.markPhaseFailed(snapshot, BootstrapPhase.PROVISION);
+
+            BootstrapStatePersistence.load(CLUSTER_NAME)
+                                     .onEmpty(() -> fail("the snapshot fallback must still write a state file"))
+                                     .onPresent(state -> assertEquals(BootstrapState.PhaseStatus.FAILED,
+                                                                      state.phases().get(BootstrapPhase.PROVISION)));
+        }
+    }
+}

--- a/aether/cli/src/test/java/org/pragmatica/aether/cli/cluster/ClusterDestroyCommandTest.java
+++ b/aether/cli/src/test/java/org/pragmatica/aether/cli/cluster/ClusterDestroyCommandTest.java
@@ -13,18 +13,27 @@ import org.pragmatica.aether.environment.ClusterName;
 import org.pragmatica.aether.cli.ExitCode;
 import org.pragmatica.aether.cli.cluster.BootstrapState.PhaseStatus;
 import org.pragmatica.aether.cli.cluster.CreatedResource.ProvisionedVm;
+import org.pragmatica.http.HttpOperations;
+import org.pragmatica.http.HttpResult;
 import org.pragmatica.lang.Cause;
 import org.pragmatica.lang.Option;
+import org.pragmatica.lang.Promise;
 import org.pragmatica.lang.Result;
 import org.pragmatica.lang.Unit;
+import org.pragmatica.lang.utils.Causes;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
+import java.net.http.HttpHeaders;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse.BodyHandler;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.EnumMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
@@ -467,6 +476,186 @@ class ClusterDestroyCommandTest {
             public Integer call() {
                 return ExitCode.CLEANUP_FAILED;
             }
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // #995 — progress output. A teardown command that emits nothing is the one case where an operator
+    // cannot tell "working" from "wedged", and the cost of guessing wrong is a half-destroyed cluster.
+    // ---------------------------------------------------------------------------------------------
+
+    /// Fails every request immediately, so the node-enumeration path is exercised without waiting out the
+    /// real 130s ceiling. This pins the OBSERVABILITY properties that made #995 invisible — that the
+    /// request is announced before it blocks and that its failure is reported — not the latency itself.
+    private record FailingHttpOperations(String message) implements HttpOperations {
+        @Override
+        public <T> Promise<HttpResult<T>> send(HttpRequest request, BodyHandler<T> handler) {
+            return Causes.cause(message).promise();
+        }
+    }
+
+    @Nested
+    class DestroyProgressOutput {
+
+        private final ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+        private final ByteArrayOutputStream err = new ByteArrayOutputStream();
+
+        private PrintStream originalOut;
+
+        private PrintStream originalErr;
+
+        private HttpOperations originalHttpOps;
+
+        private String originalEndpoint;
+
+        @BeforeEach
+        void captureStreamsAndStubHttp() {
+            originalOut = System.out;
+            originalErr = System.err;
+            originalHttpOps = ClusterHttpClient.HTTP_OPS_REF.get();
+            originalEndpoint = ClusterHttpClient.ENDPOINT_OVERRIDE.get();
+            System.setOut(new PrintStream(out, true, StandardCharsets.UTF_8));
+            System.setErr(new PrintStream(err, true, StandardCharsets.UTF_8));
+            ClusterHttpClient.setEndpointOverride("https://10.255.255.1:8080");
+            ClusterHttpClient.HTTP_OPS_REF.set(new FailingHttpOperations("connection timed out"));
+        }
+
+        @AfterEach
+        void restoreStreamsAndHttp() {
+            System.setOut(originalOut);
+            System.setErr(originalErr);
+            ClusterHttpClient.HTTP_OPS_REF.set(originalHttpOps);
+            ClusterHttpClient.ENDPOINT_OVERRIDE.set(originalEndpoint);
+        }
+
+        private String stdout() {
+            return out.toString(StandardCharsets.UTF_8);
+        }
+
+        private String stderr() {
+            return err.toString(StandardCharsets.UTF_8);
+        }
+
+        /// #995 expectation 1+2. The node list is the FIRST thing destroy does and the last thing it used to
+        /// talk about: one management request with a 130s ceiling, printed nothing before it and nothing
+        /// after it failed. The announcement has to precede the request, or it cannot be read during it.
+        @Test
+        void fetchNodeIds_announcesTheRequestAndItsTimeout_beforeBlocking() {
+            var nodeIds = new ClusterDestroyCommand().fetchNodeIds();
+
+            assertTrue(nodeIds.isEmpty(), "precondition: the stubbed request fails, so no nodes are returned");
+            assertTrue(stdout().contains("[Phase 1/5: ENUMERATE_NODES]"),
+                       () -> "the phase must be announced in bootstrap's own shape; got:\n" + stdout());
+            assertTrue(stdout().contains("https://10.255.255.1:8080"),
+                       () -> "and name the endpoint it is waiting on; got:\n" + stdout());
+            assertTrue(stdout().contains("timeout " + ClusterHttpClient.REQUEST_TIMEOUT.get().toSeconds() + "s"),
+                       () -> "the announced timeout must be read from the timeout actually in force, so it "
+                             + "cannot drift from the code; got:\n" + stdout());
+        }
+
+        /// The announcement is worthless if it is printed after the wait. Asserted positionally: the phase
+        /// line must appear at character zero of stdout, before anything the request produced.
+        @Test
+        void fetchNodeIds_printsThePhaseLineFirst_notAfterTheRequestReturns() {
+            new ClusterDestroyCommand().fetchNodeIds();
+
+            assertEquals(0,
+                         stdout().indexOf("[Phase 1/5: ENUMERATE_NODES]"),
+                         () -> "the announcement must be the FIRST output, not a retrospective note; got:\n" + stdout());
+        }
+
+        /// `.or(List.of())` discarded this failure entirely, so a cluster whose management endpoint was
+        /// unreachable looked exactly like a cluster with no nodes — and destroy went on to report success.
+        @Test
+        void fetchNodeIds_reportsTheFailure_insteadOfSilentlyTreatingItAsNoNodes() {
+            new ClusterDestroyCommand().fetchNodeIds();
+
+            assertTrue(stderr().contains("could not list cluster nodes"),
+                       () -> "the failure must be reported, not swallowed; got:\n" + stderr());
+            assertTrue(stderr().contains("connection timed out"),
+                       () -> "including the underlying cause; got:\n" + stderr());
+            assertTrue(stderr().contains("without a graceful drain"),
+                       () -> "and its CONSEQUENCE: an empty node list means drain and shutdown are skipped; "
+                             + "got:\n" + stderr());
+        }
+
+        /// Positive control for the two assertions above: the same seam, a SUCCEEDING request. Without it,
+        /// "stderr contains the warning" proves only that some failure path ran, and the count of nodes
+        /// reported could be a constant.
+        @Test
+        void fetchNodeIds_reportsTheNodeCount_andWarnsNothing_whenTheRequestSucceeds() {
+            ClusterHttpClient.HTTP_OPS_REF.set(new FixedBodyHttpOperations("""
+                [{"nodeId":"core-0"},{"nodeId":"core-1"}]
+                """));
+
+            var nodeIds = new ClusterDestroyCommand().fetchNodeIds();
+
+            assertEquals(List.of("core-0", "core-1"), nodeIds, "the stubbed body must parse");
+            assertTrue(stdout().contains("2 node(s) reported by the cluster"),
+                       () -> "a successful enumeration reports its own count; got:\n" + stdout());
+            assertFalse(stderr().contains("could not list cluster nodes"),
+                        () -> "and warns about nothing — which is what makes the failure case above a real "
+                              + "signal rather than an always-on line; got:\n" + stderr());
+        }
+
+        /// #995 expectation 3 — "if it can take minutes, say so before the wait begins", and say it with the
+        /// figures that actually bound the waits rather than a hand-written guess.
+        @Test
+        void drainAllNodes_announcesTheDrainPhaseAndItsCeiling() {
+            new ClusterDestroyCommand().drainAllNodes(List.of());
+
+            assertTrue(stdout().contains("[Phase 2/5: DRAIN_NODES]"),
+                       () -> "drain must announce itself even with nothing to do, so a silent stretch is never "
+                             + "ambiguous; got:\n" + stdout());
+            assertTrue(stdout().contains("Nothing to drain"),
+                       () -> "an empty node list is a statement, not silence; got:\n" + stdout());
+        }
+
+        @Test
+        void shutdownAllNodes_announcesTheShutdownPhase() {
+            new ClusterDestroyCommand().shutdownAllNodes(List.of());
+
+            assertTrue(stdout().contains("[Phase 3/5: SHUTDOWN_NODES]"),
+                       () -> "got:\n" + stdout());
+        }
+
+        /// The cleanup phase is where the minutes actually go — per-resource deletes plus a firewall retry
+        /// budget. It must say so before it starts, and name the retry budget from the constants that bound it.
+        @Test
+        void cleanupCloudResources_announcesThePhaseAndTheFirewallRetryBudget() {
+            ClusterDestroyCommand.stateLoader = name -> none();
+
+            new ClusterDestroyCommand().cleanupCloudResources(CLUSTER_NAME);
+
+            assertTrue(stdout().contains("[Phase 4/5: CLOUD_CLEANUP]"), () -> "got:\n" + stdout());
+            assertTrue(stdout().contains("retried up to " + BootstrapCleanup.FIREWALL_DELETE_ATTEMPTS + " times"),
+                       () -> "the retry budget must come from the constant that enforces it; got:\n" + stdout());
+        }
+
+        @Test
+        void finalizeDestruction_announcesTheRegistryPhase_andWhyTheEntryIsKept_whenCleanupFailed() {
+            ClusterDestroyCommand.finalizeDestruction(ClusterRegistry.clusterRegistry(Path.of("unused-registry.toml"), none(), List.of()),
+                                                      CLUSTER_NAME,
+                                                      false,
+                                                      List.of(),
+                                                      List.of(),
+                                                      List.of());
+
+            assertTrue(stdout().contains("[Phase 5/5: REGISTRY]"), () -> "got:\n" + stdout());
+            assertTrue(stdout().contains("Keeping the registry entry"),
+                       () -> "the reason the entry survives is the operator's handle on billing resources — "
+                             + "saying it beside the decision is the point; got:\n" + stdout());
+        }
+    }
+
+    /// Returns one fixed body for every request, so the SUCCESS arm of the node-enumeration control has a
+    /// real parse to do rather than an empty list asserted against itself.
+    private record FixedBodyHttpOperations(String body) implements HttpOperations {
+        @Override
+        @SuppressWarnings("unchecked")
+        public <T> Promise<HttpResult<T>> send(HttpRequest request, BodyHandler<T> handler) {
+            return Promise.success(new HttpResult<>(200, HttpHeaders.of(Map.of(), (a, b) -> true), (T) body));
         }
     }
 }

--- a/aether/cli/src/test/java/org/pragmatica/aether/cli/cluster/ClusterDestroyCommandTest.java
+++ b/aether/cli/src/test/java/org/pragmatica/aether/cli/cluster/ClusterDestroyCommandTest.java
@@ -56,7 +56,7 @@ class ClusterDestroyCommandTest {
 
     private static final ClusterName CLUSTER_NAME = clusterName("test-cluster").unwrap();
 
-    private Function<ClusterName, Option<BootstrapState>> originalLoader;
+    private Function<ClusterName, Result<Option<BootstrapState>>> originalLoader;
 
     private Function<BootstrapState, Result<Unit>> originalCleaner;
 
@@ -105,7 +105,7 @@ class ClusterDestroyCommandTest {
         @Test
         void destroy_invokesBootstrapCleanup_whenStateFileExists() {
             var captured = new AtomicReference<BootstrapState>();
-            ClusterDestroyCommand.stateLoader = name -> some(stateWithVms(2));
+            ClusterDestroyCommand.stateLoader = name -> Result.success(some(stateWithVms(2)));
             ClusterDestroyCommand.resourceCleaner = state -> {
                 captured.set(state);
                 return Result.unitResult();
@@ -121,7 +121,7 @@ class ClusterDestroyCommandTest {
         @Test
         void destroy_skipsCleanup_whenStateFileMissing() {
             var calls = new AtomicInteger(0);
-            ClusterDestroyCommand.stateLoader = name -> none();
+            ClusterDestroyCommand.stateLoader = name -> Result.success(none());
             ClusterDestroyCommand.resourceCleaner = state -> {
                 calls.incrementAndGet();
                 return Result.unitResult();
@@ -137,7 +137,7 @@ class ClusterDestroyCommandTest {
         @Test
         void destroy_skipsCleanup_whenBootstrapStateHasNoResources() {
             var calls = new AtomicInteger(0);
-            ClusterDestroyCommand.stateLoader = name -> some(emptyState());
+            ClusterDestroyCommand.stateLoader = name -> Result.success(some(emptyState()));
             ClusterDestroyCommand.resourceCleaner = state -> {
                 calls.incrementAndGet();
                 return Result.unitResult();
@@ -156,7 +156,7 @@ class ClusterDestroyCommandTest {
             var cleanerCalls = new AtomicInteger(0);
             ClusterDestroyCommand.stateLoader = name -> {
                 loaderCalls.incrementAndGet();
-                return some(stateWithVms(3));
+                return Result.success(some(stateWithVms(3)));
             };
             ClusterDestroyCommand.resourceCleaner = state -> {
                 cleanerCalls.incrementAndGet();
@@ -174,7 +174,7 @@ class ClusterDestroyCommandTest {
 
         @Test
         void destroy_partialCleanupFailure_returnsFalseButDoesNotThrow() {
-            ClusterDestroyCommand.stateLoader = name -> some(stateWithVms(1));
+            ClusterDestroyCommand.stateLoader = name -> Result.success(some(stateWithVms(1)));
             ClusterDestroyCommand.resourceCleaner = state -> new TestCause("api error").result();
             var command = new ClusterDestroyCommand();
 
@@ -188,7 +188,7 @@ class ClusterDestroyCommandTest {
             var capturedName = new AtomicReference<ClusterName>();
             ClusterDestroyCommand.stateLoader = name -> {
                 capturedName.set(name);
-                return none();
+                return Result.success(none());
             };
             ClusterDestroyCommand.resourceCleaner = state -> Result.unitResult();
             var command = new ClusterDestroyCommand();
@@ -202,7 +202,7 @@ class ClusterDestroyCommandTest {
         @Test
         void destroy_invokesSshKeySweeper_afterStateCleanup() {
             var sweepClusterName = new AtomicReference<ClusterName>();
-            ClusterDestroyCommand.stateLoader = name -> some(stateWithVms(2));
+            ClusterDestroyCommand.stateLoader = name -> Result.success(some(stateWithVms(2)));
             ClusterDestroyCommand.resourceCleaner = state -> Result.unitResult();
             ClusterDestroyCommand.sshKeySweeper = (state, clusterName) -> {
                 sweepClusterName.set(clusterName);
@@ -219,7 +219,7 @@ class ClusterDestroyCommandTest {
 
         @Test
         void destroy_sweeperFailure_returnsFalseButDoesNotThrow() {
-            ClusterDestroyCommand.stateLoader = name -> some(stateWithVms(1));
+            ClusterDestroyCommand.stateLoader = name -> Result.success(some(stateWithVms(1)));
             ClusterDestroyCommand.resourceCleaner = state -> Result.unitResult();
             ClusterDestroyCommand.sshKeySweeper = (state, clusterName) -> new TestCause("sweep api error").result();
             var command = new ClusterDestroyCommand();
@@ -232,7 +232,7 @@ class ClusterDestroyCommandTest {
         @Test
         void destroy_keepResourcesFlag_skipsSweep() {
             var sweepCalls = new AtomicInteger(0);
-            ClusterDestroyCommand.stateLoader = name -> some(stateWithVms(3));
+            ClusterDestroyCommand.stateLoader = name -> Result.success(some(stateWithVms(3)));
             ClusterDestroyCommand.resourceCleaner = state -> Result.unitResult();
             ClusterDestroyCommand.sshKeySweeper = (state, clusterName) -> {
                 sweepCalls.incrementAndGet();
@@ -313,7 +313,7 @@ class ClusterDestroyCommandTest {
             var loaderCalls = new AtomicInteger(0);
             ClusterDestroyCommand.stateLoader = name -> {
                 loaderCalls.incrementAndGet();
-                return some(stateWithVms(2));
+                return Result.success(some(stateWithVms(2)));
             };
             ClusterDestroyCommand.resourceCleaner = state -> Result.unitResult();
 
@@ -331,7 +331,7 @@ class ClusterDestroyCommandTest {
             var capturedName = new AtomicReference<ClusterName>();
             ClusterDestroyCommand.stateLoader = name -> {
                 capturedName.set(name);
-                return none();
+                return Result.success(none());
             };
             ClusterDestroyCommand.resourceCleaner = state -> Result.unitResult();
 
@@ -599,10 +599,14 @@ class ClusterDestroyCommandTest {
                               + "signal rather than an always-on line; got:\n" + stderr());
         }
 
-        /// #995 expectation 3 — "if it can take minutes, say so before the wait begins", and say it with the
-        /// figures that actually bound the waits rather than a hand-written guess.
+        /// #994 verification finding SF-3 — **renamed.** This was called
+        /// `drainAllNodes_announcesTheDrainPhaseAndItsCeiling` and asserted the phase line and
+        /// "Nothing to drain"; it passed an EMPTY node list, so it never entered the branch that prints a
+        /// ceiling at all. The name claimed coverage the body did not have, which is worse than no test,
+        /// because a reader auditing #995's deliverables would tick the ceiling off and move on. The ceiling
+        /// is pinned by the sibling below, against a non-empty list.
         @Test
-        void drainAllNodes_announcesTheDrainPhaseAndItsCeiling() {
+        void drainAllNodes_announcesThePhase_whenThereIsNothingToDrain() {
             new ClusterDestroyCommand().drainAllNodes(List.of());
 
             assertTrue(stdout().contains("[Phase 2/5: DRAIN_NODES]"),
@@ -610,6 +614,34 @@ class ClusterDestroyCommandTest {
                              + "ambiguous; got:\n" + stdout());
             assertTrue(stdout().contains("Nothing to drain"),
                        () -> "an empty node list is a statement, not silence; got:\n" + stdout());
+        }
+
+        /// #995 expectation 2, actually exercised: "if it can take minutes, say so before the wait begins",
+        /// with the figures that bound the wait. Only the NON-EMPTY branch prints a ceiling, and no test
+        /// entered it — so stripping the per-node ceiling line left all 724 tests green (measured, probe V9).
+        ///
+        /// The stubbed drain request fails immediately, so the announcement is asserted without waiting out
+        /// the real 120 seconds; the ceiling is read from the enforcing constants rather than restated, so the
+        /// announcement cannot drift from the code.
+        @Test
+        void drainAllNodes_announcesThePerNodeCeilingAndPollInterval_whenThereAreNodesToDrain() {
+            var results = new ClusterDestroyCommand().drainAllNodes(List.of("core-0"));
+
+            assertEquals(1, results.size(), "precondition: one node was processed");
+            assertFalse(results.getFirst().success(),
+                        "precondition: the stubbed drain POST fails, so the 120s poll loop is never entered");
+            assertTrue(stdout().contains("Draining 1 node(s), up to " + ClusterDestroyCommand.DRAIN_TIMEOUT_SECONDS + "s each"),
+                       () -> "the phase line must name the per-node budget and the worst-case total; got:\n" + stdout());
+            assertTrue(stdout().contains("Draining node core-0 (waiting up to "
+                                         + ClusterDestroyCommand.DRAIN_TIMEOUT_SECONDS
+                                         + "s for DECOMMISSIONED, polling every "
+                                         + ClusterDestroyCommand.DRAIN_POLL_INTERVAL_MS
+                                         + "ms)"),
+                       () -> "and each node must name its own ceiling BEFORE its wait begins — this is the line "
+                             + "that turns a two-minute silence into a stated wait; got:\n" + stdout());
+            assertFalse(stdout().contains("Nothing to drain"),
+                        () -> "the empty-list wording must not appear for a non-empty list, or the two branches "
+                              + "are indistinguishable; got:\n" + stdout());
         }
 
         @Test
@@ -624,7 +656,7 @@ class ClusterDestroyCommandTest {
         /// budget. It must say so before it starts, and name the retry budget from the constants that bound it.
         @Test
         void cleanupCloudResources_announcesThePhaseAndTheFirewallRetryBudget() {
-            ClusterDestroyCommand.stateLoader = name -> none();
+            ClusterDestroyCommand.stateLoader = name -> Result.success(none());
 
             new ClusterDestroyCommand().cleanupCloudResources(CLUSTER_NAME);
 
@@ -646,6 +678,104 @@ class ClusterDestroyCommandTest {
             assertTrue(stdout().contains("Keeping the registry entry"),
                        () -> "the reason the entry survives is the operator's handle on billing resources — "
                              + "saying it beside the decision is the point; got:\n" + stdout());
+        }
+
+        /// #994 verification finding SF-3 — **no test reached `performDestruction` at all.** The three phase
+        /// methods were each driven individually and every test entering via `call()` returned early, so
+        /// deleting `announceDestroyPlan(clusterName)` — #995's entire "say so before the wait begins"
+        /// deliverable — left all 724 tests green (measured, probe V3), and the PHASE ORDER was unpinned for
+        /// the same reason.
+        ///
+        /// Driven end to end with the failing HTTP stub (so enumeration returns nothing and the drain and
+        /// shutdown loops have nothing to wait for), no bootstrap state (so cleanup is a no-op) and a
+        /// no-op registry remover. What is left is exactly the observable sequence an operator reads.
+        @Test
+        void performDestruction_announcesThePlanFirst_thenRunsAllFivePhasesInOrder() {
+            ClusterDestroyCommand.stateLoader = name -> Result.success(none());
+            var originalRemover = ClusterDestroyCommand.registryRemover;
+
+            ClusterDestroyCommand.registryRemover = (registry, name) -> Result.success(registry);
+            try {
+                var exitCode = new ClusterDestroyCommand().performDestruction(registryWithNoEntries(), CLUSTER_NAME);
+
+                exitCode.onFailure(cause -> fail("destroy must produce a summary: " + cause.message()))
+                        .onSuccess(code -> assertEquals(ExitCode.SUCCESS, (int) code,
+                                                        "nothing failed, so the command must exit 0"));
+                assertEquals(0,
+                             stdout().indexOf("Destroying cluster '" + CLUSTER_NAME + "' in 5 phases"),
+                             () -> "the plan must be the FIRST thing printed — announced after the first wait it "
+                                   + "cannot be read during it; got:\n" + stdout());
+                assertTrue(stdout().contains("This can take minutes"),
+                           () -> "#995 expectation 3: say up front that it can take minutes; got:\n" + stdout());
+                assertTrue(stdout().contains("node enumeration waits up to "
+                                             + ClusterHttpClient.REQUEST_TIMEOUT.get().toSeconds() + "s"),
+                           () -> "with the enumeration ceiling read from the timeout in force; got:\n" + stdout());
+                assertTrue(stdout().contains("each node's drain up to " + ClusterDestroyCommand.DRAIN_TIMEOUT_SECONDS + "s"),
+                           () -> "and the drain ceiling read from the constant that enforces it; got:\n" + stdout());
+                assertPhasesInOrder();
+            } finally {
+                ClusterDestroyCommand.registryRemover = originalRemover;
+            }
+        }
+
+        /// Order, not merely presence: the announced plan describes a sequence, and a destroy that deleted
+        /// cloud resources before draining would print the same five lines.
+        private void assertPhasesInOrder() {
+            var transcript = stdout();
+            var phases = List.of("[Phase 1/5: ENUMERATE_NODES]",
+                                 "[Phase 2/5: DRAIN_NODES]",
+                                 "[Phase 3/5: SHUTDOWN_NODES]",
+                                 "[Phase 4/5: CLOUD_CLEANUP]",
+                                 "[Phase 5/5: REGISTRY]");
+            var previous = -1;
+
+            for (var phase : phases) {
+                var at = transcript.indexOf(phase);
+
+                assertTrue(at > previous,
+                           () -> "expected " + phase + " after the previous phase, in:\n" + transcript);
+                previous = at;
+            }
+        }
+
+        private static ClusterRegistry registryWithNoEntries() {
+            return ClusterRegistry.clusterRegistry(Path.of("unused-registry.toml"), none(), List.of());
+        }
+
+        /// #994 verification finding SF-1 — **an unreadable ledger is not an empty cluster.** Under the old
+        /// `Option`-valued seam a torn `bootstrap-state.json` arrived as empty, which this method read as "no
+        /// bootstrap state — skipping resource cleanup", returned `true` for, and which then removed the
+        /// registry entry and exited 0 while every server the ledger named kept billing. The torn file is
+        /// reachable by exactly the failure both incidents ended in: the operator killing bootstrap mid-write.
+        @Test
+        void cleanupCloudResources_refusesToReportDone_whenTheLedgerIsPresentButUnreadable() {
+            ClusterDestroyCommand.stateLoader = name -> new TestCause("state file is not valid JSON").result();
+
+            var ok = new ClusterDestroyCommand().cleanupCloudResources(CLUSTER_NAME);
+
+            assertFalse(ok,
+                        "a ledger that cannot be read names no resources, so cleanup CANNOT have succeeded — "
+                        + "reporting true removes the registry entry, the operator's last handle on billing VMs");
+            assertTrue(stderr().contains("REFUSING"),
+                       () -> "and the refusal must be stated; got:\n" + stderr());
+            assertTrue(stderr().contains("cloud-reaper.sh"),
+                       () -> "with the recovery action; got:\n" + stderr());
+        }
+
+        /// Positive control, and it is the load-bearing arm: an ABSENT ledger must still be the cheerful path
+        /// — nothing was created, so there is nothing to reap and `destroy` should finish. Without this,
+        /// "returns false" would also be satisfied by a method that refuses whenever there is no state.
+        @Test
+        void cleanupCloudResources_reportsDone_whenThereIsNoLedgerAtAll() {
+            ClusterDestroyCommand.stateLoader = name -> Result.success(none());
+
+            var ok = new ClusterDestroyCommand().cleanupCloudResources(CLUSTER_NAME);
+
+            assertTrue(ok, "no state file means nothing was created — destroy has nothing to reap and must finish");
+            assertTrue(stdout().contains("No bootstrap state"),
+                       () -> "and it says which of the two cases this is; got:\n" + stdout());
+            assertFalse(stderr().contains("REFUSING"),
+                        () -> "absent is not unreadable — conflating them is the defect; got:\n" + stderr());
         }
     }
 

--- a/aether/cli/src/test/java/org/pragmatica/aether/cli/cluster/SecureFilesTest.java
+++ b/aether/cli/src/test/java/org/pragmatica/aether/cli/cluster/SecureFilesTest.java
@@ -11,7 +11,13 @@ import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.attribute.PosixFilePermission;
+
+import org.pragmatica.lang.Result;
+import org.pragmatica.lang.Unit;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
@@ -84,6 +90,100 @@ class SecureFilesTest {
                 }
             } catch (Exception e) {
                 // The file does not exist yet — not an observation either way; keep sampling.
+            }
+        }
+    }
+
+    /// #994 verification finding SF-1 — **a concurrent reader must never observe a PARTIAL file.** The
+    /// previous implementation opened the target itself with `TRUNCATE_EXISTING` and wrote in place, so a
+    /// reader (or a process that died) could see a zero-byte or half-written file. For `bootstrap-state.json`
+    /// that is not a cosmetic window: `Files.exists` is true, `fromJson` fails, and the ledger of paid VMs
+    /// reads as EMPTY — indistinguishable from "nothing was ever created".
+    ///
+    /// Same sampler shape as the permissions pin above, different property: every observation must be EXACTLY
+    /// the old content or EXACTLY the new one. The sampler's own read count is asserted non-zero, because an
+    /// assertion about what was never seen is vacuous if nothing was seen at all; and the observed set is
+    /// asserted to contain the old content, which proves the sampler was running BEFORE the write landed
+    /// rather than only after it.
+    ///
+    /// The 1 MiB payload exists only to widen the write past sampling granularity.
+    @Test
+    void writeSecure_neverExposesAPartialFile_toAConcurrentReader(@TempDir Path dir) throws Exception {
+        var file = dir.resolve("bootstrap-state.json");
+        var oldContent = "{\"createdResources\":[\"vm-1\",\"vm-2\"]}";
+        var newContent = "n".repeat(1024 * 1024);
+
+        Files.writeString(file, oldContent);
+        var observed = new HashSet<String>();
+        var reads = new AtomicInteger();
+        var stop = new AtomicBoolean(false);
+        // Daemon + try/finally: `awaitFirstRead` can fail, and a live non-daemon sampler spinning past a
+        // failed assertion would wedge the surefire fork instead of reporting the failure. An instrument
+        // that hangs on its own failure is worse than one that reports it.
+        var sampler = Thread.ofPlatform().daemon().start(() -> sampleContentUntilStopped(file, observed, reads, stop));
+        Result<Unit> result;
+
+        try {
+            // The sampler is required to have read the PRE-write file before the write starts. Without this
+            // barrier the test is racy in the direction that HIDES the defect: a sampler that first runs
+            // after the write completed observes only the new content and passes vacuously.
+            awaitFirstRead(reads);
+            result = SecureFiles.writeSecure(file, newContent);
+        } finally {
+            stop.set(true);
+            sampler.join();
+        }
+
+        assertThat(result.isSuccess()).isTrue();
+        assertThat(reads.get()).as("the sampler must have actually read the file, or every assertion below is vacuous")
+                  .isGreaterThan(0);
+        assertThat(snapshotOf(observed)).as("the pre-write content, guaranteed by the barrier above — this is what "
+                                            + "proves the sampler was running ACROSS the write")
+                  .contains(oldContent);
+        assertThat(snapshotOf(observed)).as("every observation must be one WHOLE version or the other; a prefix of "
+                                            + "the new content, or an empty file, is the torn state that makes a "
+                                            + "ledger of paid VMs read as empty")
+                  .isSubsetOf(oldContent, newContent);
+        assertThat(Files.readString(file)).isEqualTo(newContent);
+
+        try (var entries = Files.list(dir)) {
+            assertThat(entries.filter(entry -> entry.getFileName().toString().endsWith(".tmp")).toList())
+                      .as("the temp file must not survive a successful write")
+                      .isEmpty();
+        }
+    }
+
+    private static Set<String> snapshotOf(Set<String> observed) {
+        synchronized (observed) {
+            return Set.copyOf(observed);
+        }
+    }
+
+    /// Bounded: a sampler that never reads is a broken instrument, and hanging here would hide that.
+    @SuppressWarnings("JBCT-EX-01")
+    private static void awaitFirstRead(AtomicInteger reads) {
+        var deadline = System.nanoTime() + 5_000_000_000L;
+
+        while (reads.get() == 0 && System.nanoTime() < deadline) {
+            Thread.onSpinWait();
+        }
+
+        assertThat(reads.get()).as("the sampler thread must read the file before the write begins")
+                  .isGreaterThan(0);
+    }
+
+    @SuppressWarnings("JBCT-EX-01")
+    private static void sampleContentUntilStopped(Path file, Set<String> observed, AtomicInteger reads, AtomicBoolean stop) {
+        while (!stop.get()) {
+            try {
+                var content = Files.readString(file);
+
+                reads.incrementAndGet();
+                synchronized (observed) {
+                    observed.add(content);
+                }
+            } catch (Exception e) {
+                // A read that races the rename can fail outright; that is not an observation of torn content.
             }
         }
     }

--- a/changelog.d/994-bootstrap-cleanup-ledger-and-order.md
+++ b/changelog.d/994-bootstrap-cleanup-ledger-and-order.md
@@ -1,0 +1,43 @@
+### Fixed (2026-09-11 — #994: a mid-PROVISION bootstrap failure stranded every server already created)
+
+- **The ledger, not the delete order, was the defect.** `BootstrapCleanup.inDestructionOrder` already
+  ranked VMs ahead of firewalls; the observed run deleted the firewall first because the cleanup ledger
+  held **no VM records at all**. `BootstrapPhaseProvision` wrote them only in `buildUpdatedState`, which
+  runs *after every source has provisioned successfully* — so when a dedicated-core quota refused the
+  third of three `ccx23` servers, the failing phase returned the pre-phase context, three separate layers
+  discarded the nodes already created (`rotateZonesForRoleGroup` returns an empty list on failure,
+  `provisionCloudWithCompute` drops its accumulator, `execute` returns the original context), and
+  teardown issued **zero server deletes** while two servers kept billing. The firewall delete then failed
+  `422 resource_in_use` six times against servers the cleanup could not name.
+  [mechanism: each VM is appended to the **persisted** state as the provider reports it created, via a
+  `recordingProvisioner` aspect composed around the per-node seam in `provisionCloudRoleGroup`; the state
+  file is the only channel that survives a failed phase, because a `Result` failure carries no context
+  and `ClusterBootstrapOrchestrator.cleanupOnFailure` re-loads the file]
+- **The FAILED-phase marker no longer rolls the ledger back.** `markPhaseFailed` saved the *pre-phase*
+  in-memory snapshot, which would have erased every record the phase had just written to the file. It now
+  re-loads the persisted state and marks the phase FAILED on that, falling back to the snapshot only when
+  nothing is persisted. Without this half the recording above is undone at the moment it matters.
+- **The per-source cleanup handle is persisted BEFORE the first server is created.** It was also written
+  only by `buildUpdatedState`, so teardown of a mid-provision failure had no credential mapping to
+  re-derive the provisioning token and fell back to a raw env var that may name a different account.
+- **The retry diagnostic no longer asserts a mechanism that is not running.** It printed *"servers are
+  still detaching; retrying..."* on every attempt — including the observed run, where **no server delete
+  had been issued**, so nothing was detaching; the message sent an operator to look at server shutdown
+  while the actual problem was the ledger. It now quotes the provider's own refusal verbatim and states
+  the observed accounting: how many VMs the ledger records for that source, and how many this cleanup
+  deleted. Zero recorded VMs reads as *"whatever still holds the firewall is a server this cleanup cannot
+  name"*, with the label selector that finds it.
+- **A partial cleanup enumerates what it left behind, by type and id.** `"orphan resources may remain"`
+  is replaced by a `NOT REAPED` block listing every resource that was not deleted plus the
+  `cloud-reaper.sh` invocation that finishes the job, and the same enumeration is carried in the failure
+  `Cause` so it survives into `BootstrapFailedWithOrphans` after the transcript has scrolled away.
+- Pinned by `BootstrapPhaseProvisionLedgerTest` (the observed shape: two servers created, the third
+  refused `403 resource_limit_exceeded`, ledger asserted to hold both; plus a negative control that a
+  *refused* attempt records nothing, so teardown never chases a phantom id) and
+  `BootstrapCleanupTest.DestructionOrder` / `.FirewallRefusalDiagnostic` (delete order asserted against a
+  ledger that records the VM first, so the guarantee comes from the rank sort rather than from which phase
+  recorded first). Each assertion of an absence has a positive control beside it.
+- **[unverified: no cloud run]** — every claim above is established against the real compositions in-JVM.
+  That two `ccx23` servers are actually deleted by a quota-refused `aether cluster bootstrap` is **not**
+  demonstrated here; the confirming run is a deliberate 3×`ccx23` request against the ~8-core dedicated
+  quota, which reliably creates two servers and `403`s on the third.

--- a/changelog.d/994-bootstrap-cleanup-ledger-and-order.md
+++ b/changelog.d/994-bootstrap-cleanup-ledger-and-order.md
@@ -41,3 +41,68 @@
   That two `ccx23` servers are actually deleted by a quota-refused `aether cluster bootstrap` is **not**
   demonstrated here; the confirming run is a deliberate 3×`ccx23` request against the ~8-core dedicated
   quota, which reliably creates two servers and `403`s on the third.
+
+### Fixed (2026-09-11 — #994 adversarial-verification round: the ledger's own durability)
+
+The four findings below come from the adversarial verification of the fix above. None was a live
+defect in the shipped behaviour; each narrows a guarantee the fix asserts, or pins a production line
+that was removable without reddening a single test.
+
+- **The ledger write is all-or-nothing, and an UNREADABLE ledger is never overwritten.**
+  [verification finding SF-1] The fix above promotes `bootstrap-state.json` to the sole surviving
+  record of money-bearing resources — and nothing verified that it could be written, or that what came
+  back from it was real. Three holes, all closed:
+  - `SecureFiles.writeSecure` opened the target itself with `TRUNCATE_EXISTING` and wrote in place, so
+    a process that died part-way through left a zero-byte or half-written file: `Files.exists` true,
+    `fromJson` failing, the ledger of paid VMs reading as **EMPTY**. Both the #994 and #995 incidents
+    ended with the operator **killing** the process. Content now lands in a sibling temp file and
+    arrives at the target by `ATOMIC_MOVE`.
+    [mechanism: `rename(2)` within one directory either completed or did not, and the page cache
+    survives process death; the temp file's bytes are `force`d before the rename, so what a completed
+    rename publishes is on the device]
+    **[unverified: host power loss]** — the DIRECTORY entry is not fsync'd, so a power loss inside the
+    window can still lose the last write. Process death, the observed failure mode, cannot.
+  - **`absent` and `unparseable` are now different answers.** `BootstrapStatePersistence.read` returns
+    `Result<Option<BootstrapState>>`; `load` keeps its old shape for callers that only want a state if
+    there is one. Under the old `load` both arrived as an empty `Option`, and the two callers whose
+    decisions are money-bearing both guessed wrong: `markPhaseFailed` saved the VM-less **pre-phase
+    snapshot over a torn ledger** — leaving valid JSON that nothing downstream could distinguish from a
+    cluster that created nothing, which is #994's outcome reached by another route — and
+    `cluster destroy` read a torn ledger as *"no bootstrap state — skipping resource cleanup"*,
+    returned cleanup-OK, removed the registry entry and exited 0 while every server the ledger named
+    kept billing. Both now REFUSE, name the file, and print the `cloud-reaper.sh` invocation; destroy
+    additionally keeps its registry entry and exits non-zero, which is #521's property applied to a
+    ledger it cannot read. Failing closed costs nothing on either path: `markPhaseFailed` runs only
+    after the bootstrap has already failed, and an unreadable ledger names no resource destroy could
+    have reaped anyway.
+  - **Every PROVISION-path write is consumed, and every way recording can fail prints the SERVER ID.**
+    The pre-phase save that guarantees a file exists, an absent ledger, an unreadable one, and a failed
+    append were all silent — and `recordProvisionedVm` is a no-op when the load is empty, so an
+    unchecked save at the top of the phase silently dropped every VM the phase created. The id now
+    reaches stderr even when the ledger cannot hold it, because with the ledger broken it is the only
+    thing that can still name the server. It **warns rather than aborting**: the VM already exists and
+    already bills, so failing the run cannot un-bill it, while a full disk under `~/.aether` would turn
+    a recoverable problem into a dead bootstrap.
+- **Production's USE of the recording composition is pinned, not just the composition.**
+  [verification finding SF-2] `provisionAndRecordRoleGroup` was covered; the line in
+  `provisionCloudRoleGroup` that CALLS it was not, so replacing that call with a direct
+  `rotateZonesForRoleGroup` — deleting the entire recording behaviour — left all 724 tests green. #994
+  *was* an unwired mechanism: `buildUpdatedState` existed, worked, and never ran on the failure path,
+  so a regression that re-unwires recording is the same defect class. Pinned by
+  `BootstrapPhaseProvisionLedgerTest.ProductionWiresTheRecorder`, which drives
+  `provisionCloudRoleGroup` through a real `ComputeProvider`: every layer between the provider's
+  "created" and the state file is production code.
+- **The `NOT REAPED` enumeration covers all THREE teardown paths.** [verification finding SF-4] The
+  claim above was true of the ledger-driven `cleanupWith` and **false of the command as a whole**: the
+  label-scoped VM sweep reported `"VM sweep failed: <message>"` and the ssh-key sweep a joined string,
+  neither carrying a type or an id — and the VM sweep is the path whose whole purpose is the
+  **unrecorded billable VMs** that are #994's theme. Both now route their failures through
+  `ReapFailure` over a real `CreatedResource`, so all three paths print the same enumerated block and
+  carry it in their `Cause` (`VmSweepFailed` / `SshKeySweepFailed`, both now `(detail, notReaped)`).
+  A swept VM's `role` is recorded as `label-swept` rather than guessed: a VM the ledger never held has
+  no recorded role, and that absence is why the sweep exists.
+- **Test-state isolation.** `BootstrapPhaseProvisionLedgerTest` writes the real
+  `$HOME/.aether/clusters/<name>` path (`AETHER_DIR` is an interface constant off `user.home`), and
+  used a FIXED cluster name — so two concurrent `aether/cli` reactors on one machine shared it and one
+  test's `@BeforeEach` delete could race the other's write. Same class as #939's fixed port. The name
+  now carries a per-JVM random suffix and the directory is removed afterwards.

--- a/changelog.d/995-destroy-progress-output.md
+++ b/changelog.d/995-destroy-progress-output.md
@@ -32,3 +32,22 @@
   firewall's `--admin-cidr` /32 for the endpoint to be reachable at all, which would produce exactly this
   shape if it had changed, but that is a hypothesis and is not claimed here. What is fixed is that the
   silence can no longer hide any of it.
+
+### Fixed (2026-09-11 — #995 adversarial-verification round: the announcements are pinned)
+
+- **`performDestruction` is reached by a test.** [verification finding SF-3] It was reached by none:
+  the three phase methods were each driven individually and every test entering through `call()`
+  returned early (invalid `--cluster`, or an aborted confirmation prompt). So deleting
+  `announceDestroyPlan(clusterName)` — the whole of expectation 3, *"if it can take minutes, say so
+  before the wait begins"* — left all 724 tests green, and the **phase ORDER** was unpinned for the
+  same reason. `ClusterDestroyCommandTest.DestroyProgressOutput` now drives the command end to end
+  against the stubbed HTTP seam and asserts the banner is at character zero of stdout, its figures
+  against the constants that enforce them, and the five phase lines in ascending position.
+- **The drain ceiling is exercised.** The test named
+  `drainAllNodes_announcesTheDrainPhaseAndItsCeiling` passed an **empty** node list, so it never
+  entered the only branch that prints a ceiling — stripping the per-node ceiling line left the suite
+  green. The name claimed coverage the body did not have, which is worse than no test: an auditor
+  walking #995's deliverables would tick it off. Renamed to
+  `drainAllNodes_announcesThePhase_whenThereIsNothingToDrain`, with a new sibling driving a non-empty
+  list and asserting the per-node budget and poll interval against `DRAIN_TIMEOUT_SECONDS` /
+  `DRAIN_POLL_INTERVAL_MS`.

--- a/changelog.d/995-destroy-progress-output.md
+++ b/changelog.d/995-destroy-progress-output.md
@@ -1,0 +1,34 @@
+### Fixed (2026-09-11 — #995: cluster destroy emitted nothing for minutes while paid servers kept running)
+
+- **Diagnosed, then fixed.** Against a healthy 3-node cloud cluster, `cluster destroy --cluster <name>
+  --yes` produced zero output for ~2.5 minutes and deleted nothing, and was killed. Reading the path:
+  `performDestruction`'s **first** statement is `fetchNodeIds()`, a single management request bounded by
+  `ClusterHttpClient.REQUEST_TIMEOUT` — **130 seconds** by default — with nothing printed before it; its
+  failure was then discarded by `.or(List.of())`, and with an empty node list the drain and shutdown loops
+  print nothing either. So the command's entire observable output could begin more than two minutes in,
+  and an unreachable management endpoint was indistinguishable from a cluster with no nodes.
+  [mechanism: `JdkHttpOperations.send` resolves its Promise on both completion paths, so the per-request
+  ceiling is the 130s `HttpRequest.timeout()` rather than an unbounded wait]
+- **Every phase announces itself before it blocks**, in the same `[Phase n/m: NAME]` shape bootstrap uses,
+  so one operator reading both transcripts reads one format: `ENUMERATE_NODES`, `DRAIN_NODES`,
+  `SHUTDOWN_NODES`, `CLOUD_CLEANUP`, `REGISTRY`.
+- **Waits name what they are waiting for and their ceiling**, read from the constants that enforce them
+  rather than restated — the node-list request names its endpoint and timeout, each drain names the
+  `DECOMMISSIONED` state it polls for with its 120s budget and 2s interval, and the cleanup phase names the
+  firewall retry budget. An announced timeout that does not match the one in force is the same class of
+  false diagnostic as #994's *"servers are still detaching"*.
+- **A failed node enumeration is reported with its consequence**, not swallowed: an empty node list means
+  drain and shutdown are skipped, so nodes are deleted **without a graceful drain** while cloud cleanup
+  still proceeds from the bootstrap ledger and the command can still exit 0.
+- **The command says up front that it can take minutes**, with the figures that bound it, before the first
+  wait begins.
+- Pinned by `ClusterDestroyCommandTest.DestroyProgressOutput`, including a positional assertion that the
+  phase line is the *first* output rather than a retrospective note, an assertion that the announced
+  timeout equals `ClusterHttpClient.REQUEST_TIMEOUT` so the two cannot drift apart, and a succeeding-request
+  positive control so "stderr contains the warning" is a real signal rather than an always-on line.
+- **[unverified: the residual silence]** — the 130s ceiling accounts for the great majority of the observed
+  ~2.5 minutes but not all of it, and the run was killed rather than allowed to complete, so **why** the
+  request blocked (rather than being refused) is not established. The operator's IP had to match the
+  firewall's `--admin-cidr` /32 for the endpoint to be reachable at all, which would produce exactly this
+  shape if it had changed, but that is a hypothesis and is not claimed here. What is fixed is that the
+  silence can no longer hide any of it.


### PR DESCRIPTION
Issues: #994 and #995 (referenced **without** closing keywords — closing is a tracker decision, not a merge side effect)

## What was wrong

**#994 — bootstrap cleanup could not reap servers created before a mid-PROVISION failure.** Found by a real Hetzner run: the 403 on node 3 of 3 left two `ccx23` running after the process exited with code 4, and they had to be deleted by hand.

**The cause was an empty inventory, not a bad delete order.** `destructionRank` already ranked `ProvisionedVm → 1` ahead of `CloudFirewall → 3`. `BootstrapPhaseProvision.execute` returned the *original* context on failure (`return result.map(_ -> ctx)`), so `buildUpdatedState` — the only writer of a `ProvisionedVm` record — never ran, and `allNodes` was discarded with it. Cleanup read a state holding only the firewall and ssh key, deleted the firewall **correctly per its own ordering**, and had nothing else to delete. The log *looked* like an ordering bug because the firewall was the only item in the list.

Confirmed from the incident artifact itself: `~/.aether/clusters/rc4tip-probe/bootstrap-state.json` holds `PROVISION: FAILED`, 1 firewall, **0 VMs**, `sources: []`, with the healthy `rc4tip-probe2` state as positive control.

**#995 — `cluster destroy` emitted nothing for a ~157s operation.** `fetchNodeIds`' failure was discarded by `.or(List.of())` with no message, and no phase output existed anywhere. It was **never stalled**: measured end-to-end at 157s on the fixed build, against an operator kill at ~150s. The defect is the absence of output during a legitimately slow destructive operation — which is exactly what invites the intervention that happened.

## What changed

**The ledger (#994)** — each VM and each per-source cleanup handle is recorded into the **persisted** state at creation, not after every source succeeds.

**The ledger's durability**, because the fix makes `bootstrap-state.json` the only record of billable resources:
- `SecureFiles` writes via temp file + `ATOMIC_MOVE` with `force` before rename, owner-only mode preserved. The javadoc states the precise guarantee: **process death covered, host power loss not**.
- `BootstrapStatePersistence.read()` returns `Result<Option<BootstrapState>>`, so **absent and unparseable are different answers**. `markPhaseFailed` now refuses to overwrite an unreadable ledger — previously `load(...).or(preSnapshot)` could not tell the two apart and wrote a VM-less snapshot over a torn file, reproducing #994's outcome by another route.
- Every PROVISION-path write is consumed, and every unrecordable VM prints its **server id** so an operator can reap by hand.

**Diagnostics (#994)** — the retry line reports observed state instead of asserting a process. It previously printed *"servers are still detaching"* when no server delete had been issued. It now reads *"accounted for all N VM(s) the bootstrap ledger records … (deleted, or already gone and reported as such above), and the provider still reports the firewall in use"* — "accounted for" rather than "deleted", because `tolerateAlreadyGone` converts `InstanceNotFound` into success and the old wording claimed a deletion that may never have happened.

**Enumeration (#994)** — all three teardown paths route failures through `ReapFailure`, so the VM sweep and SSH-key sweep name type and id like the ledger-driven path. Previously the unqualified "every unreaped resource" claim was true of `cleanupWith` and false of the command, and the resources it missed were the unrecorded billable VMs that are #994's whole theme.

**Destroy output (#995)** — five announced phases, an upfront banner naming the real waits with ceilings read from the enforcing constants, per-resource delete reporting, and a closing summary. An unreadable ledger now yields cleanup-false, keeps the registry entry, and exits non-zero — previously it read as empty and exited 0 with the entry removed, which is the same money-bearing mechanism as above and was found while fixing it.

## Verification

| | |
|---|---|
| `aether/cli` | **745 testcases**, 0 failures / errors / skips; reconciles exactly with 745 `@Test` (baseline 724, +21) |
| Root `mvn clean install` | **145 SUCCESS / 0 FAILURE / 0 SKIPPED**, **13,678 testcases** (surefire 13,662 + failsafe 16), 0 failures, 19 skipped — +21 testcases, +0 skips vs baseline |
| Gate | `Running JBCT check on 105 Java file(s)` → 0 format, 0 lint, `JBCT check passed.` |
| Changelog | `ok (2 fragment(s), needs_fragment=true)` |
| Mutation probes | **9 run, 9 RED**, zero mismatches, each naming the predicted test |

Probe scope is stated rather than implied: **90 testcases across 4 classes**. It does not support a "nothing else broke" claim.

### Confirmed against real infrastructure

The `logCreateRequest`-style paths this touches cannot be reached by unit tests, so the cleanup path was exercised on Hetzner using the **dedicated-core quota as a deterministic mid-PROVISION failure injector** (3× `ccx23` = 12 dedicated cores against a ~8 ceiling: two provision, the third 403s).

On the final commit:

```
403 (resource_limit_exceeded): dedicated core limit exceeded
Cleaned up VM 165483558 (primary/core)
Cleaned up VM 165483554 (primary/core)
Firewall 11606209 NOT deleted (attempt 1/6) — 422 (resource_in_use)
  observed: this cleanup accounted for all 2 VM(s) ... Retrying in 5000ms.
Cleaned up Firewall aether-rc4tip-probe5-primary (id=11606209, source=primary)
```

Registry returned to **zero with no manual intervention** (servers, firewalls, volumes, load-balancers, networks), and both VM ids return `Server not found` — confirmed against the provider, not against the tool's own output. Exit code is now 1 (provisioning failed) rather than 4 (cleanup failed), with no "orphan resources may remain". Zero occurrences of the pre-fix signatures.

**Scope of that confirmation, stated precisely:** the jar tested was an integration build of this branch merged with #993 (the CLI logging branch), because the provider diagnostics are only readable with a real slf4j binding. #993 does not touch cleanup, but the artifact exercised was the merge of the two, not this branch alone. A separate earlier run confirmed the same behaviour on an earlier commit of this branch; the run quoted above is the final code.

## History of this branch, since it bears on trust

The first brief for this work **specified the wrong fix** — it asked for a delete-order change. The implementing agent checked the claim against `destructionRank`, found VMs already ranked first, and reported the contradiction instead of implementing it. #994's title and body were corrected, and `know: 8a3f04ed0` corrects the `know:` commit that carried the wrong mechanism.

An adversarial pass in an isolated clone then returned **0 BLOCKING, 4 SHOULD-FIX, 11 NOTE** and recommended merging. All four SHOULD-FIX were fixed anyway, because SF-1 showed the fix promoted `bootstrap-state.json` to load-bearing for money without hardening its write path — and both incidents that motivated this work ended with the operator killing the process mid-run. Two of the new pins close probes the verifier measured GREEN (V1, V4A).

## Bounds

- `[unverified]` Host power loss during the ledger write. The atomic rename covers process death; it does not make the write durable against power loss, and the javadoc says so.
- `[unverified]` One line in `execute` calling `persistCleanupHandle` is pinned only indirectly — its behaviour and failure paths are pinned, the call site is not. Driving `execute` needs a `ProviderResolver` seam that does not exist, and adding production API solely for a test was judged the worse trade.
- `[unverified]` The probe matrix covers 90 testcases across 4 classes.

## Related, filed separately and NOT fixed here

- **#997** — `cluster destroy` deletes the firewall before the label VM sweep, so unrecorded workers can strand it. Same class, different path; the fix would change `PROTECTED_CLUSTERS` failure semantics on the bootstrap path.
- **#998** — the registry endpoint for a cloud cluster omits the management port, so node enumeration fails and drain/shutdown are skipped on every cloud destroy. Found only because this branch made the failure visible.
- **#1000** — `scripts/changelog-check.sh` exits 0 when its base ref does not resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
