### PR TITLE
chore: move every GitHub Actions pin off deprecated Node 16/20 runtimes (main)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Java 25
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '25'
           distribution: 'zulu'
@@ -46,7 +46,7 @@ jobs:
         timeout-minutes: 15
 
       - name: Upload test results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: always()
         with:
           name: test-results
@@ -61,10 +61,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Java 25
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '25'
           distribution: 'zulu'
@@ -83,7 +83,7 @@ jobs:
         timeout-minutes: 30
 
       - name: Upload Forge test results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: always()
         with:
           name: forge-test-results

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,10 +14,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Java 25
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '25'
           distribution: 'zulu'
@@ -49,7 +49,7 @@ jobs:
             > SHA256SUMS
 
       - name: Create Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v3
         with:
           name: Pragmatica ${{ steps.version.outputs.VERSION }}
           draft: false
@@ -73,10 +73,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Java 25
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '25'
           distribution: 'zulu'
@@ -98,7 +98,7 @@ jobs:
           aether/dist/build-dist.sh --version ${{ steps.version.outputs.VERSION }}
 
       - name: Upload macOS archives to release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v3
         with:
           files: |
             aether/dist/output/*.tar.gz
@@ -113,10 +113,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Java 25
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '25'
           distribution: 'zulu'
@@ -138,7 +138,7 @@ jobs:
           aether/dist/build-dist.sh --version ${{ steps.version.outputs.VERSION }}
 
       - name: Upload arm64 archives to release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v3
         with:
           files: |
             aether/dist/output/*.tar.gz
@@ -155,27 +155,27 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Extract version from tag
         id: version
         run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Java 25
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '25'
           distribution: 'zulu'
@@ -187,7 +187,7 @@ jobs:
           mvn package -B -DskipTests
 
       - name: Build and push aether-node
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: aether
           file: aether/docker/aether-node/Dockerfile
@@ -199,7 +199,7 @@ jobs:
             ghcr.io/${{ github.repository_owner }}/aether-node:latest
 
       - name: Build and push aether-forge
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: aether
           file: aether/docker/aether-forge/Dockerfile
@@ -217,10 +217,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Java 25
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '25'
           distribution: 'zulu'
@@ -238,7 +238,7 @@ jobs:
         timeout-minutes: 15
 
       - name: Upload E2E test results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: always()
         with:
           name: e2e-test-results


### PR DESCRIPTION
Companion to #996, which applies the same change to `release-1.0.0-rc4`. `main` carries its own copies of these workflows and was not covered by that PR.

## Why

Every GitHub Actions pin on `main` targets a **deprecated Node runtime**. Today they warn; when GitHub stops force-upgrading them they will fail, and it will arrive as a CI break with no code change to blame.

Runtimes read from each action's own `action.yml` at the pinned tag (`runs.using`), not from release notes or the deprecation warning:

| action | was | runtime | now | runtime |
|---|---|---|---|---|
| `actions/checkout` | v4 | node20 | **v5** | node24 |
| `actions/setup-java` | v4 | node20 | **v5** | node24 |
| `actions/upload-artifact` | v4 | node20 | **v6** | node24 |
| `softprops/action-gh-release` | v1 | **node16** | **v3** | node24 |
| `docker/setup-qemu-action` | v3 | node20 | **v4** | node24 |
| `docker/setup-buildx-action` | v3 | node20 | **v4** | node24 |
| `docker/login-action` | v3 | node20 | **v4** | node24 |
| `docker/build-push-action` | v6 | node20 | **v7** | node24 |

**Two traps that following the guidance rather than the source would have walked into:**

1. **`actions/upload-artifact@v5` is still node20.** Bumping one major — the obvious fix, and the pattern the deprecation notice suggests for `setup-java` — leaves it deprecated. `v6` is the first node24 release. The v5.0.0 release note says *"BREAKING CHANGE: this update supports Node `v24.x`"* while `action.yml` at both `v5` and `v5.0.0` (commit `330a01c49`) declares `using: node20`.
2. **`softprops/action-gh-release@v1` was on node16**, a generation worse than node20 and long past end of life. It appears only in `release.yml`, which never runs on a pull request, so no PR annotation has ever reported it.

## Applied to main's own files, not copied from rc4

Checked rather than assumed, and they are not the same:

- **`main` has 2 workflow files** (`ci.yml`, `release.yml`); rc4 has 4 — it also carries `catalog.yml` and `changelog.yml`.
- **`main`'s `ci.yml` is byte-identical to rc4's.**
- **`main`'s `release.yml` DIFFERS from rc4's by 55+/7−.** Copying rc4's file across would have dragged unrelated changes onto `main`; the version bumps here are applied to main's own content.

Consequence worth knowing: because `main` has no `changelog.yml` or `catalog.yml`, the `fragment` and `statistics` checks do not exist on this branch at all.

## Why minimum-node24 majors and not latest

Several actions are further ahead (`checkout` v7, `setup-java` v6, `upload-artifact` v7). This moves to the **lowest major with a supported runtime**: it fully fixes the defect, and it minimises unexamined breaking-change surface — which matters most because **17 of the 25 pins live in `release.yml`, which no pull request can exercise.** Moving to latest majors is a reasonable follow-up, done deliberately rather than as a side effect of this one.

## Verification

- **25 pins changed, 2 files.** Counts verified against a pre-edit baseline per action — 7 / 7 / 3 / 3 / 1 / 1 / 1 / 2, summing to 25, the total number of `uses:` pins on `main`. No pin sits outside the replacement set and zero old pins remain.
- **All 50 changed lines (25 added, 25 removed) contain `uses:`** — the change is provably confined to version strings, so workflow structure is untouched. (`pyyaml` was unavailable locally, so no YAML parse was run; this confinement check is offered in its place rather than an unverified claim of validity.)
- All runners are GitHub-hosted (`ubuntu-latest`, `macos-latest`, `ubuntu-24.04-arm`), so the **runner floor of v2.327.1** that `setup-java@v5` and `upload-artifact@v6` require is satisfied automatically. It would matter on self-hosted runners.

## What this PR cannot establish

**The 17 pins in `release.yml` are not exercised by any PR check** — it triggers on a release. That includes the `action-gh-release` v1→v3 jump (two majors) and all four `docker/*` bumps. Their release notes describe the runtime move as the change, and `action-gh-release` v3.0.0's notes describe only that, but **no run in this PR proves it.** The first real exercise is the next release, which is worth knowing in advance rather than discovering mid-release.

The pins this PR does verify are `ci.yml`'s — `checkout@v5`, `setup-java@v5`, `upload-artifact@v6` — exercised by this PR's own `build-and-test` and `forge-tests`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated build, test, and release workflows to use newer versions of their underlying actions.
  * Workflow steps and behavior remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->