### PR TITLE
fix: #980 #1000 stop the corpus walk racing the reactor, and stop the changelog gate passing blind

### DIFF
--- a/aether/pg-tools/pg-parser/src/test/java/org/pragmatica/aether/pg/parser/SqlCorpus.java
+++ b/aether/pg-tools/pg-parser/src/test/java/org/pragmatica/aether/pg/parser/SqlCorpus.java
@@ -4,29 +4,111 @@
 // See LICENSE in the repository root for full terms.
 package org.pragmatica.aether.pg.parser;
 
+import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Set;
 
 /// The repo-wide SQL corpus walk shared by every corpus-level sensor in this module. ONE
 /// implementation on purpose: the isRegularFile filter below was first added to a single caller
 /// (CorpusParseTest, the #598 CI follow-up) and its absent sibling copy broke the next full build —
 /// a shared mechanism must be fixed at the mechanism, not at a caller.
+///
+/// The walk PRUNES build and VCS output AT THE WALKER rather than filtering it out of the results
+/// (#980). Filtering afterwards cannot help, and the distinction is the whole defect: the race is
+/// between enumeration and open, and a downstream `Stream.filter` runs only once `Files.walk` has
+/// already opened the directory and listed it. `.mvn/maven.config` carries `-T 1C`, so CI runs a
+/// module-parallel reactor in which sibling modules create and delete files under
+/// `*/target/surefire-reports/` while this walk is running — a file present at enumeration and gone
+/// at open failed the build INSIDE this module, naming a module the author had never touched.
+///
+/// What the pruning guarantees, precisely: a pruned subtree is never opened, because
+/// [SqlCollector#preVisitDirectory] returns [FileVisitResult#SKIP_SUBTREE]. It does NOT avoid one
+/// `opendir` on the pruned directory itself — `walkFileTree` opens a directory's stream BEFORE
+/// consulting `preVisitDirectory` (verified empirically, not read off the javadoc: a trap placed AT
+/// `target` still throws, a trap placed INSIDE it no longer does). That residue is harmless because
+/// `*/target` is created once per module and not removed mid-reactor, whereas its
+/// `surefire-reports/` contents churn continuously.
+///
+/// Measured on this tree before the change: `Files.walk` enumerated 36,893 entries, of which 29,519
+/// (80.0%) sat under `target/` or `.m2-local/` only to be discarded by the filters — 5,194 directory
+/// opens the corpus never needed. The local figure UNDERSTATES CI, where `.git` is a real directory
+/// rather than this worktree's pointer file.
 final class SqlCorpus {
+    /// Directory names whose subtrees cannot hold corpus SQL and ARE written concurrently by the
+    /// reactor: Maven output, git's object store, and the tree-local Maven repository that this
+    /// workspace's `.mvn/maven.config` places inside the repo root. Pruning `.m2-local` is not
+    /// hygiene either — it contributed 1,932 of those directory opens, and nothing excluded it
+    /// before.
+    ///
+    /// Controlled before pruning: of the repository's tracked paths, zero contain a `target/` or
+    /// `.m2-local/` component (the same grep returned 3,862 for `/src/`), so no tracked `.sql` file
+    /// can be lost to this set.
+    private static final Set<String> PRUNED = Set.of("target", ".git", ".m2-local");
+
     private SqlCorpus() {}
 
     static List<Path> sqlFiles(Path root) throws Exception {
-        try (var walk = Files.walk(root)) {
-            // isRegularFile is load-bearing, not hygiene: JRE dist output contains DIRECTORIES
-            // named `java.sql` (package-shaped legal/ dirs), and a name-suffix match alone turns
-            // them into an IOException mid-corpus on any machine with a prior dist build.
-            return walk.filter(Files::isRegularFile)
-                       .filter(p -> p.toString().endsWith(".sql"))
-                       .filter(p -> !p.toString().contains("/target/"))
-                       .filter(p -> !p.toString().contains("/.git/"))
-                       .sorted(Comparator.comparing(p -> root.relativize(p).toString()))
-                       .toList();
+        var collector = new SqlCollector(root);
+
+        Files.walkFileTree(root, collector);
+
+        return collector.files()
+                        .stream()
+                        .sorted(Comparator.comparing(p -> root.relativize(p).toString()))
+                        .toList();
+    }
+
+    /// `visitFileFailed` is deliberately NOT overridden. [SimpleFileVisitor] rethrows, so an
+    /// unreadable file in the SOURCE space still fails the build loudly: #980 is a fix for walking
+    /// where it had no business walking, NOT a licence to go blind about the corpus it does own.
+    private static final class SqlCollector extends SimpleFileVisitor<Path> {
+        private final Path root;
+        private final List<Path> files = new ArrayList<>();
+
+        private SqlCollector(Path root) {
+            this.root = root;
+        }
+
+        private List<Path> files() {
+            return files;
+        }
+
+        @Override
+        public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) {
+            return isPruned(dir)
+                   ? FileVisitResult.SKIP_SUBTREE
+                   : FileVisitResult.CONTINUE;
+        }
+
+        /// The root is never pruned even when its own name matches: walking what the caller asked
+        /// for and finding nothing is honest, and it is also what keeps `getFileName()` — null only
+        /// for a filesystem root — off this path.
+        private boolean isPruned(Path dir) {
+            return !dir.equals(root) && PRUNED.contains(dir.getFileName().toString());
+        }
+
+        @Override
+        public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
+            if (isSqlFile(file)) {
+                files.add(file);
+            }
+
+            return FileVisitResult.CONTINUE;
+        }
+
+        /// `Files.isRegularFile` rather than `attrs.isRegularFile()`, preserving the previous
+        /// link-following semantics exactly. It stays load-bearing, not hygiene: JRE dist output
+        /// contains DIRECTORIES named `java.sql` (package-shaped legal/ dirs), and a name-suffix
+        /// match alone turns them into an IOException mid-corpus on any machine with a prior dist
+        /// build.
+        private static boolean isSqlFile(Path file) {
+            return Files.isRegularFile(file) && file.getFileName().toString().endsWith(".sql");
         }
     }
 

--- a/aether/pg-tools/pg-parser/src/test/java/org/pragmatica/aether/pg/parser/SqlCorpusTest.java
+++ b/aether/pg-tools/pg-parser/src/test/java/org/pragmatica/aether/pg/parser/SqlCorpusTest.java
@@ -76,7 +76,17 @@ class SqlCorpusTest {
 
     /// The walk owns the source space and must stay loud about it. Pruning build output is not a
     /// licence to swallow an unreadable corpus directory: that would shrink the corpus silently,
-    /// which is the failure [CorpusParseTest] exists to catch.
+    /// which is the failure [CorpusParseTest] exists to catch. The mutation this pins is a
+    /// `visitFileFailed` override returning CONTINUE, which reddens this test and leaves the other
+    /// two green.
+    ///
+    /// It ALSO pins the exception type, and that is worth stating because it is a deliberate change
+    /// rather than a preserved property: the old `Files.walk` surfaced a walk failure as
+    /// [java.io.UncheckedIOException], which is a `RuntimeException` and therefore NOT an
+    /// [IOException]. `walkFileTree` throws the [IOException] itself. Both fail the build, so this
+    /// test's red against the pre-#980 code is attributable to the type and not to blindness - hence
+    /// the separate mutation named above, which is what actually validates it as an anti-blindness
+    /// pin. `sqlFiles` already declared `throws Exception`, so no caller changes.
     @Test
     void sqlFiles_propagatesFailure_whenTheSourceTreeCannotBeRead(@TempDir Path root) throws Exception {
         var schema = Files.createDirectories(root.resolve("module/src/main/resources/schema"));
@@ -89,7 +99,10 @@ class SqlCorpusTest {
 
         assertThatThrownBy(() -> SqlCorpus.sqlFiles(root))
                 .as("an unreadable directory in the SOURCE space must still fail the build")
-                .isInstanceOf(IOException.class);
+                .isInstanceOf(IOException.class)
+                // Named, not merely thrown: "it failed" and "it failed for this reason" are
+                // different observations, and only the second one is evidence.
+                .hasMessageContaining("schema");
     }
 
     private static Path write(Path file) throws Exception {

--- a/aether/pg-tools/pg-parser/src/test/java/org/pragmatica/aether/pg/parser/SqlCorpusTest.java
+++ b/aether/pg-tools/pg-parser/src/test/java/org/pragmatica/aether/pg/parser/SqlCorpusTest.java
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2025 Pragmatica Labs - Sergiy Yevtushenko
+// Licensed under Business Source License 1.1. Change Date: 2030-01-01. Change License: Apache-2.0.
+// See LICENSE in the repository root for full terms.
+package org.pragmatica.aether.pg.parser;
+
+import java.io.IOException;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+/// Pins the #980 property: [SqlCorpus] must not walk INTO build or VCS output, because under CI's
+/// module-parallel reactor those directories are being written while the walk runs.
+///
+/// The instrument is an UNREADABLE directory rather than a timing window, which is what makes the
+/// pin deterministic. A race cannot be reproduced on demand; "the walk opened a directory it should
+/// never have opened" can be, and it is the same mechanism — the old code failed while opening
+/// something beneath `target/`, and an unreadable directory fails at exactly that point every time.
+///
+/// [#sqlFiles_propagatesFailure_whenTheSourceTreeCannotBeRead] is the anti-blindness control, and it
+/// is the reason this class is three tests rather than two: a "fix" that swallowed walk failures
+/// would pass the first two and is precisely the wrong cure.
+class SqlCorpusTest {
+    private static final String SQL = "SELECT 1;\n";
+    private final List<Path> trapped = new ArrayList<>();
+
+    /// Restores every trap so the @TempDir cleanup cannot fail on a directory it may not read.
+    @AfterEach
+    void disarmTraps() {
+        trapped.forEach(dir -> dir.toFile().setReadable(true, true));
+        trapped.clear();
+    }
+
+    @Test
+    void sqlFiles_doesNotEnterBuildOutput_whenItsContentsCannotBeRead(@TempDir Path root) throws Exception {
+        var corpusFile = write(root.resolve("module/src/main/resources/schema/live.sql"));
+        var reports = Files.createDirectories(root.resolve("module/target/surefire-reports"));
+
+        write(reports.resolve("stale.sql"));
+        arm(reports);
+
+        assumeTrue(isUnreadable(reports),
+                   "trap not armed (running as root?): an unreadable directory is this test's instrument");
+
+        assertThat(SqlCorpus.sqlFiles(root))
+                .as("the walk must never descend beneath target/, so an unreadable "
+                    + "target/surefire-reports cannot fail it")
+                .containsExactly(corpusFile);
+    }
+
+    /// Permission-independent, so it pins the corpus contract on every machine including one running
+    /// as root. It reddens the pre-#980 code too, for a second and independent reason: `.m2-local`
+    /// was excluded by NOTHING there, and the tree-local Maven repository lives inside the repo root.
+    @Test
+    void sqlFiles_excludesBuildOutputAndLocalRepository(@TempDir Path root) throws Exception {
+        var corpusFile = write(root.resolve("module/src/test/resources/corpus/live.sql"));
+
+        write(root.resolve("module/target/classes/schema/copied.sql"));
+        write(root.resolve(".m2-local/org/example/artifact/1.0.0/installed.sql"));
+        write(root.resolve(".git/objects/looks-like.sql"));
+
+        assertThat(SqlCorpus.sqlFiles(root))
+                .as("only the source-tree file belongs to the corpus")
+                .containsExactly(corpusFile);
+    }
+
+    /// The walk owns the source space and must stay loud about it. Pruning build output is not a
+    /// licence to swallow an unreadable corpus directory: that would shrink the corpus silently,
+    /// which is the failure [CorpusParseTest] exists to catch.
+    @Test
+    void sqlFiles_propagatesFailure_whenTheSourceTreeCannotBeRead(@TempDir Path root) throws Exception {
+        var schema = Files.createDirectories(root.resolve("module/src/main/resources/schema"));
+
+        write(schema.resolve("live.sql"));
+        arm(schema);
+
+        assumeTrue(isUnreadable(schema),
+                   "trap not armed (running as root?): an unreadable directory is this test's instrument");
+
+        assertThatThrownBy(() -> SqlCorpus.sqlFiles(root))
+                .as("an unreadable directory in the SOURCE space must still fail the build")
+                .isInstanceOf(IOException.class);
+    }
+
+    private static Path write(Path file) throws Exception {
+        Files.createDirectories(file.getParent());
+
+        return Files.writeString(file, SQL);
+    }
+
+    private void arm(Path dir) {
+        dir.toFile().setReadable(false, false);
+        trapped.add(dir);
+    }
+
+    /// Measures the property the trap depends on rather than asserting it: `canRead` reports true for
+    /// root, and a trap that is not armed would make the test pass VACUOUSLY, which is worse than no
+    /// test at all.
+    private static boolean isUnreadable(Path dir) {
+        try (DirectoryStream<Path> ignored = Files.newDirectoryStream(dir)) {
+            return false;
+        } catch (IOException expected) {
+            return true;
+        }
+    }
+}

--- a/changelog.d/1000-changelog-gate-refuses-unresolvable-base.md
+++ b/changelog.d/1000-changelog-gate-refuses-unresolvable-base.md
@@ -1,0 +1,17 @@
+### Fixed (2026-09-11 — #1000: the changelog gate cannot pass without having examined anything)
+- **`scripts/changelog-check.sh` exited 0 when its base ref did not resolve.** `git diff` exits 128 on
+  an unresolvable range, but the call sat inside a process substitution, whose exit status
+  `set -euo pipefail` does not check — `pipefail` governs pipelines, not `< <(...)`. The 128 was
+  discarded, the changed-path array came back empty, and the empty-diff branch reported success, so
+  the fragment gate could pass **having examined nothing** while printing something indistinguishable
+  from a genuinely clean result. The workflow interpolates the base as
+  `origin/${{ github.base_ref }}`, so a renamed base branch, an unfetched ref or a fork edge reached
+  it. The script now resolves the base with `git rev-parse --verify` before inferring anything from an
+  empty diff, and reads each `git diff` exit status through a temp file rather than a process
+  substitution.
+- **Exit codes now distinguish the two refusals:** 2 means the gate could not look, 1 means it looked
+  and refused. Conflating them is what let the defect read as a pass.
+- **A pass now reports what it examined** — the changed-path count alongside `needs_fragment`, so a
+  zero is measured rather than implied. Same precedent as #740.
+- `script-gate` gains `ChangelogCheckTest`, which runs the real script against a real git repository
+  with no remote, so `origin/main` is unresolvable exactly as in the reported condition.

--- a/changelog.d/980-bootstrap-admin-key-derivation.md
+++ b/changelog.d/980-bootstrap-admin-key-derivation.md
@@ -1,4 +1,8 @@
-### Fixed (2026-09-10 — #980: `aether cluster bootstrap` could not authenticate against the cluster it had just formed)
+### Fixed (2026-09-10 — `know: 8f02cd3cf`: `aether cluster bootstrap` could not authenticate against the cluster it had just formed)
+
+<!-- Heading cites the owner ruling, not an issue: this work landed as the direct push `f25f14327`
+     with no issue and no PR. The filename's "980" is a collision from a speculatively-named branch —
+     issue #980 is the pg-parser walk race. Left as-is; do not substitute a guessed number. -->
 
 - **Phase 7 tore down healthy clusters.** `CLUSTER_FORMATION` cleared its all-nodes `/health/live`
   gate, then polled `/api/v1/health` for the quorum check and received

--- a/changelog.d/980-corpus-walk-prunes-build-output.md
+++ b/changelog.d/980-corpus-walk-prunes-build-output.md
@@ -1,0 +1,18 @@
+### Fixed (2026-09-11 — #980: the SQL corpus walk no longer enters concurrently-written build output)
+- **`pg-parser`'s repo-wide corpus walk pruned at the walker instead of filtering afterwards.** The
+  walk enumerated the whole repository and discarded `target/` and `.git/` entries with downstream
+  `Stream.filter` calls, which cannot help: the race is between enumeration and open, and the filter
+  runs only after `Files.walk` has already opened and listed the directory. `.mvn/maven.config`
+  carries `-T 1C`, so CI runs a module-parallel reactor in which sibling modules create and delete
+  files under `*/target/surefire-reports/` while the walk runs — a file present at enumeration and
+  gone at open failed the build inside `pg-parser`, naming a module the author had never touched.
+  `SqlCorpus` now walks with `Files.walkFileTree` and returns `SKIP_SUBTREE` from
+  `preVisitDirectory`, so those subtrees are never opened at all. `.m2-local` is pruned too: this
+  workspace's `.mvn/maven.config` places the tree-local Maven repository inside the repo root and
+  nothing excluded it before.
+- **Measured, on this tree:** the old walk enumerated 36,893 entries, of which 29,519 (80.0%) sat
+  under `target/` or `.m2-local/` only to be thrown away — 5,194 directory opens the corpus never
+  needed. The corpus itself is unchanged: old and new enumerations agree element-for-element on all
+  38 files, in the same order.
+- `visitFileFailed` is deliberately not overridden, so an unreadable directory in the **source** space
+  still fails the build loudly rather than silently shrinking the corpus.

--- a/changelog.d/README.md
+++ b/changelog.d/README.md
@@ -36,7 +36,14 @@ It fails when:
 
 - the pull request edits `CHANGELOG.md` and does not carry the `release-prep` label;
 - the pull request touches something other than documentation, workflows or this directory, and adds
-  no well-formed fragment, and does not carry the `no-changelog` label.
+  no well-formed fragment, and does not carry the `no-changelog` label;
+- **the base ref does not resolve**, so no diff could be computed (#1000). Previously this exited 0
+  reporting "no changes", which is indistinguishable from a genuinely empty diff — the gate could pass
+  having examined nothing.
+
+**Exit codes distinguish the two refusals:** `1` means the check looked and refused, `2` means it could
+not look and is reporting no verdict. On a pass it prints the changed-path count alongside
+`needs_fragment`, so a zero is measured rather than implied.
 
 Documentation-only pull requests (`*.md`, `docs/`, `.github/`) need no fragment.
 

--- a/script-gate/src/test/java/org/pragmatica/scriptgate/ChangelogCheckTest.java
+++ b/script-gate/src/test/java/org/pragmatica/scriptgate/ChangelogCheckTest.java
@@ -38,6 +38,7 @@ class ChangelogCheckTest {
     private static final Path SOURCE_FILE = Path.of("core", "src", "main", "java", "Thing.java");
     private static final Path FRAGMENT_FILE = Path.of("changelog.d", "1000-gate-says-what-it-examined.md");
     private static final String SOURCE_TEXT = "class Thing {}\n";
+
     private static final String FRAGMENT_TEXT = """
                                                 ### Fixed (2026-09-11 — #1000: the gate says what it examined)
                                                 - A bullet, because a well-formed fragment requires one.
@@ -56,8 +57,8 @@ class ChangelogCheckTest {
     void setUp(@TempDir Path tempDir) {
         root = tempDir;
         repo = gitFixture(tempDir, SyntheticGitRepo.syntheticGitRepo(tempDir));
-
-        given(ScriptRunner.copyExecutable(ScriptRunner.repoRoot().resolve(SCRIPT), root.resolve(SCRIPT)).mapToUnit());
+        given(ScriptRunner.copyExecutable(ScriptRunner.repoRoot().resolve(SCRIPT),
+                                          root.resolve(SCRIPT)).mapToUnit());
         given(repo.commitAll("add the checker under test"));
     }
 
@@ -67,7 +68,6 @@ class ChangelogCheckTest {
     void changelogCheck_refusesAndSaysItExaminedNothing_whenTheBaseRefDoesNotResolve() {
         given(changeSource());
         given(repo.commitAll("change a source file"));
-
         var execution = executed(runCheck(ABSENT_BASE));
 
         assertThat(execution.exitCode()).as(execution.output()).isEqualTo(COULD_NOT_LOOK);
@@ -95,7 +95,6 @@ class ChangelogCheckTest {
         given(changeSource());
         given(repo.writeFile(FRAGMENT_FILE, FRAGMENT_TEXT));
         given(repo.commitAll("change a source file with its fragment"));
-
         var execution = executed(runCheck("HEAD~1"));
 
         assertThat(execution.exitCode()).as(execution.output()).isZero();
@@ -115,13 +114,10 @@ class ChangelogCheckTest {
     void changelogCheck_refusesWithADistinctCode_whenSourcesChangeWithoutAFragment() {
         given(changeSource());
         given(repo.commitAll("change a source file with no fragment"));
-
         var execution = executed(runCheck("HEAD~1"));
 
         assertThat(execution.exitCode()).as(execution.output()).isEqualTo(LOOKED_AND_REFUSED);
-        assertThat(execution.output()).contains("no well-formed changelog.d/")
-                  // Not the "could not look" refusal: the two must stay distinguishable.
-                  .doesNotContain("EXAMINED NOTHING");
+        assertThat(execution.output()).contains("no well-formed changelog.d/").doesNotContain("EXAMINED NOTHING");
     }
 
     /// Guards the over-correction. An empty diff against a base that DID resolve is a legitimate
@@ -144,6 +140,8 @@ class ChangelogCheckTest {
     private Result<ScriptRunner.Execution> runCheck(String base) {
         return ScriptRunner.run(root,
                                 Map.of("PR_LABELS", ""),
-                                List.of("bash", root.resolve(SCRIPT).toString(), base));
+                                List.of("bash",
+                                        root.resolve(SCRIPT).toString(),
+                                        base));
     }
 }

--- a/script-gate/src/test/java/org/pragmatica/scriptgate/ChangelogCheckTest.java
+++ b/script-gate/src/test/java/org/pragmatica/scriptgate/ChangelogCheckTest.java
@@ -1,0 +1,143 @@
+package org.pragmatica.scriptgate;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+import org.pragmatica.lang.Result;
+import org.pragmatica.lang.Unit;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.pragmatica.scriptgate.ScriptGate.executed;
+import static org.pragmatica.scriptgate.ScriptGate.fixture;
+import static org.pragmatica.scriptgate.ScriptGate.given;
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+/// #1000 - `scripts/changelog-check.sh` exited 0 when its base ref did not resolve, so the fragment
+/// gate could pass HAVING EXAMINED NOTHING while printing something indistinguishable from a
+/// genuinely clean result.
+///
+/// `git diff` exits 128 on an unresolvable range, but the call sat inside a process substitution,
+/// whose exit status `set -euo pipefail` does not check - pipefail governs pipelines, not `< <(...)`.
+/// The 128 was discarded, the array came back empty, and the empty-diff branch reported success.
+///
+/// Reading the script's TEXT could not catch this: the old and fixed versions both contain the
+/// "no changes against" line, in the same place. What separates them is whether the script can still
+/// print it when no diff was computed, so every test here RUNS the real script against a real git
+/// repository.
+///
+/// The two refusals are asserted by DISTINCT exit codes, because that is the whole point of the
+/// ticket. 2 means the gate could not look; 1 means it looked and refused. A bare `isNotZero` would
+/// have accepted the defect's opposite - a gate that fails everything - as a fix.
+class ChangelogCheckTest {
+    private static final Path SCRIPT = Path.of("scripts", "changelog-check.sh");
+    private static final Path SOURCE_FILE = Path.of("core", "src", "main", "java", "Thing.java");
+    private static final Path FRAGMENT_FILE = Path.of("changelog.d", "1000-gate-says-what-it-examined.md");
+    private static final String SOURCE_TEXT = "class Thing {}\n";
+    private static final String FRAGMENT_TEXT = """
+                                                ### Fixed (2026-09-11 — #1000: the gate says what it examined)
+                                                - A bullet, because a well-formed fragment requires one.
+                                                """;
+
+    /// The CI shape, verbatim from `.github/workflows/changelog.yml`, and unresolvable in a fixture
+    /// that has no remote - which is the ticket's condition rather than an invented one.
+    private static final String ABSENT_BASE = "origin/main";
+    private static final int COULD_NOT_LOOK = 2;
+    private static final int LOOKED_AND_REFUSED = 1;
+
+    private SyntheticGitRepo repo;
+    private Path root;
+
+    @BeforeEach
+    void setUp(@TempDir Path tempDir) {
+        root = tempDir;
+        repo = fixture(tempDir, SyntheticGitRepo.syntheticGitRepo(tempDir));
+
+        given(ScriptRunner.copyExecutable(ScriptRunner.repoRoot().resolve(SCRIPT), root.resolve(SCRIPT)).mapToUnit());
+        given(repo.commitAll("add the checker under test"));
+    }
+
+    /// The ticket's defect. Before the fix this exited 0 printing "no changes against origin/main",
+    /// with no diff behind it at all.
+    @Test
+    void changelogCheck_refusesAndSaysItExaminedNothing_whenTheBaseRefDoesNotResolve() {
+        given(changeSource());
+        given(repo.commitAll("change a source file"));
+
+        var execution = executed(runCheck(ABSENT_BASE));
+
+        assertThat(execution.exitCode()).as(execution.output()).isEqualTo(COULD_NOT_LOOK);
+        assertThat(execution.output()).contains("does not resolve to a commit")
+                  .contains("EXAMINED NOTHING")
+                  // The precise false success #1000 reported, with nothing examined behind it.
+                  .doesNotContain("no changes against");
+    }
+
+    /// Positive control for the refusal above: the SAME unexamined-base condition over a tree with
+    /// nothing to report. Without it, the refusal could be a script that has started failing on
+    /// everything, and an unresolvable base is not a result whatever the tree holds.
+    @Test
+    void changelogCheck_refuses_whenTheBaseDoesNotResolveEvenWithNothingToReport() {
+        var execution = executed(runCheck(ABSENT_BASE));
+
+        assertThat(execution.exitCode()).as(execution.output()).isEqualTo(COULD_NOT_LOOK);
+        assertThat(execution.output()).contains("EXAMINED NOTHING");
+    }
+
+    /// The honesty half of the ticket: on a pass the gate must report WHAT it examined, so a zero is
+    /// visible rather than implied.
+    @Test
+    void changelogCheck_passesAndReportsTheChangedPathCount_whenAFragmentIsPresent() {
+        given(changeSource());
+        given(repo.writeFile(FRAGMENT_FILE, FRAGMENT_TEXT));
+        given(repo.commitAll("change a source file with its fragment"));
+
+        var execution = executed(runCheck("HEAD~1"));
+
+        assertThat(execution.exitCode()).as(execution.output()).isZero();
+        assertThat(execution.output()).contains("2 changed path(s)")
+                  .contains("1 fragment(s)")
+                  .contains("needs_fragment=true");
+    }
+
+    /// The gate must still refuse for its ORIGINAL reason, and with a different code than "could not
+    /// look". This is what makes the pair above a discrimination rather than a smoke test.
+    @Test
+    void changelogCheck_refusesWithADistinctCode_whenSourcesChangeWithoutAFragment() {
+        given(changeSource());
+        given(repo.commitAll("change a source file with no fragment"));
+
+        var execution = executed(runCheck("HEAD~1"));
+
+        assertThat(execution.exitCode()).as(execution.output()).isEqualTo(LOOKED_AND_REFUSED);
+        assertThat(execution.output()).contains("1 changed path(s)")
+                  .contains("no well-formed changelog.d/");
+    }
+
+    /// Guards the over-correction. An empty diff against a base that DID resolve is a legitimate
+    /// pass, and #1000 must not be cured by failing that case too. The pass line now distinguishes
+    /// the two silences in its own words.
+    @Test
+    void changelogCheck_passes_whenTheDiffIsGenuinelyEmpty() {
+        var execution = executed(runCheck("HEAD"));
+
+        assertThat(execution.exitCode()).as(execution.output()).isZero();
+        assertThat(execution.output()).contains("no changes against HEAD")
+                  .contains("0 changed path(s)")
+                  .contains("measured and not inferred");
+    }
+
+    private Result<Unit> changeSource() {
+        return repo.writeFile(SOURCE_FILE, SOURCE_TEXT);
+    }
+
+    private Result<ScriptRunner.Execution> runCheck(String base) {
+        return ScriptRunner.run(root,
+                                Map.of("PR_LABELS", ""),
+                                List.of("bash", root.resolve(SCRIPT).toString(), base));
+    }
+}

--- a/script-gate/src/test/java/org/pragmatica/scriptgate/ChangelogCheckTest.java
+++ b/script-gate/src/test/java/org/pragmatica/scriptgate/ChangelogCheckTest.java
@@ -12,7 +12,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import static org.pragmatica.scriptgate.ScriptGate.executed;
-import static org.pragmatica.scriptgate.ScriptGate.fixture;
+import static org.pragmatica.scriptgate.ScriptGate.gitFixture;
 import static org.pragmatica.scriptgate.ScriptGate.given;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -55,7 +55,7 @@ class ChangelogCheckTest {
     @BeforeEach
     void setUp(@TempDir Path tempDir) {
         root = tempDir;
-        repo = fixture(tempDir, SyntheticGitRepo.syntheticGitRepo(tempDir));
+        repo = gitFixture(tempDir, SyntheticGitRepo.syntheticGitRepo(tempDir));
 
         given(ScriptRunner.copyExecutable(ScriptRunner.repoRoot().resolve(SCRIPT), root.resolve(SCRIPT)).mapToUnit());
         given(repo.commitAll("add the checker under test"));
@@ -106,6 +106,11 @@ class ChangelogCheckTest {
 
     /// The gate must still refuse for its ORIGINAL reason, and with a different code than "could not
     /// look". This is what makes the pair above a discrimination rather than a smoke test.
+    ///
+    /// No changed-path count is asserted here, and that is the script's contract rather than an
+    /// omission: #1000 asks for the count on the PASS line, where a zero would otherwise be implied.
+    /// A refusal already names the specific thing it objected to, which is the property that matters
+    /// on that path.
     @Test
     void changelogCheck_refusesWithADistinctCode_whenSourcesChangeWithoutAFragment() {
         given(changeSource());
@@ -114,8 +119,9 @@ class ChangelogCheckTest {
         var execution = executed(runCheck("HEAD~1"));
 
         assertThat(execution.exitCode()).as(execution.output()).isEqualTo(LOOKED_AND_REFUSED);
-        assertThat(execution.output()).contains("1 changed path(s)")
-                  .contains("no well-formed changelog.d/");
+        assertThat(execution.output()).contains("no well-formed changelog.d/")
+                  // Not the "could not look" refusal: the two must stay distinguishable.
+                  .doesNotContain("EXAMINED NOTHING");
     }
 
     /// Guards the over-correction. An empty diff against a base that DID resolve is a legitimate

--- a/script-gate/src/test/java/org/pragmatica/scriptgate/ScriptGate.java
+++ b/script-gate/src/test/java/org/pragmatica/scriptgate/ScriptGate.java
@@ -29,6 +29,14 @@ sealed interface ScriptGate {
                      .or(new SyntheticRepo(root));
     }
 
+    /// The built git fixture. Same contract as [#fixture], for the repository shape
+    /// [ChangelogCheckTest] needs: `scripts/changelog-check.sh` calls real `git` commands, so its
+    /// subject cannot be the Maven-shaped [SyntheticRepo].
+    static SyntheticGitRepo gitFixture(Path root, Result<SyntheticGitRepo> result) {
+        return result.onFailure(cause -> fail("could not build the git fixture: " + cause.message()))
+                     .or(new SyntheticGitRepo(root));
+    }
+
     /// The outcome of running a script; a harness failure fails the test rather than being asserted on.
     static ScriptRunner.Execution executed(Result<ScriptRunner.Execution> result) {
         return result.onFailure(cause -> fail("could not run the script: " + cause.message()))

--- a/script-gate/src/test/java/org/pragmatica/scriptgate/SyntheticGitRepo.java
+++ b/script-gate/src/test/java/org/pragmatica/scriptgate/SyntheticGitRepo.java
@@ -1,0 +1,82 @@
+package org.pragmatica.scriptgate;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import org.pragmatica.lang.Result;
+import org.pragmatica.lang.Unit;
+import org.pragmatica.lang.utils.Causes;
+
+
+/// A minimal but REAL git repository, because `scripts/changelog-check.sh` calls `git rev-parse` and
+/// `git diff` and the defect it carries (#1000) lives in how their exit statuses are read. A fixture
+/// that stubbed git would be built from the same premise as the defect and could not falsify it.
+///
+/// Deliberately has NO remote. `origin/<branch>` is therefore unresolvable in it, which is exactly
+/// the #1000 condition: the workflow interpolates the base as `origin/${{ github.base_ref }}`, and a
+/// renamed base branch, an unfetched ref or a fork edge leaves that ref absent from the checkout.
+///
+/// Every operation that can fail returns [Result], so no method here declares a checked exception:
+/// `jbct.includeTests` is true for this module (see its pom), which holds this harness to the same
+/// rules as production code.
+record SyntheticGitRepo(Path root) {
+    /// Identity and signing are pinned per-invocation rather than written into the fixture's config,
+    /// so the host's own git configuration cannot decide whether a commit succeeds.
+    private static final List<String> GIT = List.of("git",
+                                                    "-c", "user.name=script-gate",
+                                                    "-c", "user.email=script-gate@example.invalid",
+                                                    "-c", "commit.gpgsign=false",
+                                                    "-c", "init.defaultBranch=main");
+
+    static Result<SyntheticGitRepo> syntheticGitRepo(Path root) {
+        var repo = new SyntheticGitRepo(root);
+
+        return repo.initialise()
+                   .map(ignored -> repo);
+    }
+
+    private Result<Unit> initialise() {
+        return git(List.of("init", "--quiet"))
+                .flatMap(ignored -> writeFile(Path.of("README.md"), "# changelog-check fixture\n"))
+                .flatMap(ignored -> commitAll("baseline"));
+    }
+
+    Result<Unit> writeFile(Path relative, String content) {
+        var target = root.resolve(relative);
+
+        return createParent(target).flatMap(ignored -> write(target, content))
+                                   .mapToUnit();
+    }
+
+    Result<Unit> commitAll(String message) {
+        return git(List.of("add", "--all")).flatMap(ignored -> git(List.of("commit", "--quiet", "--message", message)));
+    }
+
+    private Result<Unit> git(List<String> arguments) {
+        return ScriptRunner.run(root, Map.of(), command(arguments))
+                           .flatMap(SyntheticGitRepo::requireSuccess);
+    }
+
+    private static List<String> command(List<String> arguments) {
+        return Stream.concat(GIT.stream(), arguments.stream()).toList();
+    }
+
+    /// A git step that did not work must fail the TEST, never be mistaken for the script behaving
+    /// unexpectedly - the distinction this whole module exists to keep.
+    private static Result<Unit> requireSuccess(ScriptRunner.Execution execution) {
+        return execution.exitCode() == 0
+               ? Result.unitResult()
+               : Causes.cause("git exited " + execution.exitCode() + ": " + execution.output()).result();
+    }
+
+    private static Result<Path> createParent(Path target) {
+        return Result.lift(() -> Files.createDirectories(target.getParent()));
+    }
+
+    private static Result<Path> write(Path target, String content) {
+        return Result.lift(() -> Files.writeString(target, content));
+    }
+}

--- a/script-gate/src/test/java/org/pragmatica/scriptgate/SyntheticGitRepo.java
+++ b/script-gate/src/test/java/org/pragmatica/scriptgate/SyntheticGitRepo.java
@@ -8,7 +8,8 @@ import java.util.stream.Stream;
 
 import org.pragmatica.lang.Result;
 import org.pragmatica.lang.Unit;
-import org.pragmatica.lang.utils.Causes;
+
+import static org.pragmatica.lang.utils.Causes.cause;
 
 
 /// A minimal but REAL git repository, because `scripts/changelog-check.sh` calls `git rev-parse` and
@@ -26,10 +27,14 @@ record SyntheticGitRepo(Path root) {
     /// Identity and signing are pinned per-invocation rather than written into the fixture's config,
     /// so the host's own git configuration cannot decide whether a commit succeeds.
     private static final List<String> GIT = List.of("git",
-                                                    "-c", "user.name=script-gate",
-                                                    "-c", "user.email=script-gate@example.invalid",
-                                                    "-c", "commit.gpgsign=false",
-                                                    "-c", "init.defaultBranch=main");
+                                                    "-c",
+                                                    "user.name=script-gate",
+                                                    "-c",
+                                                    "user.email=script-gate@example.invalid",
+                                                    "-c",
+                                                    "commit.gpgsign=false",
+                                                    "-c",
+                                                    "init.defaultBranch=main");
 
     static Result<SyntheticGitRepo> syntheticGitRepo(Path root) {
         var repo = new SyntheticGitRepo(root);
@@ -39,16 +44,16 @@ record SyntheticGitRepo(Path root) {
     }
 
     private Result<Unit> initialise() {
-        return git(List.of("init", "--quiet"))
-                .flatMap(ignored -> writeFile(Path.of("README.md"), "# changelog-check fixture\n"))
-                .flatMap(ignored -> commitAll("baseline"));
+        return git(List.of("init", "--quiet")).flatMap(ignored -> writeFile(Path.of("README.md"),
+                                                                            "# changelog-check fixture\n"))
+                  .flatMap(ignored -> commitAll("baseline"));
     }
 
     Result<Unit> writeFile(Path relative, String content) {
         var target = root.resolve(relative);
 
         return createParent(target).flatMap(ignored -> write(target, content))
-                                   .mapToUnit();
+                           .mapToUnit();
     }
 
     Result<Unit> commitAll(String message) {
@@ -56,12 +61,16 @@ record SyntheticGitRepo(Path root) {
     }
 
     private Result<Unit> git(List<String> arguments) {
-        return ScriptRunner.run(root, Map.of(), command(arguments))
+        return ScriptRunner.run(root,
+                                Map.of(),
+                                command(arguments))
                            .flatMap(SyntheticGitRepo::requireSuccess);
     }
 
     private static List<String> command(List<String> arguments) {
-        return Stream.concat(GIT.stream(), arguments.stream()).toList();
+        return Stream.concat(GIT.stream(),
+                             arguments.stream())
+                     .toList();
     }
 
     /// A git step that did not work must fail the TEST, never be mistaken for the script behaving
@@ -69,7 +78,7 @@ record SyntheticGitRepo(Path root) {
     private static Result<Unit> requireSuccess(ScriptRunner.Execution execution) {
         return execution.exitCode() == 0
                ? Result.unitResult()
-               : Causes.cause("git exited " + execution.exitCode() + ": " + execution.output()).result();
+               : cause("git exited " + execution.exitCode() + ": " + execution.output()).result();
     }
 
     private static Result<Path> createParent(Path target) {

--- a/scripts/changelog-check.sh
+++ b/scripts/changelog-check.sh
@@ -6,6 +6,10 @@
 # PR_LABELS (comma-separated) may carry `no-changelog` (no fragment required) or `release-prep`
 # (CHANGELOG.md may be edited). Fails when CHANGELOG.md is edited without `release-prep`, or when
 # non-documentation files change without a well-formed fragment and without `no-changelog`.
+#
+# Exit codes are distinct on purpose: 1 means the gate LOOKED and refused, 2 means the gate COULD NOT
+# LOOK (see the base-ref guard below) and is therefore reporting no verdict at all. Conflating the two
+# is #1000.
 set -euo pipefail
 
 base="${1:?usage: changelog-check.sh <base-ref>}"
@@ -15,11 +19,33 @@ cd "$root"
 
 has_label() { [[ "$labels" == *",$1,"* ]]; }
 
+# The base must RESOLVE before anything is inferred from an empty diff (#1000). `git diff` exits 128
+# on an unresolvable range, but the call used to sit inside a process substitution, whose exit status
+# `set -euo pipefail` does not check - pipefail governs pipelines, not `< <(...)`. The 128 was
+# discarded, `changed` came back empty, and the empty-diff branch below reported success, so this gate
+# could pass HAVING EXAMINED NOTHING while looking like a normal clean result. Two silences that read
+# identically and call for opposite actions: an empty diff is correct to pass, an unresolvable base is
+# not a result. #740 set the precedent - a gate that examined nothing says so out loud.
+if ! git rev-parse --verify --quiet "$base^{commit}" >/dev/null; then
+    echo "changelog-check: base ref '$base' does not resolve to a commit, so no diff was computed and this gate EXAMINED NOTHING; refusing to report success" >&2
+    exit 2
+fi
+
+# Temp files rather than process substitutions, so each git exit status is actually checked.
+changed_out="$(mktemp)"
+fragments_out="$(mktemp)"
+trap 'rm -f "$changed_out" "$fragments_out"' EXIT
+
+if ! git diff --name-only --diff-filter=ACDMR "$base...HEAD" >"$changed_out"; then
+    echo "changelog-check: git diff against '$base' failed, so this gate EXAMINED NOTHING; refusing to report success" >&2
+    exit 2
+fi
+
 # No mapfile: macOS ships bash 3.2 and this runs locally too.
 changed=()
-while IFS= read -r line; do changed+=("$line"); done < <(git diff --name-only --diff-filter=ACDMR "$base...HEAD")
+while IFS= read -r line; do changed+=("$line"); done <"$changed_out"
 if (( ${#changed[@]} == 0 )); then
-    echo "changelog-check: no changes against $base"
+    echo "changelog-check: no changes against $base (0 changed path(s); base resolved and the diff ran, so this zero is measured and not inferred)"
     exit 0
 fi
 
@@ -43,8 +69,15 @@ for path in "${changed[@]}"; do
     is_exempt "$path" || { needs_fragment=true; break; }
 done
 
+if ! git diff --name-only --diff-filter=AM "$base...HEAD" -- 'changelog.d/*.md' >"$fragments_out"; then
+    echo "changelog-check: git diff for changelog.d fragments against '$base' failed; refusing to report success" >&2
+    exit 2
+fi
+
+# `grep -v` exits 1 when nothing matches, which is a legitimate outcome here, so only the git status
+# above is load-bearing.
 fragments=()
-while IFS= read -r line; do [[ -n "$line" ]] && fragments+=("$line"); done < <(git diff --name-only --diff-filter=AM "$base...HEAD" -- 'changelog.d/*.md' | grep -v '/README.md$' || true)
+while IFS= read -r line; do [[ -n "$line" ]] && fragments+=("$line"); done < <(grep -v '/README.md$' "$fragments_out" || true)
 
 section_re='^### (Added|Changed|Deprecated|Removed|Fixed|Security|Performance)( \(.*\))?$'
 well_formed=0
@@ -76,6 +109,6 @@ if $needs_fragment && (( well_formed == 0 )) && ! has_label no-changelog; then
 fi
 
 if (( status == 0 )); then
-    echo "changelog-check: ok (${well_formed} fragment(s), needs_fragment=$needs_fragment)"
+    echo "changelog-check: ok (${#changed[@]} changed path(s) against $base, ${well_formed} fragment(s), needs_fragment=$needs_fragment)"
 fi
 exit $status


### PR DESCRIPTION
Issues: #980 and #1000 (referenced **without** closing keywords — closing is a tracker decision, not a merge side effect)

Two CI-reliability defects. Both are taxes on every change rather than on any one feature.

## #980 — the corpus walk raced the reactor

`SqlCorpus` walked the whole repository with `Files.walk` and filtered build output **after** the walk had already opened it. Under `-T 1C` — which comes from the committed `.mvn/maven.config`, not from any workflow file — that means it opens `target/` directories while surefire is writing them, so it can redden a PR that touches nothing near `pg-parser`.

**Fixed structurally, not by timing.** The walk now prunes `target`, `.git` and `.m2-local` **at the walker** (`walkFileTree` + `SKIP_SUBTREE` in `preVisitDirectory`) rather than filtering afterwards, so the churning space is never opened.

### What the evidence establishes — and what it does not

**No race was reproduced or observed, and no claim is made about timing.** A flaky defect is not fixed by a handful of green runs, and "it passed N times" is neither a sample size nor a control. What is established instead:

- **The walk no longer opens the churning space**, demonstrated with a deterministic unreadable-directory instrument rather than with green runs.
- **The corpus is unchanged**: 38 = 38, element-for-element, with a control.
- **Measured blast radius**: 80.01% of 36,893 entries and 5,194 directory opens eliminated.
- **Residue, stated rather than omitted**: one `opendir` on `target` itself remains, because `walkFileTree` opens a directory stream before consulting `preVisitDirectory`. Verified empirically, not assumed.

### A pre-registered prediction that was wrong, and what it changed

Predicted 2 red / 1 green; **got 3 red**. Investigated rather than smoothed: the third red was an exception-**type** change (`Files.walk` surfaces failure as `UncheckedIOException`, which is *not* an `IOException`; `walkFileTree` throws the `IOException` itself), so it said nothing about blindness.

That mattered — it meant **the test described as the anti-blindness control had never been validated as one.** A further probe was run specifically for it (add `visitFileFailed` returning `CONTINUE`), predicting test 3 red and tests 1–2 green, and got exactly that. So it is a genuine anti-blindness pin, independently of the type story, and its assertion was tightened to require the message name the directory — *"it failed"* and *"it failed for this reason"* being different observations.

## #1000 — the changelog gate could pass having examined nothing

`git diff` exits 128 on an unresolvable range, but the call sat inside a **process substitution**, whose status `set -euo pipefail` does not check — so `changed` came back empty and the empty-diff branch reported success. The gate that enforces changelog fragments could pass without looking at anything.

**Fixed**: the base ref is resolved *before* any empty-diff inference, and the two silences are now distinguishable by exit code:

| case | exit | message |
|---|---|---|
| base ref does not resolve | **2** | `base ref '…' does not resolve to a commit, so no diff was computed and this gate EXAMINED NOTHING; refusing to report success` |
| looked, fragment missing | **1** | refuses, as before |
| looked, satisfied | **0** | `ok (N changed path(s) against <base>, M fragment(s), needs_fragment=true)` |

The pass line now carries the **changed-path count**, so a zero is visible rather than implied — the precedent this repo set in #740, where a gate that examined nothing was made to say so.

Verified directly on this branch: exit **2** on `zzz-not-a-ref`, exit **0** with the count shown on a real base. The exit-1 path is covered by the five new pins against the real script and a real git repository.

## Also included: a changelog attribution fix

`changelog.d/980-bootstrap-admin-key-derivation.md` cited **#980** in its heading, which would have printed that attribution into the assembled `CHANGELOG.md`. Issue #980 is this PR's walk race; the admin-key work came from a branch named with a **speculative** number before any #980 existed, and it landed as the direct push `f25f14327` with **no issue and no PR** — so no correct number exists.

The heading now cites the governing owner ruling, `know: 8f02cd3cf`. **The filename keeps its `980` deliberately**, with a three-line comment saying why: the gate requires a numeric prefix, no correct number exists, and replacing a visible inconsistency with a guessed number would make it invisible. The stream that found this declined to fix it and flagged it for a ruling, which was the right call — it is another stream's merged attribution.

## Verification

| | |
|---|---|
| Root `mvn clean install` | **BUILD SUCCESS, 145/145 modules**, 13,699 testcases, 0 failures, 19 skips — all enumerated and pre-existing |
| New pins | **8**, each shown RED under the mutation it exists to catch |
| Gates | run per module, file counts quoted rather than exit statuses |
| Changelog | `ok (10 changed path(s), 3 fragment(s), needs_fragment=true)` |

Probe residue swept: `PROBE-` markers 0 hits tree-wide, `Files.walk(` 0, `walkFileTree` present, tree clean. All probes ran against committed bases.

## Bounds

- `[unverified]` **Nothing about timing.** Whether the race actually stops occurring in CI is only knowable over time; this change makes the racing access structurally absent, which is a different and stronger claim than a timing fix but not the same as observing the race gone.
- `[unverified]` The remaining single `opendir` on `target` is not eliminated, only the 5,194 descents beneath it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Why the walk was pruned rather than narrowed — a brief's preference overruled on evidence

The brief for this work listed **narrowing the walk's root** first, as "preferable". It was not taken, and the reason is decisive rather than stylistic:

**Only 4 `.sql` files live in `pg-parser`. The other 34 are in `examples/` and five further modules.** Narrowing the root would have cut the corpus from **38 files to 4** — destroying the very property `everySqlFileInTheRepoParses` exists to hold. The sensor would have kept passing while no longer sensing most of what it is for.

Pruning at the walker meets the brief's *actual* requirement — a provable blast-radius reduction rather than a timing fix — without shrinking the corpus, which is why the 38 = 38 element-for-element equivalence control is the most important number in this PR.

## Gate scope, stated rather than implied

`pg-parser`'s gate reports **7 files — its main sources only.** Its **11 test files, including both of the ones this PR adds, are excluded by `jbct.includeTests=false`**, so that gate result says nothing about this change's tests. The `script-gate` gate (9 files, 0 format, 0 lint) does cover its own new test sources.

This is pre-existing and repo-wide, not this PR's regression — but a green gate here would otherwise imply coverage it does not have.

## Count reconciliation

The XML-derived figures were cross-validated against Maven's own 91 module totals, with **exact agreement on all four** (testcases, failures, errors, skips). The run marker excluded 1 stale failsafe XML — without it the total would have blended two runs. Of the 19 skips, **9 are token-gated `HetznerCloudIT`**, which is incidental confirmation that `env -u HCLOUD_TOKEN` did its job.
