### PR TITLE
docs: fix every route, body and citation defect found by executing the lifecycle-verification runbook

### DIFF
--- a/aether/docs/operators/runbooks/lifecycle-verification.md
+++ b/aether/docs/operators/runbooks/lifecycle-verification.md
@@ -2,6 +2,11 @@
 
 This runbook verifies the slice lifecycle implementation matches the design in `docs/contributors/slice-lifecycle.md`.
 
+Every management-API path below is versioned (`/api/v1/...`). The prefix is composed at one site —
+`ManagementRoute.API_BASE` — and it is mandatory: an unversioned `/api/...` request on port 5150 does
+not reach the router at all. It falls through to the static file handler, which answers
+`404 File not found: /api/...`, so a missing `/v1/` looks like a missing page rather than a bad route.
+
 ## Prerequisites
 
 1. Build the project:
@@ -15,17 +20,40 @@ This runbook verifies the slice lifecycle implementation matches the design in `
    ls aether/cli/target/aether.jar
    ```
 
+3. Start from clean simulator state. Forge keeps per-node data under `$AETHER_HOME/forge-data`,
+   falling back to `~/.aether/forge-data`. A run that inherits stale or partially-written snapshots
+   logs `Snapshot restore failed` per node on boot and may never reach quorum, which presents as
+   step 2 hanging rather than as a storage error. Point Forge at a fresh directory instead of
+   deleting the default one:
+
+   ```bash
+   export AETHER_HOME="$(mktemp -d)"
+   ```
+
+   Leader election took **8s** from clean state. On inherited state it took 62s on one run, and on
+   another no leader was elected within 125s (`activePeerCount=1, clusterSize=5, quorumSize=3`).
+   This is why step 1 polls for readiness rather than sleeping for a fixed interval.
+
 ---
 
 ## Method 1: Forge (Standalone Simulator)
 
 ### 1. Start Forge
 
+Forge is a long-lived foreground server. Background it so the remaining steps can run in the same
+shell, then wait for leader election: every route below is leader-bound and answers
+`503 No leader elected for leader-bound management route` until election completes.
+
 ```bash
-java -jar aether/forge/forge-core/target/aether-forge.jar
+java -jar aether/forge/forge-core/target/aether-forge.jar > /tmp/forge.log 2>&1 &
+
+for i in $(seq 1 120); do
+  curl -sf http://localhost:5150/api/v1/nodes/status | grep -q '"isLeader":true' && break
+  sleep 1
+done
 ```
 
-Expected output:
+Expected output in `/tmp/forge.log`:
 ```
 ============================================================
     AETHER FORGE
@@ -38,53 +66,115 @@ Expected output:
 ### 2. Verify Cluster Status
 
 ```bash
-curl -s http://localhost:5150/api/nodes/status
+curl -s http://localhost:5150/api/v1/nodes/status
 ```
 
-Expected: JSON with `status: "running"`, `isLeader: true`
+Expected: JSON carrying `"status":"running"` and `"isLeader":true` at the top level, plus a `cluster`
+object reporting `"nodeCount":5` and `"quorate":true`.
 
 ### 3. Check Nodes
 
 ```bash
-curl -s http://localhost:5150/api/nodes
+curl -s http://localhost:5150/api/v1/nodes
 ```
 
-Expected: `{"nodes":["node-1"]}`
+Expected: one **object** per node — `nodeId`, `role`, `isLeader` — for all five simulator nodes, not
+a list of bare ID strings:
+
+```json
+{"nodes":[{"nodeId":"node-1","role":"CORE","isLeader":true},{"nodeId":"node-2","role":"CORE","isLeader":false}]}
+```
+
+(Abridged: the live response carries all five nodes. Ordering is not stable.)
 
 ### 4. Deploy a Slice
 
+The request body is a **TOML** blueprint document, not JSON — `SliceRoutes.handleBlueprint` passes the
+raw body to `BlueprintParser.parse`, which hands it to `TomlParser`. The blueprint `id` must be a full
+artifact coordinate (`group:artifact:version`); a bare name is rejected by `BlueprintId`.
+
 ```bash
-curl -s -X POST http://localhost:5150/api/blueprints \
-  -H "Content-Type: application/json" \
-  -d '{"id": "test-blueprint", "slices": [{"artifact": "org.example:test-slice:1.0.0", "instances": 1}]}'
+cat > /tmp/test-blueprint.toml <<'TOML'
+id = "org.example:test-blueprint:1.0.0"
+
+[[slices]]
+artifact = "org.example:test-slice:1.0.0"
+instances = 1
+TOML
+
+curl -s -X POST http://localhost:5150/api/v1/blueprints \
+  -H "Content-Type: text/plain" \
+  --data-binary @/tmp/test-blueprint.toml
 ```
 
-Expected: `{"status":"accepted","id":"test-blueprint"}`
-
-### 5. Verify Lifecycle States in Logs
-
-Watch the Forge logs for state transitions:
-
-```
-LOAD → LOADING → FAILED (artifact not found)
+Expected, when the slice artifact resolves:
+```json
+{"status":"applied","blueprint":"org.example:test-blueprint:1.0.0","targetInstances":1,"activeInstances":0,"failedInstances":0,"statusUrl":"/api/v1/blueprints/status/org.example%3Atest-blueprint%3A1.0.0"}
 ```
 
-Expected log messages:
+`"applied"` means **accepted, not deployed** — it is written before allocation runs and is never
+updated with the outcome. Poll `statusUrl` for progress. See
+[management-api.md](../../reference/management-api.md#post-apiv1blueprints).
+
+`org.example:test-slice:1.0.0` is a placeholder. Publishing resolves the slice artifact from the
+local repository **synchronously**, so a coordinate that is not installed is refused at this step
+rather than being accepted and failing later in the lifecycle:
+
+```json
+{"title":"Internal Server Error","status":500,"detail":"Artifact not found in local repository: org.example:test-slice:1.0.0 at /Users/<you>/.m2/repository/org/example/test-slice/1.0.0/test-slice-1.0.0.jar"}
 ```
-Issuing LOAD command for slices/node-1/org.example:test-slice:1.0.0
-ValuePut received for key: slices/node-1/org.example:test-slice:1.0.0, state: LOAD
-ValuePut received for key: slices/node-1/org.example:test-slice:1.0.0, state: LOADING
-ValuePut received for key: slices/node-1/org.example:test-slice:1.0.0, state: FAILED
-Slice org.example:test-slice:1.0.0 entered FAILED state
+
+To exercise steps 5 and 6, substitute a slice artifact that is installed in the local repository.
+Note the lookup uses the default `~/.m2/repository` — the Forge JVM does not read `.mvn/maven.config`,
+so a per-tree `maven.repo.local` does not apply here.
+
+Two further failure shapes worth recognising, both `500`:
+
+| Body / value | `detail` |
+|---|---|
+| Bare `id` such as `test-blueprint` | `Invalid blueprint ID format: test-blueprint` |
+| A JSON body | `TOML parse error: TOML syntax error at line 1: {...}` |
+
+### 5. Verify Lifecycle States
+
+For a resolvable artifact the state sequence is:
+
 ```
+LOAD → LOADING → LOADED → ACTIVATE → ACTIVATING → ACTIVE
+```
+
+and, when a load fails, `LOAD → LOADING → FAILED`.
+
+Poll the status endpoint — it reports per-instance state and is the reliable surface for this:
+
+```bash
+curl -s http://localhost:5150/api/v1/slices/status
+```
+
+**There is no per-state log line.** `NodeDeploymentState.Active.transitionTo` writes each state to the
+KV store without logging, so LOADING/LOADED/ACTIVATING are observable through the status endpoint
+only. Two lines do accompany the lifecycle, and neither is visible at the default INFO threshold
+alone:
+
+| Log line | Level | Source |
+|---|---|---|
+| `Issuing LOAD command for slices/<nodeId>/<artifact>` | `DEBUG` | `ClusterDeploymentState` |
+| `Slice <artifact> entered FAILED state` | `WARN` | `NodeDeploymentState.Active.handleFailed` |
 
 ### 6. Check Slice Status
 
 ```bash
-curl -s http://localhost:5150/api/slices/status
+curl -s http://localhost:5150/api/v1/slices/status
 ```
 
-Expected: Slice in FAILED state
+Expected, with a slice deployed:
+```json
+{"slices":[{"artifact":"org.example:my-slice:1.0.0","state":"ACTIVE","instances":[{"nodeId":"node-1","state":"ACTIVE","health":"HEALTHY"}]}]}
+```
+
+With nothing deployed — including after an `ALL_OR_NOTHING` rollback — the response is `{}`. An empty
+response is therefore not evidence that a deploy never happened; see
+[failure-almanac.md](../../reference/failure-almanac.md#per-node-deployment-failure-under-all_or_nothing-rollback).
 
 ### 7. Cleanup
 
@@ -93,64 +183,120 @@ Stop Forge with Ctrl+C or:
 pkill -f "aether-forge.jar"
 ```
 
+`pkill` returns before the JVM has exited. Confirm termination rather than assuming it:
+```bash
+for i in $(seq 1 30); do pgrep -f "aether-forge.jar" >/dev/null || break; sleep 1; done
+pgrep -f "aether-forge.jar" || echo "stopped"
+```
+
 ---
 
 ## Method 2: AetherCli
+
+This method drives the same lifecycle through the CLI instead of `curl`.
+
+The CLI assembles every request path from the same `ManagementRoute` enum the server routes with, so
+it carries the `/api/v1` prefix automatically — no manual prefixing is needed or possible. The CLI
+defaults to `localhost:8080`, while Forge's node-1 management API listens on 5150, so pass
+`--connect` on every invocation.
 
 ### 1. Start Forge (as cluster backend)
 
 ```bash
 java -jar aether/forge/forge-core/target/aether-forge.jar > /tmp/forge.log 2>&1 &
-sleep 8
+
+for i in $(seq 1 120); do
+  curl -sf http://localhost:5150/api/v1/nodes/status | grep -q '"isLeader":true' && break
+  sleep 1
+done
 ```
 
 ### 2. Check Status via CLI
 
-**Note:** CLI endpoints need `/api/` prefix. Current CLI has a path mismatch issue.
-
-Direct API access:
 ```bash
-# Status
-curl -s http://localhost:5150/api/nodes/status
+# Cluster status
+java -jar aether/cli/target/aether.jar --connect localhost:5150 status
 
 # Nodes
-curl -s http://localhost:5150/api/nodes
+java -jar aether/cli/target/aether.jar --connect localhost:5150 nodes
 
 # Slices (cluster-wide view)
-curl -s http://localhost:5150/api/slices
+java -jar aether/cli/target/aether.jar --connect localhost:5150 slices
 
 # Slices (per-node flat list)
-curl -s http://localhost:5150/api/nodes/slices
+java -jar aether/cli/target/aether.jar --connect localhost:5150 nodes slices
 
 # Health
-curl -s http://localhost:5150/api/health
+java -jar aether/cli/target/aether.jar --connect localhost:5150 health
 ```
 
-### 3. Deploy via API
+The CLI pretty-prints the same documents the endpoints in Method 1 return.
+
+### 3. Deploy via CLI
+
+`blueprints apply` takes a path to a `.toml` blueprint and POSTs its contents — the same
+`POST /api/v1/blueprints` call as Method 1 step 4, with the same body rules.
 
 ```bash
-curl -s -X POST http://localhost:5150/api/blueprints \
-  -H "Content-Type: application/json" \
-  -d '{"id": "test-blueprint", "slices": [{"artifact": "org.pragmatica-lite.aether.demo:inventory-service:0.1.0", "instances": 1}]}'
+cat > /tmp/test-blueprint.toml <<'TOML'
+id = "org.example:test-blueprint:1.0.0"
+
+[[slices]]
+artifact = "org.example:test-slice:1.0.0"
+instances = 1
+TOML
+
+java -jar aether/cli/target/aether.jar --connect localhost:5150 \
+  blueprints apply /tmp/test-blueprint.toml
 ```
+
+Expected: the `"applied"` document from Method 1 step 4.
 
 ### 4. Monitor Lifecycle
 
 ```bash
-# Watch slice status
-watch -n 1 'curl -s http://localhost:5150/api/slices/status'
-
-# Check logs for state transitions
-grep -E "LOAD|LOADING|LOADED|ACTIVATE|ACTIVATING|ACTIVE|FAILED" /tmp/forge.log
+# Poll slice status. `watch` is not installed by default on macOS, so loop instead.
+while true; do
+  java -jar aether/cli/target/aether.jar --connect localhost:5150 slices status
+  sleep 2
+done
 ```
+
+```bash
+# Check logs for the two lifecycle lines that exist (see Method 1 step 5)
+grep -E "Issuing LOAD command|entered FAILED state" /tmp/forge.log
+```
+
+Do not grep for `LOAD|LOADING|LOADED|ACTIVATE|ACTIVATING|ACTIVE|FAILED`. That pattern matches
+node-lifecycle transitions (`NodeLifecycle: JOINING -> ACTIVE`), consensus lines
+(`ConsensusBridge: ACTIVE for ...`), snapshot states (`LOADING_SNAPSHOT`) and stream-create
+warnings — on a measured run it returned 51 matches, **none** of which referenced a slice key.
 
 ### 5. Undeploy
 
 ```bash
-curl -s -X DELETE http://localhost:5150/api/blueprints/test-blueprint
+java -jar aether/cli/target/aether.jar --connect localhost:5150 \
+  blueprints delete org.example:test-blueprint:1.0.0 --force
 ```
 
+Expected: `Deleted blueprint: org.example:test-blueprint:1.0.0`
+
+`--force` skips the interactive `(y/N)` confirmation, which otherwise blocks a scripted run.
+
+The equivalent direct call — note `id` is a **path segment**, not a query parameter:
+```bash
+curl -s -X DELETE http://localhost:5150/api/v1/blueprints/org.example:test-blueprint:1.0.0
+```
+Expected: `{"status":"deleted","id":"org.example:test-blueprint:1.0.0"}`
+
+(`DELETE /api/v1/blueprints?id=...` answers `404 File not found: /api/v1/blueprints` — the route
+matcher strips the query string before matching, so the query form matches no DELETE route.)
+
 Expected lifecycle: `DEACTIVATE → DEACTIVATING → LOADED → UNLOAD → UNLOADING → (deleted)`
+
+### 6. Cleanup
+
+As Method 1 step 7.
 
 ---
 
@@ -160,29 +306,40 @@ Expected lifecycle: `DEACTIVATE → DEACTIVATING → LOADED → UNLOAD → UNLOA
 
 | Transition | Expected Behavior | Verification |
 |------------|-------------------|--------------|
-| LOAD → LOADING | Write LOADING to KV before starting load | Check logs for LOADING state write |
-| LOADING → LOADED | On success after load completes | Check slice status shows LOADED |
-| LOADING → FAILED | On error during load | Check logs for "entered FAILED state" |
+| LOAD → LOADING | Write LOADING to KV before starting load | `GET /api/v1/slices/status` reports LOADING |
+| LOADING → LOADED | On success after load completes | Status shows LOADED |
+| LOADING → FAILED | On error during load | Logs show "entered FAILED state" (WARN) |
 | LOADED → (no auto-activate) | Requires explicit ACTIVATE | Verify slice stays in LOADED |
-| ACTIVATE → ACTIVATING | Write ACTIVATING before activation | Check logs |
-| ACTIVATING → ACTIVE | After start + register + publish | Check slice status shows ACTIVE |
-| DEACTIVATE → DEACTIVATING | Write DEACTIVATING + remove endpoints | Check logs |
-| DEACTIVATING → LOADED | After stop completes | Check slice status |
-| UNLOAD → UNLOADING | Write UNLOADING before unload | Check logs |
-| UNLOADING → (deleted) | Delete KV key after unload | Check slice no longer in status |
+| ACTIVATE → ACTIVATING | Write ACTIVATING before activation | Status shows ACTIVATING |
+| ACTIVATING → ACTIVE | After start + register + publish | Status shows ACTIVE |
+| DEACTIVATE → DEACTIVATING | Write DEACTIVATING + remove endpoints | Status shows DEACTIVATING |
+| DEACTIVATING → LOADED | After stop completes | Status shows LOADED |
+| UNLOAD → UNLOADING | Write UNLOADING before unload | Status shows UNLOADING |
+| UNLOADING → (deleted) | Delete KV key after unload | Slice no longer in status |
 
 ### Key Fixes Verified
 
+The slice-lifecycle handlers live on `NodeDeploymentState.Active` (in
+`aether/aether-deployment/.../deployment/node/fsm/NodeDeploymentState.java`), dispatched from its
+state-machine switch — **not** on `NodeDeploymentManager`, which owns quorum/membership
+reconciliation instead.
+
 1. **sliceStore** (record): Uses `ConcurrentHashMap<Artifact, Promise<LoadedSliceEntry>>` with `computeIfAbsent` for atomic loading
-2. **NodeDeploymentManager.handleLoading**: Writes LOADING state before calling `SliceStore.loadSlice()`
-3. **NodeDeploymentManager.handleLoaded**: No auto-activation (requires explicit ACTIVATE from ClusterDeploymentManager)
-4. **NodeDeploymentManager.handleActivating**: Calls `SliceStore.activateSlice()`, registers + publishes BEFORE transitioning to ACTIVE
-5. **NodeDeploymentManager.handleFailed**: Logs "entered FAILED state" message
-6. **NodeDeploymentManager.handleUnloading**: Writes UNLOADING, calls `SliceStore.unloadSlice()`, then deletes KV key
+2. **`NodeDeploymentState.Active.handleLoading`**: Writes LOADING state before calling `SliceStore.loadSlice()`
+3. **`NodeDeploymentState.Active.handleLoaded`**: No auto-activation (requires explicit ACTIVATE from ClusterDeploymentManager)
+4. **`NodeDeploymentState.Active.handleActivating`**: Calls `SliceStore.activateSlice()`, then registers invocation and publishes topic/stream/scheduled-task/route entries before transitioning to ACTIVE (endpoint publication follows the ACTIVE write)
+5. **`NodeDeploymentState.Active.handleFailed`**: Logs "entered FAILED state" message
+6. **`NodeDeploymentState.Active.handleUnloading`**: Writes UNLOADING, calls `SliceStore.unloadSlice()`, then deletes KV key
 
 ---
 
 ## Troubleshooting
+
+### Step 2 never returns / `503 No leader elected`
+- The management routes are leader-bound; wait for election rather than retrying immediately
+- Check for inherited simulator state: `Snapshot restore failed` on boot, or
+  `activePeerCount=1, clusterSize=5, quorumSize=3` in the log, means the cluster is not reaching
+  quorum. Restart with a fresh `AETHER_HOME` (see Prerequisites step 3)
 
 ### Slice stuck in LOAD state
 - Check if artifact exists in repository
@@ -190,12 +347,19 @@ Expected lifecycle: `DEACTIVATE → DEACTIVATING → LOADED → UNLOAD → UNLOA
 - Verify SliceStore is processing the request
 
 ### No state transitions visible
-- Ensure logging is at INFO level
+- There is no per-state log line — read `GET /api/v1/slices/status`, not the log (see Method 1 step 5)
+- `Issuing LOAD command` is logged at **DEBUG**, so it is absent at the default INFO threshold
 - Check correct port (5150 for node-1 management API)
 
-### CLI returns 404
-- CLI currently doesn't add `/api/` prefix
-- Use curl with `/api/` prefix directly
+### `404 File not found: /api/...`
+- The path is missing the version prefix. Every management route is under `/api/v1/`
+- An unversioned `/api/...` request is served by the static file handler, not the router, which is
+  why the body is `File not found:` rather than a JSON problem-detail document
+
+### CLI cannot connect
+- The CLI defaults to `localhost:8080`; Forge's node-1 management API is on 5150. Pass
+  `--connect localhost:5150`
+- The CLI composes `/api/v1` itself from `ManagementRoute` — do not add a prefix to CLI arguments
 
 ### Dashboard not loading
 - Dashboard is at http://localhost:8888

--- a/aether/docs/operators/runbooks/lifecycle-verification.md
+++ b/aether/docs/operators/runbooks/lifecycle-verification.md
@@ -20,19 +20,27 @@ not reach the router at all. It falls through to the static file handler, which 
    ls aether/cli/target/aether.jar
    ```
 
-3. Start from clean simulator state. Forge keeps per-node data under `$AETHER_HOME/forge-data`,
-   falling back to `~/.aether/forge-data`. A run that inherits stale or partially-written snapshots
-   logs `Snapshot restore failed` per node on boot and may never reach quorum, which presents as
-   step 2 hanging rather than as a storage error. Point Forge at a fresh directory instead of
-   deleting the default one:
+3. **Confirm no other Forge is running on this machine first.** Only one Forge instance can run
+   per host. Its management, app and dashboard ports come from `ForgeConfig`, but the cluster's
+   QUIC base port does not: `ForgeServer` passes the `EmberCluster.DEFAULT_BASE_PORT` constant
+   (`6000`, so nodes occupy `6000`–`6000+nodes-1`), and no configuration overrides it. There is
+   therefore no port-offset arrangement that lets two instances coexist — a second instance's nodes
+   cannot form a cluster, and the symptom is step 2 never returning rather than a bind error.
+
+   ```bash
+   lsof -nP -iTCP:5150 -sTCP:LISTEN    # expect no output before you start
+   ```
+
+4. Start from clean simulator state. Forge keeps per-node data under `$AETHER_HOME/forge-data`,
+   falling back to `~/.aether/forge-data`. Pointing Forge at a fresh directory removes inherited
+   state as a variable, and is preferable to deleting the default directory:
 
    ```bash
    export AETHER_HOME="$(mktemp -d)"
    ```
 
-   Leader election took **8s** from clean state. On inherited state it took 62s on one run, and on
-   another no leader was elected within 125s (`activePeerCount=1, clusterSize=5, quorumSize=3`).
-   This is why step 1 polls for readiness rather than sleeping for a fixed interval.
+   Leader election is not instantaneous, and how long it takes depends on the host, so step 1 polls
+   for readiness rather than sleeping for a fixed interval.
 
 ---
 
@@ -46,12 +54,15 @@ shell, then wait for leader election: every route below is leader-bound and answ
 
 ```bash
 java -jar aether/forge/forge-core/target/aether-forge.jar > /tmp/forge.log 2>&1 &
+FORGE_PID=$!
 
 for i in $(seq 1 120); do
   curl -sf http://localhost:5150/api/v1/nodes/status | grep -q '"isLeader":true' && break
   sleep 1
 done
 ```
+
+Keep `$FORGE_PID` — step 7 uses it to stop *this* instance without matching on process name.
 
 Expected output in `/tmp/forge.log`:
 ```
@@ -178,15 +189,27 @@ response is therefore not evidence that a deploy never happened; see
 
 ### 7. Cleanup
 
-Stop Forge with Ctrl+C or:
+Stop Forge with Ctrl+C, or by the PID captured in step 1:
 ```bash
-pkill -f "aether-forge.jar"
+kill "$FORGE_PID"
 ```
 
-`pkill` returns before the JVM has exited. Confirm termination rather than assuming it:
+If you no longer have the PID, resolve it from the port rather than from the process name:
 ```bash
-for i in $(seq 1 30); do pgrep -f "aether-forge.jar" >/dev/null || break; sleep 1; done
-pgrep -f "aether-forge.jar" || echo "stopped"
+FORGE_PID=$(lsof -t -nP -iTCP:5150 -sTCP:LISTEN)
+kill "$FORGE_PID"
+```
+
+> **Do not stop Forge with `pkill -f aether-forge.jar` or any other name-matching kill.** The
+> pattern matches every Forge on the host, in every working tree, including instances belonging to
+> other people's runs. On a shared machine that silently kills unrelated work, and the victim sees
+> an unexplained `SIGTERM` (surfacing as surefire `Process Exit Code: 143`) that reads as a product
+> failure rather than as someone else's cleanup step. Kill the PID you started.
+
+`kill` returns before the JVM has exited. Confirm termination by PID rather than assuming it:
+```bash
+for i in $(seq 1 30); do ps -p "$FORGE_PID" >/dev/null 2>&1 || break; sleep 1; done
+ps -p "$FORGE_PID" >/dev/null 2>&1 && echo "still running" || echo "stopped"
 ```
 
 ---
@@ -204,6 +227,7 @@ defaults to `localhost:8080`, while Forge's node-1 management API listens on 515
 
 ```bash
 java -jar aether/forge/forge-core/target/aether-forge.jar > /tmp/forge.log 2>&1 &
+FORGE_PID=$!
 
 for i in $(seq 1 120); do
   curl -sf http://localhost:5150/api/v1/nodes/status | grep -q '"isLeader":true' && break
@@ -337,9 +361,13 @@ reconciliation instead.
 
 ### Step 2 never returns / `503 No leader elected`
 - The management routes are leader-bound; wait for election rather than retrying immediately
-- Check for inherited simulator state: `Snapshot restore failed` on boot, or
-  `activePeerCount=1, clusterSize=5, quorumSize=3` in the log, means the cluster is not reaching
-  quorum. Restart with a fresh `AETHER_HOME` (see Prerequisites step 3)
+- A log line like `activePeerCount=1, clusterSize=5, quorumSize=3` means the embedded nodes are not
+  seeing each other, so quorum is never reached. Two causes produce it, and they are not
+  distinguishable from that line alone:
+  - **Another Forge on the host** holding the fixed QUIC base ports `6000+` (Prerequisites step 3).
+    Check first — it is the one you can rule out definitively, with `lsof`
+  - **Inherited simulator state**: `Snapshot restore failed` per node on boot. Restart with a fresh
+    `AETHER_HOME` (Prerequisites step 4)
 
 ### Slice stuck in LOAD state
 - Check if artifact exists in repository

--- a/aether/docs/reference/management-api.md
+++ b/aether/docs/reference/management-api.md
@@ -740,7 +740,10 @@ Scale a blueprint-deployed slice to a new instance count. The slice must be part
 
 ### POST /api/v1/blueprints
 
-Publish (apply) a blueprint definition. The request body is the raw blueprint YAML/JSON string.
+Publish (apply) a blueprint definition. The request body is the raw blueprint **TOML** document
+(`BlueprintParser.parse` hands it to `TomlParser`); a JSON body is rejected with
+`500 TOML parse error`. The blueprint `id` must be a full artifact coordinate
+(`group:artifact:version`) — a bare name is rejected with `500 Invalid blueprint ID format`.
 
 **Request:** Raw blueprint content as request body (string).
 


### PR DESCRIPTION
Fixes the documentation defects found by **executing** `aether/docs/operators/runbooks/lifecycle-verification.md` — the first `aether/docs/` runbook anyone has run. That execution aborted at Method 1 step 4.

No issue reference: these are documentation defects found by a runbook execution round, not a tracked ticket. `.md` and `docs/` are exempt from the changelog gate, confirmed below.

## What was wrong, and the count is higher than the test reported

**12 of 12 route call sites were missing the `/api/v1/` prefix**, not the 8 the test reported. Enumerated by whole-file grep rather than taken from the report: **15 `/api/` occurrences, 12 executable, 3 prose.** The test's tally omitted **both deploy POSTs, Method 1 step 6, the `watch`, and the DELETE.**

Also fixed:
- **Deploy body JSON → TOML.** The documented JSON cannot work on any path: wrong prefix 404s, the Forge proxy 400s, and the correct endpoint 500s because it parses TOML.
- **Blueprint `id` must be a `group:artifact:version` coordinate** — a defect the test never reached. `test-blueprint` fails on this independently of the TOML issue, so fixing only the body would have left the step broken.
- **Five handler citations re-attributed.** `handleLoading` / `handleLoaded` / `handleActivating` / `handleFailed` / `handleUnloading` do not exist on `NodeDeploymentManager`; they are on `NodeDeploymentState.Active`.
- **A fabricated step-5 log block replaced** with real output, two response shapes corrected, the `nodes` key fixed to `nodeId`, and readiness **polls** replacing fixed waits.
- **Method 2 now genuinely uses the CLI.** It previously did not, and the doc's own "path mismatch" excuse for that is refuted live.
- **A clean-state prerequisite added** — see below, it is the substantive finding.
- One line in `reference/management-api.md`: `POST /api/v1/blueprints` said "raw blueprint YAML/JSON string". **Scope extended deliberately**, because the runbook now cites that section as the authority and leaving it would make the two documents contradict each other.

## Three of the test's findings were REFUTED by re-running them

This matters for how much weight a single execution round carries:

1. **DELETE binds `id` as a PATH SEGMENT, not a query parameter.** The query form 404s. The doc's original shape was right and only the prefix was broken — **correcting it as briefed would have replaced a working path with a broken one.** I briefed that finding to this stream as established fact; it was source-confirmed only, and source-confirmed was wrong.
2. **`sleep 8` is adequate** — a readiness poll replaces it regardless, which is right under any cause.
3. **The `nodes` response key** differed from what the test recorded.

## Verification

- **Jars rebuilt first so the instrument's provenance is provable**: `build.timestamp=2026-09-11T11:17:12Z`. Every load-bearing observable came from a run reporting that stamp.
- **Live, with `REAL_EXIT` captured inside each command**: 6 GETs (200), POST (200 `"applied"`), DELETE (200 `{"status":"deleted"}`), **3 negative controls (all 404)**, **3 failure shapes (all 500, distinct `detail`)**, 7 CLI invocations (all exit 0).
- **Source-confirmed only**, stated as such: the two lifecycle log lines' DEBUG/WARN levels, and one ordering nuance.
- **Gate**: `changelog-check: ok (0 fragment(s), needs_fragment=false)` — correct, since `.md`/`docs/` are exempt. Quoted from the **post-commit** run, because the pre-commit run reported `no changes` and exited 0 **having examined nothing**.

## One excluded measurement, and the tell that caught it

A final verbatim pass accidentally queried a **foreign Forge instance** (pid 58005, build stamp `10:21:10Z`) holding port 5150. **Its `ELAPSED=0s` readiness figure is void and has been excluded.** The tell was a **0s election beside a 137s uptime** — an impossible pairing. That instance was not killed.

An attempt to move the owner's `~/.aether/forge-data` aside was **denied by the permission classifier**; rather than working around the denial, `AETHER_HOME` was used instead. That left the 177 MB untouched **and produced better runbook advice**, since a clean-state prerequisite is what a reader actually needs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Correction round (commit `1ba6d9752`) — a causal claim retracted and the `pkill` guidance removed

**RETRACTED: "the 62s / 125s elections were caused by stale `~/.aether/forge-data`."** That was a confounded before/after measured on a contended box. Verified at the producer: `EmberCluster.java:93` defines `DEFAULT_BASE_PORT = 6000` and `ForgeServer.java:243` passes it **as a constant**, while `ForgeConfig` exposes the other three ports and never references it — so a second Forge yields `activePeerCount=1` **directly**. All three timings (8s / 62s / 125s) are withdrawn.

The author's own diagnosis of the error is worth quoting, because it is the generalisable part: *"`activePeerCount=1` was the shared symptom of both hypotheses and I attributed it to the one I'd been reading about. I never asked what else produces that line; the answer was a constant in the file I already had open."*

**The runbook no longer tells anyone to `pkill`.** It used `pkill -f aether-forge.jar` for cleanup — which matches by command line **across every working tree** and SIGTERMed an unrelated investigation's process today, where exit 143 read as a product failure. Replaced with `FORGE_PID=$!` at launch and `kill "$FORGE_PID"` at cleanup, an `lsof -t` fallback, and an explicit prohibition explaining the trap. A new prerequisite checks `lsof -nP -iTCP:5150` first, because **no port-offset arrangement exists** (see #1008).

Quorum troubleshooting now **names both causes without picking one**.

**What survives unchanged, and why:** the route prefixes, TOML body, `group:artifact:version` rule, response shapes, `nodeId`, and DELETE path-segment binding are **deterministic** — contention cannot alter route matching or body parsing — and each has a named producer (`ManagementRoute`, `BlueprintParser`, `BlueprintId`, `RouteMatcher`, `RouteMatcherTest#match_handlesDeleteWithParam`). Only the timings and the causal claim were ever at risk, and only those were retracted.