### PR TITLE
fix: #718 bound the per-attempt retry WARN and dedup the lazy QUIC lane re-open

### DIFF
--- a/changelog.d/718-retry-logging-bound-lane-open-dedup.md
+++ b/changelog.d/718-retry-logging-bound-lane-open-dedup.md
@@ -1,0 +1,69 @@
+### Fixed (2026-09-11 — #718: an unbounded per-attempt retry WARN was self-terminating Forge, and the lazy lane re-open was exhausting the QUIC stream credit)
+- **`Retry` logged once PER ATTEMPT at WARN, and on the QUIC consensus send wrapper that is a 200x
+  multiplier on a hot path.** A stale `forge-data` directory triggers a DHT backpressure burst at
+  cluster formation; each backpressured send is wrapped in `200 attempts x 25ms`
+  (`QuicTransportTuning`), and every attempt emitted a WARN through the packaged `log4j2.xml`'s
+  single **synchronous** Console appender — on the very Netty event-loop threads that have to drain
+  the QUIC write buffers for the backpressure to clear. Measured: ~4.2 million log lines in 72
+  seconds, the lane mesh stuck at 1 of 10, the 64-stream credit exhausted, `cluster.start()` missing
+  its fixed 60s budget at `ForgeServer:401`, and the resulting `System.exit(1)` running the shutdown
+  hook — which is the `EmberCluster.stop()` line that made this look like a self-fence. Interleaved
+  arms: stale data + stock logging **3/3 fatal** (72s/73s/72s); clean data **2/2 healthy** (4.6s);
+  stale data with only this one logger silenced **4/4 healthy** (8.4s), with **84,166 backpressure
+  events still occurring and clearing in 3.5s**. The logging was the loop's gain, not its trigger.
+- **The per-attempt line is now DEBUG; giving up is WARN and carries the attempt count.** The
+  resulting bound is structural rather than measured: **at most one WARN per `Retry.execute()` call,
+  independent of `maxAttempts`**. Raise `org.pragmatica.lang.utils.Retry` to DEBUG to get every
+  attempt back. Two things make this more signal rather than less:
+  - The **spent-budget path logged nothing at all** before this change — `Retry` failed its promise
+    silently after burning its whole budget. It now emits exactly one WARN naming the count, which is
+    the aggregate the per-attempt lines were being read for.
+  - The busiest caller **already documents DEBUG as the level for per-retry lines**
+    (`QuicClusterNetwork#retryBackpressuredWrite` logs its own retry and give-up lines at `debug`,
+    and `writeIfWritable`'s comment reads "per-retry logging stays at debug below"). The WARN in
+    `Retry` was overriding a level the call site had chosen.
+  The unretryable-cause WARN is unchanged. `Retry` is a core utility, so this is a repo-wide
+  observability change; **no code, test, script or doc in the repository matched the per-attempt
+  message text** (searched across all tracked files with `git grep`), so nothing was keying on it.
+- **What still reports an 84k-event backpressure burst:** the transport's own
+  `Backpressure on peer {} lane {}` WARN at `QuicClusterNetwork#writeIfWritable` — untouched, already
+  separate, and **one line per backpressure entry rather than per attempt**. The discriminating
+  experiment left that logger fully enabled and recorded all 84,166 of its lines while the cluster
+  formed in 8.4s, so the burst remains discoverable with the multiplier gone.
+- **Separately, the lazy lane re-open fired per outbound message with no in-flight dedup**, and each
+  firing created a stream against `initialMaxStreamsBidirectional(64)`. The coupling was measured as
+  **equal counts, not a correlation**: failed lazy re-opens == `STREAM_LIMIT_ERROR`s, **857==857** in
+  one run and **639==639** in another. There is now **one in-flight open per (peer, lane)**; messages
+  arriving inside the open window are queued onto it (bounded at 64, drop-oldest, mirroring the
+  offline buffer's policy) and written when it completes. New counters
+  `quic_stream_zombie_lazy_open_coalesced_total` and `quic_stream_zombie_lazy_open_drops_total` make
+  the yield and any overflow visible; the drop is counted, not warned, deliberately.
+  **The BACKSTOP eviction stays reachable** — a coalesced message is a distinct admission outcome
+  from a failed open, so deduplication never reports "unhealable" and a genuinely dead lane is still
+  evicted for a clean re-dial.
+- **`registerStream` overwrote a live lane stream without closing it**, leaving it open but
+  unreachable (the lane resolves to the replacement) and holding one of the connection's 64 stream
+  credits for the life of the connection. The displaced stream is now closed. Bound stated honestly:
+  writes already buffered on it at the instant of replacement are failed by the close — they were
+  already unreachable, and recovery is the retransmit's job, which is the convention this send path
+  already documents for the outcomes it reports as optimistically `Sent`.
+- **#718's own earlier measurements are no longer comparable across this change.** Any count derived
+  from `Operation failed (attempt N/M)` lines — including the `6,525` / `10,630` figures in the
+  ticket — measured a line that no longer appears at default levels. Re-measure against the
+  coalesced/drop counters and the transport's backpressure WARN instead.
+- **Not addressed here, and both are real:** what a stale `forge-data` should mean at boot (an
+  unreadable snapshot set currently boots silently and the runbook never mentions the directory), and
+  Forge's fixed 60s formation budget sitting at exactly the same value as the 60,000ms higher-id
+  force-dial grace in `QuicClusterNetwork` with nothing relating the two. Neither is ruled; neither is
+  bundled into this fix.
+  [mechanism: level demotion plus a count-carrying terminal WARN in `Retry`; a per-(peer, lane)
+  in-flight marker whose lifetime is the `QuicPeerConnection` itself, so an eviction and re-dial
+  clears a leaked marker instead of suppressing that peer's healing permanently —
+  `RetryLoggingBoundTest` (`core`), `QuicPeerConnectionLaneOpenDedupTest` and
+  `QuicClusterNetworkStreamZombieTest$LazyOpenDedup` (`integrations/consensus`)]
+  **What is NOT verified here:** the 60s-timeout outcome itself. That is a timing and volume claim
+  about a live five-node Forge cluster, and Forge's QUIC base port is a hard-coded constant
+  (`ForgeServer:243`) so two concurrent local runs always collide silently — no Forge run was made
+  for this fix. The pins assert what is deterministic: that the per-attempt line is no longer emitted
+  per attempt, that the detail survives at DEBUG, that the give-up line reports the count, that a
+  burst opens one stream and loses nothing, and that the BACKSTOP still evicts.

--- a/core/src/main/java/org/pragmatica/lang/utils/Retry.java
+++ b/core/src/main/java/org/pragmatica/lang/utils/Retry.java
@@ -40,6 +40,30 @@ import static org.pragmatica.lang.io.TimeSpan.timeSpan;
 ///```
 /// The implementation is stateless and thread-safe, so single instance could be used to run several
 /// requests at once.
+///
+/// ## Logging contract (#718) — at most ONE WARN per [#execute] call
+///
+/// Volume here is multiplied by the attempt count, so the level is part of the contract rather than a
+/// detail. A per-attempt WARN on a hot retry path is an unbounded synchronous log: measured at
+/// `200 attempts x 25ms` on the QUIC consensus send wrapper it produced ~4.2 MILLION lines in 72
+/// seconds through a single synchronous Console appender, starving the very event loops whose
+/// progress the retries were waiting on, and the Forge cluster then missed its 60s formation budget
+/// 3/3. Silencing only this logger converted that to 4/4 healthy formations in 8.4s.
+///
+/// Therefore:
+///
+///   - **Per-attempt progress is DEBUG.** Off by default; raise
+///     `org.pragmatica.lang.utils.Retry` to DEBUG to get every attempt back. This is also the level
+///     the busiest caller already documents for its own per-retry lines
+///     (`QuicClusterNetwork#retryBackpressuredWrite`), so WARN here was overriding a level the call
+///     site had already chosen.
+///   - **Giving up is WARN, and carries the attempt count.** Both terminal paths — an unretryable
+///     `Cause` and a spent attempt budget — emit exactly one line. This is what keeps a retry burst
+///     discoverable after the demotion: the count IS the aggregate. Before #718 the spent-budget
+///     path logged nothing at all.
+///
+/// The resulting bound is structural, not a measurement: WARN lines <= calls to [#execute],
+/// independent of `maxAttempts`. Do not reintroduce a WARN inside the retry loop.
 public interface Retry {
     /// Executes an asynchronous operation with retry logic.
     ///
@@ -76,15 +100,21 @@ public interface Retry {
                                  failure.cause().message());
                         yield output.fail(failure.cause());
                     }
-                    case Result.Failure<T> failure when(attempt >= maxAttempts) -> output.fail(failure.cause());
+                    case Result.Failure<T> failure when(attempt >= maxAttempts) -> {
+                        log.warn("Operation failed after {} of {} attempts, giving up: {}",
+                                 attempt,
+                                 maxAttempts,
+                                 failure.cause().message());
+                        yield output.fail(failure.cause());
+                    }
                     case Result.Failure<T> failure -> {
                         var delay = backoffStrategy.nextTimeout(attempt);
 
-                        log.warn("Operation failed (attempt {}/{}), retrying after {}: {}",
-                                 attempt,
-                                 maxAttempts,
-                                 delay,
-                                 failure.cause().message());
+                        log.debug("Operation failed (attempt {}/{}), retrying after {}: {}",
+                                  attempt,
+                                  maxAttempts,
+                                  delay,
+                                  failure.cause().message());
                         SharedScheduler.schedule(() -> executeWithLoop(operation, attempt + 1, output), delay);
                         yield output;
                     }

--- a/core/src/test/java/org/pragmatica/lang/utils/RetryLoggingBoundTest.java
+++ b/core/src/test/java/org/pragmatica/lang/utils/RetryLoggingBoundTest.java
@@ -1,0 +1,352 @@
+/*
+ *  Copyright (c) 2025 Sergiy Yevtushenko.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package org.pragmatica.lang.utils;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.Filter;
+import org.apache.logging.log4j.core.Layout;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.apache.logging.log4j.core.config.Configuration;
+import org.apache.logging.log4j.core.config.LoggerConfig;
+import org.apache.logging.log4j.core.config.Property;
+import org.apache.logging.log4j.core.layout.PatternLayout;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.pragmatica.lang.Promise;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.pragmatica.lang.io.TimeSpan.timeSpan;
+
+/// #718 — THE PIN for [Retry]'s logging volume.
+///
+/// The defect was not that a retry logged, it was that it logged ONCE PER ATTEMPT at WARN. With the
+/// QUIC consensus send wrapper's `200 attempts x 25ms` budget that is a 200x multiplier on a hot send
+/// path, through a single synchronous Console appender, on the very Netty event-loop threads whose
+/// progress the retries were waiting for. Measured: ~4.2 million lines in 72 seconds, Forge missing
+/// its 60s cluster-formation budget 3/3; silencing only this logger gave 4/4 healthy formations in
+/// 8.4s with 84,166 backpressure events still occurring and clearing in 3.5s.
+///
+/// So the property under test is a BOUND, and it is structural rather than statistical: the number of
+/// WARN lines one [Retry#execute] can emit is at most ONE, whatever `maxAttempts` is. That is what
+/// [#warnVolume_isIndependentOfTheAttemptBudget] asserts directly, by comparing two budgets that
+/// differ 40-fold.
+///
+/// Every assertion here reads the LEVEL of each captured event, never merely its presence. That
+/// matters because the fix MOVED a line rather than deleting it: a test that only checked "no WARN
+/// containing 'retrying after'" would also pass if the line had been deleted outright, which would
+/// have destroyed the diagnostic this project still wants at DEBUG
+/// ([#perAttemptDetail_survivesAtDebugLevel]).
+///
+/// **This class is an instrument, so it carries a positive control.** Three of its assertions are
+/// about ABSENCE, and an empty capture list satisfies an absence assertion just as well as correct
+/// production code does. [#SENTINEL] is emitted through the SAME logger the appender is bound to,
+/// before each exercise, and asserted present — a detached appender, a renamed logger or a swallowed
+/// setup failure therefore fails the class rather than passing it vacuously. Capture strategy follows
+/// the house pattern in `BootstrapAdminKeyLegFallbackWarnTest` (`aether/node`), with one deliberate
+/// divergence: the appender is attached with a `null` level so it adds no filter of its own, and the
+/// LOGGER's level is the single variable each test sets. Filtering in the appender would have made
+/// the DEBUG half unobservable.
+@Timeout(30)
+class RetryLoggingBoundTest {
+    private static final String LOGGER_NAME = Retry.class.getName();
+    /// Fragment of the per-attempt line — the one that used to be WARN and is now DEBUG.
+    private static final String PER_ATTEMPT_FRAGMENT = "retrying after";
+    /// Fragment of the give-up line. Before #718 the spent-budget path logged NOTHING, so this is new
+    /// signal, not relocated signal.
+    private static final String GAVE_UP_FRAGMENT = "giving up";
+    /// Fragment of the pre-existing unretryable-cause line, asserted unchanged.
+    private static final String TERMINAL_FRAGMENT = "TERMINAL cause";
+    private static final String SENTINEL = "positive control: RetryLoggingBoundTest appender is attached";
+
+    private CapturingAppender appender;
+    private LoggerConfig loggerConfig;
+    private Level originalLevel;
+
+    @BeforeEach
+    void setUp() {
+        appender = CapturingAppender.create("RetryLoggingBoundCapture");
+        appender.start();
+
+        var ctx = (LoggerContext) LogManager.getContext(false);
+
+        loggerConfig = getOrCreateLoggerConfig(ctx.getConfiguration());
+        originalLevel = loggerConfig.getLevel();
+        loggerConfig.addAppender(appender, null, null);
+        ctx.updateLoggers();
+    }
+
+    @AfterEach
+    void tearDown() {
+        var ctx = (LoggerContext) LogManager.getContext(false);
+
+        loggerConfig.removeAppender(appender.getName());
+        loggerConfig.setLevel(originalLevel);
+        ctx.updateLoggers();
+        appender.stop();
+    }
+
+    /// THE pin, at the level an operator actually runs. A 50-attempt budget that is fully spent emits
+    /// ONE line: the give-up WARN. The pre-#718 code emitted 49 WARNs here.
+    @Test
+    void retryLoop_atDefaultInfoLevel_emitsOneWarnForFiftyAttempts() {
+        useLevel(Level.INFO);
+        emitSentinel();
+
+        var attempts = exhaustBudget(50);
+
+        assertThat(attempts)
+            .describedAs("precondition: the budget must actually be spent, or nothing could have been logged")
+            .isEqualTo(50);
+        assertSentinelWasCaptured();
+        assertThat(messagesContaining(PER_ATTEMPT_FRAGMENT))
+            .describedAs("the per-attempt line must not reach a default INFO configuration at all — "
+                         + "this is the 200x multiplier #718 removed")
+            .isEmpty();
+        assertThat(warnsContaining(GAVE_UP_FRAGMENT))
+            .describedAs("exactly one give-up WARN, and it must carry the COUNT so a spent budget is "
+                         + "still discoverable as an aggregate")
+            .hasSize(1)
+            .allMatch(message -> message.contains("50 of 50 attempts"));
+    }
+
+    /// The structural claim stated as a comparison rather than an absolute: WARN volume does not scale
+    /// with the attempt budget. Two budgets 40x apart, same WARN count.
+    @Test
+    void warnVolume_isIndependentOfTheAttemptBudget() {
+        useLevel(Level.INFO);
+        emitSentinel();
+
+        exhaustBudget(5);
+        var afterSmallBudget = warnCountExcludingSentinel();
+
+        exhaustBudget(200);
+        var afterLargeBudget = warnCountExcludingSentinel();
+
+        assertSentinelWasCaptured();
+        assertThat(afterSmallBudget)
+            .describedAs("a 5-attempt budget emits one give-up WARN")
+            .isEqualTo(1);
+        assertThat(afterLargeBudget - afterSmallBudget)
+            .describedAs("a 200-attempt budget emits ONE more WARN, not 200 — the bound is per "
+                         + "execute() call, not per attempt")
+            .isEqualTo(1);
+    }
+
+    /// The other half of the bound, and the reason the line was demoted rather than deleted: every
+    /// per-attempt line is still there, at DEBUG, for whoever is diagnosing a retry storm. Asserted by
+    /// LEVEL — if the fix had deleted the line, or left it at WARN, this fails.
+    @Test
+    void perAttemptDetail_survivesAtDebugLevel() {
+        useLevel(Level.DEBUG);
+        emitSentinel();
+
+        exhaustBudget(5);
+
+        assertSentinelWasCaptured();
+        assertThat(eventsContaining(PER_ATTEMPT_FRAGMENT))
+            .describedAs("attempts 1..4 each report; the 5th takes the give-up branch instead")
+            .hasSize(4);
+        assertThat(eventsContaining(PER_ATTEMPT_FRAGMENT))
+            .describedAs("and every one of them is DEBUG — a single WARN here reinstates the defect")
+            .allMatch(event -> event.level() == Level.DEBUG);
+        assertThat(warnsContaining(GAVE_UP_FRAGMENT))
+            .describedAs("the give-up line stays WARN even when the detail is turned on")
+            .hasSize(1);
+    }
+
+    /// A retry that SUCCEEDS must be silent at WARN. This is the shape the measured incident actually
+    /// had — an 84,166-event backpressure burst that cleared itself in 3.5 seconds — so a WARN per
+    /// recovered operation would reintroduce volume proportional to the burst.
+    @Test
+    void retryThatEventuallySucceeds_emitsNoWarnAtAll() {
+        useLevel(Level.INFO);
+        emitSentinel();
+
+        var attempts = new AtomicInteger();
+        var result = Retry.retry()
+                          .attempts(10)
+                          .strategy(Retry.BackoffStrategy.fixed().interval(timeSpan(1).millis()))
+                          .execute(() -> attempts.incrementAndGet() < 3
+                                         ? Causes.cause("transient").promise()
+                                         : Promise.success("recovered"))
+                          .await();
+
+        assertThat(result.isSuccess())
+            .describedAs("precondition: the operation must recover, or this tests the wrong branch")
+            .isTrue();
+        assertSentinelWasCaptured();
+        assertThat(warnCountExcludingSentinel())
+            .describedAs("a recovered retry is not an operator event — the burst is reported by the "
+                         + "caller's own backpressure WARN, which #718 left untouched")
+            .isZero();
+    }
+
+    /// The pre-existing unretryable-cause WARN is unchanged: one line, still WARN. Included because
+    /// the fix touched the switch this case lives in, and because it is the symmetric partner of the
+    /// give-up line — both are "we are not trying again", and both must be audible.
+    @Test
+    void terminalCause_stillWarnsExactlyOnce() {
+        useLevel(Level.INFO);
+        emitSentinel();
+
+        var attempts = new AtomicInteger();
+        var result = Retry.retry()
+                          .attempts(20)
+                          .strategy(Retry.BackoffStrategy.fixed().interval(timeSpan(1).millis()))
+                          .execute(() -> {
+                              attempts.incrementAndGet();
+
+                              return Causes.terminal("unretryable").promise();
+                          })
+                          .await();
+
+        assertThat(result.isFailure()).isTrue();
+        assertThat(attempts.get())
+            .describedAs("precondition: a terminal cause stops after the first attempt")
+            .isEqualTo(1);
+        assertSentinelWasCaptured();
+        assertThat(warnsContaining(TERMINAL_FRAGMENT))
+            .describedAs("the unretryable-cause WARN is unchanged by #718")
+            .hasSize(1);
+        assertThat(warnsContaining(GAVE_UP_FRAGMENT))
+            .describedAs("a terminal cause is not a spent budget — the two give-up lines are distinct "
+                         + "and must not both fire")
+            .isEmpty();
+    }
+
+    private static int exhaustBudget(int maxAttempts) {
+        var attempts = new AtomicInteger();
+        var result = Retry.retry()
+                          .attempts(maxAttempts)
+                          .strategy(Retry.BackoffStrategy.fixed().interval(timeSpan(1).millis()))
+                          .execute(() -> Causes.cause("always fails " + attempts.incrementAndGet()).promise())
+                          .await();
+
+        assertThat(result.isFailure())
+            .describedAs("precondition: the budget must be spent for the give-up branch to run")
+            .isTrue();
+
+        return attempts.get();
+    }
+
+    private void useLevel(Level level) {
+        var ctx = (LoggerContext) LogManager.getContext(false);
+
+        loggerConfig.setLevel(level);
+        ctx.updateLoggers();
+    }
+
+    /// Emits [#SENTINEL] on exactly [#LOGGER_NAME], at WARN so it survives every level this class
+    /// sets, inside the same capture window the real assertions read.
+    private static void emitSentinel() {
+        LogManager.getLogger(LOGGER_NAME).warn(SENTINEL);
+    }
+
+    /// Paired with every assertion, and load-bearing for the three that assert ABSENCE: without it an
+    /// empty capture list would satisfy them.
+    private void assertSentinelWasCaptured() {
+        assertThat(appender.messages())
+            .describedAs("the appender must be attached to %s and the logger must be emitting, or "
+                         + "these assertions examine nothing", LOGGER_NAME)
+            .anyMatch(message -> message.contains(SENTINEL));
+    }
+
+    private List<CapturedEvent> eventsContaining(String fragment) {
+        return appender.events()
+                       .stream()
+                       .filter(event -> event.message().contains(fragment))
+                       .toList();
+    }
+
+    private List<String> messagesContaining(String fragment) {
+        return eventsContaining(fragment).stream()
+                                         .map(CapturedEvent::message)
+                                         .toList();
+    }
+
+    private List<String> warnsContaining(String fragment) {
+        return eventsContaining(fragment).stream()
+                                         .filter(event -> event.level() == Level.WARN)
+                                         .map(CapturedEvent::message)
+                                         .toList();
+    }
+
+    /// WARN count with the sentinel discounted — the sentinel is itself a WARN, so a raw count would
+    /// never be zero.
+    private long warnCountExcludingSentinel() {
+        return appender.events()
+                       .stream()
+                       .filter(event -> event.level() == Level.WARN)
+                       .filter(event -> !event.message().contains(SENTINEL))
+                       .count();
+    }
+
+    private static LoggerConfig getOrCreateLoggerConfig(Configuration configuration) {
+        var existing = configuration.getLoggerConfig(LOGGER_NAME);
+
+        if (LOGGER_NAME.equals(existing.getName())) {
+            return existing;
+        }
+
+        var fresh = new LoggerConfig(LOGGER_NAME, Level.INFO, false);
+
+        configuration.addLogger(LOGGER_NAME, fresh);
+
+        return fresh;
+    }
+
+    private record CapturedEvent(Level level, String message) {}
+
+    /// In-memory log4j2 appender retaining the LEVEL alongside the message. Every level is captured;
+    /// what actually reaches here is decided by the logger config the test sets, because the appender
+    /// is attached with a `null` level and so adds no filter of its own.
+    private static final class CapturingAppender extends AbstractAppender {
+        private final List<CapturedEvent> captured = new CopyOnWriteArrayList<>();
+
+        private CapturingAppender(String name, Layout<?> layout) {
+            super(name, (Filter) null, layout, true, Property.EMPTY_ARRAY);
+        }
+
+        static CapturingAppender create(String name) {
+            return new CapturingAppender(name, PatternLayout.createDefaultLayout());
+        }
+
+        @Override
+        public void append(LogEvent event) {
+            captured.add(new CapturedEvent(event.getLevel(), event.getMessage().getFormattedMessage()));
+        }
+
+        List<CapturedEvent> events() {
+            return List.copyOf(captured);
+        }
+
+        List<String> messages() {
+            return captured.stream()
+                           .map(CapturedEvent::message)
+                           .toList();
+        }
+    }
+}

--- a/integrations/consensus/src/main/java/org/pragmatica/consensus/net/quic/QuicClusterNetwork.java
+++ b/integrations/consensus/src/main/java/org/pragmatica/consensus/net/quic/QuicClusterNetwork.java
@@ -1801,35 +1801,86 @@ public class QuicClusterNetwork implements ClusterNetwork {
                                               Message.Wired message,
                                               StreamType lane,
                                               QuicPeerConnection connection) {
+        return encodeLoudly(message, peerId).fold(_ -> encodeFailedOutcome(peerId, message),
+                                                  bytes -> admitLaneOpen(peerId, lane, connection, bytes));
+    }
+
+    /// #718 — ONE in-flight lazy open per (peer, lane). The heal was firing per outbound message, and
+    /// each firing created a stream: the failed opens equalled the `STREAM_LIMIT_ERROR`s exactly
+    /// (857==857, 639==639 across two measured runs), so a transiently missing lane was exhausting the
+    /// connection's 64-stream credit. Messages arriving inside the open window now ride the open
+    /// already in flight instead of starting their own.
+    ///
+    /// Note what did NOT change: the BACKSTOP stays reachable. A coalesced message is a distinct
+    /// admission outcome from a FAILED open, so deduplication never reports "unhealable" and never
+    /// suppresses the eviction that a genuinely dead lane still needs.
+    private WriteOutcome admitLaneOpen(NodeId peerId, StreamType lane, QuicPeerConnection connection, byte[] bytes) {
+        return switch (connection.beginLaneOpen(lane, bytes)) {
+            case QuicPeerConnection.LaneOpenAdmission.Started _ -> startLaneOpen(peerId, lane, connection);
+            case QuicPeerConnection.LaneOpenAdmission.Coalesced(boolean oldestDropped) -> coalesceOntoInFlightOpen(peerId,
+                                                                                                                   lane,
+                                                                                                                   oldestDropped);
+        };
+    }
+
+    /// This caller owns the open: announce the heal once, then drive it. The WARN sits HERE rather
+    /// than at the write site so its volume is one line per open cycle, not one per message.
+    private WriteOutcome startLaneOpen(NodeId peerId, StreamType lane, QuicPeerConnection connection) {
         quicMetrics.onStreamZombieLazyOpen();
         log.warn("No {} stream for CONNECTED peer {} — lazily (re)opening the lane (stream-zombie heal)", lane, peerId);
 
-        return encodeLoudly(message, peerId).fold(_ -> encodeFailedOutcome(peerId, message),
-                                                  bytes -> openLaneAndDeliver(peerId, lane, connection, bytes));
+        return openLaneAndDeliver(peerId, lane, connection);
     }
 
-    private WriteOutcome openLaneAndDeliver(NodeId peerId,
-                                            StreamType lane,
-                                            QuicPeerConnection connection,
-                                            byte[] bytes) {
-        connection.openLane(lane, opened -> onLaneOpened(peerId, lane, connection, bytes, opened));
+    /// The message joined an open already in flight. Reported as optimistically `Sent`, consistent
+    /// with the owning open's own return: the bytes are queued on the connection and are written when
+    /// that open completes.
+    private WriteOutcome coalesceOntoInFlightOpen(NodeId peerId, StreamType lane, boolean oldestDropped) {
+        quicMetrics.onStreamZombieLazyOpenCoalesced();
+
+        return oldestDropped
+               ? droppedOldestPendingLaneWrite(peerId, lane)
+               : new WriteOutcome.Sent(peerId);
+    }
+
+    /// Pending-queue overflow inside one open window. Counted always, logged at DEBUG — the same
+    /// split `dispatchToPeer` uses for the offline buffer's drop-oldest, and deliberately not a WARN:
+    /// this path exists because an unbounded WARN on a hot send path is what #718 is about.
+    private WriteOutcome droppedOldestPendingLaneWrite(NodeId peerId, StreamType lane) {
+        quicMetrics.onStreamZombieLazyOpenDrop();
+        log.debug("Pending {} writes for peer {} at capacity while the lane open is in flight — dropped the oldest",
+                  lane,
+                  peerId);
 
         return new WriteOutcome.Sent(peerId);
     }
 
-    /// Lazy-open callback: write the captured bytes to the freshly-opened stream, or engage the
-    /// BACKSTOP when the open could not heal the lane.
+    private WriteOutcome openLaneAndDeliver(NodeId peerId, StreamType lane, QuicPeerConnection connection) {
+        connection.openLane(lane, opened -> onLaneOpened(peerId, lane, connection, opened));
+
+        return new WriteOutcome.Sent(peerId);
+    }
+
+    /// Lazy-open callback: write every message that waited on this open to the freshly-opened stream,
+    /// or engage the BACKSTOP when the open could not heal the lane. The marker is released on BOTH
+    /// outcomes — a leak here would make the lane unhealable for the rest of the connection's life.
     private void onLaneOpened(NodeId peerId,
                               StreamType lane,
                               QuicPeerConnection connection,
-                              byte[] bytes,
                               Option<QuicStreamChannel> opened) {
-        opened.onPresent(stream -> writeLaneOpened(stream, bytes, peerId, lane))
+        var pending = connection.completeLaneOpen(lane);
+
+        opened.onPresent(stream -> writeLaneOpened(stream, pending, peerId, lane))
               .onEmpty(() -> backstopUnhealableStream(peerId, connection));
     }
 
     @Contract
-    private void writeLaneOpened(QuicStreamChannel stream, byte[] bytes, NodeId peerId, StreamType lane) {
+    private void writeLaneOpened(QuicStreamChannel stream, List<byte[]> pending, NodeId peerId, StreamType lane) {
+        pending.forEach(bytes -> writePendingLaneMessage(stream, bytes, peerId, lane));
+    }
+
+    @Contract
+    private void writePendingLaneMessage(QuicStreamChannel stream, byte[] bytes, NodeId peerId, StreamType lane) {
         var _ = writeIfWritable(stream, bytes, peerId, lane);
     }
 

--- a/integrations/consensus/src/main/java/org/pragmatica/consensus/net/quic/QuicPeerConnection.java
+++ b/integrations/consensus/src/main/java/org/pragmatica/consensus/net/quic/QuicPeerConnection.java
@@ -15,6 +15,11 @@
  */
 package org.pragmatica.consensus.net.quic;
 
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
 import java.util.function.Consumer;
 
 import org.pragmatica.consensus.NodeId;
@@ -28,6 +33,8 @@ import org.pragmatica.messaging.StreamType;
 import io.netty.channel.WriteBufferWaterMark;
 import io.netty.handler.codec.quic.QuicChannel;
 import io.netty.handler.codec.quic.QuicStreamChannel;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static org.pragmatica.lang.Option.option;
 
@@ -60,12 +67,59 @@ public final class QuicPeerConnection {
         }
     }
 
+    /// #718 — admission decision for a lazy lane (re)open: does THIS caller own the single in-flight
+    /// open for the lane, or did it join one already running?
+    ///
+    /// Three outcomes were needed, not two, and that is the whole point of the type. The pre-#718 code
+    /// expressed the open's result as `Option<QuicStreamChannel>`, where empty means "unhealable —
+    /// evict the connection" (the BACKSTOP). A suppressed duplicate is NOT that: it is a healthy
+    /// coalesce onto a healing lane, and reporting it as empty would fire the BACKSTOP eviction on
+    /// every deduplicated message — converting a volume defect into a connection-churn defect.
+    public sealed interface LaneOpenAdmission {
+        /// No open was in flight for this lane: the caller owns it and must drive
+        /// [QuicPeerConnection#openLane], then hand the opened stream every message that
+        /// [QuicPeerConnection#completeLaneOpen] returns.
+        record Started() implements LaneOpenAdmission {}
+
+        /// An open for this lane was already in flight; the offered message joined its pending queue
+        /// and will be written when that open completes. `oldestDropped` is true when the queue was at
+        /// [QuicPeerConnection#PENDING_LANE_WRITES_MAX] and the oldest pending message was dropped to
+        /// make room — the same drop-oldest policy, and the same reporting shape, as
+        /// `PeerState.OfferOutcome.Queued`.
+        record Coalesced(boolean oldestDropped) implements LaneOpenAdmission {}
+    }
+
+    /// #718 — bound on messages retained per (peer, lane) while one lane open is in flight.
+    ///
+    /// The coalescing window is a single lane-open round trip on an ALREADY-LIVE QUIC connection
+    /// (create stream, write preamble) — sub-millisecond locally, one RTT at worst — so this bound is
+    /// only ever reached by a genuine burst. 64 is chosen to mirror
+    /// `initialMaxStreamsBidirectional(64)`, the very credit this dedup exists to stop exhausting:
+    /// the connection retains at most as many queued messages per lane as it has streams in total.
+    /// That tie is a deliberate aesthetic choice, not a derived figure.
+    ///
+    /// Worst-case retention is 64 x the largest framed message (a ~64KB DHT block response) per
+    /// (peer, lane) — and only for a lane that is mid-open, which is the only way into this path.
+    /// Overflow drops the OLDEST, which is strictly better than the behaviour it replaces: before
+    /// #718 every one of these messages opened its own stream, and past the 64-stream credit they
+    /// failed with `STREAM_LIMIT_ERROR` — losing the message AND burning the credit.
+    static final int PENDING_LANE_WRITES_MAX = 64;
+
     private final NodeId peerId;
     private final QuicChannel connection;
     private final QuicStreamChannel[] longLivedStreams;
     private final int consensusWatermarkLowBytes;
     private final int consensusWatermarkHighBytes;
     private volatile LaneOpener laneOpener = LaneOpener.noop();
+    /// #718 — lanes with a lazy open IN FLIGHT, each mapped to the messages waiting on it. A present
+    /// key IS the in-flight marker; [#completeLaneOpen] removing it IS the release. Guarded by this
+    /// instance's monitor.
+    ///
+    /// The marker lives on the CONNECTION, not in a `(peerId, lane)` map on the transport, and the
+    /// lifetime is the reason: an eviction and re-dial builds a FRESH `QuicPeerConnection`, so a
+    /// marker leaked by a callback that never fires dies with the connection that owned it. Keyed by
+    /// peer id instead, the same leak would suppress lane healing for that peer permanently.
+    private final Map<StreamType, Deque<byte[]>> inFlightLaneOpens = new EnumMap<>(StreamType.class);
 
     private QuicPeerConnection(NodeId peerId,
                                QuicChannel connection,
@@ -122,6 +176,61 @@ public final class QuicPeerConnection {
         laneOpener.open(lane, onResult);
     }
 
+    /// #718 — admit `bytes` to the single in-flight lazy open for `lane`, starting one if none is
+    /// running. Returns [LaneOpenAdmission.Started] to exactly one caller per open cycle; that caller
+    /// drives [#openLane] and must pair this with [#completeLaneOpen].
+    ///
+    /// Without this gate the lazy re-open fired once PER OUTBOUND MESSAGE whose lane was missing, and
+    /// each one created a stream: 1,570 attempted opens in one measured 72-second run, of which the
+    /// 857 that failed were *exactly* the 857 `STREAM_LIMIT_ERROR`s — equal counts, in every arm. One
+    /// transiently missing lane was being converted into exhaustion of the 64-stream credit for the
+    /// whole connection.
+    public synchronized LaneOpenAdmission beginLaneOpen(StreamType lane, byte[] bytes) {
+        var pending = inFlightLaneOpens.get(lane);
+
+        if (pending == null) {
+            inFlightLaneOpens.put(lane, freshPendingQueue(bytes));
+
+            return new LaneOpenAdmission.Started();
+        }
+
+        var wasFull = pending.size() >= PENDING_LANE_WRITES_MAX;
+
+        if (wasFull) {
+            pending.pollFirst();
+        }
+
+        pending.offerLast(bytes);
+
+        return new LaneOpenAdmission.Coalesced(wasFull);
+    }
+
+    /// #718 — release the in-flight marker for `lane` and hand back every message that was waiting on
+    /// it, oldest first, including the one offered by the caller that got
+    /// [LaneOpenAdmission.Started]. Must be called on BOTH outcomes of the open — success and failure
+    /// — or the marker leaks and the lane can never be healed again on this connection. Returns an
+    /// empty list when no open was in flight, so a duplicate call is inert rather than harmful.
+    public synchronized List<byte[]> completeLaneOpen(StreamType lane) {
+        var pending = inFlightLaneOpens.remove(lane);
+
+        return pending == null
+               ? List.of()
+               : List.copyOf(pending);
+    }
+
+    /// Visible for tests: lanes currently holding an in-flight lazy open.
+    synchronized int inFlightLaneOpenCount() {
+        return inFlightLaneOpens.size();
+    }
+
+    private static Deque<byte[]> freshPendingQueue(byte[] bytes) {
+        var queue = new ArrayDeque<byte[]>();
+
+        queue.offerLast(bytes);
+
+        return queue;
+    }
+
     /// Get a long-lived stream, if already opened.
     public Option<QuicStreamChannel> stream(StreamType type) {
         return option(longLivedStreams[type.streamIndex()]);
@@ -136,6 +245,16 @@ public final class QuicPeerConnection {
     /// async retry wrap in `QuicClusterNetwork.writeIfWritable` is the safety net for the
     /// pathological case. `WriteBufferWaterMark` is a Netty `ChannelConfig` facility and is
     /// supported by the incubator `QuicStreamChannel`'s config.
+    /// #718 — a re-registration that REPLACES a live stream now CLOSES the one it displaced. The
+    /// overwrite was silent before: nothing can look the old stream up again, so it stayed open,
+    /// unreachable, holding one of the connection's 64 bidirectional stream credits for the lifetime
+    /// of the connection. That is a credit leak on the exact resource the lazy-open storm exhausts.
+    ///
+    /// Honest bound on the close: writes already sitting in the superseded channel's Netty buffer at
+    /// the instant of replacement are failed by `close()`. Those messages were ALREADY unreachable —
+    /// the lane now resolves to `channel` — and recovering them is the retransmit's job, which is the
+    /// convention this send path already documents for the lazy-open and offline-buffer outcomes it
+    /// reports as optimistically `Sent`.
     @Contract
     public void registerStream(StreamType type, QuicStreamChannel channel) {
         if (type == StreamType.CONSENSUS) {
@@ -144,7 +263,26 @@ public final class QuicPeerConnection {
                                                                      consensusWatermarkHighBytes));
         }
 
+        var superseded = longLivedStreams[type.streamIndex()];
+
         longLivedStreams[type.streamIndex()] = channel;
+        closeSuperseded(type, superseded, channel);
+    }
+
+    /// Closes a lane stream displaced by [#registerStream]. A re-register with the SAME channel (the
+    /// idempotent case) and an already-dead channel are both no-ops — only a live, genuinely
+    /// displaced stream is closed.
+    @Contract
+    private void closeSuperseded(StreamType type, QuicStreamChannel superseded, QuicStreamChannel replacement) {
+        if (superseded == null || superseded == replacement || !superseded.isActive()) {
+            return;
+        }
+
+        log.debug("Closing superseded {} stream for peer {} — re-registered on the same connection, "
+                 + "returning its stream credit",
+                  type,
+                  peerId);
+        superseded.close();
     }
 
     /// Check if the underlying QUIC connection is active.
@@ -164,6 +302,8 @@ public final class QuicPeerConnection {
         closeLongLivedStreams();
         connection.close().sync();
     }
+
+    private static final Logger log = LoggerFactory.getLogger(QuicPeerConnection.class);
 
     private void closeLongLivedStreams() {
         for (int i = 0; i < longLivedStreams.length; i++) {

--- a/integrations/consensus/src/main/java/org/pragmatica/consensus/net/quic/QuicTransportMetrics.java
+++ b/integrations/consensus/src/main/java/org/pragmatica/consensus/net/quic/QuicTransportMetrics.java
@@ -45,6 +45,17 @@ public final class QuicTransportMetrics {
     /// Count of stream-zombie BACKSTOP evictions: a write found a CONNECTED peer with no usable
     /// stream AND the lazy open could not heal it, so the connection was evicted for a clean re-dial.
     private final LongAdder streamZombieEvictions = new LongAdder();
+    /// #718: count of writes that joined a lazy lane open ALREADY in flight instead of starting their
+    /// own. This is the deduplication's yield, and reading it against [#streamZombieLazyOpens] is how
+    /// the fix is observed in a live cluster: before #718 every one of these was its own stream, and
+    /// past the 64-stream credit every one became a `STREAM_LIMIT_ERROR`.
+    private final LongAdder streamZombieLazyOpenCoalesced = new LongAdder();
+    /// #718: count of pending messages DROPPED because the per-(peer, lane) queue was already at
+    /// `QuicPeerConnection.PENDING_LANE_WRITES_MAX` when another message arrived during the open
+    /// window. Counted rather than warned — the log line is DEBUG, because an unbounded WARN on a hot
+    /// send path is the defect #718 exists to remove. A persistently non-zero value here means the
+    /// bound is too small for the offered load, not that the dedup is misbehaving.
+    private final LongAdder streamZombieLazyOpenDrops = new LongAdder();
     /// #487: count of sends DROPPED to a peer with no PeerState (dead or never-connected). Counts EVERY
     /// drop, not just the rate-limited WARNs, so ops see true drop volume (the invisibility of this class
     /// hid the #467/#457 self-send drops for months).
@@ -145,6 +156,20 @@ public final class QuicTransportMetrics {
         streamZombieEvictions.increment();
     }
 
+    /// #718: records a write that joined a lazy lane open already in flight rather than opening a
+    /// second stream for the same lane.
+    @Contract
+    public void onStreamZombieLazyOpenCoalesced() {
+        streamZombieLazyOpenCoalesced.increment();
+    }
+
+    /// #718: records a pending message dropped because the per-(peer, lane) queue was full while the
+    /// lane open was in flight. Drop-oldest, mirroring the offline buffer.
+    @Contract
+    public void onStreamZombieLazyOpenDrop() {
+        streamZombieLazyOpenDrops.increment();
+    }
+
     /// #487: records a send DROPPED to a peer with no PeerState. Every drop is counted, whether or not
     /// the accompanying WARN was rate-limited.
     @Contract
@@ -192,6 +217,10 @@ public final class QuicTransportMetrics {
         metrics.put("quic_backpressure_queue_depth", backpressureQueueDepth.get());
         metrics.put("quic_stream_zombie_lazy_opens_total", streamZombieLazyOpens.sum());
         metrics.put("quic_stream_zombie_evictions_total", streamZombieEvictions.sum());
+        // #718: the dedup's yield and its overflow. Coalesced writes would each have been a separate
+        // stream before the fix; drops mean the pending bound was reached inside one open window.
+        metrics.put("quic_stream_zombie_lazy_open_coalesced_total", streamZombieLazyOpenCoalesced.sum());
+        metrics.put("quic_stream_zombie_lazy_open_drops_total", streamZombieLazyOpenDrops.sum());
         metrics.put("quic_drop_to_unknown_peer_total", dropToUnknownPeer.sum());
         // #726: payload bytes at the lane boundary (no QUIC framing/TLS overhead/retransmits) —
         // not a wire-byte or bandwidth figure.
@@ -249,6 +278,16 @@ public final class QuicTransportMetrics {
 
     public long streamZombieEvictionCount() {
         return streamZombieEvictions.sum();
+    }
+
+    /// #718: writes that joined a lazy lane open already in flight, cumulative.
+    public long streamZombieLazyOpenCoalescedCount() {
+        return streamZombieLazyOpenCoalesced.sum();
+    }
+
+    /// #718: pending messages dropped on per-(peer, lane) queue overflow during an open, cumulative.
+    public long streamZombieLazyOpenDropCount() {
+        return streamZombieLazyOpenDrops.sum();
     }
 
     public long dropToUnknownPeerCount() {

--- a/integrations/consensus/src/test/java/org/pragmatica/consensus/net/quic/QuicClusterNetworkStreamZombieTest.java
+++ b/integrations/consensus/src/test/java/org/pragmatica/consensus/net/quic/QuicClusterNetworkStreamZombieTest.java
@@ -22,10 +22,27 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+
 import io.netty.channel.ChannelFuture;
 import io.netty.handler.codec.quic.QuicChannel;
 import io.netty.handler.codec.quic.QuicSslContext;
 import io.netty.handler.codec.quic.QuicStreamChannel;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.Filter;
+import org.apache.logging.log4j.core.Layout;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.apache.logging.log4j.core.config.Configuration;
+import org.apache.logging.log4j.core.config.LoggerConfig;
+import org.apache.logging.log4j.core.config.Property;
+import org.apache.logging.log4j.core.layout.PatternLayout;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -348,7 +365,295 @@ class QuicClusterNetworkStreamZombieTest {
         }
     }
 
+    /// #718 — the lazy open is ONE PER (peer, lane), not one per message.
+    ///
+    /// The PRIMARY heal above is correct and stays; what was missing is a gate in front of it. Each
+    /// firing created a stream, so a burst of writes arriving inside the open window consumed the
+    /// connection's `initialMaxStreamsBidirectional(64)` credit. The coupling was measured as EQUAL
+    /// counts, not a correlation: failed lazy re-opens == `STREAM_LIMIT_ERROR`s, 857==857 in one
+    /// 72-second run and 639==639 in another.
+    ///
+    /// These tests drive the real `writeToStream` path through a DEFERRING opener — one that records
+    /// the callback and completes only when the test says so. That is what reproduces the defect's
+    /// window: while the open is outstanding nothing is registered on the connection, so every write
+    /// in the burst genuinely finds the lane missing. An opener that registers synchronously (the one
+    /// `PrimaryLazyOpen` uses) would let writes 2..N find the healed lane and could not distinguish a
+    /// deduplicating implementation from a non-deduplicating one.
+    @Nested
+    class LazyOpenDedup {
+        private static final String HEAL_FRAGMENT = "lazily (re)opening the lane";
+        private static final String SENTINEL = "positive control: LazyOpenDedup appender is attached";
+        private static final int BURST = 12;
+
+        /// THE pin. Twelve messages onto a lane whose open has not completed create ONE stream, and
+        /// all twelve are still delivered when it does — the dedup must not cost a message.
+        @Test
+        void writeToStream_burstOnAMissingLane_opensOnceAndDeliversEveryMessage() {
+            var network = network();
+            var peerId = new NodeId("dedup-burst-peer");
+            var opener = new DeferringOpener();
+            var connection = connectionWithOpener(peerId, opener);
+
+            network.seedPeerForTests(peerId, connectedPeerState(peerId, connection));
+            writeBurst(network, peerId, connection, BURST);
+
+            assertThat(opener.openCount())
+                .as("twelve writes, ONE stream created — before #718 this was twelve, against a "
+                    + "64-stream credit")
+                .isEqualTo(1);
+            assertThat(network.quicMetrics().streamZombieLazyOpenCount())
+                .as("exactly one write owned the open")
+                .isEqualTo(1L);
+            assertThat(network.quicMetrics().streamZombieLazyOpenCoalescedCount())
+                .as("the other eleven coalesced onto it")
+                .isEqualTo(BURST - 1L);
+
+            var opened = writableStream();
+
+            // Mirror the production opener: register the lane, then report it.
+            connection.registerStream(StreamType.CONTROL, opened);
+            opener.completeWith(Option.some(opened));
+
+            verify(opened, times(BURST)).writeAndFlush(any());
+            assertThat(network.quicMetrics().streamZombieLazyOpenDropCount())
+                .as("a burst well inside the pending bound loses nothing")
+                .isZero();
+        }
+
+        /// The volume half of the same claim, and the reason it is worth a separate assertion: the heal
+        /// line is a WARN on a hot send path. One per open cycle is diagnostic; one per message is the
+        /// #718 amplification pattern in a second place.
+        @Test
+        void writeToStream_burstOnAMissingLane_emitsOneHealWarnNotOnePerMessage() {
+            var network = network();
+            var peerId = new NodeId("dedup-warn-volume-peer");
+            var opener = new DeferringOpener();
+            var connection = connectionWithOpener(peerId, opener);
+
+            network.seedPeerForTests(peerId, connectedPeerState(peerId, connection));
+            emitSentinel();
+            writeBurst(network, peerId, connection, BURST);
+
+            assertSentinelWasCaptured();
+            assertThat(warnsContaining(HEAL_FRAGMENT))
+                .as("one heal WARN for twelve messages — the line announces the OPEN, not the write")
+                .hasSize(1);
+        }
+
+        /// The report's standing risk note, pinned: deduplication must not mask a genuinely dead lane.
+        /// A coalesced message is a distinct admission outcome from a FAILED open, so the BACKSTOP
+        /// eviction is still reached when the open reports empty.
+        @Test
+        void writeToStream_unhealableLaneAfterDedup_stillEvictsViaBackstop() {
+            var network = network();
+            var peerId = new NodeId("dedup-backstop-peer");
+            var opener = new DeferringOpener();
+            var connection = connectionWithOpener(peerId, opener);
+
+            network.seedPeerForTests(peerId, connectedPeerState(peerId, connection));
+            writeBurst(network, peerId, connection, BURST);
+
+            assertThat(network.quicMetrics().streamZombieEvictionCount())
+                .as("precondition: nothing is evicted while the open is still outstanding")
+                .isZero();
+
+            opener.completeWith(Option.empty());
+
+            assertThat(network.quicMetrics().streamZombieEvictionCount())
+                .as("an unhealable lane still evicts for a clean re-dial — dedup did not swallow it")
+                .isEqualTo(1L);
+            assertThat(network.connectedPeers())
+                .as("and the peer drops out so the reconciler re-dials")
+                .doesNotContain(peerId);
+        }
+
+        /// No marker leak THROUGH THE TRANSPORT. The in-flight marker must be released on the failure
+        /// outcome too, or the first unhealable open would make that lane permanently undealable for
+        /// the rest of the connection's life — trading a stream-credit leak for a worse one.
+        @Test
+        void writeToStream_afterAFailedOpen_nextWriteStartsAFreshOpen() {
+            var network = network();
+            var peerId = new NodeId("dedup-marker-release-peer");
+            var opener = new DeferringOpener();
+            var connection = connectionWithOpener(peerId, opener);
+
+            network.seedPeerForTests(peerId, connectedPeerState(peerId, connection));
+            writeBurst(network, peerId, connection, 1);
+            opener.completeWith(Option.empty());
+
+            // Re-CONNECT the same (still lane-less) connection: the BACKSTOP evicted it above, and the
+            // marker — not the peer phase — is what this test is about.
+            var state = connectedPeerState(peerId, connection);
+
+            network.seedPeerForTests(peerId, state);
+            writeBurst(network, peerId, connection, 1);
+
+            assertThat(opener.openCount())
+                .as("the second write drove a SECOND open — a leaked marker would have coalesced it "
+                    + "onto an open that already finished")
+                .isEqualTo(2);
+            assertThat(network.quicMetrics().streamZombieLazyOpenCount()).isEqualTo(2L);
+            assertThat(network.quicMetrics().streamZombieLazyOpenCoalescedCount())
+                .as("neither write coalesced — they are separate open cycles")
+                .isZero();
+        }
+
+        /// Overflow of the pending queue is COUNTED and bounded. Retention caps at the bound, the
+        /// oldest are the ones dropped, and the drop is visible in metrics rather than in a WARN —
+        /// deliberately, since an unbounded WARN on this path is the defect being fixed.
+        @Test
+        void writeToStream_burstPastThePendingBound_dropsOldestAndCountsIt() {
+            var network = network();
+            var peerId = new NodeId("dedup-overflow-peer");
+            var opener = new DeferringOpener();
+            var connection = connectionWithOpener(peerId, opener);
+            var bound = QuicPeerConnection.PENDING_LANE_WRITES_MAX;
+
+            network.seedPeerForTests(peerId, connectedPeerState(peerId, connection));
+            // One owner + (bound - 1) coalesced fills the queue exactly; the final two overflow it.
+            writeBurst(network, peerId, connection, bound + 2);
+
+            assertThat(network.quicMetrics().streamZombieLazyOpenCount())
+                .as("still ONE open, however long the burst")
+                .isEqualTo(1L);
+            assertThat(network.quicMetrics().streamZombieLazyOpenCoalescedCount())
+                .isEqualTo(bound + 1L);
+            assertThat(network.quicMetrics().streamZombieLazyOpenDropCount())
+                .as("exactly the two messages past the bound are dropped")
+                .isEqualTo(2L);
+
+            var opened = writableStream();
+
+            connection.registerStream(StreamType.CONTROL, opened);
+            opener.completeWith(Option.some(opened));
+
+            verify(opened, times(bound)).writeAndFlush(any());
+        }
+
+        // --- dedup fixtures ---
+
+        private CapturingAppender appender;
+        private LoggerConfig loggerConfig;
+
+        @BeforeEach
+        void attachAppender() {
+            appender = CapturingAppender.create("LazyOpenDedupCapture");
+            appender.start();
+
+            var ctx = (LoggerContext) LogManager.getContext(false);
+
+            loggerConfig = getOrCreateLoggerConfig(ctx.getConfiguration());
+            loggerConfig.addAppender(appender, Level.WARN, null);
+            ctx.updateLoggers();
+        }
+
+        @AfterEach
+        void detachAppender() {
+            var ctx = (LoggerContext) LogManager.getContext(false);
+
+            loggerConfig.removeAppender(appender.getName());
+            ctx.updateLoggers();
+            appender.stop();
+        }
+
+        private static void writeBurst(QuicClusterNetwork network,
+                                       NodeId peerId,
+                                       QuicPeerConnection connection,
+                                       int count) {
+            for (var index = 0; index < count; index++) {
+                network.writeToStreamForTests(peerId, new NetworkMessage.KeepAlive(peerId), connection);
+            }
+        }
+
+        private static void emitSentinel() {
+            LogManager.getLogger(QuicClusterNetwork.class).warn(SENTINEL);
+        }
+
+        /// Load-bearing for the volume assertion: `hasSize(1)` would also be satisfied by a detached
+        /// appender that captured one stray line, and an absent capture would make a `hasSize(0)`
+        /// variant pass vacuously.
+        private void assertSentinelWasCaptured() {
+            assertThat(appender.messages())
+                .as("the appender must be attached to %s, or the volume assertion examines nothing",
+                    QuicClusterNetwork.class.getName())
+                .anyMatch(message -> message.contains(SENTINEL));
+        }
+
+        private List<String> warnsContaining(String fragment) {
+            return appender.messages()
+                           .stream()
+                           .filter(message -> message.contains(fragment))
+                           .toList();
+        }
+
+        private static LoggerConfig getOrCreateLoggerConfig(Configuration configuration) {
+            var name = QuicClusterNetwork.class.getName();
+            var existing = configuration.getLoggerConfig(name);
+
+            if (name.equals(existing.getName())) {
+                return existing;
+            }
+
+            var fresh = new LoggerConfig(name, Level.WARN, true);
+
+            configuration.addLogger(name, fresh);
+
+            return fresh;
+        }
+    }
+
     // --- Helpers ---
+
+    /// A [QuicPeerConnection.LaneOpener] that RECORDS the open and defers its outcome until the test
+    /// calls [#completeWith]. Registering nothing meanwhile is the point: it holds the lane-missing
+    /// window open, which is the state the #718 burst actually arrives in.
+    private static final class DeferringOpener implements QuicPeerConnection.LaneOpener {
+        private final List<Consumer<Option<QuicStreamChannel>>> pending = new CopyOnWriteArrayList<>();
+        /// Counted separately from [#pending], which [#completeWith] drains — the question these tests
+        /// ask is how many opens were EVER driven, across completion cycles.
+        private final AtomicInteger opens = new AtomicInteger();
+
+        @Override
+        public void open(StreamType lane, Consumer<Option<QuicStreamChannel>> onResult) {
+            opens.incrementAndGet();
+            pending.add(onResult);
+        }
+
+        void completeWith(Option<QuicStreamChannel> outcome) {
+            var outstanding = List.copyOf(pending);
+
+            pending.clear();
+            outstanding.forEach(callback -> callback.accept(outcome));
+        }
+
+        int openCount() {
+            return opens.get();
+        }
+    }
+
+    /// In-memory log4j2 appender capturing WARN-and-above messages for the dedup volume assertion.
+    private static final class CapturingAppender extends AbstractAppender {
+        private final List<String> captured = new CopyOnWriteArrayList<>();
+
+        private CapturingAppender(String name, Layout<?> layout) {
+            super(name, (Filter) null, layout, true, Property.EMPTY_ARRAY);
+        }
+
+        static CapturingAppender create(String name) {
+            return new CapturingAppender(name, PatternLayout.createDefaultLayout());
+        }
+
+        @Override
+        public void append(LogEvent event) {
+            if (event.getLevel().isMoreSpecificThan(Level.WARN)) {
+                captured.add(event.getMessage().getFormattedMessage());
+            }
+        }
+
+        List<String> messages() {
+            return List.copyOf(captured);
+        }
+    }
 
     /// A mock QUIC lane stream that is active + writable and returns a self-listening future.
     private static QuicStreamChannel writableStream() {

--- a/integrations/consensus/src/test/java/org/pragmatica/consensus/net/quic/QuicPeerConnectionLaneOpenDedupTest.java
+++ b/integrations/consensus/src/test/java/org/pragmatica/consensus/net/quic/QuicPeerConnectionLaneOpenDedupTest.java
@@ -1,0 +1,303 @@
+/*
+ *  Copyright (c) 2020-2025 Sergiy Yevtushenko.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.pragmatica.consensus.net.quic;
+
+import java.nio.charset.StandardCharsets;
+import java.util.stream.IntStream;
+
+import io.netty.handler.codec.quic.QuicChannel;
+import io.netty.handler.codec.quic.QuicStreamChannel;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.pragmatica.consensus.NodeId;
+import org.pragmatica.lang.Option;
+import org.pragmatica.messaging.StreamType;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+/// #718 — unit coverage for the two credit leaks that live on [QuicPeerConnection].
+///
+/// Both are about the connection's 64 bidirectional stream credits, and both were silent:
+///
+///   1. **No in-flight dedup on the lazy lane open.** The heal fired per outbound message whose lane
+///      was missing, and each firing created a stream. In two measured 72-second runs the FAILED
+///      opens equalled the `STREAM_LIMIT_ERROR`s exactly — 857==857 and 639==639 — so one
+///      transiently missing lane was consuming the whole connection's credit.
+///   2. **`registerStream` overwrote without closing.** The displaced stream became unreachable (the
+///      lane now resolves to the replacement) while staying OPEN, holding its credit for the life of
+///      the connection.
+///
+/// The state deliberately lives on the CONNECTION rather than in a `(peerId, lane)` map on the
+/// transport, and [#markerDiesWithTheConnection] is the test that states why: a marker leaked by a
+/// callback that never fires must not be able to outlive the connection it belonged to and suppress
+/// healing for a peer permanently.
+@Timeout(30)
+class QuicPeerConnectionLaneOpenDedupTest {
+
+    @Nested
+    class InFlightAdmission {
+
+        /// The first write to find a missing lane owns the open. Exactly one caller per cycle gets
+        /// this, and it is the only one that may create a stream.
+        @Test
+        void beginLaneOpen_firstCallForALane_reportsStarted() {
+            var connection = connection();
+
+            assertThat(connection.beginLaneOpen(StreamType.DHT, payload("first")))
+                .isInstanceOf(QuicPeerConnection.LaneOpenAdmission.Started.class);
+            assertThat(connection.inFlightLaneOpenCount())
+                .describedAs("the lane now carries an in-flight marker")
+                .isEqualTo(1);
+        }
+
+        /// THE pin for leak 1. Every subsequent write while the open is in flight joins it instead of
+        /// starting its own — so twelve messages create ONE stream, not twelve.
+        @Test
+        void beginLaneOpen_whileAnOpenIsInFlight_coalescesEverySubsequentWrite() {
+            var connection = connection();
+
+            var admissions = IntStream.range(0, 12)
+                                      .mapToObj(index -> connection.beginLaneOpen(StreamType.DHT, payload("m" + index)))
+                                      .toList();
+
+            assertThat(admissions.getFirst())
+                .describedAs("only the first write owns the open")
+                .isInstanceOf(QuicPeerConnection.LaneOpenAdmission.Started.class);
+            assertThat(admissions.subList(1, admissions.size()))
+                .describedAs("the other eleven ride the open already in flight — before #718 each of "
+                             + "these created its own stream against a 64-stream credit")
+                .hasSize(11)
+                .allMatch(QuicPeerConnection.LaneOpenAdmission.Coalesced.class::isInstance);
+            assertThat(connection.inFlightLaneOpenCount())
+                .describedAs("twelve writes, ONE in-flight open")
+                .isEqualTo(1);
+        }
+
+        /// The gate is per (peer, LANE), not per connection: a missing DHT lane must not block a
+        /// missing SYNC lane from healing. The measured incident's dominant healed lane was SYNC while
+        /// DHT was the registered-but-unwritable one, so conflating them would have stalled the wrong
+        /// lane.
+        @Test
+        void beginLaneOpen_differentLanes_eachOwnsItsOwnOpen() {
+            var connection = connection();
+
+            assertThat(connection.beginLaneOpen(StreamType.DHT, payload("dht")))
+                .isInstanceOf(QuicPeerConnection.LaneOpenAdmission.Started.class);
+            assertThat(connection.beginLaneOpen(StreamType.SYNC, payload("sync")))
+                .describedAs("a second LANE is a second open, never a coalesce")
+                .isInstanceOf(QuicPeerConnection.LaneOpenAdmission.Started.class);
+            assertThat(connection.inFlightLaneOpenCount()).isEqualTo(2);
+        }
+
+        /// Completion hands back everything that waited, oldest first, INCLUDING the owner's own
+        /// message — the owner queues its bytes through the same gate, so there is one drain path and
+        /// not a special case.
+        @Test
+        void completeLaneOpen_returnsEveryPendingMessageOldestFirst() {
+            var connection = connection();
+
+            connection.beginLaneOpen(StreamType.DHT, payload("owner"));
+            connection.beginLaneOpen(StreamType.DHT, payload("second"));
+            connection.beginLaneOpen(StreamType.DHT, payload("third"));
+
+            assertThat(connection.completeLaneOpen(StreamType.DHT).stream().map(QuicPeerConnectionLaneOpenDedupTest::text))
+                .describedAs("the owner's message is first, then arrival order — nothing is lost")
+                .containsExactly("owner", "second", "third");
+        }
+
+        /// Completion RELEASES the marker. This is the no-leak pin: a lane that healed once must be
+        /// able to heal again, or a second zombie on the same lane would be permanently unhealable.
+        @Test
+        void completeLaneOpen_releasesTheMarkerSoTheLaneCanHealAgain() {
+            var connection = connection();
+
+            connection.beginLaneOpen(StreamType.DHT, payload("first cycle"));
+            connection.completeLaneOpen(StreamType.DHT);
+
+            assertThat(connection.inFlightLaneOpenCount())
+                .describedAs("the marker is gone once the open has been accounted for")
+                .isZero();
+            assertThat(connection.beginLaneOpen(StreamType.DHT, payload("second cycle")))
+                .describedAs("a later write starts a FRESH open rather than coalescing onto a corpse")
+                .isInstanceOf(QuicPeerConnection.LaneOpenAdmission.Started.class);
+        }
+
+        /// A duplicate or unpaired completion is inert. The transport calls this on BOTH outcomes of
+        /// the open, and an empty return must not be mistaken for a lane with pending work.
+        @Test
+        void completeLaneOpen_withNothingInFlight_returnsEmptyAndDoesNotThrow() {
+            assertThat(connection().completeLaneOpen(StreamType.DHT)).isEmpty();
+        }
+
+        /// The bound, asserted at its exact edge. `PENDING_LANE_WRITES_MAX` messages are retained;
+        /// the next one drops the OLDEST and says so, mirroring the offline buffer's documented
+        /// drop-oldest policy rather than inventing a second one.
+        @Test
+        void beginLaneOpen_pastThePendingBound_dropsTheOldestAndReportsIt() {
+            var connection = connection();
+            var bound = QuicPeerConnection.PENDING_LANE_WRITES_MAX;
+
+            // One Started + (bound - 1) Coalesced fills the queue to exactly the bound.
+            var fillingAdmissions = IntStream.range(0, bound)
+                                             .mapToObj(index -> connection.beginLaneOpen(StreamType.DHT,
+                                                                                         payload("m" + index)))
+                                             .toList();
+
+            assertThat(fillingAdmissions.subList(1, fillingAdmissions.size()))
+                .describedAs("filling up to the bound drops nothing")
+                .allMatch(admission -> admission instanceof QuicPeerConnection.LaneOpenAdmission.Coalesced(boolean dropped)
+                                       && !dropped);
+
+            var overflow = connection.beginLaneOpen(StreamType.DHT, payload("overflow"));
+
+            assertThat(overflow)
+                .describedAs("the message past the bound reports that it cost the oldest one")
+                .isEqualTo(new QuicPeerConnection.LaneOpenAdmission.Coalesced(true));
+
+            var drained = connection.completeLaneOpen(StreamType.DHT);
+
+            assertThat(drained)
+                .describedAs("retention is capped AT the bound, never above it")
+                .hasSize(bound);
+            assertThat(text(drained.getFirst()))
+                .describedAs("the OLDEST was the one dropped — m0 is gone and m1 is now the head")
+                .isEqualTo("m1");
+            assertThat(text(drained.getLast()))
+                .describedAs("the newest message is retained")
+                .isEqualTo("overflow");
+        }
+
+        /// Why the marker lives on the connection and not in a transport-level map keyed by peer id.
+        /// An eviction and re-dial builds a fresh [QuicPeerConnection]; a marker leaked by an opener
+        /// whose callback never fires therefore dies with the connection that owned it. Keyed by peer,
+        /// the same leak would suppress that peer's lane healing for the process lifetime.
+        @Test
+        void markerDiesWithTheConnection() {
+            var leaked = connection();
+
+            leaked.beginLaneOpen(StreamType.DHT, payload("never completed"));
+
+            assertThat(leaked.inFlightLaneOpenCount())
+                .describedAs("precondition: this connection really is holding a leaked marker")
+                .isEqualTo(1);
+
+            var afterRedial = connection();
+
+            assertThat(afterRedial.inFlightLaneOpenCount())
+                .describedAs("the re-dialled connection starts clean — the leak cannot cross it")
+                .isZero();
+            assertThat(afterRedial.beginLaneOpen(StreamType.DHT, payload("after re-dial")))
+                .describedAs("and the lane heals normally on the new connection")
+                .isInstanceOf(QuicPeerConnection.LaneOpenAdmission.Started.class);
+        }
+    }
+
+    @Nested
+    class SupersededStreamClose {
+
+        /// THE pin for leak 2. Re-registering a lane displaces the previous stream; that stream is now
+        /// unreachable for writes, so leaving it open holds one of 64 stream credits forever.
+        @Test
+        void registerStream_replacingALiveStream_closesTheSupersededOne() {
+            var connection = connection();
+            var first = liveStream();
+            var second = liveStream();
+
+            connection.registerStream(StreamType.DHT, first);
+            connection.registerStream(StreamType.DHT, second);
+
+            verify(first, times(1)).close();
+            verify(second, never()).close();
+            assertThat(connection.stream(StreamType.DHT))
+                .describedAs("the lane resolves to the replacement")
+                .isEqualTo(Option.some(second));
+        }
+
+        /// Re-registering the SAME channel is idempotent, not a self-close. The acceptor path can
+        /// register a lane it already holds; closing it there would tear down a healthy lane.
+        @Test
+        void registerStream_sameChannelAgain_doesNotCloseIt() {
+            var connection = connection();
+            var stream = liveStream();
+
+            connection.registerStream(StreamType.DHT, stream);
+            connection.registerStream(StreamType.DHT, stream);
+
+            verify(stream, never()).close();
+            assertThat(connection.stream(StreamType.DHT)).isEqualTo(Option.some(stream));
+        }
+
+        /// An already-dead displaced stream needs no close — there is no credit left to return, and
+        /// calling close on it would be noise on the reconnect path, which is exactly where this fires.
+        @Test
+        void registerStream_supersedingADeadStream_doesNotCloseIt() {
+            var connection = connection();
+            var dead = liveStream();
+
+            lenient().when(dead.isActive()).thenReturn(false);
+            connection.registerStream(StreamType.DHT, dead);
+            connection.registerStream(StreamType.DHT, liveStream());
+
+            verify(dead, never()).close();
+        }
+
+        /// The first registration of a lane has nothing to supersede — the common case, and it must
+        /// not touch the stream it is installing.
+        @Test
+        void registerStream_firstRegistrationOfALane_closesNothing() {
+            var connection = connection();
+            var only = liveStream();
+
+            connection.registerStream(StreamType.DHT, only);
+
+            verify(only, never()).close();
+            assertThat(connection.stream(StreamType.DHT)).isEqualTo(Option.some(only));
+        }
+    }
+
+    // --- Helpers ---
+
+    private static QuicPeerConnection connection() {
+        var channel = mock(QuicChannel.class);
+
+        lenient().when(channel.isActive()).thenReturn(true);
+
+        return QuicPeerConnection.quicPeerConnection(new NodeId("dedup-peer"), channel);
+    }
+
+    private static QuicStreamChannel liveStream() {
+        var stream = mock(QuicStreamChannel.class);
+
+        lenient().when(stream.isActive()).thenReturn(true);
+        lenient().when(stream.isWritable()).thenReturn(true);
+
+        return stream;
+    }
+
+    private static byte[] payload(String marker) {
+        return marker.getBytes(StandardCharsets.UTF_8);
+    }
+
+    private static String text(byte[] bytes) {
+        return new String(bytes, StandardCharsets.UTF_8);
+    }
+}


### PR DESCRIPTION
Issue: #718 — the only `blocking` issue on the rc4 milestone (referenced **without** a closing keyword)

Implements **shapes 1 and 2** from `oss/internal/investigate-selfterm-2026-09-11.md` §6, as ruled by the owner. Shapes 3 and 4 are deliberately **not** included.

## What #718 actually is

A stock single-host Forge start **loses its whole cluster in 60–90 s with zero API calls.** Established by controlled experiment on a verified-quiet box, arms interleaved so fatal ones bracket healthy ones:

| arms | stale `forge-data` | `Retry.java:83` per-attempt WARN | result |
|---|---|---|---|
| 2 | present | **stock** | **FATAL 2/2** — 73 s, 72 s |
| 2 | present | **silenced** | **HEALTHY 2/2** — 85–86k backpressure WARNs still logged, burst clears in 3.5 s |
| 3 | absent | stock | healthy 3/3 |

**Between the fatal and healthy arms the only change is one log statement.** The chain: stale state → backpressure → a WARN *per attempt* → **200 attempts × 25 ms through a single SYNCHRONOUS log4j2 Console appender starves the event loops that would drain the QUIC write buffers** → formation exceeds the fixed 60 s `cluster.start().await()` at `ForgeServer.java:401` → throws → `System.exit(1)` → shutdown hook → `EmberCluster.stop()`.

## Shape 1 — demote the per-attempt line to DEBUG, add a WARN on budget exhaustion

**The decisive reason is not taste: `Retry` was overriding a level its call site had already chosen.** `QuicClusterNetwork#writeIfWritable`'s own comment states *"per-retry logging stays at debug below"*, and `retryBackpressuredWrite` already logs at debug — then the core utility emitted WARN per attempt regardless.

**The new bound is structural, not tuned: at most one WARN per `execute()`, independent of `maxAttempts`.** A rate limit or a first-and-last scheme would still scale with attempt count in some configuration; this does not.

### Signal survives, and there is net MORE of it

- The transport's own `Backpressure on peer/lane` WARN is **untouched** — one line per *entry*, not per attempt. The discriminating arm recorded all **84,166** of them while forming healthily in 8.4 s.
- **Budget exhaustion was previously SILENT.** It now emits a WARN carrying the attempt count. So the change removes a per-attempt flood and adds a signal that did not exist.

Blast radius of the level change is enumerated in the report with its space stated.

## Shape 2 — one in-flight lane open per (peer, lane)

`lazyOpenLaneAndWrite` fired **per message with no in-flight dedup**, which is what exhausts the 64-stream credit — failed re-opens equalled `STREAM_LIMIT_ERROR` count **exactly** (857 == 857, 639 == 639). Now one in-flight open per (peer, lane), with the superseded stream closed.

**This stands on its own in review**: it fixes the transport defect regardless of shape 1, and shape 1 fixes the process death regardless of it.

## Verification

| | |
|---|---|
| Mutation probes | **8, all RED** under the mutation each exists to catch, with distinct named sets |
| Root `mvn clean install` | **BUILD SUCCESS ×2**, 145 modules, 0 non-SUCCESS |
| Tests | **13,713 `<testcase>` elements** (13,697 surefire + 16 failsafe), **0 failures, 0 errors, 19 skipped** |
| Marker | dropped **before** the build; **0 XML excluded** |
| Changelog | `needs_fragment=true` |

**The reactor was built twice on purpose.** The first run was green at `688ad278b`; one gratuitous FQCN was then removed from a test file, and rather than ship "the build covers a SHA one token from the final one" as a caveat, the whole reactor was re-run at the final SHA. **Both runs produced identical counts.**

**The gate was run per module with a base-SHA control**, because a combined reactor can return a module as `SKIPPED` with no result at all, and both modules inherit `jbct.skip=true` so `-Djbct.skip=false` is mandatory or the goal exits green having examined nothing:

- `core`: 62 files, **identical** to base — all failures pre-existing.
- `integrations/consensus`: first run showed **6 format issues against base's 4 — the +2 were MINE.** Fixed with `jbct:format`, then **every file except those two was reverted**, so pre-existing debt in `TopologyObserver`, `BackoffConfig`, `QuicClusterClient` and `RabiaEngine` is left exactly as found. The formatter's diff was inspected hunk by hunk and touched only added lines.

**Scope statement, because it decides what the remaining gate failure means:** neither module is inside any lifecycle gate. Space: `git grep -l jbct-maven-plugin` over all poms → 37, none of which is `core` or `integrations`.

## What this does NOT do

- `[unverified]` **The 60 s timeout was not re-measured.** No Forge run was made — two agents contaminated each other on this box today, so Forge was forbidden for this work. **The fatal-to-healthy attribution rests on the prior controlled arm alone**, not on anything this branch measured.
- **The trigger remains.** This stops the node dying; it does not explain or remove what makes restored on-disk state saturate the DHT/SYNC plane at formation. After this lands, a node with stale `forge-data` still produces an 85–86k-event burst at boot — it survives it, forming in ~8.4 s instead of dying at 72 s. **Why that saturation happens is still unknown and was not guessed at.** That is what §6 shape 3 is for.
- Shapes **3** (what stale `forge-data` should mean at boot) and **4** (the 60 s budget's relationship to the higher-id grace, and a failure message naming what did not finish) are **not ruled and not bundled.**

Related: **#1008** — Forge's QUIC base port is hard-coded, which is why no concurrent-arm verification was possible and why this PR carries an unverified timing claim rather than a measured one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Shape 2 in full — it is more than a guard

- **`LaneOpenAdmission`** (`Started` / `Coalesced`) with `beginLaneOpen` / `completeLaneOpen` as the gate.
- **`PENDING_LANE_WRITES_MAX = 64`** bounds what can queue behind an in-flight open.
- **`registerStream` now closes the superseded stream** — previously the zombie was simply dropped.
- **`onLaneOpened` drains every pending message**, so coalescing does not silently lose writes.
- The heal WARN moved to the **open owner**, so one open produces one line rather than one per coalesced message.
- **New metrics: `quic_stream_zombie_lazy_open_coalesced_total` and `…_drops_total`** with accessors — so the dedup's behaviour is observable rather than inferred.

**22 new tests**: `RetryLoggingBoundTest` (5), `QuicPeerConnectionLaneOpenDedupTest` (12), and a `LazyOpenDedup` nested class in `QuicClusterNetworkStreamZombieTest` (5).

## The probe that makes the DEBUG half load-bearing

**M2 mutates "demote the line" into "delete the line" — and reddens exactly one test.** That is the discriminator: without it, a reviewer could not tell whether the DEBUG level is carrying weight or whether the line could simply have been removed. M5 and M8 are singletons disjoint from every other red set. **No probe came back green where red was expected.**

## The counting instrument was validated against a known truth before use

The `<testcase>` counter was checked against a case where the two methods disagree: **`LaneOpenDedupTest` reports `tests="0"` while holding 12 children.** That is the `<testsuite tests="N">` attribute carrying the same `@Nested` defect as a `.txt` header — a 21% error on this reactor if trusted. The quoted 13,713 is an element count, with **0 XML excluded by a marker dropped before the build**, so the total belongs to exactly one run.

## Two findings against the author's own work, both fixed

1. The `integrations/consensus` gate went **4 → 6** format issues; **the two added were this change's two files.** Fixed with `jbct:format`, every other file reverted, back to exact base parity.
2. **The first `changelog-check` run exited 0 having evaluated nothing** — uncommitted work is invisible to `git diff <range>`. That green was vacuous, and the quoted pass is the post-commit run.

## A correction in the author's favour on the evidence

The report states the fatal-to-healthy attribution rests on the investigation's **F1 arm alone (n=1)**. That understates it: the investigation's **verified-quiet round 2** independently produced **2/2 stale-with-WARN-silenced healthy** (arms R1c and R2c, interleaved between fatal arms), alongside 2/2 fatal with the WARN stock and 3/3 clean healthy. So the silenced-healthy observation is **n=3 across two rounds**, not n=1.

The caveat itself stands and is the right one to keep: **no run in this branch measured the 60s timeout**, and nothing here should be read as having re-verified it.

## Both changes stand independently of #718's timing claim

This is the argument that matters if the timing attribution is ever questioned: **an unbounded synchronous log on a hot retry path is a defect on its own terms**, and **a per-message stream open with no in-flight dedup against a 64-stream credit is a defect on its own terms.** Neither needs #718 to justify it.
