### PR TITLE
fix: make Forge's QUIC base port configurable and fail loudly on a collision (#1008)

### DIFF
--- a/aether/docs/operators/runbooks/lifecycle-verification.md
+++ b/aether/docs/operators/runbooks/lifecycle-verification.md
@@ -20,15 +20,20 @@ not reach the router at all. It falls through to the static file handler, which 
    ls aether/cli/target/aether.jar
    ```
 
-3. **Confirm no other Forge is running on this machine first.** Only one Forge instance can run
-   per host. Its management, app and dashboard ports come from `ForgeConfig`, but the cluster's
-   QUIC base port does not: `ForgeServer` passes the `EmberCluster.DEFAULT_BASE_PORT` constant
-   (`6000`, so nodes occupy `6000`–`6000+nodes-1`), and no configuration overrides it. There is
-   therefore no port-offset arrangement that lets two instances coexist — a second instance's nodes
-   cannot form a cluster, and the symptom is step 2 never returning rather than a bind error.
+3. **Confirm no other Forge is running on this machine first.** All four of Forge's port settings
+   are configurable in `forge.toml` — `base_port` (the cluster's QUIC/consensus UDP range,
+   `base_port`–`base_port+nodes-1`, default `6000`), `management_port`, `app_http_port` and
+   `dashboard_port`. Moving all four lets a second instance coexist; moving only the other three
+   does not, because the QUIC range is the one whose collision the kernel does not report (the
+   sockets carry `SO_REUSEADDR`, so a duplicate bind succeeds and the datagrams are split silently).
+
+   Since #1008 Forge checks its whole QUIC range at startup and exits non-zero naming the occupied
+   ports, so that collision is loud rather than appearing as step 2 never returning. A start that
+   fails this way is a port collision and not stale `forge-data` state — no node was started.
 
    ```bash
    lsof -nP -iTCP:5150 -sTCP:LISTEN    # expect no output before you start
+   lsof -nP -iUDP:6000                 # QUIC base port; expect no output before you start
    ```
 
 4. Start from clean simulator state. Forge keeps per-node data under `$AETHER_HOME/forge-data`,

--- a/aether/docs/slice-developers/forge-guide.md
+++ b/aether/docs/slice-developers/forge-guide.md
@@ -153,7 +153,14 @@ base_port = 6000             # Base QUIC/consensus UDP port (node i binds base_p
 management_port = 5150       # Base management port
 dashboard_port = 8888        # Dashboard port
 app_http_port = 8070         # Base app HTTP port (load target)
+start_timeout_seconds = 60   # How long to wait for the cluster to finish forming before exiting
 ```
+
+If the cluster does not finish forming inside `start_timeout_seconds`, Forge exits non-zero and
+reports what it had reached at the deadline — how many nodes were consensus-active, the leader (or
+`none`), each node with its state and QUIC port, and any per-node start failure. Raise the value if
+formation on your host is merely slow; a stale `AETHER_HOME/forge-data` directory is a common reason
+for formation to consume the whole budget.
 
 ### Running two Forge instances on one host
 

--- a/aether/docs/slice-developers/forge-guide.md
+++ b/aether/docs/slice-developers/forge-guide.md
@@ -149,10 +149,23 @@ Three things worth knowing:
 
 [cluster]
 nodes = 5                    # Number of nodes to simulate
+base_port = 6000             # Base QUIC/consensus UDP port (node i binds base_port + i)
 management_port = 5150       # Base management port
 dashboard_port = 8888        # Dashboard port
 app_http_port = 8070         # Base app HTTP port (load target)
 ```
+
+### Running two Forge instances on one host
+
+All four port settings must be moved, `base_port` included. It is the cluster's QUIC/consensus range
+(`base_port` through `base_port + nodes - 1`), and it is the one that does **not** announce a
+collision by itself: the QUIC sockets are bound with `SO_REUSEADDR`, so a second instance left on the
+default 6000 binds successfully, silently splits the range's datagrams with the first instance, and
+never reaches quorum — surfacing only as `activePeerCount=1`, which is also what genuinely stale
+`forge-data/` state looks like.
+
+Forge therefore checks the whole range at startup and refuses to start when any of it is held,
+naming the ports. If you see that message it is a collision, not stale state — no node was started.
 
 ### Auto-Healing
 

--- a/aether/ember/src/main/java/org/pragmatica/aether/ember/EmberConfig.java
+++ b/aether/ember/src/main/java/org/pragmatica/aether/ember/EmberConfig.java
@@ -20,6 +20,13 @@ import org.pragmatica.lang.Result;
 /// collide invisibly: relocating the three configurable ports removed the loud TCP guard while
 /// leaving the QUIC range fixed. Configurability alone does not make that collision visible (the
 /// duplicate UDP bind SUCCEEDS under `SO_REUSEADDR`); `ForgePortPreflight` is the guard.
+///
+/// #718 shape 4 — `startTimeoutSeconds` is how long Forge waits for the cluster to finish forming
+/// before giving up and exiting. It was a hard-coded 60-second literal at the single `await` site,
+/// so a host on which formation is merely slow had no way to buy more time. Deliberately NOT derived
+/// from, and not coupled to, the 60-second higher-id grace in `QuicClusterNetwork` (#491): the two
+/// are numerically equal and serve unrelated purposes, and no evidence of a real relationship was
+/// found.
 public record EmberConfig(int nodes,
                           int basePort,
                           int managementPort,
@@ -29,7 +36,8 @@ public record EmberConfig(int nodes,
                           ObservabilityConfig observability,
                           boolean lbEnabled,
                           int lbPort,
-                          int coreMax) {
+                          int coreMax,
+                          int startTimeoutSeconds) {
     public static final int DEFAULT_NODES = 5;
     /// Single source of truth stays [EmberCluster#DEFAULT_BASE_PORT]; mirrored here so config
     /// callers need not reach into the cluster class for a default.
@@ -40,6 +48,7 @@ public record EmberConfig(int nodes,
     public static final boolean DEFAULT_LB_ENABLED = true;
     public static final int DEFAULT_LB_PORT = 8080;
     public static final int DEFAULT_CORE_MAX = 0;
+    public static final int DEFAULT_START_TIMEOUT_SECONDS = 60;
 
     public static final EmberConfig DEFAULT = new EmberConfig(DEFAULT_NODES,
                                                               DEFAULT_BASE_PORT,
@@ -50,7 +59,8 @@ public record EmberConfig(int nodes,
                                                               ObservabilityConfig.DEFAULT,
                                                               DEFAULT_LB_ENABLED,
                                                               DEFAULT_LB_PORT,
-                                                              DEFAULT_CORE_MAX);
+                                                              DEFAULT_CORE_MAX,
+                                                              DEFAULT_START_TIMEOUT_SECONDS);
 
     public static Result<EmberConfig> emberConfig(int nodes, int managementPort, int dashboardPort) {
         return emberConfig(nodes,
@@ -146,11 +156,13 @@ public record EmberConfig(int nodes,
                            observability,
                            lbEnabled,
                            lbPort,
-                           coreMax);
+                           coreMax,
+                           DEFAULT_START_TIMEOUT_SECONDS);
     }
 
-    /// #1008 — the only overload that takes the QUIC/consensus base port. Every shorter overload
-    /// defaults it to [#DEFAULT_BASE_PORT], so existing callers keep their present behaviour.
+    /// #1008 / #718 shape 4 — the only overload that takes the QUIC/consensus base port and the
+    /// cluster start budget. Every shorter overload defaults both, so existing callers keep their
+    /// present behaviour.
     public static Result<EmberConfig> emberConfig(int nodes,
                                                   int basePort,
                                                   int managementPort,
@@ -160,7 +172,8 @@ public record EmberConfig(int nodes,
                                                   ObservabilityConfig observability,
                                                   boolean lbEnabled,
                                                   int lbPort,
-                                                  int coreMax) {
+                                                  int coreMax,
+                                                  int startTimeoutSeconds) {
         if (nodes < 1) {
             return EmberConfigError.invalidValue("nodes", nodes, "must be at least 1").result();
         }
@@ -199,6 +212,14 @@ public record EmberConfig(int nodes,
             return EmberConfigError.invalidValue("lb_port", lbPort, "must be valid port").result();
         }
 
+        // A non-positive budget would make the await expire before the cluster could possibly form,
+        // turning every start into the timeout this value exists to govern.
+        if (startTimeoutSeconds < 1) {
+            return EmberConfigError.invalidValue("start_timeout_seconds",
+                                                 startTimeoutSeconds,
+                                                 "must be at least 1").result();
+        }
+
         return Result.success(new EmberConfig(nodes,
                                               basePort,
                                               managementPort,
@@ -208,7 +229,8 @@ public record EmberConfig(int nodes,
                                               observability,
                                               lbEnabled,
                                               lbPort,
-                                              coreMax));
+                                              coreMax,
+                                              startTimeoutSeconds));
     }
 
     public static Result<EmberConfig> load(Path path) {
@@ -240,6 +262,7 @@ public record EmberConfig(int nodes,
         boolean lbEnabled = doc.getBoolean("lb", "enabled").or(DEFAULT_LB_ENABLED);
         int lbPort = doc.getInt("lb", "port").or(DEFAULT_LB_PORT);
         int coreMax = doc.getInt("cluster", "core_max").or(DEFAULT_CORE_MAX);
+        int startTimeoutSeconds = doc.getInt("cluster", "start_timeout_seconds").or(DEFAULT_START_TIMEOUT_SECONDS);
 
         return emberConfig(nodes,
                            basePort,
@@ -250,7 +273,8 @@ public record EmberConfig(int nodes,
                            observability,
                            lbEnabled,
                            lbPort,
-                           coreMax);
+                           coreMax,
+                           startTimeoutSeconds);
     }
 
     private static ObservabilityConfig parseObservabilityConfig(org.pragmatica.config.toml.TomlDocument doc) {

--- a/aether/ember/src/main/java/org/pragmatica/aether/ember/EmberConfig.java
+++ b/aether/ember/src/main/java/org/pragmatica/aether/ember/EmberConfig.java
@@ -211,13 +211,10 @@ public record EmberConfig(int nodes,
         if (lbEnabled && (lbPort < 1 || lbPort > 65535)) {
             return EmberConfigError.invalidValue("lb_port", lbPort, "must be valid port").result();
         }
-
         // A non-positive budget would make the await expire before the cluster could possibly form,
         // turning every start into the timeout this value exists to govern.
         if (startTimeoutSeconds < 1) {
-            return EmberConfigError.invalidValue("start_timeout_seconds",
-                                                 startTimeoutSeconds,
-                                                 "must be at least 1").result();
+            return EmberConfigError.invalidValue("start_timeout_seconds", startTimeoutSeconds, "must be at least 1").result();
         }
 
         return Result.success(new EmberConfig(nodes,

--- a/aether/ember/src/main/java/org/pragmatica/aether/ember/EmberConfig.java
+++ b/aether/ember/src/main/java/org/pragmatica/aether/ember/EmberConfig.java
@@ -13,7 +13,15 @@ import org.pragmatica.lang.Option;
 import org.pragmatica.lang.Result;
 
 
+/// #1008 — `basePort` is the cluster's QUIC/consensus UDP base port: node `i` binds `basePort + i`,
+/// so a cluster of `nodes` occupies `basePort .. basePort + nodes - 1`. It was the one port Forge
+/// could not move — management, dashboard and app HTTP were configurable while this stayed pinned
+/// at [EmberCluster#DEFAULT_BASE_PORT] — which is precisely what made a second Forge instance
+/// collide invisibly: relocating the three configurable ports removed the loud TCP guard while
+/// leaving the QUIC range fixed. Configurability alone does not make that collision visible (the
+/// duplicate UDP bind SUCCEEDS under `SO_REUSEADDR`); `ForgePortPreflight` is the guard.
 public record EmberConfig(int nodes,
+                          int basePort,
                           int managementPort,
                           int dashboardPort,
                           int appHttpPort,
@@ -23,6 +31,9 @@ public record EmberConfig(int nodes,
                           int lbPort,
                           int coreMax) {
     public static final int DEFAULT_NODES = 5;
+    /// Single source of truth stays [EmberCluster#DEFAULT_BASE_PORT]; mirrored here so config
+    /// callers need not reach into the cluster class for a default.
+    public static final int DEFAULT_BASE_PORT = EmberCluster.DEFAULT_BASE_PORT;
     public static final int DEFAULT_MANAGEMENT_PORT = 5150;
     public static final int DEFAULT_DASHBOARD_PORT = 8888;
     public static final int DEFAULT_APP_HTTP_PORT = 8070;
@@ -31,6 +42,7 @@ public record EmberConfig(int nodes,
     public static final int DEFAULT_CORE_MAX = 0;
 
     public static final EmberConfig DEFAULT = new EmberConfig(DEFAULT_NODES,
+                                                              DEFAULT_BASE_PORT,
                                                               DEFAULT_MANAGEMENT_PORT,
                                                               DEFAULT_DASHBOARD_PORT,
                                                               DEFAULT_APP_HTTP_PORT,
@@ -125,12 +137,49 @@ public record EmberConfig(int nodes,
                                                   boolean lbEnabled,
                                                   int lbPort,
                                                   int coreMax) {
+        return emberConfig(nodes,
+                           DEFAULT_BASE_PORT,
+                           managementPort,
+                           dashboardPort,
+                           appHttpPort,
+                           h2Config,
+                           observability,
+                           lbEnabled,
+                           lbPort,
+                           coreMax);
+    }
+
+    /// #1008 — the only overload that takes the QUIC/consensus base port. Every shorter overload
+    /// defaults it to [#DEFAULT_BASE_PORT], so existing callers keep their present behaviour.
+    public static Result<EmberConfig> emberConfig(int nodes,
+                                                  int basePort,
+                                                  int managementPort,
+                                                  int dashboardPort,
+                                                  int appHttpPort,
+                                                  EmberH2Config h2Config,
+                                                  ObservabilityConfig observability,
+                                                  boolean lbEnabled,
+                                                  int lbPort,
+                                                  int coreMax) {
         if (nodes < 1) {
             return EmberConfigError.invalidValue("nodes", nodes, "must be at least 1").result();
         }
 
         if (nodes > 100) {
             return EmberConfigError.invalidValue("nodes", nodes, "must be at most 100").result();
+        }
+
+        if (basePort < 1 || basePort > 65535) {
+            return EmberConfigError.invalidValue("base_port", basePort, "must be valid port").result();
+        }
+
+        // The cluster binds basePort + i for each of `nodes` nodes, so the whole range must be
+        // addressable — a base port that is individually valid can still run the cluster off the
+        // end of the port space.
+        if (basePort + nodes - 1 > 65535) {
+            return EmberConfigError.invalidValue("base_port",
+                                                 basePort,
+                                                 "range for " + nodes + " nodes exceeds 65535").result();
         }
 
         if (managementPort < 1 || managementPort > 65535) {
@@ -154,6 +203,7 @@ public record EmberConfig(int nodes,
         }
 
         return Result.success(new EmberConfig(nodes,
+                                              basePort,
                                               managementPort,
                                               dashboardPort,
                                               appHttpPort,
@@ -184,6 +234,7 @@ public record EmberConfig(int nodes,
 
     private static Result<EmberConfig> fromDocument(org.pragmatica.config.toml.TomlDocument doc, Option<Path> baseDir) {
         int nodes = doc.getInt("cluster", "nodes").or(DEFAULT_NODES);
+        int basePort = doc.getInt("cluster", "base_port").or(DEFAULT_BASE_PORT);
         int managementPort = doc.getInt("cluster", "management_port").or(DEFAULT_MANAGEMENT_PORT);
         int dashboardPort = doc.getInt("cluster", "dashboard_port").or(DEFAULT_DASHBOARD_PORT);
         int appHttpPort = doc.getInt("cluster", "app_http_port").or(DEFAULT_APP_HTTP_PORT);
@@ -194,6 +245,7 @@ public record EmberConfig(int nodes,
         int coreMax = doc.getInt("cluster", "core_max").or(DEFAULT_CORE_MAX);
 
         return emberConfig(nodes,
+                           basePort,
                            managementPort,
                            dashboardPort,
                            appHttpPort,

--- a/aether/ember/src/main/java/org/pragmatica/aether/ember/EmberConfig.java
+++ b/aether/ember/src/main/java/org/pragmatica/aether/ember/EmberConfig.java
@@ -172,14 +172,11 @@ public record EmberConfig(int nodes,
         if (basePort < 1 || basePort > 65535) {
             return EmberConfigError.invalidValue("base_port", basePort, "must be valid port").result();
         }
-
         // The cluster binds basePort + i for each of `nodes` nodes, so the whole range must be
         // addressable — a base port that is individually valid can still run the cluster off the
         // end of the port space.
         if (basePort + nodes - 1 > 65535) {
-            return EmberConfigError.invalidValue("base_port",
-                                                 basePort,
-                                                 "range for " + nodes + " nodes exceeds 65535").result();
+            return EmberConfigError.invalidValue("base_port", basePort, "range for " + nodes + " nodes exceeds 65535").result();
         }
 
         if (managementPort < 1 || managementPort > 65535) {

--- a/aether/ember/src/main/java/org/pragmatica/aether/ember/EmberInstance.java
+++ b/aether/ember/src/main/java/org/pragmatica/aether/ember/EmberInstance.java
@@ -37,7 +37,7 @@ public final class EmberInstance {
 
         instance.startH2();
         instance.cluster.start()
-                        .await(TimeSpan.timeSpan(60).seconds())
+                        .await(TimeSpan.timeSpan(config.startTimeoutSeconds()).seconds())
                         .onFailure(cause -> log.error("Failed to start cluster: {}",
                                                       cause.message()));
 

--- a/aether/ember/src/main/java/org/pragmatica/aether/ember/EmberInstance.java
+++ b/aether/ember/src/main/java/org/pragmatica/aether/ember/EmberInstance.java
@@ -23,7 +23,7 @@ public final class EmberInstance {
     private EmberInstance(EmberConfig config) {
         this.config = config;
         this.cluster = EmberCluster.emberCluster(config.nodes(),
-                                                 EmberCluster.DEFAULT_BASE_PORT,
+                                                 config.basePort(),
                                                  config.managementPort(),
                                                  config.appHttpPort(),
                                                  "node",

--- a/aether/ember/src/test/java/org/pragmatica/aether/ember/EmberConfigBasePortTest.java
+++ b/aether/ember/src/test/java/org/pragmatica/aether/ember/EmberConfigBasePortTest.java
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2025 Pragmatica Labs - Sergiy Yevtushenko
+// Licensed under Business Source License 1.1. Change Date: 2030-01-01. Change License: Apache-2.0.
+// See LICENSE in the repository root for full terms.
+package org.pragmatica.aether.ember;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+/// #1008 — the QUIC/consensus base port is the fourth Forge port, and it was the only one
+/// `EmberConfig` did not expose. Three configurable ports and one pinned constant is what let an
+/// operator relocate a Forge instance, believe it was isolated, and still collide on 6000-6004.
+class EmberConfigBasePortTest {
+    private static String toml(String clusterBody) {
+        return "[cluster]\n" + clusterBody + "\n";
+    }
+
+    private static EmberConfig parse(String content) {
+        return EmberConfig.loadFromString(content)
+                          .fold(cause -> fail("must parse: " + cause.message()), config -> config);
+    }
+
+    private static String errorOf(String content) {
+        return EmberConfig.loadFromString(content)
+                          .fold(cause -> cause.message(), _ -> fail("expected a failure, got success"));
+    }
+
+    @Nested
+    class Defaults {
+        /// The default must stay 6000, or every existing forge.toml silently moves its cluster.
+        @Test
+        void basePort_defaultsToSixThousand_whenKeyAbsent() {
+            assertThat(parse(toml("nodes = 5")).basePort()).isEqualTo(6000);
+            assertThat(EmberConfig.DEFAULT.basePort()).isEqualTo(6000);
+        }
+
+        /// The constant Forge used to pass positionally is still the single source of truth.
+        @Test
+        void basePort_defaultTracksTheClusterConstant() {
+            assertThat(EmberConfig.DEFAULT_BASE_PORT).isEqualTo(EmberCluster.DEFAULT_BASE_PORT);
+        }
+    }
+
+    @Nested
+    class Parsing {
+        @Test
+        void basePort_isReadFromCluster_whenPresent() {
+            assertThat(parse(toml("nodes = 3\nbase_port = 7100")).basePort()).isEqualTo(7100);
+        }
+
+        /// The reason the key exists: a second Forge must be able to move off 6000 while keeping
+        /// the other three ports independently configurable.
+        @Test
+        void basePort_isIndependentOfTheOtherPorts() {
+            var config = parse(toml("""
+                                    nodes = 3
+                                    base_port = 7100
+                                    management_port = 5250
+                                    dashboard_port = 8988
+                                    app_http_port = 8170"""));
+
+            assertThat(config.basePort()).isEqualTo(7100);
+            assertThat(config.managementPort()).isEqualTo(5250);
+            assertThat(config.dashboardPort()).isEqualTo(8988);
+            assertThat(config.appHttpPort()).isEqualTo(8170);
+        }
+    }
+
+    @Nested
+    class Validation {
+        @Test
+        void basePort_isRejected_whenOutOfPortRange() {
+            assertThat(errorOf(toml("nodes = 3\nbase_port = 70000"))).contains("base_port");
+            assertThat(errorOf(toml("nodes = 3\nbase_port = 0"))).contains("base_port");
+        }
+
+        /// A base port that is individually valid can still run the cluster off the end of the port
+        /// space, because node `i` binds `base_port + i`.
+        @Test
+        void basePort_isRejected_whenRangeForNodesExceedsPortSpace() {
+            var message = errorOf(toml("nodes = 10\nbase_port = 65530"));
+
+            assertThat(message).contains("base_port")
+                               .contains("65535");
+        }
+
+        @Test
+        void basePort_isAccepted_atTheTopOfTheRange() {
+            assertThat(parse(toml("nodes = 5\nbase_port = 65531")).basePort()).isEqualTo(65531);
+        }
+    }
+}

--- a/aether/ember/src/test/java/org/pragmatica/aether/ember/EmberConfigStartTimeoutTest.java
+++ b/aether/ember/src/test/java/org/pragmatica/aether/ember/EmberConfigStartTimeoutTest.java
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2025 Pragmatica Labs - Sergiy Yevtushenko
+// Licensed under Business Source License 1.1. Change Date: 2030-01-01. Change License: Apache-2.0.
+// See LICENSE in the repository root for full terms.
+package org.pragmatica.aether.ember;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+/// #718 shape 4 — the cluster start budget was a hard-coded 60-second literal at the single `await`
+/// site, so a host where formation is merely slow had no way to buy more time and Forge exited.
+class EmberConfigStartTimeoutTest {
+    private static String toml(String clusterBody) {
+        return "[cluster]\n" + clusterBody + "\n";
+    }
+
+    private static EmberConfig parse(String content) {
+        return EmberConfig.loadFromString(content)
+                          .fold(cause -> fail("must parse: " + cause.message()), config -> config);
+    }
+
+    private static String errorOf(String content) {
+        return EmberConfig.loadFromString(content)
+                          .fold(cause -> cause.message(), _ -> fail("expected a failure, got success"));
+    }
+
+    @Nested
+    class Defaults {
+        /// 60 s must stay the default, or every existing forge.toml silently changes its budget.
+        @Test
+        void startTimeoutSeconds_defaultsToSixty_whenKeyAbsent() {
+            assertThat(parse(toml("nodes = 5")).startTimeoutSeconds()).isEqualTo(60);
+            assertThat(EmberConfig.DEFAULT.startTimeoutSeconds()).isEqualTo(60);
+        }
+    }
+
+    @Nested
+    class Parsing {
+        @Test
+        void startTimeoutSeconds_isReadFromCluster_whenPresent() {
+            assertThat(parse(toml("nodes = 3\nstart_timeout_seconds = 180")).startTimeoutSeconds()).isEqualTo(180);
+        }
+
+        /// The budget is independent of the QUIC range: #1008 and #718 shape 4 are separate knobs
+        /// that happen to live in the same section.
+        @Test
+        void startTimeoutSeconds_isIndependentOfBasePort() {
+            var config = parse(toml("""
+                                    nodes = 3
+                                    base_port = 7100
+                                    start_timeout_seconds = 120"""));
+
+            assertThat(config.startTimeoutSeconds()).isEqualTo(120);
+            assertThat(config.basePort()).isEqualTo(7100);
+        }
+    }
+
+    @Nested
+    class Validation {
+        /// A non-positive budget makes the await expire before the cluster could possibly form,
+        /// turning every start into the timeout this value exists to govern.
+        @Test
+        void startTimeoutSeconds_isRejected_whenNotPositive() {
+            assertThat(errorOf(toml("nodes = 3\nstart_timeout_seconds = 0"))).contains("start_timeout_seconds");
+            assertThat(errorOf(toml("nodes = 3\nstart_timeout_seconds = -5"))).contains("start_timeout_seconds");
+        }
+
+        @Test
+        void startTimeoutSeconds_isAccepted_atOne() {
+            assertThat(parse(toml("nodes = 3\nstart_timeout_seconds = 1")).startTimeoutSeconds()).isEqualTo(1);
+        }
+    }
+}

--- a/aether/forge/forge-core/src/main/java/org/pragmatica/aether/forge/ForgePortPreflight.java
+++ b/aether/forge/forge-core/src/main/java/org/pragmatica/aether/forge/ForgePortPreflight.java
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2025 Pragmatica Labs - Sergiy Yevtushenko
+// Licensed under Business Source License 1.1. Change Date: 2030-01-01. Change License: Apache-2.0.
+// See LICENSE in the repository root for full terms.
+package org.pragmatica.aether.forge;
+
+import java.net.InetSocketAddress;
+import java.net.StandardProtocolFamily;
+import java.nio.channels.DatagramChannel;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import org.pragmatica.lang.Cause;
+import org.pragmatica.lang.Result;
+import org.pragmatica.lang.Unit;
+
+
+/// #1008 — startup guard refusing to form a Forge cluster on QUIC ports another process already holds.
+///
+/// WHY A PREFLIGHT AND NOT A GUARD ON THE BIND ITSELF. The QUIC bind cannot report this collision.
+/// `QuicClusterServer` sets `SO_REUSEADDR` on its `NioDatagramChannel` — deliberately, so a restarting
+/// node rebinds its own port immediately — and two UDP sockets that BOTH set `SO_REUSEADDR` bind the
+/// same port successfully. Measured on Darwin 25.5.0, all four combinations: holder and probe both
+/// carrying `SO_REUSEADDR` is the ONLY one where the second bind succeeds; the other three are refused
+/// with `Address already in use`. Forge-versus-Forge is exactly that one case. So a second Forge does
+/// not fail to bind — it binds, then splits the port's datagrams with the first instance and never
+/// reaches quorum, presenting as `activePeerCount=1`.
+///
+/// `QuicTransportError.BindFailed` already names the port and already aborts the whole cluster start,
+/// so propagating bind failures harder changes nothing: on this path nothing fails. The probe below
+/// therefore binds each port WITHOUT `SO_REUSEADDR`, which IS refused while any holder exists, and
+/// reports before a single node is created.
+///
+/// LIMITATION, stated rather than papered over: this is a time-of-check/time-of-use probe. Each socket
+/// is closed before the cluster binds the port for real, so a process claiming it inside that window is
+/// not caught and the collision is silent again. It turns the overwhelmingly common case — another
+/// Forge already running — from silent into loud. It is not a lock, and it is not claimed to be one.
+public sealed interface ForgePortPreflight {
+    /// Verify every QUIC/consensus UDP port this cluster is about to bind is free.
+    ///
+    /// @param basePort first UDP port of the range; node `i` binds `basePort + i`
+    /// @param nodes    cluster size, so the range checked is `basePort .. basePort + nodes - 1`
+    ///
+    /// @return success when the whole range is free, otherwise a cause naming every occupied port
+    static Result<Unit> ensureQuicPortsFree(int basePort, int nodes) {
+        return verdict(basePort, nodes, occupiedPorts(basePort, nodes));
+    }
+
+    private static Result<Unit> verdict(int basePort, int nodes, List<Integer> occupied) {
+        return occupied.isEmpty()
+               ? Result.unitResult()
+               : ForgePortError.quicPortsInUse(basePort, basePort + nodes - 1, occupied).result();
+    }
+
+    private static List<Integer> occupiedPorts(int basePort, int nodes) {
+        return IntStream.range(0, nodes)
+                        .map(offset -> basePort + offset)
+                        .filter(ForgePortPreflight::isOccupied)
+                        .boxed()
+                        .toList();
+    }
+
+    private static boolean isOccupied(int port) {
+        return probe(port).isFailure();
+    }
+
+    private static Result<InetSocketAddress> probe(int port) {
+        return Result.lift(() -> bindAndClose(port));
+    }
+
+    /// Adapter leaf — the kernel is the only authority on whether a port is free. Deliberately does
+    /// NOT set `SO_REUSEADDR`: that omission is the entire mechanism (see the type documentation).
+    private static InetSocketAddress bindAndClose(int port) throws Exception {
+        try (var channel = DatagramChannel.open(StandardProtocolFamily.INET)) {
+            channel.bind(new InetSocketAddress(port));
+
+            return (InetSocketAddress) channel.getLocalAddress();
+        }
+    }
+
+    sealed interface ForgePortError extends Cause {
+        /// The message discriminates this failure from the other producer of `activePeerCount=1` —
+        /// stale on-disk `forge-data` state — because once the cluster is up the two are
+        /// indistinguishable from the output, which is what cost the debugging time in #1008.
+        record QuicPortsInUse(int basePort, int lastPort, List<Integer> occupied) implements ForgePortError {
+            @Override
+            public String message() {
+                return "Aether Forge needs UDP ports " + basePort + "-" + lastPort
+                       + " for cluster consensus (QUIC), but " + describeOccupied()
+                       + " already in use - most likely another Forge instance on this host. "
+                       + "This is a PORT COLLISION caught before startup: no node was started, so it is "
+                       + "NOT stale cluster state in forge-data/ and NOT a consensus fault. "
+                       + "Set base_port under [cluster] in forge.toml to a free range, or stop the "
+                       + "process holding these ports (lsof -nP -iUDP:" + basePort + ").";
+            }
+
+            private String describeOccupied() {
+                return occupied.size() == 1
+                       ? "port " + occupied.getFirst() + " is"
+                       : "ports " + occupied.stream()
+                                            .map(String::valueOf)
+                                            .collect(Collectors.joining(", ")) + " are";
+            }
+        }
+
+        static ForgePortError quicPortsInUse(int basePort, int lastPort, List<Integer> occupied) {
+            return new QuicPortsInUse(basePort, lastPort, occupied);
+        }
+    }
+
+    record unused() implements ForgePortPreflight {}
+}

--- a/aether/forge/forge-core/src/main/java/org/pragmatica/aether/forge/ForgePortPreflight.java
+++ b/aether/forge/forge-core/src/main/java/org/pragmatica/aether/forge/ForgePortPreflight.java
@@ -71,6 +71,7 @@ public sealed interface ForgePortPreflight {
 
     /// Adapter leaf — the kernel is the only authority on whether a port is free. Deliberately does
     /// NOT set `SO_REUSEADDR`: that omission is the entire mechanism (see the type documentation).
+    @SuppressWarnings("JBCT-EX-01")
     private static InetSocketAddress bindAndClose(int port) throws Exception {
         try (var channel = DatagramChannel.open(StandardProtocolFamily.INET)) {
             channel.bind(new InetSocketAddress(port));
@@ -86,13 +87,15 @@ public sealed interface ForgePortPreflight {
         record QuicPortsInUse(int basePort, int lastPort, List<Integer> occupied) implements ForgePortError {
             @Override
             public String message() {
-                return "Aether Forge needs UDP ports " + basePort + "-" + lastPort
-                       + " for cluster consensus (QUIC), but " + describeOccupied()
-                       + " already in use - most likely another Forge instance on this host. "
-                       + "This is a PORT COLLISION caught before startup: no node was started, so it is "
-                       + "NOT stale cluster state in forge-data/ and NOT a consensus fault. "
-                       + "Set base_port under [cluster] in forge.toml to a free range, or stop the "
-                       + "process holding these ports (lsof -nP -iUDP:" + basePort + ").";
+                return "Aether Forge needs UDP ports " + basePort
+                     + "-" + lastPort
+                     + " for cluster consensus (QUIC), but " + describeOccupied()
+                     + " already in use - most likely another Forge instance on this host. "
+                     + "This is a PORT COLLISION caught before startup: no node was started, so it is "
+                     + "NOT stale cluster state in forge-data/ and NOT a consensus fault. "
+                     + "Set base_port under [cluster] in forge.toml to a free range, or stop the "
+                     + "process holding these ports (lsof -nP -iUDP:" + basePort
+                     + ").";
             }
 
             private String describeOccupied() {

--- a/aether/forge/forge-core/src/main/java/org/pragmatica/aether/forge/ForgeServer.java
+++ b/aether/forge/forge-core/src/main/java/org/pragmatica/aether/forge/ForgeServer.java
@@ -135,6 +135,19 @@ public final class ForgeServer {
         var forgeConfig = loadForgeConfig(startupConfig);
 
         printBanner(forgeConfig, startupConfig);
+
+        // #1008 — checked before anything is created. A second Forge BINDS these UDP ports happily
+        // (both sockets carry SO_REUSEADDR) and then never reaches quorum, with nothing naming a
+        // port, so there is no bind failure downstream for this to be inherited from.
+        var quicPortCheck = ForgePortPreflight.ensureQuicPortsFree(forgeConfig.basePort(),
+                                                                   forgeConfig.nodes());
+
+        quicPortCheck.onFailure(cause -> log.error("{}", cause.message()));
+        if (quicPortCheck.isFailure()) {
+            System.exit(1);
+            return;
+        }
+
         var server = new ForgeServer(startupConfig, forgeConfig);
 
         Runtime.getRuntime().addShutdownHook(new Thread(() -> {
@@ -207,6 +220,9 @@ public final class ForgeServer {
         log.info("=".repeat(60));
         log.info("  Dashboard: http://localhost:{}", forgeConfig.dashboardPort());
         log.info("  Cluster size: {} nodes", forgeConfig.nodes());
+        log.info("  Cluster QUIC ports: {}-{} (UDP, consensus)",
+                 forgeConfig.basePort(),
+                 forgeConfig.basePort() + forgeConfig.nodes() - 1);
         log.info("  App HTTP port: {} (load target)", forgeConfig.appHttpPort());
         if (forgeConfig.lbEnabled()) {
             log.info("  Load balancer: http://localhost:{}", forgeConfig.lbPort());
@@ -240,7 +256,7 @@ public final class ForgeServer {
     private void initializeComponents(Option<ConfigurationProvider> configProvider) {
         var metricsInstance = ForgeMetrics.forgeMetrics();
         var clusterInstance = EmberCluster.emberCluster(forgeConfig.nodes(),
-                                                        EmberCluster.DEFAULT_BASE_PORT,
+                                                        forgeConfig.basePort(),
                                                         forgeConfig.managementPort(),
                                                         forgeConfig.appHttpPort(),
                                                         "node",

--- a/aether/forge/forge-core/src/main/java/org/pragmatica/aether/forge/ForgeServer.java
+++ b/aether/forge/forge-core/src/main/java/org/pragmatica/aether/forge/ForgeServer.java
@@ -461,13 +461,13 @@ public final class ForgeServer {
         return "Cluster did not finish forming within the " + config.startTimeoutSeconds()
              + "s start budget (cluster.start_timeout_seconds): " + detail
              + " — exiting rather than leaving a cluster that never formed looking healthy. "
-             + "Reached at the deadline: " + activeCount(status) + " of " + config.nodes()
-             + " node(s) consensus-active, leader=" + status.leaderId() + ". "
-             + describeNodes(status)
-             + describeNodeFailures(nodeFailures)
+             + "Reached at the deadline: " + activeCount(status)
+             + " of " + config.nodes()
+             + " node(s) consensus-active, leader=" + status.leaderId()
+             + ". " + describeNodes(status) + describeNodeFailures(nodeFailures)
              + "'consensus-active' is AetherNode.isReady(), NOT a general health verdict. "
-             + "Forge's startup preflight verified UDP " + config.basePort() + "-"
-             + (config.basePort() + config.nodes() - 1)
+             + "Forge's startup preflight verified UDP " + config.basePort()
+             + "-" + (config.basePort() + config.nodes() - 1)
              + " was free immediately before this start, so a QUIC port collision at that moment is "
              + "ruled out. Forge did NOT check, and any of these is consistent with what is reported "
              + "above: stale per-node state under AETHER_HOME/forge-data (a retry/backpressure storm "
@@ -483,12 +483,14 @@ public final class ForgeServer {
     }
 
     private static String describeNodes(ClusterStatus status) {
-        return status.nodes().isEmpty()
+        return status.nodes()
+                     .isEmpty()
                ? "No node reached the point of being registered. "
                : "Per node: " + status.nodes()
                                       .stream()
                                       .map(ForgeServer::describeNode)
-                                      .collect(Collectors.joining(", ")) + ". ";
+                                      .collect(Collectors.joining(", "))
+                + ". ";
     }
 
     private static String describeNode(NodeStatus node) {
@@ -498,11 +500,12 @@ public final class ForgeServer {
     private static String describeNodeFailures(Map<String, String> nodeFailures) {
         return nodeFailures.isEmpty()
                ? "No node reported a start failure, so the budget expired with the start still in "
-                 + "progress rather than with a node erroring out. "
+                + "progress rather than with a node erroring out. "
                : "Node start failures: " + nodeFailures.entrySet()
                                                        .stream()
                                                        .map(entry -> entry.getKey() + ": " + entry.getValue())
-                                                       .collect(Collectors.joining("; ")) + ". ";
+                                                       .collect(Collectors.joining("; "))
+                + ". ";
     }
 
     private void startMetricsCollection() {

--- a/aether/forge/forge-core/src/main/java/org/pragmatica/aether/forge/ForgeServer.java
+++ b/aether/forge/forge-core/src/main/java/org/pragmatica/aether/forge/ForgeServer.java
@@ -135,16 +135,15 @@ public final class ForgeServer {
         var forgeConfig = loadForgeConfig(startupConfig);
 
         printBanner(forgeConfig, startupConfig);
-
         // #1008 — checked before anything is created. A second Forge BINDS these UDP ports happily
         // (both sockets carry SO_REUSEADDR) and then never reaches quorum, with nothing naming a
         // port, so there is no bind failure downstream for this to be inherited from.
-        var quicPortCheck = ForgePortPreflight.ensureQuicPortsFree(forgeConfig.basePort(),
-                                                                   forgeConfig.nodes());
+        var quicPortCheck = ForgePortPreflight.ensureQuicPortsFree(forgeConfig.basePort(), forgeConfig.nodes());
 
         quicPortCheck.onFailure(cause -> log.error("{}", cause.message()));
         if (quicPortCheck.isFailure()) {
             System.exit(1);
+
             return;
         }
 

--- a/aether/forge/forge-core/src/main/java/org/pragmatica/aether/forge/ForgeServer.java
+++ b/aether/forge/forge-core/src/main/java/org/pragmatica/aether/forge/ForgeServer.java
@@ -12,6 +12,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -21,6 +22,9 @@ import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 
 import org.pragmatica.aether.ember.EmberCluster;
+import org.pragmatica.aether.ember.EmberCluster.ClusterStatus;
+import org.pragmatica.aether.ember.EmberCluster.NodeStatus;
+import org.pragmatica.aether.ember.EmberCluster.StartFailure;
 import org.pragmatica.aether.ember.EmberConfig;
 import org.pragmatica.aether.config.AetherConfig;
 import org.pragmatica.aether.config.AppHttpConfig;
@@ -42,6 +46,7 @@ import org.pragmatica.http.server.HttpServerConfig;
 import org.pragmatica.http.websocket.WebSocketEndpoint;
 import org.pragmatica.http.HttpOperations;
 import org.pragmatica.http.JdkHttpOperations;
+import org.pragmatica.lang.Cause;
 import org.pragmatica.lang.Contract;
 import org.pragmatica.lang.Option;
 import org.pragmatica.lang.Result;
@@ -411,13 +416,93 @@ public final class ForgeServer {
     }
 
     private void startCluster() {
-        log.info("Starting {} node cluster...", forgeConfig.nodes());
-        cluster.onPresent(c -> c.start()
-                                .await(TimeSpan.timeSpan(60).seconds())
-                                .onFailure(cause -> {
-                                               throw new IllegalStateException("Failed to start cluster: " + cause.message());
-                                           }));
+        log.info("Starting {} node cluster (start budget {}s)...",
+                 forgeConfig.nodes(),
+                 forgeConfig.startTimeoutSeconds());
+        cluster.onPresent(this::awaitClusterStart);
         TimeSpan.timeSpan(2).seconds().sleep();
+    }
+
+    private void awaitClusterStart(EmberCluster emberCluster) {
+        emberCluster.start()
+                    .await(TimeSpan.timeSpan(forgeConfig.startTimeoutSeconds()).seconds())
+                    .onFailure(cause -> failClusterStart(emberCluster, cause));
+    }
+
+    private void failClusterStart(EmberCluster emberCluster, Cause cause) {
+        throw new IllegalStateException(clusterStartFailureMessage(forgeConfig,
+                                                                   emberCluster.status(),
+                                                                   nodeFailuresOf(emberCluster),
+                                                                   cause.message()));
+    }
+
+    private static Map<String, String> nodeFailuresOf(EmberCluster emberCluster) {
+        return emberCluster.lastStartFailure()
+                           .map(StartFailure::nodeFailures)
+                           .or(Map.of());
+    }
+
+    /// The message this failure carries (#718 shape 4).
+    ///
+    /// It used to be `"Failed to start cluster: " + cause.message()`, which on the timeout path
+    /// surfaces as `Promise is not resolved within specified timeout` — a sentence naming no phase,
+    /// no peer and no port, and IDENTICAL whether nothing formed at all or four of five nodes were
+    /// consensus-active. The reader of a formation stall learned only that something did not finish.
+    ///
+    /// Every value below is read from the cluster at the deadline; none is inferred. `state` comes
+    /// from [EmberCluster#observedState], which is deliberately named for what it measures — a
+    /// diagnostic that fabricates a field is worse than one that omits it (#727). The message states
+    /// the one thing Forge DID verify (the QUIC range was free at startup, via the #1008 preflight)
+    /// and then lists the candidates it did not probe, without ranking them.
+    static String clusterStartFailureMessage(EmberConfig config,
+                                             ClusterStatus status,
+                                             Map<String, String> nodeFailures,
+                                             String detail) {
+        return "Cluster did not finish forming within the " + config.startTimeoutSeconds()
+             + "s start budget (cluster.start_timeout_seconds): " + detail
+             + " — exiting rather than leaving a cluster that never formed looking healthy. "
+             + "Reached at the deadline: " + activeCount(status) + " of " + config.nodes()
+             + " node(s) consensus-active, leader=" + status.leaderId() + ". "
+             + describeNodes(status)
+             + describeNodeFailures(nodeFailures)
+             + "'consensus-active' is AetherNode.isReady(), NOT a general health verdict. "
+             + "Forge's startup preflight verified UDP " + config.basePort() + "-"
+             + (config.basePort() + config.nodes() - 1)
+             + " was free immediately before this start, so a QUIC port collision at that moment is "
+             + "ruled out. Forge did NOT check, and any of these is consistent with what is reported "
+             + "above: stale per-node state under AETHER_HOME/forge-data (a retry/backpressure storm "
+             + "during formation can consume this whole budget); host load; or a genuine consensus "
+             + "fault. If formation on this host is merely slow, raise cluster.start_timeout_seconds.";
+    }
+
+    private static long activeCount(ClusterStatus status) {
+        return status.nodes()
+                     .stream()
+                     .filter(node -> EmberCluster.STATE_ACTIVE.equals(node.state()))
+                     .count();
+    }
+
+    private static String describeNodes(ClusterStatus status) {
+        return status.nodes().isEmpty()
+               ? "No node reached the point of being registered. "
+               : "Per node: " + status.nodes()
+                                      .stream()
+                                      .map(ForgeServer::describeNode)
+                                      .collect(Collectors.joining(", ")) + ". ";
+    }
+
+    private static String describeNode(NodeStatus node) {
+        return node.id() + "=" + node.state() + "(quic " + node.port() + ")";
+    }
+
+    private static String describeNodeFailures(Map<String, String> nodeFailures) {
+        return nodeFailures.isEmpty()
+               ? "No node reported a start failure, so the budget expired with the start still in "
+                 + "progress rather than with a node erroring out. "
+               : "Node start failures: " + nodeFailures.entrySet()
+                                                       .stream()
+                                                       .map(entry -> entry.getKey() + ": " + entry.getValue())
+                                                       .collect(Collectors.joining("; ")) + ". ";
     }
 
     private void startMetricsCollection() {

--- a/aether/forge/forge-core/src/test/java/org/pragmatica/aether/forge/ForgePortPreflightTest.java
+++ b/aether/forge/forge-core/src/test/java/org/pragmatica/aether/forge/ForgePortPreflightTest.java
@@ -1,0 +1,215 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2025 Pragmatica Labs - Sergiy Yevtushenko
+// Licensed under Business Source License 1.1. Change Date: 2030-01-01. Change License: Apache-2.0.
+// See LICENSE in the repository root for full terms.
+package org.pragmatica.aether.forge;
+
+import java.net.InetSocketAddress;
+import java.net.StandardProtocolFamily;
+import java.net.StandardSocketOptions;
+import java.nio.channels.DatagramChannel;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.pragmatica.lang.Result;
+import org.pragmatica.lang.Unit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+/// #1008 — the QUIC base port was hard-coded AND its collision was invisible. These tests pin the
+/// second half: a Forge whose QUIC range is already held must say so and name the port.
+///
+/// The mechanism under test is subtle enough to be worth stating. `QuicClusterServer` binds with
+/// `SO_REUSEADDR`, and two UDP sockets that BOTH set it share a port without error — so the second
+/// Forge never sees a bind failure at all. The preflight works only because it OMITS that option.
+/// [SocketMechanism] pins that omission as a property of the OS rather than of our code, so a future
+/// edit that "helpfully" adds `SO_REUSEADDR` to the probe has a test standing against it.
+class ForgePortPreflightTest {
+    private static final int NODES = 5;
+    private static final Random RANDOM = new Random();
+
+    /// A base port whose whole `NODES`-wide range is bindable right now. Scans from a random high
+    /// base so concurrent modules in a parallel reactor do not converge on one range (#939).
+    private static int freeBase() {
+        for (var attempt = 0; attempt < 200; attempt++) {
+            var candidate = 20_000 + RANDOM.nextInt(40_000);
+
+            if (rangeIsBindable(candidate)) {
+                return candidate;
+            }
+        }
+
+        return fail("no free " + NODES + "-port UDP range found in 200 attempts");
+    }
+
+    private static boolean rangeIsBindable(int base) {
+        var held = new ArrayList<DatagramChannel>();
+
+        try {
+            for (var offset = 0; offset < NODES; offset++) {
+                held.add(bind(base + offset, false));
+            }
+
+            return true;
+        } catch (Exception e) {
+            return false;
+        } finally {
+            closeAll(held);
+        }
+    }
+
+    private static DatagramChannel bind(int port, boolean reuseAddr) throws Exception {
+        var channel = DatagramChannel.open(StandardProtocolFamily.INET);
+
+        if (reuseAddr) {
+            channel.setOption(StandardSocketOptions.SO_REUSEADDR, true);
+        }
+
+        try {
+            channel.bind(new InetSocketAddress(port));
+
+            return channel;
+        } catch (Exception e) {
+            channel.close();
+
+            throw e;
+        }
+    }
+
+    private static void closeAll(List<DatagramChannel> channels) {
+        channels.forEach(ForgePortPreflightTest::closeQuietly);
+    }
+
+    private static void closeQuietly(DatagramChannel channel) {
+        try {
+            channel.close();
+        } catch (Exception e) {
+            // Test teardown: a channel that cannot be closed cannot affect the assertion already made.
+        }
+    }
+
+    @Nested
+    class FreeRange {
+        @Test
+        void ensureQuicPortsFree_succeeds_whenWholeRangeIsFree() {
+            var base = freeBase();
+
+            ForgePortPreflight.ensureQuicPortsFree(base, NODES)
+                              .onFailure(cause -> fail("free range " + base + " rejected: " + cause.message()));
+        }
+    }
+
+    @Nested
+    class OccupiedRange {
+        @Test
+        void ensureQuicPortsFree_fails_whenAPortInRangeIsHeld() throws Exception {
+            var base = freeBase();
+            var holder = bind(base + 2, false);
+
+            try {
+                ForgePortPreflight.ensureQuicPortsFree(base, NODES)
+                                  .onSuccess(_ -> fail("held port " + (base + 2) + " was not detected"));
+            } finally {
+                holder.close();
+            }
+        }
+
+        /// THE case that matters. A real Forge holds the port with `SO_REUSEADDR` set, which is
+        /// precisely the configuration under which a second `SO_REUSEADDR` bind SUCCEEDS. A probe
+        /// that copied `QuicClusterServer`'s options would report this range as free.
+        @Test
+        void ensureQuicPortsFree_fails_whenHolderSetsReuseAddr() throws Exception {
+            var base = freeBase();
+            var holder = bind(base, true);
+
+            try {
+                ForgePortPreflight.ensureQuicPortsFree(base, NODES)
+                                  .onSuccess(_ -> fail("SO_REUSEADDR holder on " + base + " was not detected"));
+            } finally {
+                holder.close();
+            }
+        }
+
+        @Test
+        void ensureQuicPortsFree_namesEveryOccupiedPort() throws Exception {
+            var base = freeBase();
+            var first = bind(base + 1, true);
+            var second = bind(base + 3, false);
+
+            try {
+                var message = messageOf(ForgePortPreflight.ensureQuicPortsFree(base, NODES));
+
+                assertThat(message).contains(String.valueOf(base + 1))
+                                   .contains(String.valueOf(base + 3))
+                                   .contains(base + "-" + (base + NODES - 1));
+            } finally {
+                first.close();
+                second.close();
+            }
+        }
+
+        /// `activePeerCount=1` is produced by BOTH a QUIC collision and stale on-disk `forge-data`.
+        /// Once the cluster is up the two are indistinguishable from the output, which is what cost
+        /// the debugging time in #1008, so the message must rule the other one out explicitly.
+        @Test
+        void ensureQuicPortsFree_messageDiscriminatesFromStaleForgeData() throws Exception {
+            var base = freeBase();
+            var holder = bind(base, true);
+
+            try {
+                var message = messageOf(ForgePortPreflight.ensureQuicPortsFree(base, NODES));
+
+                assertThat(message).contains("PORT COLLISION")
+                                   .contains("forge-data")
+                                   .contains("no node was started")
+                                   .contains("base_port");
+            } finally {
+                holder.close();
+            }
+        }
+
+        private String messageOf(Result<Unit> result) {
+            return result.fold(cause -> cause.message(),
+                               _ -> fail("expected a failure, got success"));
+        }
+    }
+
+    /// The OS behaviour the preflight is built on, pinned here so a platform or JDK change that
+    /// invalidates it fails loudly instead of silently disarming the guard.
+    @Nested
+    class SocketMechanism {
+        /// The mechanism the probe relies on, and it holds on every platform: a plain bind is
+        /// refused while ANY holder exists, including one that set `SO_REUSEADDR`.
+        @Test
+        void plainBind_isRefused_whileReuseAddrHolderExists() throws Exception {
+            var port = freeBase();
+            var holder = bind(port, true);
+
+            try {
+                var duplicate = bind(port, false);
+
+                duplicate.close();
+                fail("plain bind on " + port + " succeeded despite a SO_REUSEADDR holder - "
+                     + "the preflight's detection mechanism no longer works on this platform");
+            } catch (Exception e) {
+                assertThat(e).hasMessageContaining("Address already in use");
+            } finally {
+                holder.close();
+            }
+        }
+
+        /// POSITIVE CONTROL for the test above: the same plain bind on a free port must succeed, so
+        /// a refusal there is evidence about the holder rather than about a broken instrument.
+        @Test
+        void plainBind_succeeds_whenNoHolderExists() throws Exception {
+            var port = freeBase();
+            var channel = bind(port, false);
+
+            channel.close();
+        }
+    }
+}

--- a/aether/forge/forge-core/src/test/java/org/pragmatica/aether/forge/ForgeServerMessageTest.java
+++ b/aether/forge/forge-core/src/test/java/org/pragmatica/aether/forge/ForgeServerMessageTest.java
@@ -4,9 +4,18 @@
 // See LICENSE in the repository root for full terms.
 package org.pragmatica.aether.forge;
 
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.pragmatica.aether.ember.EmberCluster;
+import org.pragmatica.aether.ember.EmberCluster.ClusterStatus;
+import org.pragmatica.aether.ember.EmberCluster.NodeStatus;
+import org.pragmatica.aether.ember.EmberConfig;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 /// #952 — the startup-deploy failure message must report what Forge checked, not diagnose what it
 /// did not.
@@ -70,5 +79,128 @@ class ForgeServerMessageTest {
         var message = ForgeServer.startupDeployFailureMessage(COORDINATES, DETAIL);
 
         assertThat(message).doesNotContainPattern(MAVEN_INSTALL_ADVICE);
+    }
+
+    /// #718 shape 4 — the cluster-start failure message.
+    ///
+    /// The old text was `"Failed to start cluster: " + cause.message()`, which on the timeout path
+    /// reads `Promise is not resolved within specified timeout`. That sentence is IDENTICAL whether
+    /// nothing formed at all or four of five nodes were consensus-active, so it cannot tell the two
+    /// apart — and telling them apart is the whole point of reading it.
+    @Nested
+    class ClusterStartFailure {
+        private static final String TIMEOUT_DETAIL = "Promise is not resolved within specified timeout";
+
+        private static NodeStatus node(int index, String state) {
+            return new NodeStatus("node-" + index, 6000 + index - 1, 5150 + index - 1, state, false);
+        }
+
+        /// `activeCount` is DERIVED by the code under test from the node list; it is not a value the
+        /// fixture hands it. That is what these assertions actually probe.
+        private static ClusterStatus status(int active, int inactive, String leaderId) {
+            var nodes = new java.util.ArrayList<NodeStatus>();
+
+            for (var i = 1; i <= active; i++) {
+                nodes.add(node(i, EmberCluster.STATE_ACTIVE));
+            }
+            for (var i = active + 1; i <= active + inactive; i++) {
+                nodes.add(node(i, EmberCluster.STATE_INACTIVE));
+            }
+
+            return new ClusterStatus(List.copyOf(nodes), leaderId);
+        }
+
+        private static String message(ClusterStatus status, Map<String, String> nodeFailures) {
+            return ForgeServer.clusterStartFailureMessage(EmberConfig.DEFAULT, status, nodeFailures, TIMEOUT_DETAIL);
+        }
+
+        @Test
+        void clusterStartFailure_namesTheBudgetAndItsSetting() {
+            assertThat(message(status(0, 5, "none"), Map.of())).contains("60s start budget")
+                                                              .contains("start_timeout_seconds")
+                                                              .contains(TIMEOUT_DETAIL);
+        }
+
+        /// THE load-bearing property. Nothing-formed and partially-formed must not render the same
+        /// sentence — that identity is the defect being fixed.
+        @Test
+        void clusterStartFailure_distinguishesNothingFormedFromPartialFormation() {
+            var nothingFormed = message(status(0, 5, "none"), Map.of());
+            var partiallyFormed = message(status(4, 1, "node-1"), Map.of());
+
+            assertThat(nothingFormed).isNotEqualTo(partiallyFormed);
+            assertThat(nothingFormed).contains("0 of 5 node(s) consensus-active")
+                                     .contains("leader=none");
+            assertThat(partiallyFormed).contains("4 of 5 node(s) consensus-active")
+                                       .contains("leader=node-1");
+        }
+
+        @Test
+        void clusterStartFailure_namesEachNodeWithItsStateAndQuicPort() {
+            var message = message(status(1, 1, "none"), Map.of());
+
+            assertThat(message).contains("node-1=active(quic 6000)")
+                               .contains("node-2=inactive(quic 6001)");
+        }
+
+        @Test
+        void clusterStartFailure_reportsNodeStartFailures_whenAnyWereRecorded() {
+            var message = message(status(0, 3, "none"), Map.of("node-3", "Failed to bind to port 5152"));
+
+            assertThat(message).contains("node-3")
+                               .contains("Failed to bind to port 5152");
+        }
+
+        /// The absence of recorded failures is itself information: the budget expired mid-start
+        /// rather than a node erroring out. The message must say which of the two it was.
+        @Test
+        void clusterStartFailure_saysNoNodeErrored_whenNoFailuresWereRecorded() {
+            assertThat(message(status(0, 5, "none"), Map.of())).contains("No node reported a start failure");
+        }
+
+        /// #727's lesson, pinned here. `NodeStatus.state` was once the unconditional literal
+        /// `"healthy"`, so every failing cluster reported healthy nodes beside `leader=none`. A
+        /// diagnostic that fabricates its own evidence sends the next reader to the wrong place.
+        @Test
+        void clusterStartFailure_neverCallsANodeHealthy() {
+            assertThat(message(status(2, 3, "none"), Map.of())).doesNotContainIgnoringCase("healthy node")
+                                                              .doesNotContainPattern("(?i)node[^.]*\\bhealthy\\b");
+        }
+
+        /// Same property as `startupDeployFailure_neverDirectsTheReaderToAMavenInstall`: never
+        /// present an unchecked candidate as the cause. Forge does not probe forge-data, host load
+        /// or consensus, so the message must offer them as candidates and say so outright.
+        @Test
+        void clusterStartFailure_offersCandidatesWithoutDiagnosingOne() {
+            var message = message(status(0, 5, "none"), Map.of());
+
+            assertThat(message).contains("did NOT check")
+                               .contains("forge-data")
+                               .contains("host load")
+                               .doesNotContainPattern("(?i)\\b(caused by|because of|due to)\\b");
+        }
+
+        /// Both figures above are read from `EmberConfig.DEFAULT`, whose budget IS 60 and whose base
+        /// port IS 6000 — so a hard-coded literal would satisfy them vacuously. This drives the same
+        /// message from a NON-default config, which is what makes those pins real.
+        @Test
+        void clusterStartFailure_readsBudgetAndPortRangeFromTheConfig() {
+            var config = EmberConfig.loadFromString("[cluster]\nnodes = 3\nbase_port = 7300\nstart_timeout_seconds = 180\n")
+                                    .fold(cause -> fail("must parse: " + cause.message()), parsed -> parsed);
+            var message = ForgeServer.clusterStartFailureMessage(config, status(0, 3, "none"), Map.of(), TIMEOUT_DETAIL);
+
+            assertThat(message).contains("180s start budget")
+                               .contains("0 of 3 node(s) consensus-active")
+                               .contains("7300-7302")
+                               .doesNotContain("60s start budget")
+                               .doesNotContain("6000-6004");
+        }
+
+        /// The one thing Forge DID verify, so the reader can rule it out instead of re-checking it.
+        @Test
+        void clusterStartFailure_statesThatThePortRangeWasVerifiedFree() {
+            assertThat(message(status(0, 5, "none"), Map.of())).contains("6000-6004")
+                                                              .contains("ruled out");
+        }
     }
 }

--- a/changelog.d/1008-forge-quic-base-port.md
+++ b/changelog.d/1008-forge-quic-base-port.md
@@ -1,0 +1,38 @@
+### Fixed (2026-09-11 — #1008: Forge's QUIC base port is configurable, and a collision on it is now loud)
+- **`[cluster] base_port` is now a `forge.toml` setting** (default `6000`, unchanged), so all four of
+  Forge's ports move together instead of three moving and the fourth staying pinned. `EmberConfig`
+  gains a `basePort` component and validates it as a range — a base port that is individually valid
+  can still run a cluster of `nodes` off the end of the port space, so `base_port + nodes - 1 > 65535`
+  is refused. `ForgeServer` and `EmberInstance` now read it instead of passing
+  `EmberCluster.DEFAULT_BASE_PORT` positionally. Every existing `emberConfig(...)` overload keeps its
+  signature and defaults the new value, so no caller changes behaviour.
+- **Configurability alone would not have fixed this, and propagating the bind failure would not
+  either — there is no bind failure.** `QuicClusterServer` sets `SO_REUSEADDR` on its
+  `NioDatagramChannel` (deliberately: a restarting node must rebind its own port at once), and two UDP
+  sockets that BOTH set it bind the same port successfully. Measured on Darwin 25.5.0 across all four
+  holder/probe combinations: both-`SO_REUSEADDR` is the ONLY one where the second bind succeeds, and
+  Forge-versus-Forge is exactly that case. So the second instance does not fail to bind — it binds,
+  splits the range's datagrams with the first instance, and never reaches quorum.
+  `QuicTransportError.BindFailed` already names the port and already aborts the whole cluster start;
+  it simply never fires here.
+- **New `ForgePortPreflight`, run before any node is created**, binds each port of
+  `base_port .. base_port + nodes - 1` **without** `SO_REUSEADDR` — which the kernel does refuse while
+  any holder exists — and on a collision Forge logs the occupied ports and exits non-zero.
+  **The message discriminates the two causes of `activePeerCount=1`**, naming the ports, stating that
+  it is a port collision caught before startup, and that no node was started so it is not stale
+  `forge-data` state. That ambiguity is what cost the debugging time in the reported incident.
+  The startup banner now also prints the QUIC range.
+- **Limitation, stated rather than papered over:** the preflight is a time-of-check/time-of-use probe.
+  Each socket is closed before the cluster binds the port for real, so a process claiming it inside
+  that window is still silent. It converts the overwhelmingly common case — another Forge already
+  running — from silent to loud; it is not a lock and is not claimed to be one.
+- **Not done here:** issue item 3, enumerating likely causes on a live `activePeerCount=1`, is left
+  open. It belongs to the membership/status surface rather than to Forge startup, and the preflight
+  removes the port collision from that symptom's candidate set at the only point where it can be
+  ruled out cheaply.
+- `aether/docs/slice-developers/forge-guide.md` documents `base_port` and what running two instances
+  requires; `aether/docs/operators/runbooks/lifecycle-verification.md` step 3 said that no
+  configuration overrides the QUIC base port and that two instances therefore cannot coexist — true
+  when written, false as of this change, and corrected.
+  [mechanism: `ForgePortPreflight` plain-bind probe — `ForgePortPreflightTest` (7 tests, `forge-core`),
+  `EmberConfigBasePortTest` (7 tests, `ember`); both mutation-probed, see the PR for the reddened sets]

--- a/changelog.d/718-forge-start-budget.md
+++ b/changelog.d/718-forge-start-budget.md
@@ -1,0 +1,29 @@
+### Fixed (2026-09-11 — #718 shape 4: Forge's cluster-start budget is configurable, and its timeout says what did not finish)
+- **`[cluster] start_timeout_seconds` is now a `forge.toml` setting** (default `60`, unchanged).
+  It was a hard-coded literal at the single `await` site, so a host where formation is merely slow
+  had no way to buy more time — Forge simply exited. `EmberConfig` gains a `startTimeoutSeconds`
+  component, rejects a non-positive budget (which would expire before the cluster could possibly
+  form), and both consumers — `ForgeServer.startCluster` and `EmberInstance` — read it.
+- **The timeout message now names what did not finish.** It was
+  `"Failed to start cluster: " + cause.message()`, which on the timeout path surfaces as
+  `Promise is not resolved within specified timeout` — a sentence naming no phase, no peer and no
+  port, and **identical whether nothing formed at all or four of five nodes were consensus-active**.
+  It now reports, all read from the cluster at the deadline and none inferred: the budget and the
+  setting that governs it, how many of N nodes were consensus-active, the leader (or `none`), each
+  node with its state and QUIC port, and any per-node start failure — or, when none was recorded,
+  that the budget expired with the start still in progress rather than with a node erroring out.
+- **It states what Forge DID verify and refuses to diagnose what it did not.** The #1008 preflight
+  verified the QUIC range was free immediately before the start, so a port collision is ruled out and
+  the reader need not re-check it. Stale `forge-data`, host load and a genuine consensus fault are
+  offered as candidates without ranking, explicitly labelled as unchecked — the same discipline as
+  the #952 startup-deploy message.
+- **The message never calls a node healthy.** `state` is `AetherNode.isReady()` (consensus-active),
+  labelled as such and not as a general health verdict — #727's defect was an unconditional
+  `"healthy"` literal that made every failing cluster report healthy nodes beside `leader=none`.
+- **Explicitly NOT coupled to the 60-second higher-id grace** in `QuicClusterNetwork` (#491). The two
+  values are numerically equal and serve unrelated purposes — that grace exists to avoid a cold-boot
+  dual-Hello race for a never-connected peer. No evidence of a real relationship was found, and per
+  owner ruling none was assumed; neither value is derived from the other.
+  [mechanism: `ForgeServer.clusterStartFailureMessage` renders only values read from
+  `EmberCluster.status()` at the deadline — `ForgeServerMessageTest.ClusterStartFailure` (9 tests),
+  `EmberConfigStartTimeoutTest` (5 tests); mutation-probed, see the PR for the reddened sets]


### PR DESCRIPTION
Fixes #1008.

## The correction that shaped this fix

The issue asks for a guard "on the QUIC bind itself". **There is no bind failure to guard.** Measured
on this box (Darwin 25.5.0), all four holder/probe combinations:

| holder | probe | result |
|---|---|---|
| `SO_REUSEADDR` | `SO_REUSEADDR` | **binds — collision invisible** |
| `SO_REUSEADDR` | plain | refused, `Address already in use` |
| plain | `SO_REUSEADDR` | refused |
| plain | plain | refused |

`QuicClusterServer` sets `SO_REUSEADDR` (deliberately — a restarting node must rebind its own port),
so Forge-versus-Forge is exactly the one row that succeeds. `QuicTransportError.BindFailed` already
names the port and `EmberCluster.start()` already aborts the whole start on it — that path simply
never fires. Propagating bind failures harder would have changed nothing.

So the guard is a **preflight that binds each port WITHOUT `SO_REUSEADDR`**, which the kernel does
refuse while any holder exists, run before a single node is created.

## What changed

1. **`[cluster] base_port`** is now a `forge.toml` setting (default `6000`, unchanged). `EmberConfig`
   gains a `basePort` component and validates the whole range (`base_port + nodes - 1 > 65535` is
   refused). `ForgeServer` and `EmberInstance` read it instead of passing the constant positionally.
   Every existing `emberConfig(...)` overload keeps its signature and defaults the new value.
2. **`ForgePortPreflight`** refuses startup and exits non-zero, naming every occupied port. The
   message **discriminates the two producers of `activePeerCount=1`**, stating that no node was
   started so it is not stale `forge-data` state — the ambiguity that cost the debugging time.
3. Startup banner prints the QUIC range; forge-guide documents `base_port`; the
   lifecycle-verification runbook said no configuration overrides the QUIC base port — true when
   written, false now, corrected.

## Verification

**Root build** `env -u HCLOUD_TOKEN mvn clean install` from ROOT, no `-pl`, no `-DskipTests`:
BUILD SUCCESS, 145 modules, 0 `[ERROR]`, 0 SKIPPED/FAILURE. **13,748 `<testcase>` elements**
(counted as elements, not the `<testsuite tests=>` attribute), 0 failures, across surefire **and**
failsafe reports newer than a pre-build marker; the 5 files the marker excluded are 4 days old.

**Gate**, run separately per module, quoting file counts:
`aether/ember` → `Running JBCT check on 6 Java file(s)` / `JBCT check passed.`;
`aether/forge/forge-core` → `Running JBCT check on 3 Java file(s)` / `JBCT check passed.`
(The gate caught a format violation and a `JBCT-EX-01` lint error the lifecycle build did not.)

**Mutation probes** — each reverts one hunk against the committed base; red sets are named:

| probe | reverted | RED set |
|---|---|---|
| P1 | probe sets `SO_REUSEADDR` | 3: `whenHolderSetsReuseAddr`, `messageDiscriminatesFromStaleForgeData`, `namesEveryOccupiedPort` |
| P2 | `base_port` no longer read from TOML | 5 in `EmberConfigBasePortTest` |
| P3 | range-overflow check removed | 1: `basePort_isRejected_whenRangeForNodesExceedsPortSpace` |
| P4 | **both `ForgeServer` wiring hunks** | **0 — unpinned by unit tests** |

P1's set is disjoint from P2/P3's. **P3's set is a strict subset of P2's** (removing the TOML read
means `base_port` never reaches validation) — stated rather than claimed as independence.

**P4 is an honest gap**, so the wiring is pinned by a live Forge run instead (suite lock held; killed
by PID, never `pkill -f`):

- **Arm A** — a holder owns UDP 6000-6004 with `SO_REUSEADDR` (confirmed by `lsof`), second Forge on
  the default range: **exit 1**, ~15 ms after the banner, message naming all five ports.
- **Arm B** — same holder still on 6000-6004, `base_port = 7300`: Forge starts, **binds exactly
  7300-7304** (`lsof` on its PID), reaches **full membership 5/5, `quorumSafe=true`**, leader
  elected, zero bind errors, no collision message.

Arm B proves `base_port` reaches `EmberCluster` end-to-end; Arm A proves the collision is loud.

## Limitations, stated

- The preflight is **time-of-check/time-of-use**. Each socket closes before the cluster binds for
  real, so a process claiming a port inside that window is still silent. It converts the common case
  (another Forge already running) from silent to loud; it is not a lock.
- The duplicate-bind measurement is from **Darwin 25.5.0**. On Linux a duplicate UDP unicast bind
  under `SO_REUSEADDR` is refused anyway, so the preflight is correct there but less load-bearing.
  Consequently `ensureQuicPortsFree_fails_whenHolderSetsReuseAddr` is a genuine discriminator on
  macOS and passes vacuously on Linux.
- Test sources are not gated (`jbct.includeTests=false`, repo-wide, pre-existing).
- **Issue item 3 (enumerating causes on a live `activePeerCount=1`) is NOT done.** It belongs to the
  membership/status surface, not Forge startup. This fix removes the port collision from that
  symptom's candidate set at the only point where it can be ruled out cheaply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
