### PR TITLE
fix: the published node image no longer ships a built-in administrative credential

### DIFF
--- a/aether/cli/src/main/java/org/pragmatica/aether/cli/cluster/ClusterRotateKeyCommand.java
+++ b/aether/cli/src/main/java/org/pragmatica/aether/cli/cluster/ClusterRotateKeyCommand.java
@@ -104,6 +104,12 @@ class ClusterRotateKeyCommand implements Callable<Integer> {
     /// An unreadable or non-array body never resolves to a key; it fails, so the rotation cannot
     /// proceed against a guess. More than one ACTIVE key is refused unless `--key-id` names the
     /// one to retire.
+    /// Mirrors `ApiKeyRoutes.SOURCE_CLUSTER` / `SOURCE_CONFIG`. Duplicated rather than imported: the
+    /// CLI talks to a node over HTTP and is versioned independently of it, so this is a wire
+    /// contract, not a shared constant.
+    static final String SOURCE_CLUSTER = "cluster";
+    static final String SOURCE_CONFIG = "config";
+
     static Result<String> resolveKeyToRetire(String requestedKeyId, String keysJson) {
         return parseActiveKeyIds(keysJson).flatMap(activeKeyIds -> selectKeyToRetire(requestedKeyId, activeKeyIds));
     }
@@ -156,15 +162,25 @@ class ClusterRotateKeyCommand implements Callable<Integer> {
     private static Result<KeyEntry> readKeyEntry(JsonNode keyRecord) {
         var keyId = keyRecord.path("keyId").asText("");
         var status = keyRecord.path("status").asText("");
+        var source = keyRecord.path("source").asText(SOURCE_CLUSTER);
 
         return Verify.Is.present(keyId) && Verify.Is.present(status)
-               ? Result.success(new KeyEntry(keyId, status))
+               ? Result.success(new KeyEntry(keyId, status, source))
                : new RotateKeyError.KeyListUnreadable("a key record carries no keyId/status pair").result();
     }
 
+    /// Rotation candidates: ACTIVE **and** rotatable.
+    ///
+    /// The source filter is not cosmetic. `GET /api/v1/cluster/keys` now also reports keys declared
+    /// in a node's configuration, and it reports them ACTIVE because the node does accept them.
+    /// Without this filter a cluster whose nodes declare one config key would see two ACTIVE
+    /// records, and [#selectSoleActiveKey] refuses to act on an ambiguous set — so `rotate-key`
+    /// would stop working on exactly the deployments that pre-provision a credential, and the
+    /// `--key-id` escape hatch would then name a key the revoke endpoint refuses.
     private static List<String> activeKeyIds(List<KeyEntry> entries) {
         return entries.stream()
                       .filter(KeyEntry::isActive)
+                      .filter(KeyEntry::isRotatable)
                       .map(KeyEntry::keyId)
                       .toList();
     }
@@ -274,9 +290,19 @@ class ClusterRotateKeyCommand implements Callable<Integer> {
 
     private record RotationOutcome(String json, String newKeyId, String oldKeyId) {}
 
-    private record KeyEntry(String keyId, String status) {
+    /// `source` distinguishes a cluster-held key from one declared in a node's configuration file.
+    /// Absent on a node predating the `source` field, where every listed record was cluster-held, so
+    /// a missing value reads as [#SOURCE_CLUSTER] and this command behaves against such a node
+    /// exactly as it did before.
+    private record KeyEntry(String keyId, String status, String source) {
         boolean isActive() {
             return ACTIVE_STATUS.equals(status);
+        }
+
+        /// A config-declared key cannot be rotated: `POST /api/v1/cluster/keys/revoke/{id}` refuses
+        /// it, because its configuration file is its authority and this API cannot rewrite one.
+        boolean isRotatable() {
+            return ! SOURCE_CONFIG.equals(source);
         }
     }
 

--- a/aether/docker/aether-node/aether.toml
+++ b/aether/docker/aether-node/aether.toml
@@ -24,17 +24,39 @@ repositories = ["builtin"]
 [app-http]
 enabled = true
 
-# Rich-syntax key entry — ADMIN role to match cloud's formation-time test key
-# (cloud-hetzner-b.toml uses ADMIN since formation POSTs hit /api/cluster/config,
-# /api/cluster/keys, /api/cluster/await-quiesced — all default-gated to ADMIN by
-# RoutePermissionRegistry's catch-all for non-OPERATOR-listed mutations). Simple
-# `api_keys = ["..."]` defaults to VIEWER per `ApiKeyEntry.DEFAULT_ROLE`, which
-# 403s on every mutation endpoint. Cloud bootstrap composes its own runtime TOML
-# via BootstrapOverlayGenerator and is unaffected by this file; this default is
-# consumed only by docker-compose / Forge / direct-image deployments where
-# there's no bootstrap-time composition.
-[app-http.api-keys.aether-integration-test-key]
-authorization_role = "ADMIN"
+# NO `[app-http.api-keys.*]` STANZA HERE, DELIBERATELY, AND NOTHING MAY ADD ONE.
+#
+# This file is COPYed into the published `ghcr.io/pragmaticalabs/aether-node` image by
+# `docker/aether-node/Dockerfile` and is the config every docker-compose, Forge and
+# direct-image deployment boots with. A key written here is a constant in a public
+# repository, so it is not a credential — it is a published one, identical on every
+# install, and it would be the node's only ADMIN credential out of the box.
+#
+# The node is therefore FAIL-CLOSED by default: `ConfigLoader` leaves `security_mode`
+# at its `API_KEY` default (#290), `AetherNode` installs the config validator over an
+# EMPTY key map, and `KvStoreApiKeyValidator` falls through to the cluster's KV-held
+# keys. With no key configured and none registered, every non-public management route
+# is refused. Public routes (`/health/live`, `/health/ready`) still answer, which is
+# what the container health check probes.
+#
+# HOW AN OPERATOR GETS A CREDENTIAL — two supported paths, neither baked into an image:
+#
+#   1. The cluster bootstrap admin key. At first leadership the leader derives an ADMIN
+#      key from the cluster secret (`BootstrapAdminKeyLeg`, #980) and commits its hash
+#      through consensus. It is printed ONCE at formation, and — unlike a key declared
+#      in this file — it is enumerable via `GET /api/v1/cluster/keys`, revocable, and
+#      audited. This is the default path and needs no configuration at all.
+#   2. `AETHER_API_KEYS`, read by `ConfigLoader.resolveApiKeys` ahead of ANY TOML, as
+#      `<key>:<name>:<roles>:<ROLE>` segments separated by `;`. This is how the
+#      integration suite supplies its own credential (see
+#      `aether/tests/integration/docker-compose.yml`) without a second image or a
+#      second config file to drift out of sync with this one.
+#
+# Declaring keys here is still valid for an operator-authored config, and such keys are
+# honoured. Note the asymmetry before choosing that path: a key declared in a FILE
+# cannot be revoked through the cluster-keys API, because the file is its authority and
+# the node cannot rewrite an operator's file. `GET /api/v1/cluster/keys` lists it with
+# `"source": "config"` so the gap is visible rather than silent.
 
 [messaging.click-events]
 topic_name = "click-events"
@@ -52,7 +74,12 @@ network_name = "aether-network"
 # then applies its own numeric defaults (5150 / 8070).
 management_port_base = "${env:AETHER_MGMT_PORT_BASE}"
 app_port_base = "${env:AETHER_APP_PORT_BASE}"
-api_key = "aether-integration-test-key"
+# CLIENT credential the provider hands each container it mints as AETHER_API_KEY (what
+# the CLI SENDS; `AETHER_API_KEYS` plural is what the node ACCEPTS). Env-resolved, not a
+# literal: it used to be the same constant this file baked in as a server-side key, so
+# the two agreed only because the image shipped the credential. Unset resolves to the
+# literal placeholder, which authenticates nothing — fail-closed, not fail-open.
+api_key = "${env:AETHER_API_KEY}"
 docker_gid = "${env:DOCKER_GID}"
 cluster_port = "6000"
 socket_path = "/var/run/docker.sock"

--- a/aether/docs/reference/management-api.md
+++ b/aether/docs/reference/management-api.md
@@ -3483,6 +3483,14 @@ List all API keys with status.
 (`ACTIVE`, `REVOKED`, or `EXPIRED`) — clients must read the per-record field rather than matching
 a status token against the whole document.
 
+The listing covers **every credential the node accepts**, from both sources, and `source` says
+which:
+
+| `source` | Where the key lives | Revocable via this API |
+|---|---|---|
+| `cluster` | The replicated cluster key store, created by `POST /api/v1/cluster/keys` or minted at formation as the bootstrap admin key | **Yes** |
+| `config` | The node's `[app-http.api-keys.<key>]` table or the `AETHER_API_KEYS` environment variable | **No** — see below |
+
 ```json
 [
   {
@@ -3492,16 +3500,45 @@ a status token against the whole document.
     "expiresAt": -1,
     "revokedAt": -1,
     "gracePeriodMs": 300000,
-    "authorizationRole": "ADMIN"
+    "authorizationRole": "ADMIN",
+    "source": "cluster"
+  },
+  {
+    "keyId": "config:ops-preprovisioned",
+    "status": "ACTIVE",
+    "createdAt": -1,
+    "expiresAt": -1,
+    "revokedAt": -1,
+    "gracePeriodMs": 0,
+    "authorizationRole": "ADMIN",
+    "source": "config"
   }
 ]
 ```
+
+A `config` record's `keyId` is synthetic (`config:<declared name>`) and never the key value; its
+timestamps are `-1` because a file declaration has no creation, expiry or revocation event. It is
+reported `ACTIVE` because the node does accept it.
+
+**Clients that act on this listing must filter on `source`.** `aether cluster rotate-key` does:
+it considers only `cluster` records, because a `config` record cannot be retired here. A record
+with no `source` field comes from an older node and is treated as `cluster`.
 
 ### POST /api/v1/cluster/keys/revoke/{id}
 
 Revoke an API key. The key remains valid during its grace period.
 
 **RBAC:** ADMIN
+
+**Only `source: "cluster"` keys can be revoked here.** Revocation commits a `REVOKED` record
+through consensus, which works because the cluster key store is that key's authority. A key
+declared in a node's configuration file is refused, with a message naming the file: the file is its
+authority, the node cannot rewrite an operator's file, and the config validator is consulted before
+the cluster key store — so a tombstone would sit in the store while the key kept authenticating.
+Reporting success there would tell an operator a live credential was dead.
+
+To retire a `config` key, remove its `[app-http.api-keys.<key>]` table (or its `AETHER_API_KEYS`
+entry) and restart the node.
 
 **Request:**
 ```json

--- a/aether/environment-integration/src/main/java/org/pragmatica/aether/environment/ClusterIdentityEnv.java
+++ b/aether/environment-integration/src/main/java/org/pragmatica/aether/environment/ClusterIdentityEnv.java
@@ -30,10 +30,20 @@ public sealed interface ClusterIdentityEnv {
     /// worker-community grouping reads it — but both provisioning paths iterate THIS allow-list, so a
     /// provisioned node never received the variable and every node came up zoneless. Fixing the grouping
     /// alone would have left the whole chain inert.
+    /// `AETHER_API_KEYS` (PLURAL) is the node's SERVER-side credential set — the keys it ACCEPTS,
+    /// parsed by `ConfigLoader.resolveApiKeys` ahead of any TOML. `AETHER_API_KEY` (SINGULAR, above)
+    /// is the CLIENT credential the CLI SENDS. They are different variables read by different code,
+    /// and only the singular one was propagated. That was invisible for as long as the published
+    /// image baked a server-side key into `docker/aether-node/aether.toml`: a minted node inherited
+    /// no key set but did not need one, because its image already carried a matching ADMIN key.
+    /// With that baked credential removed the omission becomes load-bearing — a CTM-minted or
+    /// auto-healed node would accept NOTHING its compose-fixed siblings accept, which is this
+    /// allow-list's stated "replacements miss what seeds get" class arriving one variable over.
     List<String> IDENTITY_VARS = List.of("AETHER_CLUSTER_NAME",
                                          "AETHER_CLUSTER_SECRET",
                                          "AETHER_PROVISIONED_BY",
                                          "AETHER_API_KEY",
+                                         "AETHER_API_KEYS",
                                          "AETHER_SOURCE",
                                          "AETHER_ROLE",
                                          "AETHER_ZONE");

--- a/aether/node/src/main/java/org/pragmatica/aether/api/ManagementServer.java
+++ b/aether/node/src/main/java/org/pragmatica/aether/api/ManagementServer.java
@@ -77,6 +77,7 @@ import org.pragmatica.aether.http.handler.security.SecurityPolicy;
 import org.pragmatica.aether.http.security.AuditLog;
 import org.pragmatica.aether.http.security.SecurityError;
 import org.pragmatica.aether.api.OperationalEvent;
+import org.pragmatica.aether.config.ApiKeyEntry;
 import org.pragmatica.aether.http.security.SecurityValidator;
 import org.pragmatica.aether.invoke.InvocationTraceStore;
 import org.pragmatica.aether.invoke.ScheduledTaskManager;
@@ -154,6 +155,7 @@ public interface ManagementServer {
                                              Option<TlsConfig> tls,
                                              SecurityValidator securityValidator,
                                              boolean securityEnabled,
+                                             Supplier<Map<String, ApiKeyEntry>> configuredApiKeys,
                                              Option<EventLoopGroup> bossGroup,
                                              Option<EventLoopGroup> workerGroup,
                                              HttpProtocol httpProtocol,
@@ -178,6 +180,7 @@ public interface ManagementServer {
                                         tls,
                                         securityValidator,
                                         securityEnabled,
+                                        configuredApiKeys,
                                         bossGroup,
                                         workerGroup,
                                         httpProtocol,
@@ -209,6 +212,10 @@ class ManagementServerImpl implements ManagementServer {
     private final HttpRequestObserver requestObserver;
     private final Option<TlsConfig> tls;
     private final SecurityValidator securityValidator;
+    /// The node's config-declared keys, so `GET /api/v1/cluster/keys` can report every credential
+    /// this node accepts rather than only the cluster-held ones. A supplier, not a snapshot, so a
+    /// future reloadable config is reflected without re-wiring the server.
+    private final Supplier<Map<String, ApiKeyEntry>> configuredApiKeys;
     private final boolean securityEnabled;
     private final Option<EventLoopGroup> bossGroup;
     private final Option<EventLoopGroup> workerGroup;
@@ -255,6 +262,7 @@ class ManagementServerImpl implements ManagementServer {
                          Option<TlsConfig> tls,
                          SecurityValidator securityValidator,
                          boolean securityEnabled,
+                         Supplier<Map<String, ApiKeyEntry>> configuredApiKeys,
                          Option<EventLoopGroup> bossGroup,
                          Option<EventLoopGroup> workerGroup,
                          HttpProtocol httpProtocol,
@@ -272,6 +280,9 @@ class ManagementServerImpl implements ManagementServer {
         this.logLevelRegistry = logLevelRegistry;
         this.securityValidator = securityValidator;
         this.securityEnabled = securityEnabled;
+        this.configuredApiKeys = configuredApiKeys == null
+                                 ? Map::of
+                                 : configuredApiKeys;
         this.bossGroup = bossGroup;
         this.workerGroup = workerGroup;
         this.httpProtocol = httpProtocol;
@@ -351,7 +362,7 @@ class ManagementServerImpl implements ManagementServer {
                                                                                                                     .streamNamespacesService()));
         routeSources.add(StorageRoutes.storageRoutes(nodeSupplier));
         routeSources.add(RetentionRoutes.retentionRoutes(nodeSupplier));
-        var apiKeyRoutes = ApiKeyRoutes.apiKeyRoutes(nodeSupplier);
+        var apiKeyRoutes = ApiKeyRoutes.apiKeyRoutes(nodeSupplier, configuredApiKeys);
 
         apiKeyRoutesRef.set(apiKeyRoutes);
         routeSources.add(apiKeyRoutes);

--- a/aether/node/src/main/java/org/pragmatica/aether/api/routes/ApiKeyRoutes.java
+++ b/aether/node/src/main/java/org/pragmatica/aether/api/routes/ApiKeyRoutes.java
@@ -6,10 +6,12 @@ package org.pragmatica.aether.api.routes;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ScheduledFuture;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
+import org.pragmatica.aether.config.ApiKeyEntry;
 import org.pragmatica.aether.management.route.ManagementRoute;
 import org.pragmatica.aether.node.ManageableNode;
 import org.pragmatica.aether.slice.kvstore.AetherKey;
@@ -21,6 +23,7 @@ import org.pragmatica.cluster.state.kvstore.KVCommand;
 import org.pragmatica.http.routing.Route;
 import org.pragmatica.http.routing.RouteSource;
 import org.pragmatica.lang.Cause;
+import org.pragmatica.lang.Option;
 import org.pragmatica.lang.Contract;
 import org.pragmatica.lang.Promise;
 import org.pragmatica.lang.io.TimeSpan;
@@ -36,17 +39,33 @@ import static org.pragmatica.http.routing.PathParameter.aString;
 public final class ApiKeyRoutes implements RouteSource {
     private static final Logger log = LoggerFactory.getLogger(ApiKeyRoutes.class);
     private static final TimeSpan SWEEP_INTERVAL = TimeSpan.timeSpan(60).seconds();
+    /// A key this API created and can revoke: its record lives in the replicated KV store.
+    public static final String SOURCE_CLUSTER = "cluster";
+    /// A key declared in the node's configuration file or `AETHER_API_KEYS`. The node HONOURS it —
+    /// [`org.pragmatica.aether.http.security.KvStoreApiKeyValidator`] consults the config validator
+    /// first — but this API is not its authority and cannot retire it. Listed so an operator can
+    /// SEE every credential the node accepts; see [#handleRevokeKey] for what revoking one does.
+    public static final String SOURCE_CONFIG = "config";
+    /// Synthetic, and never the key itself. The map key in `AppHttpConfig.apiKeys()` IS the secret,
+    /// so the listing identifies a configured key by its declared name only.
+    public static final String CONFIG_KEY_ID_PREFIX = "config:";
+    private static final String STATUS_ACTIVE = "ACTIVE";
+    private static final long NOT_APPLICABLE = -1L;
 
     private final Supplier<ManageableNode> nodeSupplier;
+    private final Supplier<Map<String, ApiKeyEntry>> configuredKeysSupplier;
     private final ScheduledFuture<?> sweepTask;
 
-    private ApiKeyRoutes(Supplier<ManageableNode> nodeSupplier) {
+    private ApiKeyRoutes(Supplier<ManageableNode> nodeSupplier,
+                         Supplier<Map<String, ApiKeyEntry>> configuredKeysSupplier) {
         this.nodeSupplier = nodeSupplier;
+        this.configuredKeysSupplier = configuredKeysSupplier;
         this.sweepTask = SharedScheduler.scheduleAtFixedRate(this::sweepExpiredKeys, SWEEP_INTERVAL);
     }
 
-    public static ApiKeyRoutes apiKeyRoutes(Supplier<ManageableNode> nodeSupplier) {
-        return new ApiKeyRoutes(nodeSupplier);
+    public static ApiKeyRoutes apiKeyRoutes(Supplier<ManageableNode> nodeSupplier,
+                                            Supplier<Map<String, ApiKeyEntry>> configuredKeysSupplier) {
+        return new ApiKeyRoutes(nodeSupplier, configuredKeysSupplier);
     }
 
     /// Cancel the expiry sweep (#642). [`SharedScheduler`] is process-wide and this route source is
@@ -97,29 +116,84 @@ public final class ApiKeyRoutes implements RouteSource {
                                                                     "ACTIVE"));
     }
 
-    private Promise<List<KeyInfo>> handleListKeys() {
-        var node = nodeSupplier.get();
+    /// Every credential this node ACCEPTS, from both of its two sources, each record naming which.
+    ///
+    /// The listing used to show cluster-held keys only, so a key declared in the node's config file
+    /// authenticated against every route while being invisible to the tooling an operator uses to
+    /// audit credentials — it could be neither enumerated nor rotated, and nothing said so. A
+    /// credential that cannot be seen cannot be reasoned about during an incident.
+    ///
+    /// Config-declared records carry `source = "config"` and a synthetic `config:<name>` id. They
+    /// are reported ACTIVE because the node does accept them; timestamps are `-1` because a file
+    /// declaration has no creation, expiry or revocation event to report. Clients that ACT on this
+    /// listing must filter on `source` — `aether cluster rotate-key` does.
+    /// Package-visible so a test can assert what an operator RECEIVES from this endpoint — that a
+    /// config-declared credential is listed, and distinguishable from a cluster-held one. Asserting
+    /// it through the route table instead would need a bound listener and would test the router.
+    Promise<List<KeyInfo>> handleListKeys() {
         var keys = new ArrayList<KeyInfo>();
 
-        node.kvStore()
-            .forEach(ApiKeyKey.class,
-                     ApiKeyValue.class,
-                     (_, v) -> keys.add(new KeyInfo(v.keyId(),
-                                                    v.status(),
-                                                    v.createdAt(),
-                                                    v.expiresAt(),
-                                                    v.revokedAt(),
-                                                    v.gracePeriodMs(),
-                                                    v.authorizationRole())));
+        nodeSupplier.get().kvStore().forEach(ApiKeyKey.class, ApiKeyValue.class, (_, v) -> keys.add(clusterKeyInfo(v)));
+        configuredKeysSupplier.get().values().forEach(entry -> keys.add(configuredKeyInfo(entry)));
 
         return Promise.success(List.copyOf(keys));
     }
 
+    private static KeyInfo clusterKeyInfo(ApiKeyValue value) {
+        return new KeyInfo(value.keyId(),
+                           value.status(),
+                           value.createdAt(),
+                           value.expiresAt(),
+                           value.revokedAt(),
+                           value.gracePeriodMs(),
+                           value.authorizationRole(),
+                           SOURCE_CLUSTER);
+    }
+
+    private static KeyInfo configuredKeyInfo(ApiKeyEntry entry) {
+        return new KeyInfo(configuredKeyId(entry),
+                           STATUS_ACTIVE,
+                           NOT_APPLICABLE,
+                           NOT_APPLICABLE,
+                           NOT_APPLICABLE,
+                           0L,
+                           entry.authorizationRole(),
+                           SOURCE_CONFIG);
+    }
+
+    static String configuredKeyId(ApiKeyEntry entry) {
+        return CONFIG_KEY_ID_PREFIX + entry.name();
+    }
+
+    /// REVOKING A CONFIG-DECLARED KEY IS REFUSED, and the refusal is the honest answer rather than a
+    /// missing feature.
+    ///
+    /// Revocation here means committing a REVOKED record through consensus. That works for a
+    /// cluster-held key because the KV store is the key's authority. It does not work for a key
+    /// declared in a file: the file is the authority, the node cannot rewrite an operator's file,
+    /// and [`org.pragmatica.aether.http.security.KvStoreApiKeyValidator`] consults the config
+    /// validator FIRST and returns on success, so a tombstone would sit in KV while the key kept
+    /// authenticating. Reporting success there would be worse than refusing — an operator would
+    /// believe a leaked credential was dead.
+    ///
+    /// Making it genuinely revocable needs a design ruling this fix deliberately does not take,
+    /// because both available answers cost something real. Consulting a KV tombstone before
+    /// accepting a config key leaves a bypass window on every restart, since an empty KV during
+    /// replay is indistinguishable from "nothing revoked" — a recurring hole exactly when a node
+    /// bounces. Gating config keys on `ManageableNode#isReady()` closes that window but stops them
+    /// authenticating before the node is ACTIVE, which is when cluster formation uses them.
+    ///
+    /// The operator's route is the file: remove the declaration and restart the node. The message
+    /// says so, because an error an operator cannot act on is a dead end.
     @SuppressWarnings("unchecked")
-    private Promise<Object> handleRevokeKey(String keyId, RevokeKeyRequest request) {
+    Promise<Object> handleRevokeKey(String keyId, RevokeKeyRequest request) {
         var node = nodeSupplier.get();
         var key = ApiKeyKey.apiKeyKey(keyId);
         var existing = node.kvStore().get(key);
+
+        if (isConfiguredKeyId(keyId)) {
+            return new ConfigDeclaredKeyError(keyId).promise();
+        }
 
         if (existing.isEmpty()) {
             return new KeyNotFoundError(keyId).promise();
@@ -206,6 +280,22 @@ public final class ApiKeyRoutes implements RouteSource {
         }
     }
 
+    private boolean isConfiguredKeyId(String keyId) {
+        return Option.option(keyId)
+                     .filter(id -> id.startsWith(CONFIG_KEY_ID_PREFIX))
+                     .map(this::matchesDeclaredKey)
+                     .or(false);
+    }
+
+    /// The prefix alone is not enough: a caller could otherwise mask any missing key behind the
+    /// config refusal by prefixing its id. The id must match a key this node actually declares.
+    private boolean matchesDeclaredKey(String keyId) {
+        return configuredKeysSupplier.get()
+                                     .values()
+                                     .stream()
+                                     .anyMatch(entry -> configuredKeyId(entry).equals(keyId));
+    }
+
     record CreateKeyRequest(String keyId,
                             String keyHash,
                             long gracePeriodMs,
@@ -219,13 +309,16 @@ public final class ApiKeyRoutes implements RouteSource {
 
     record RevokeKeyResponse(String keyId, String status, long gracePeriodMs) {}
 
+    /// `source` is [#SOURCE_CLUSTER] or [#SOURCE_CONFIG]. It is the field a client must read before
+    /// acting on a record: only cluster-held keys can be revoked through this API.
     record KeyInfo(String keyId,
                    String status,
                    long createdAt,
                    long expiresAt,
                    long revokedAt,
                    long gracePeriodMs,
-                   String authorizationRole) {}
+                   String authorizationRole,
+                   String source) {}
 
     record AuditEntry(String keyId, String action, long timestamp, String operatorHint) {}
 
@@ -233,6 +326,20 @@ public final class ApiKeyRoutes implements RouteSource {
         @Override
         public String message() {
             return "API key not found: " + keyId;
+        }
+    }
+
+    /// Distinct from [KeyNotFoundError] on purpose: the key EXISTS and the node accepts it. Saying
+    /// "not found" would tell an operator the credential is gone when it is still live.
+    record ConfigDeclaredKeyError(String keyId) implements Cause {
+        @Override
+        public String message() {
+            return "API key '" + keyId
+                 + "' is declared in node configuration, not in the cluster key store, "
+                 + "and cannot be revoked through this API: the configuration file is its authority and the "
+                 + "node cannot rewrite it. Remove the [app-http.api-keys.<key>] table (or the AETHER_API_KEYS "
+                 + "entry) and restart the node. Keys created via POST /api/v1/cluster/keys carry "
+                 + "source=\"cluster\" and are revocable here.";
         }
     }
 }

--- a/aether/node/src/main/java/org/pragmatica/aether/node/AetherNode.java
+++ b/aether/node/src/main/java/org/pragmatica/aether/node/AetherNode.java
@@ -4438,6 +4438,8 @@ public interface AetherNode extends ManageableNode {
                                                                                                            config.tls(),
                                                                                                            mgmtSecurityValidator,
                                                                                                            mgmtSecurityEnabled,
+                                                                                                           () -> config.appHttp()
+                                                                                                                       .apiKeys(),
                                                                                                            serverBossGroup,
                                                                                                            serverWorkerGroup,
                                                                                                            config.managementHttpProtocol(),

--- a/aether/node/src/main/java/org/pragmatica/aether/node/AetherNode.java
+++ b/aether/node/src/main/java/org/pragmatica/aether/node/AetherNode.java
@@ -4398,6 +4398,28 @@ public interface AetherNode extends ManageableNode {
                                                           + " = true with [app-http.api-keys.<key>] to authenticate operators (#573).",
                                                            config.managementPort());
                                               }
+                                                  // The OTHER credential-less shape, and until now it had no voice at all. Above is
+                                                  // `security_mode = "none"`. This is security ON with an EMPTY key set — which is what
+                                                  // the published image now boots with, since `docker/aether-node/aether.toml` no longer
+                                                  // bakes a key. The node is fail-closed and that is intended, so this is not a
+                                                  // misconfiguration warning; it states WHICH credential is the only way in, because the
+                                                  // alternative is an operator reading 401s with nothing in the log explaining them.
+                                                  //
+                                                  // Deliberately not silent-because-intended: a default applied when nothing was
+                                                  // configured has to be loud, or it becomes the fail-open nobody notices. The precedent
+                                                  // is this repo's own log-and-drop-plus-caller-default, which turned a fail-closed
+                                                  // encryption refusal into a green boot with plaintext.
+                                                  if (mgmtSecurityEnabled && config.appHttp()
+                                                                                   .apiKeys()
+                                                                                   .isEmpty()) {
+                                                  LOG.warn("Management API on port {} has NO key declared in configuration. This is the"
+                                                          + " FAIL-CLOSED default: every non-public route is REFUSED until a credential exists."
+                                                          + " The cluster bootstrap admin key (printed once at formation, derived from the"
+                                                          + " cluster secret) is the only credential this node will accept; it is enumerable and"
+                                                          + " revocable via /api/v1/cluster/keys. To pre-provision one instead, set"
+                                                          + " AETHER_API_KEYS=<key>:<name>:<roles>:<ROLE> or an [app-http.api-keys.<key>] table.",
+                                                           config.managementPort());
+                                              }
 
                                                   var mgmtSecurityValidator = SecurityValidator.kvStoreAwareValidator(configValidator,
                                                                                                                       () -> node.kvStore());

--- a/aether/node/src/test/java/org/pragmatica/aether/api/PublishedImageConfigFailsClosedTest.java
+++ b/aether/node/src/test/java/org/pragmatica/aether/api/PublishedImageConfigFailsClosedTest.java
@@ -1,0 +1,369 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2025 Pragmatica Labs - Sergiy Yevtushenko
+// Licensed under Business Source License 1.1. Change Date: 2030-01-01. Change License: Apache-2.0.
+// See LICENSE in the repository root for full terms.
+package org.pragmatica.aether.api;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.util.HexFormat;
+import java.util.List;
+import java.util.Map;
+
+import io.netty.buffer.ByteBuf;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.pragmatica.aether.config.AetherConfig;
+import org.pragmatica.aether.config.ConfigLoader;
+import org.pragmatica.aether.http.handler.HttpRequestContext;
+import org.pragmatica.aether.http.handler.security.AuthorizationRole;
+import org.pragmatica.aether.http.handler.security.RoleEnforcer;
+import org.pragmatica.aether.http.handler.security.SecurityContext;
+import org.pragmatica.aether.http.handler.security.SecurityPolicy;
+import org.pragmatica.aether.http.security.SecurityError;
+import org.pragmatica.aether.http.security.SecurityValidator;
+import org.pragmatica.aether.slice.kvstore.AetherKey;
+import org.pragmatica.aether.slice.kvstore.AetherKey.ApiKeyKey;
+import org.pragmatica.aether.slice.kvstore.AetherValue;
+import org.pragmatica.aether.slice.kvstore.AetherValue.ApiKeyValue;
+import org.pragmatica.cluster.state.kvstore.KVCommand.Put;
+import org.pragmatica.cluster.state.kvstore.KVStore;
+import org.pragmatica.lang.Cause;
+import org.pragmatica.lang.Result;
+import org.pragmatica.messaging.MessageRouter;
+import org.pragmatica.serialization.Deserializer;
+import org.pragmatica.serialization.Serializer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+/// The published `ghcr.io/pragmaticalabs/aether-node` image must not carry a built-in
+/// administrative credential.
+///
+/// WHERE THIS SITS, AND WHY IT READS A FILE. The claim is about an ARTIFACT — the config the
+/// release workflow bakes into the image — so the subject under test is the file on disk, loaded
+/// through the real [ConfigLoader], not a hand-built config object. A fixture that constructed an
+/// empty key map and asserted refusal would assert only that an empty map is empty; it could not
+/// fail if someone put a key back in the file, which is the single thing this test exists to catch.
+///
+/// The assertions then run the pipeline `ManagementServerImpl#validateManagementSecurity` runs —
+/// `securityValidator.validate(...)` then `RoleEnforcer.enforce(...)` — against the validator
+/// wiring `AetherNode` installs for the management plane, with an EMPTY KV store, which is a
+/// freshly-started node before any bootstrap admin key is registered. That is the state a
+/// `docker run` of the published image is in.
+///
+/// A FAIL-OPEN LOOKS EXACTLY LIKE A FAIL-CLOSED FROM A GREEN TEST, so every denial below is
+/// accompanied by controls that run INSIDE this same class: the config was really parsed from the
+/// real file (not defaulted empty because the path was wrong), the Dockerfile really copies THAT
+/// file, the route really resolves to an ADMIN permission, and the harness can really reach a
+/// success. Without those, "refused" is indistinguishable from "never arrived".
+class PublishedImageConfigFailsClosedTest {
+    /// The file `docker/aether-node/Dockerfile` COPYs to `/app/aether.toml`, via its
+    /// `ARG CONFIG_PATH` default, in the image the release workflow pushes to ghcr.
+    private static final String SHIPPED_CONFIG = "aether/docker/aether-node/aether.toml";
+    private static final String NODE_DOCKERFILE = "aether/docker/aether-node/Dockerfile";
+
+    /// The constant this file used to declare with `authorization_role = "ADMIN"`. It is a literal
+    /// here on purpose: it is already public in this repository's history, and the whole point is
+    /// that it must now authenticate NOTHING.
+    private static final String FORMERLY_BAKED_KEY = "aether-integration-test-key";
+
+    /// ADMIN-gated by `ManagementRoutePermissions.adminRoutes()`.
+    private static final String PRIVILEGED_METHOD = "POST";
+    private static final String PRIVILEGED_PATH = "/api/v1/cluster/keys";
+
+    private static final String BOOTSTRAP_KEY = "bootstrap-admin-key-value";
+    private static final String BOOTSTRAP_KEY_ID = "bootstrap-admin";
+    /// `MissingCredentials` -> 401, `InvalidCredentials` -> 403, per
+    /// [ManagementServerImpl#resolveSecurityErrorStatus]. The distinction is the point: a caller
+    /// PRESENTING the formerly-baked key is refused as INVALID (403), which proves the key was
+    /// looked up and not found. A caller presenting nothing is refused as MISSING (401). Asserting
+    /// the wrong one of these would still be asserting a refusal, but not this refusal.
+    private static final int HTTP_UNAUTHORIZED = 401;
+    private static final int HTTP_FORBIDDEN = 403;
+
+    private KVStore<AetherKey, AetherValue> kvStore;
+
+    @BeforeEach
+    void setUp() {
+        kvStore = new KVStore<>(MessageRouter.mutable(), stubSerializer(), stubDeserializer());
+    }
+
+    /// Exactly the wiring `AetherNode` installs for the management plane: the config validator over
+    /// `[app-http.api-keys]`, wrapped by the KV-aware validator that consults cluster-held keys.
+    private SecurityValidator managementValidator(AetherConfig config) {
+        return SecurityValidator.kvStoreAwareValidator(SecurityValidator.apiKeyValidator(config.appHttp().apiKeys()),
+                                                       () -> kvStore);
+    }
+
+    private Result<SecurityContext> pipeline(SecurityValidator validator, String apiKey, String method, String path) {
+        return validator.validate(request(apiKey, method, path), SecurityPolicy.apiKeyRequired())
+                        .flatMap(sc -> RoleEnforcer.enforce(sc, ManagementServerImpl.resolvePermission(method, path)));
+    }
+
+    @Nested
+    class ShippedImageDefault {
+        @Test
+        void formerlyBakedKey_isRefused_onAnAdminRoute() {
+            var validator = managementValidator(shippedConfig());
+
+            pipeline(validator, FORMERLY_BAKED_KEY, PRIVILEGED_METHOD, PRIVILEGED_PATH)
+                .onSuccess(sc -> fail("the published image still honours a built-in credential, as "
+                                      + sc.authorizationRole()))
+                .onFailure(cause -> {
+                    assertThat(cause).isInstanceOf(SecurityError.InvalidCredentials.class);
+                    assertThat(ManagementServerImpl.resolveSecurityErrorStatus(cause).code())
+                        .isEqualTo(HTTP_FORBIDDEN);
+                });
+        }
+
+        @Test
+        void anonymousCaller_isRefused_onAnAdminRoute() {
+            var validator = managementValidator(shippedConfig());
+
+            pipeline(validator, null, PRIVILEGED_METHOD, PRIVILEGED_PATH)
+                .onSuccess(sc -> fail("anonymous caller was served as " + sc.authorizationRole()))
+                .onFailure(PublishedImageConfigFailsClosedTest::assertMissingCredentialWith401);
+        }
+
+        @Test
+        void formerlyBakedKey_isRefused_onAReadRouteToo() {
+            var validator = managementValidator(shippedConfig());
+
+            pipeline(validator, FORMERLY_BAKED_KEY, "GET", "/api/v1/nodes/status")
+                .onSuccess(sc -> fail("read route served a built-in credential as " + sc.authorizationRole()));
+        }
+
+        @Test
+        void shippedConfig_declaresNoApiKeyAtAll() {
+            assertThat(shippedConfig().appHttp().apiKeys())
+                .as("the config baked into the published image must declare no credential")
+                .isEmpty();
+        }
+
+        /// Textual, and deliberately independent of the parser: a stanza could be added in a form
+        /// [ConfigLoader] does not recognise today but a later version does.
+        ///
+        /// COMMENTS ARE STRIPPED FIRST, and that is not a convenience — the first version of this
+        /// test failed against a correctly-fixed file. The shipped config now EXPLAINS the absent
+        /// stanza, so its guidance prose contains the literal `[app-http.api-keys.<key>]`, and a
+        /// raw substring search matched the very comment documenting the fix. An instrument whose
+        /// pattern is drawn from the vocabulary of the text it inspects reports on itself.
+        @Test
+        void shippedConfigFile_declaresNoApiKeyOutsideComments() {
+            var declarations = declarationLines(SHIPPED_CONFIG);
+
+            assertThat(declarations)
+                .as("no key declaration in the shipped config, comments excluded")
+                .noneMatch(line -> line.contains("api-keys") || line.contains("api_keys"));
+        }
+
+        /// Positive control for the stripper above: a filter that returned nothing would satisfy
+        /// `noneMatch` for every possible input. This proves it kept real settings, and that the
+        /// raw file really does discuss api-keys in the prose the stripper removed.
+        @Test
+        void commentStripper_keepsSettingsAndRemovesOnlyComments() {
+            var declarations = declarationLines(SHIPPED_CONFIG);
+
+            assertThat(declarations).isNotEmpty();
+            assertThat(declarations).anyMatch(line -> line.equals("[app-http]"));
+            assertThat(declarations).anyMatch(line -> line.startsWith("enabled ="));
+            assertThat(read(SHIPPED_CONFIG))
+                .as("the raw file DOES mention api-keys in guidance prose, which is why stripping matters")
+                .contains("[app-http.api-keys.");
+        }
+    }
+
+    /// Controls. Each one runs in this same class against the same artifacts, and each excludes a
+    /// specific way the refusals above could be true for a reason other than the one claimed.
+    @Nested
+    class Controls {
+        /// THE NON-VACUITY CONTROL. If the path were wrong, [ConfigLoader] would hand back a config
+        /// whose `apiKeys()` is empty for an entirely different reason and every assertion above
+        /// would pass while reading nothing. These are non-credential settings that exist ONLY in
+        /// the shipped file, so their presence proves the parse reached it.
+        @Test
+        void shippedConfig_wasActuallyParsedFromTheRealFile() {
+            var config = shippedConfig();
+
+            assertThat(config.appHttp().enabled())
+                .as("[app-http] enabled = true is set in the shipped file")
+                .isTrue();
+            assertThat(read(SHIPPED_CONFIG))
+                .as("marker settings unique to the shipped file")
+                .contains("[messaging.click-events]")
+                .contains("provider = \"docker\"");
+        }
+
+        /// Ties the file under test to the image. Without this, the class could be asserting about a
+        /// file the published image never copies.
+        @Test
+        void dockerfile_copiesTheFileUnderTest_intoTheImage() {
+            var dockerfile = read(NODE_DOCKERFILE);
+
+            assertThat(dockerfile)
+                .as("CONFIG_PATH default is the file this test asserts about")
+                .contains("ARG CONFIG_PATH=docker/aether-node/aether.toml");
+            assertThat(dockerfile).contains("COPY --chown=aether:aether ${CONFIG_PATH} /app/aether.toml");
+            assertThat(dockerfile).contains("--config=/app/aether.toml");
+        }
+
+        /// The refusals are authentication, not a 404 in disguise and not a role check.
+        @Test
+        void privilegedRoute_resolvesToAnAdminPermission() {
+            assertThat(ManagementServerImpl.resolvePermission(PRIVILEGED_METHOD, PRIVILEGED_PATH).minimumRole())
+                .isEqualTo(AuthorizationRole.ADMIN);
+        }
+
+        /// The harness CAN reach a success: the cluster's own bootstrap admin key — the credential
+        /// that replaces the baked one — authenticates through the same validator and pipeline. So
+        /// "refused" above is not "nothing works here".
+        @Test
+        void bootstrapAdminKey_isServedWithAdmin_provingTheHarnessReachesSuccess() {
+            var validator = managementValidator(shippedConfig());
+
+            registerKvKey(BOOTSTRAP_KEY_ID, BOOTSTRAP_KEY, "ADMIN");
+
+            pipeline(validator, BOOTSTRAP_KEY, PRIVILEGED_METHOD, PRIVILEGED_PATH)
+                .onFailure(cause -> fail("the cluster bootstrap admin key was refused: " + cause.message()))
+                .onSuccess(sc -> assertThat(sc.authorizationRole()).isEqualTo(AuthorizationRole.ADMIN));
+        }
+
+        /// A key declared in config still authenticates — this fix removes a BAKED credential, it
+        /// does not disable the configuration mechanism. Proves the empty result above comes from
+        /// the file's content and not from a validator that stopped honouring config keys.
+        @Test
+        void configuredKeys_areStillHonoured_whenAFileDeclaresThem() {
+            var configured = ConfigLoader.loadFromString("""
+                                                         [app-http]
+                                                         enabled = true
+
+                                                         [app-http.api-keys.operator-declared-key]
+                                                         authorization_role = "ADMIN"
+                                                         """)
+                                         .onFailure(cause -> fail("control config did not load: " + cause.message()))
+                                         .unwrap();
+
+            assertThat(configured.appHttp().apiKeys()).containsKey("operator-declared-key");
+            pipeline(managementValidator(configured), "operator-declared-key", PRIVILEGED_METHOD, PRIVILEGED_PATH)
+                .onFailure(cause -> fail("a file-declared key was refused: " + cause.message()))
+                .onSuccess(sc -> assertThat(sc.authorizationRole()).isEqualTo(AuthorizationRole.ADMIN));
+        }
+
+        /// `ConfigLoader.resolveApiKeys` reads `AETHER_API_KEYS` ahead of any TOML, so an ambient
+        /// value in the runner's environment would silently replace the subject of this whole class.
+        /// Fail loudly rather than skip: a skipped security test is indistinguishable from a passing
+        /// one in a summary.
+        @Test
+        void ambientEnvironment_doesNotSupplyKeys() {
+            assertThat(System.getenv("AETHER_API_KEYS"))
+                .as("AETHER_API_KEYS is set in this environment and overrides the file under test; "
+                    + "unset it before running this suite")
+                .isNull();
+        }
+    }
+
+    private static void assertMissingCredentialWith401(Cause cause) {
+        assertThat(cause).isInstanceOf(SecurityError.MissingCredentials.class);
+        assertThat(cause).isNotInstanceOf(RoleEnforcer.AuthorizationError.AccessDenied.class);
+        assertThat(ManagementServerImpl.resolveSecurityErrorStatus(cause).code()).isEqualTo(HTTP_UNAUTHORIZED);
+    }
+
+    private static AetherConfig shippedConfig() {
+        return ConfigLoader.load(repositoryRoot().resolve(SHIPPED_CONFIG))
+                           .onFailure(cause -> fail("the shipped node config did not load: " + cause.message()))
+                           .unwrap();
+    }
+
+    /// Non-blank, non-comment lines of a TOML file — the lines that actually declare something.
+    private static List<String> declarationLines(String relativePath) {
+        return read(relativePath).lines()
+                                 .map(String::trim)
+                                 .filter(line -> !line.isEmpty())
+                                 .filter(line -> !line.startsWith("#"))
+                                 .toList();
+    }
+
+    private static String read(String relativePath) {
+        try {
+            return Files.readString(repositoryRoot().resolve(relativePath));
+        } catch (Exception e) {
+            throw new AssertionError("could not read " + relativePath, e);
+        }
+    }
+
+    /// Walks up from the compiled test class rather than trusting `user.dir`, then VALIDATES the
+    /// result against marker paths — an unvalidated walk that lands one directory short returns a
+    /// path whose `resolve` silently yields a non-existent file.
+    private static Path repositoryRoot() {
+        var current = codeSourceLocation();
+
+        while (current != null) {
+            if (java.nio.file.Files.isRegularFile(current.resolve(SHIPPED_CONFIG))
+                && java.nio.file.Files.isRegularFile(current.resolve(NODE_DOCKERFILE))) {
+                return current;
+            }
+
+            current = current.getParent();
+        }
+
+        throw new AssertionError("repository root not found above " + codeSourceLocation()
+                                 + " — no ancestor holds both " + SHIPPED_CONFIG + " and " + NODE_DOCKERFILE);
+    }
+
+    private static Path codeSourceLocation() {
+        try {
+            return Path.of(PublishedImageConfigFailsClosedTest.class.getProtectionDomain()
+                                                                    .getCodeSource()
+                                                                    .getLocation()
+                                                                    .toURI());
+        } catch (Exception e) {
+            throw new AssertionError("cannot locate the test's own code source", e);
+        }
+    }
+
+    private void registerKvKey(String keyId, String rawKey, String role) {
+        AetherKey key = ApiKeyKey.apiKeyKey(keyId);
+        AetherValue value = ApiKeyValue.apiKeyValue(keyId, sha256Hex(rawKey), 0L, role);
+
+        kvStore.process(kvStore.createBatch(List.of(new Put<>(key, value))));
+    }
+
+    private static HttpRequestContext request(String apiKey, String method, String path) {
+        var headers = apiKey == null
+                      ? Map.<String, List<String>>of()
+                      : Map.of("X-API-Key", List.of(apiKey));
+
+        return HttpRequestContext.httpRequestContext(path, method, Map.of(), headers, new byte[0], "mgmt");
+    }
+
+    @SuppressWarnings("JBCT-EX-01")
+    private static String sha256Hex(String value) {
+        try {
+            return HexFormat.of()
+                            .formatHex(MessageDigest.getInstance("SHA-256")
+                                                    .digest(value.getBytes(StandardCharsets.UTF_8)));
+        } catch (Exception e) {
+            throw new AssertionError("SHA-256 not available", e);
+        }
+    }
+
+    private static Serializer stubSerializer() {
+        return new Serializer() {
+            @Override
+            public <T> void write(ByteBuf byteBuf, T object) {}
+        };
+    }
+
+    private static Deserializer stubDeserializer() {
+        return new Deserializer() {
+            @Override
+            public <T> T read(ByteBuf byteBuf) {
+                return null;
+            }
+        };
+    }
+}

--- a/aether/node/src/test/java/org/pragmatica/aether/api/routes/ConfiguredKeyVisibilityTest.java
+++ b/aether/node/src/test/java/org/pragmatica/aether/api/routes/ConfiguredKeyVisibilityTest.java
@@ -1,0 +1,218 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2025 Pragmatica Labs - Sergiy Yevtushenko
+// Licensed under Business Source License 1.1. Change Date: 2030-01-01. Change License: Apache-2.0.
+// See LICENSE in the repository root for full terms.
+package org.pragmatica.aether.api.routes;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import io.netty.buffer.ByteBuf;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.pragmatica.aether.config.ApiKeyEntry;
+import org.pragmatica.aether.node.ManageableNode;
+import org.pragmatica.aether.slice.kvstore.AetherKey;
+import org.pragmatica.aether.slice.kvstore.AetherKey.ApiKeyKey;
+import org.pragmatica.aether.slice.kvstore.AetherValue;
+import org.pragmatica.aether.slice.kvstore.AetherValue.ApiKeyValue;
+import org.pragmatica.cluster.state.kvstore.KVCommand.Put;
+import org.pragmatica.cluster.state.kvstore.KVStore;
+import org.pragmatica.lang.Promise;
+import org.pragmatica.messaging.MessageRouter;
+import org.pragmatica.serialization.Deserializer;
+import org.pragmatica.serialization.Serializer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/// A credential the node ACCEPTS but no operator tool can SEE is the gap this covers.
+///
+/// Keys declared in a node's config file (or `AETHER_API_KEYS`) authenticate against every route —
+/// `KvStoreApiKeyValidator` consults the config validator first — yet `GET /api/v1/cluster/keys`
+/// reported only cluster-held keys, so such a credential was invisible to the tooling an operator
+/// audits with. These tests pin what the endpoint now returns, and, just as importantly, what
+/// revoking one of those records does: it is REFUSED, with a message naming the file as the
+/// authority, because reporting success for a revocation that did not happen would leave an
+/// operator believing a leaked credential was dead.
+class ConfiguredKeyVisibilityTest {
+    private static final String CONFIG_KEY_SECRET = "operator-declared-secret-value";
+    private static final String CONFIG_KEY_NAME = "ops-preprovisioned";
+    private static final String CONFIG_KEY_ID = ApiKeyRoutes.CONFIG_KEY_ID_PREFIX + CONFIG_KEY_NAME;
+    private static final String CLUSTER_KEY_ID = "bootstrap-admin";
+
+    private KVStore<AetherKey, AetherValue> kvStore;
+    private ManageableNode node;
+    private ApiKeyRoutes routes;
+
+    @BeforeEach
+    void setUp() {
+        kvStore = new KVStore<>(MessageRouter.mutable(), stubSerializer(), stubDeserializer());
+        node = mock(ManageableNode.class);
+        when(node.kvStore()).thenReturn(kvStore);
+    }
+
+    /// `ApiKeyRoutes` arms a sweep on the process-wide `SharedScheduler` (#642); without this every
+    /// instance this class builds keeps sweeping through a dead mock.
+    @AfterEach
+    void tearDown() {
+        if (routes != null) {
+            routes.stop();
+        }
+    }
+
+    private ApiKeyRoutes routesWith(Map<String, ApiKeyEntry> configuredKeys) {
+        routes = ApiKeyRoutes.apiKeyRoutes(() -> node, () -> configuredKeys);
+
+        return routes;
+    }
+
+    private static Map<String, ApiKeyEntry> oneConfiguredAdminKey() {
+        return Map.of(CONFIG_KEY_SECRET,
+                      ApiKeyEntry.apiKeyEntry(CONFIG_KEY_NAME, Set.of("service"), "ADMIN"));
+    }
+
+    @Nested
+    class Enumeration {
+        @Test
+        void listKeys_reportsAConfigDeclaredKey_markedWithItsSource() {
+            var listed = await(routesWith(oneConfiguredAdminKey()).handleListKeys());
+
+            assertThat(listed).hasSize(1);
+            assertThat(listed.getFirst().keyId()).isEqualTo(CONFIG_KEY_ID);
+            assertThat(listed.getFirst().source()).isEqualTo(ApiKeyRoutes.SOURCE_CONFIG);
+            assertThat(listed.getFirst().status()).isEqualTo("ACTIVE");
+            assertThat(listed.getFirst().authorizationRole()).isEqualTo("ADMIN");
+        }
+
+        /// Control: cluster-held keys are still listed, and the two sources are distinguishable in
+        /// the same payload. A listing that reported everything as `config` would satisfy the test
+        /// above and break every client.
+        @Test
+        void listKeys_reportsBothSources_distinguishably() {
+            registerClusterKey(CLUSTER_KEY_ID, "ADMIN");
+
+            var listed = await(routesWith(oneConfiguredAdminKey()).handleListKeys());
+
+            assertThat(listed).hasSize(2);
+            assertThat(listed).anyMatch(info -> info.keyId().equals(CLUSTER_KEY_ID)
+                                                && info.source().equals(ApiKeyRoutes.SOURCE_CLUSTER));
+            assertThat(listed).anyMatch(info -> info.keyId().equals(CONFIG_KEY_ID)
+                                                && info.source().equals(ApiKeyRoutes.SOURCE_CONFIG));
+        }
+
+        /// Control: the pre-existing behaviour is untouched when nothing is configured — which is
+        /// what the published image now boots with.
+        @Test
+        void listKeys_reportsOnlyClusterKeys_whenNothingIsConfigured() {
+            registerClusterKey(CLUSTER_KEY_ID, "ADMIN");
+
+            var listed = await(routesWith(Map.of()).handleListKeys());
+
+            assertThat(listed).hasSize(1);
+            assertThat(listed.getFirst().source()).isEqualTo(ApiKeyRoutes.SOURCE_CLUSTER);
+        }
+
+        /// The map key in `AppHttpConfig.apiKeys()` IS the secret. Enumerating credentials must not
+        /// turn an ADMIN endpoint into a credential-disclosure endpoint.
+        @Test
+        void listKeys_neverEchoesTheSecret() {
+            var listed = await(routesWith(oneConfiguredAdminKey()).handleListKeys());
+
+            assertThat(listed.toString()).doesNotContain(CONFIG_KEY_SECRET);
+        }
+    }
+
+    @Nested
+    class Revocation {
+        @Test
+        void revoke_refusesAConfigDeclaredKey_namingTheFileAsAuthority() {
+            routesWith(oneConfiguredAdminKey()).handleRevokeKey(CONFIG_KEY_ID, revokeRequest())
+                                               .await()
+                                               .onSuccess(_ -> fail("revoking a config-declared key reported success"))
+                                               .onFailure(cause -> {
+                                                   assertThat(cause)
+                                                       .isInstanceOf(ApiKeyRoutes.ConfigDeclaredKeyError.class);
+                                                   assertThat(cause.message()).contains("node configuration");
+                                                   assertThat(cause.message()).contains("restart the node");
+                                               });
+        }
+
+        /// Control: revocation of a cluster-held key still succeeds through the same method, so the
+        /// refusal above is specific to config-declared records and not a broken revoke path.
+        @Test
+        void revoke_stillSucceeds_forAClusterHeldKey() {
+            registerClusterKey(CLUSTER_KEY_ID, "ADMIN");
+            when(node.<Object> apply(anyList())).thenReturn(Promise.success(List.of()));
+
+            routesWith(oneConfiguredAdminKey()).handleRevokeKey(CLUSTER_KEY_ID, revokeRequest())
+                                               .await()
+                                               .onFailure(cause -> fail("cluster key revocation was refused: "
+                                                                        + cause.message()))
+                                               .onSuccess(response -> assertThat(response.toString())
+                                                   .contains(CLUSTER_KEY_ID));
+        }
+
+        /// Control: an id that matches nothing still reports NOT FOUND. The config refusal must not
+        /// have swallowed that path — the two mean different things to an operator.
+        @Test
+        void revoke_stillReportsNotFound_forAnUnknownKey() {
+            routesWith(oneConfiguredAdminKey()).handleRevokeKey("no-such-key", revokeRequest())
+                                               .await()
+                                               .onSuccess(_ -> fail("unknown key reported success"))
+                                               .onFailure(cause -> assertThat(cause)
+                                                   .isInstanceOf(ApiKeyRoutes.KeyNotFoundError.class));
+        }
+
+        /// A `config:`-prefixed id that no configured key actually backs is NOT a config key. Without
+        /// this, the prefix alone would let a caller mask any missing key behind the config refusal.
+        @Test
+        void revoke_reportsNotFound_forAConfigPrefixedIdThatIsNotDeclared() {
+            routesWith(Map.of()).handleRevokeKey(ApiKeyRoutes.CONFIG_KEY_ID_PREFIX + "never-declared",
+                                                 revokeRequest())
+                                .await()
+                                .onSuccess(_ -> fail("undeclared config-prefixed id reported success"))
+                                .onFailure(cause -> assertThat(cause)
+                                    .isInstanceOf(ApiKeyRoutes.KeyNotFoundError.class));
+        }
+    }
+
+    private static ApiKeyRoutes.RevokeKeyRequest revokeRequest() {
+        return new ApiKeyRoutes.RevokeKeyRequest(true, 0L, "test");
+    }
+
+    private static <T> T await(Promise<T> promise) {
+        return promise.await()
+                      .onFailure(cause -> fail("listing failed: " + cause.message()))
+                      .unwrap();
+    }
+
+    private void registerClusterKey(String keyId, String role) {
+        AetherKey key = ApiKeyKey.apiKeyKey(keyId);
+        AetherValue value = ApiKeyValue.apiKeyValue(keyId, "hash-of-" + keyId, 0L, role);
+
+        kvStore.process(kvStore.createBatch(List.of(new Put<>(key, value))));
+    }
+
+    private static Serializer stubSerializer() {
+        return new Serializer() {
+            @Override
+            public <T> void write(ByteBuf byteBuf, T object) {}
+        };
+    }
+
+    private static Deserializer stubDeserializer() {
+        return new Deserializer() {
+            @Override
+            public <T> T read(ByteBuf byteBuf) {
+                return null;
+            }
+        };
+    }
+}

--- a/aether/tests/integration/docker-compose.yml
+++ b/aether/tests/integration/docker-compose.yml
@@ -27,6 +27,17 @@ x-node-common: &node-common
     JAVA_OPTS: "-Xmx512m -XX:+UseZGC -Djava.net.preferIPv4Stack=true"
     AETHER_CLUSTER_SECRET: "aether-integration-test-cluster-secret"
     AETHER_CLUSTER_NAME: "it"
+    # The suite's OWN ADMIN credential, supplied here rather than baked into the image.
+    # `ConfigLoader.resolveApiKeys` reads AETHER_API_KEYS (plural — the keys the node
+    # ACCEPTS) ahead of any TOML, so this needs no second config file and no
+    # `--build-arg CONFIG_PATH`: the published image stays fail-closed and the suite
+    # still authenticates. Format is `<key>:<name>:<roles>:<ROLE>`, `;`-separated.
+    # ADMIN because formation POSTs hit /api/v1/cluster/config, /api/v1/cluster/keys and
+    # /api/v1/cluster/await-quiesced, all default-gated to ADMIN by RoutePermissionRegistry's
+    # catch-all for non-OPERATOR-listed mutations; the simple `api_keys` list form maps to
+    # VIEWER (`ApiKeyEntry.DEFAULT_ROLE`) and 403s on every one of them.
+    # Value tracks lib/common.sh's API_KEY default.
+    AETHER_API_KEYS: "${AETHER_API_KEY:-aether-integration-test-key}:integration-test:service:ADMIN"
   healthcheck:
     test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:8080/health/live"]
     interval: 10s

--- a/changelog.d/1016-config-key-visibility.md
+++ b/changelog.d/1016-config-key-visibility.md
@@ -1,0 +1,28 @@
+### Changed (2026-09-11 — #1016: keys declared in node configuration were invisible to operator tooling)
+
+- **`GET /api/v1/cluster/keys` listed cluster-held keys only.** A key declared in a node's
+  `[app-http.api-keys.<key>]` table or in `AETHER_API_KEYS` authenticated against every route —
+  `KvStoreApiKeyValidator` consults the config validator first — while being absent from the listing
+  an operator audits credentials with. A credential that cannot be seen cannot be reasoned about
+  during an incident.
+- **The listing now reports every credential the node accepts**, each record carrying a `source`
+  field of `cluster` or `config`. A config record uses a synthetic `config:<declared name>` id and
+  never the key value; its timestamps are `-1` because a file declaration has no creation, expiry or
+  revocation event.
+  [verified: `aether/node/src/test/java/org/pragmatica/aether/api/routes/ConfiguredKeyVisibilityTest.java`]
+- **`aether cluster rotate-key` filters candidates on `source`.** Without it the new records would
+  have broken rotation outright: the command refuses to act on an ambiguous ACTIVE set, so any
+  deployment pre-provisioning a single config key would have presented two ACTIVE records and
+  rotation would have stopped working. A record with no `source` reads as `cluster`, so behaviour
+  against a node predating the field is unchanged.
+- **Revoking a config-declared key is refused, with a message naming the file as its authority.**
+  Revocation commits a REVOKED record through consensus, which is meaningful only where the cluster
+  key store is the key's authority. For a file-declared key the file is, the node cannot rewrite an
+  operator's file, and the config validator is consulted before the store — so a tombstone would sit
+  unread while the key kept authenticating. Reporting success would tell an operator a live
+  credential was dead. The documented route is to remove the declaration and restart the node.
+- **Making such keys genuinely revocable needs a design ruling, deliberately not taken here.**
+  Consulting a KV tombstone before accepting a config key leaves a bypass window on every restart,
+  because an empty KV during replay is indistinguishable from "nothing revoked". Gating config keys
+  on `ManageableNode#isReady()` closes that window but stops them authenticating before the node is
+  ACTIVE, which is when cluster formation uses them.

--- a/changelog.d/1016-image-default-credential.md
+++ b/changelog.d/1016-image-default-credential.md
@@ -1,0 +1,36 @@
+### Security (2026-09-11 — #1016: the published node image carried a built-in administrative credential)
+
+- **`aether/docker/aether-node/aether.toml` declared an `[app-http.api-keys.*]` table with
+  `authorization_role = "ADMIN"`.** `docker/aether-node/Dockerfile` copies that file to
+  `/app/aether.toml` through its `ARG CONFIG_PATH` default, and the release workflow builds that
+  Dockerfile with no override, so the value shipped inside the published image as its only
+  out-of-the-box ADMIN credential — the same one on every install. Docker-compose, Forge and
+  direct-image deployments were affected; cloud bootstrap was not, because it composes its own
+  runtime TOML via `BootstrapOverlayGenerator`.
+- **The shipped configuration now declares no key, and the node is fail-closed by default.**
+  `ConfigLoader` leaves `security_mode` at its `API_KEY` default (#290), `AetherNode` installs the
+  config validator over an empty key map, and `KvStoreApiKeyValidator` falls through to
+  cluster-held keys — so every non-public management route is refused until a credential exists.
+  Public routes still answer, which is what the container health check probes.
+  [verified: `aether/node/src/test/java/org/pragmatica/aether/api/PublishedImageConfigFailsClosedTest.java`]
+- **The test loads the file the image actually ships**, through the real `ConfigLoader`, and drives
+  the validator wiring `AetherNode` installs, so re-adding a key to that file reddens it. It carries
+  its own controls: that the parse reached the real file, that the Dockerfile copies that file, that
+  the route resolves to an ADMIN permission, and that a cluster bootstrap admin key still
+  authenticates through the same pipeline.
+- **Operators get a credential from one of two places, neither baked into an image.** The cluster
+  bootstrap admin key is derived from the cluster secret at formation (#980), printed once, and — 
+  unlike a file-declared key — is enumerable, revocable and audited. `AETHER_API_KEYS` pre-provisions
+  one where that is preferred; `ConfigLoader.resolveApiKeys` reads it ahead of any TOML, which is how
+  the integration suite supplies its own without a second config file to drift.
+  [mechanism: `ConfigLoader.resolveApiKeys`, `BootstrapAdminKeyLeg`]
+- **A node with security enabled and no declared key now says so at startup.** The existing warning
+  covered only `security_mode = "none"`; security ON with an empty key set had no voice at all, and
+  that is the shape the published image now boots with. A default applied when nothing was configured
+  has to be loud, or it becomes the fail-open nobody notices.
+- **`AETHER_API_KEYS` is now propagated by `ClusterIdentityEnv.IDENTITY_VARS`.** Only the singular
+  `AETHER_API_KEY` — the client credential the CLI sends — was on the allow-list; the plural form is
+  the server-side key set the node accepts. The omission was invisible **only because the image baked
+  a matching key**, so a CTM-minted or auto-healed node inherited none and did not need one. Removing
+  the baked credential makes it load-bearing: this fix exposes a pre-existing gap rather than
+  introducing one. [mechanism: `DockerComputeProvider` iterates `IDENTITY_VARS`]


### PR DESCRIPTION
## What this changes

**The published `ghcr.io/pragmaticalabs/aether-node` image no longer carries a built-in administrative credential, and the cluster-keys API now reports every credential a node accepts.**

`aether/docker/aether-node/aether.toml` declared an `[app-http.api-keys.*]` table with `authorization_role = "ADMIN"`. `docker/aether-node/Dockerfile` copies that file to `/app/aether.toml` via its `ARG CONFIG_PATH` default, and `.github/workflows/release.yml` builds that Dockerfile with no `CONFIG_PATH` override — so the value shipped in the image as its only out-of-the-box ADMIN credential, identical on every install. Cloud bootstrap is unaffected: it composes its own runtime TOML via `BootstrapOverlayGenerator`.

The node is now fail-closed by default. `ConfigLoader` leaves `security_mode` at its `API_KEY` default (#290), `AetherNode` installs the config validator over an empty key map, and `KvStoreApiKeyValidator` falls through to cluster-held keys. Operators get a credential from the bootstrap admin key derived from the cluster secret at formation (#980) — which, unlike a file-declared key, is enumerable, revocable and audited — or by pre-provisioning `AETHER_API_KEYS`.

## Not the `CONFIG_PATH` seam

`ConfigLoader.resolveApiKeys` reads `AETHER_API_KEYS` ahead of any TOML, so the integration suite supplies its own ADMIN credential from an environment variable in `aether/tests/integration/docker-compose.yml`. No second config file exists to drift against the shipped one.

## A latent defect this EXPOSES rather than causes

`ClusterIdentityEnv.IDENTITY_VARS` propagated `AETHER_API_KEY` (singular — the **client** credential the CLI sends) but not `AETHER_API_KEYS` (plural — the **server-side** key set `ConfigLoader` reads). That omission was harmless *only because the image baked a matching server-side key*: a CTM-minted or auto-healed node inherited no key set and did not need one. With the baked credential gone it becomes load-bearing, so `AETHER_API_KEYS` is added to the allow-list. This is that file's own documented "replacements miss what seeds get" class, arriving one variable over — it predates this branch.

## Please review closely: the `rotate-key` filter

`GET /api/v1/cluster/keys` now also lists config-declared keys, with a `source` field (`cluster` | `config`), a synthetic `config:<name>` id, and never the key value. That change would otherwise **break `aether cluster rotate-key`**: it refuses to act on an ambiguous ACTIVE set, so any deployment pre-provisioning one config key would see two ACTIVE records and rotation would stop working. `ClusterRotateKeyCommand` now filters candidates on `source`; a record with no `source` reads as `cluster`, so behaviour against older nodes is unchanged.

## Revocation of file-declared keys is REFUSED, deliberately

`POST /api/v1/cluster/keys/revoke/{id}` refuses a `config` record with a message naming the file as its authority. Revocation commits a REVOKED record through consensus, which works because the cluster store is a cluster key's authority. For a file-declared key the file is the authority, the node cannot rewrite an operator's file, and the config validator is consulted first and returns on success — so a tombstone would sit unread while the key kept authenticating. Reporting success there would tell an operator a live credential was dead.

Making it genuinely revocable needs a design ruling this PR does not take. Consulting a KV tombstone before accepting a config key leaves a bypass window on every restart, because an empty KV during replay is indistinguishable from "nothing revoked". Gating config keys on `ManageableNode#isReady()` closes that window but stops them authenticating before the node is ACTIVE — which is when cluster formation uses them.

## Why revocation of a file-declared key is refused rather than implemented

A promote-at-ACTIVE design was implemented and then **withdrawn after measurement on a live 3-node
cluster**. It is recorded here because it is the evidence that the refusal above is correct rather
than merely cautious:

- **Rolling restart (quorum never lost):** revoke the promoted key, all three nodes refuse it (403),
  restart one node — that node re-promotes and serves the revoked key (**HTTP 200**) while its peers
  still refuse (**403**). A revoked credential works or not depending on which node you reach.
- **Cold restart:** the registry does not survive (no persistent volume). A cluster-minted control
  key created through the API came back **403 and absent from the listing** — gone, failing closed.
  The config-declared key came back **200**, re-seeded from the file — failing open. The design
  converts a fail-closed loss into a fail-open resurrection.
- The premise it rested on — "promotion happens at ACTIVE, after replay, so the read is unambiguous
  by construction" — is false: reaching ACTIVE does not guarantee the node's KV state is populated
  from peers, so the replay ambiguity reappears one layer down. No readiness signal exists that would
  make it sound (`lastApplied`, `appliedIndex`, `snapshotRestored`, `stateLoaded`, `isSynced` — only
  `KVStore.restoreSnapshot`, with no exposed flag).

The refusal keeps **one complete authority** (the file — "edit it and restart" revokes totally)
instead of two partial ones (a file that no longer revokes, plus a registry revocation that does not
survive a cold restart).

## Verification

Re-run in full after rebasing onto rc4 tip `e3beb0f1d` — prior evidence described a tree that no
longer exists.

- Full root build from the root, no `-pl`, no `-DskipTests`: **BUILD SUCCESS**, **145 modules**
  (counted padding-independently and cross-checked against the `[N/145]` marker), 0 failures,
  0 errors, **13,753 `<testcase>` elements** across surefire + failsafe (attribute sum 11,368 — the
  expected `@Nested` undercount), counted against a run-marker.
- `jbct:check -Djbct.skip=false`, one module per invocation: `aether/node` **152 files**,
  `aether/cli` **106 files**, `aether/environment-integration` **53 files** — 0 format issues,
  0 lint errors each.
- **Measured on a live 3-node cluster** built from this Dockerfile (isolated names, ports and
  network): inside the built image, **0** occurrences of the formerly-baked key and **0** key
  declarations outside comments; on an ADMIN route, the `AETHER_API_KEYS`-supplied credential
  **200**, no credential **401**, the formerly-baked key **403**. The fail-closed property of the
  published image is measured, not inferred.
- **Mutation probe, pre-registered before running.** Restoring the baked credential reddens exactly `formerlyBakedKey_isRefused_onAnAdminRoute`, `formerlyBakedKey_isRefused_onAReadRouteToo`, `shippedConfig_declaresNoApiKeyAtAll` and `shippedConfigFile_declaresNoApiKeyOutsideComments`; all 6 `Controls` and the other 2 `ShippedImageDefault` tests stay green. The first fails with *"the published image still honours a built-in credential, as ADMIN"*, which is what proves the assertion reaches the privileged path rather than passing vacuously.
- The fail-closed test loads the **actual shipped file** through the real `ConfigLoader` and carries controls for non-vacuity (the parse really reached that file), for Dockerfile linkage (the image really copies it), for role gating, and for reachable success.

Note for anyone running the integration suite locally: `aether/tests/integration/docker-compose.yml`
publishes postgres on **5432**, which collides with a long-running `ticketing-postgres` on this
machine. The cluster itself does not need that host publish — nodes reach postgres over the compose
network — so overriding or dropping it is safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
