### PR TITLE
fix: #1012 snapshot prune no longer deletes the file LATEST names

### DIFF
--- a/aether/node/src/main/java/org/pragmatica/aether/node/StorageFactory.java
+++ b/aether/node/src/main/java/org/pragmatica/aether/node/StorageFactory.java
@@ -768,6 +768,12 @@ public final class StorageFactory {
     private static void applySnapshot(String name, MetadataSnapshot snapshot, MetadataStore metadataStore) {
         metadataStore.restoreLifecycles(snapshot.lifecycles());
         metadataStore.restoreRefs(snapshot.refs());
+        // #1012: the restored epoch has to reach the store, not just the log line below. The two
+        // calls above only INCREMENT a store that starts at zero, so without this the epoch
+        // restarted near zero on every boot and `DefaultSnapshotManager` wrote the next snapshot
+        // under a file name lower than every retained predecessor. Applied last, because both
+        // restore calls bump the epoch themselves.
+        metadataStore.restoreEpoch(snapshot.epoch());
         log.info("Restored snapshot for '{}': epoch={}, lifecycles={}, refs={}",
                  name,
                  snapshot.epoch(),

--- a/aether/node/src/test/java/org/pragmatica/aether/node/StorageFactorySnapshotEpochTest.java
+++ b/aether/node/src/test/java/org/pragmatica/aether/node/StorageFactorySnapshotEpochTest.java
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2025 Pragmatica Labs - Sergiy Yevtushenko
+// Licensed under Business Source License 1.1. Change Date: 2030-01-01. Change License: Apache-2.0.
+// See LICENSE in the repository root for full terms.
+package org.pragmatica.aether.node;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.pragmatica.aether.config.StorageConfig;
+import org.pragmatica.lang.Option;
+import org.pragmatica.storage.BlockId;
+import org.pragmatica.storage.BlockLifecycle;
+import org.pragmatica.storage.TierLevel;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/// #1012: `StorageFactory.applySnapshot` reads the restored snapshot's epoch and used it for a log
+/// line only -- `restoreLifecycles`/`restoreRefs` merely INCREMENT a store that starts at zero, so
+/// the mutation epoch restarted near zero on every boot. Since `DefaultSnapshotManager` derives the
+/// snapshot file name from that epoch, the next snapshot was written UNDER every retained
+/// predecessor and became the prune's first victim -- while `LATEST` had just been pointed at it.
+///
+/// Everything here is behavioural and goes through the real `createAll` boot path, which is the only
+/// reachable caller of the private `applySnapshot`. The restart is a second `createAll` over the same
+/// snapshot directory: a fresh `MetadataStore` that can only learn the epoch from disk.
+class StorageFactorySnapshotEpochTest {
+
+    private static final String INSTANCE = "epoch-vault";
+    private static final String NODE_ID = "node-1012";
+    private static final long MEMORY_MAX_BYTES = 8L * 1024 * 1024;
+    private static final long DISK_MAX_BYTES = 64L * 1024 * 1024;
+    private static final int MUTATIONS_BEFORE_RESTART = 6;
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void createAll_afterRestart_continuesSnapshotEpochFromDisk() {
+        var firstBoot = bootInstance();
+
+        for (var i = 0; i < MUTATIONS_BEFORE_RESTART; i++) {
+            firstBoot.metadataStore().createLifecycle(lifecycleOf("pre-restart-" + i));
+        }
+
+        firstBoot.snapshotManager().forceSnapshot();
+
+        var epochOnDisk = firstBoot.snapshotManager().lastSnapshotEpoch();
+
+        // Fixture control: a snapshot that never reached disk leaves this at zero, so the two
+        // assertions below would compare against nothing and pass vacuously.
+        assertThat(epochOnDisk).isEqualTo(MUTATIONS_BEFORE_RESTART);
+
+        var secondBoot = bootInstance();
+
+        assertThat(secondBoot.metadataStore().currentEpoch()).isGreaterThanOrEqualTo(epochOnDisk);
+
+        secondBoot.metadataStore().createLifecycle(lifecycleOf("post-restart"));
+        secondBoot.snapshotManager().forceSnapshot();
+
+        assertThat(secondBoot.snapshotManager().lastSnapshotEpoch()).isGreaterThan(epochOnDisk);
+    }
+
+    private StorageFactory.StorageSetup bootInstance() {
+        var setups = StorageFactory.createAll(Map.of(INSTANCE, instanceConfig()), NODE_ID, Option.none(), Option.none())
+                                   .onFailure(cause -> fail("createAll must succeed: " + cause.message()))
+                                   .unwrap();
+
+        assertThat(setups).containsKey(INSTANCE);
+
+        return setups.get(INSTANCE);
+    }
+
+    private StorageConfig instanceConfig() {
+        return StorageConfig.storageConfig(MEMORY_MAX_BYTES,
+                                           DISK_MAX_BYTES,
+                                           tempDir.resolve("disk").toString(),
+                                           tempDir.resolve("snapshots").toString(),
+                                           1000,
+                                           "60s",
+                                           5,
+                                           "",
+                                           false);
+    }
+
+    private static BlockLifecycle lifecycleOf(String tag) {
+        return BlockLifecycle.blockLifecycle(BlockId.blockId(tag.getBytes(StandardCharsets.UTF_8)).unwrap(), TierLevel.MEMORY);
+    }
+}

--- a/changelog.d/1012-snapshot-prune-deletes-latest.md
+++ b/changelog.d/1012-snapshot-prune-deletes-latest.md
@@ -1,0 +1,53 @@
+### Fixed (2026-09-11 — #1012: metadata snapshot pruning deleted the file `LATEST` had just been pointed at)
+
+- **Two defects in `integrations/storage` combined into self-perpetuating durable-state corruption.**
+  `InMemoryMetadataStore`'s mutation epoch starts at zero and `restoreLifecycles`/`restoreRefs` only
+  *increment* it, while `StorageFactory.applySnapshot` read the restored snapshot's own epoch and
+  used it for a log line only — so the epoch restarted near zero on every boot. `DefaultSnapshotManager`
+  derives the snapshot file name from that epoch (`snapshot-%06d.dat`), points `LATEST` at the new
+  file, and then prunes. From the second boot onward the freshly written low-epoch file sorted lowest
+  and **the prune deleted the target `LATEST` named moments earlier**, leaving a dangling pointer that
+  no later boot could restore from — which produced another low-epoch snapshot, and so on.
+- **Pruning can no longer delete the live pointer's target.** `DefaultSnapshotManager.prunableVictims`
+  subtracts whatever `LATEST` currently names from the over-retention prefix, wherever that file's
+  epoch sorts. An unreadable `LATEST` yields the unfiltered prefix: with no live pointer there is
+  nothing to protect and refusing to prune would let the directory grow without bound. Retention is
+  unchanged in the ordinary case, where `LATEST` names the newest file and is never in the prefix;
+  in the anomalous case the directory holds one file above `retentionCount` for that round rather
+  than breaking the pointer.
+- **Prune candidates are ordered by the epoch the file name *encodes*, not by the name.** The old
+  `Comparator.comparing(fileName)` agreed with numeric order only while the epoch stayed below
+  1_000_000; past that boundary `snapshot-1000000.dat` sorts ahead of `snapshot-999999.dat` and the
+  newest snapshots would have been deleted first. A name carrying no parsable epoch sorts oldest, so
+  foreign files are pruned ahead of real snapshots — and are still protected while `LATEST` names one.
+- **The restored epoch now reaches the metadata store.** `MetadataStore` gains
+  `restoreEpoch(long)` alongside `restoreLifecycles`/`restoreRefs`; `applySnapshot` calls it last,
+  after the two restore calls that bump the epoch themselves. `InMemoryMetadataStore` raises the epoch
+  and **never lowers it** (`epoch.updateAndGet(current -> Math.max(current, snapshotEpoch))`): the epoch is a monotonic mutation counter and
+  the snapshot file-name sequence at once, so restoring an older snapshot over a store that has moved
+  on must not hand out names the store has already retired.
+- **Why this mattered beyond one lost file.** A controlled three-arm experiment on a quiet host
+  (CLEAN / STALE / REPAIRED, interleaved, arms differing by exactly five `LATEST` pointer files over
+  byte-identical WALs) measured the backpressure burst at ~59k events per run with the pointers broken
+  versus ~6.1k with them repaired — 9.66×, non-overlapping ranges, 99.93% of the traffic on the DHT
+  lane. That burst is what exhausts Forge's 60 s start budget in #718. [reported mechanism, not
+  verified by this change: a dangling `LATEST` leaves `SegmentIndex.rebuildFromRefs` empty and
+  `lastSealedOffset` at −1, so the WAL replays from offset 0 — past the `maxCount` floor each record
+  evicts one, producing one-event seals, a `putRef` per seal and a `WRITE_THROUGH` to the DHT tier.
+  The tests below pin the pointer's survival, not this downstream chain.]
+- **Pinned by four tests, each reddening a distinct named set under a single-hunk revert**:
+  `SnapshotManagerTest.forceSnapshot_afterEpochReset_keepsLatestTargetOnDisk` (writes a high-epoch
+  snapshot set, simulates a restart that resets the epoch, writes again, and asserts the target
+  `LATEST` names still exists and still restores) pins the guard;
+  `forceSnapshot_prunesByEpochOrder_notByFileName` pins the ordering across the six/seven-digit
+  boundary and deliberately asserts nothing about `LATEST`, so it cannot redden for the guard;
+  `restoreEpoch_raisesEpochToSnapshotValue` and `restoreEpoch_neverLowersEpoch` pin the store
+  contract. `StorageFactorySnapshotEpochTest.createAll_afterRestart_continuesSnapshotEpochFromDisk`
+  pins the wiring through the real `createAll` boot path — the only reachable caller of the private
+  `applySnapshot` — and carries a fixture control (`epochOnDisk == 6`) so a snapshot that never
+  reached disk cannot make it pass vacuously.
+- **#1013 was considered and deliberately not bundled** — see the PR discussion. An honest fix needs
+  `SnapshotManager.restoreFromLatest()` to change from `Option<MetadataSnapshot>` to
+  `Result<Option<MetadataSnapshot>>` so a legitimate first boot is distinguishable from a failed
+  restore; that is a public-API change in `integrations/storage`, not a one-liner, and the failure it
+  would surface is already logged at WARN by `DefaultSnapshotManager.readAndValidateSnapshot`.

--- a/integrations/storage/src/main/java/org/pragmatica/storage/DefaultSnapshotManager.java
+++ b/integrations/storage/src/main/java/org/pragmatica/storage/DefaultSnapshotManager.java
@@ -17,6 +17,7 @@ import org.pragmatica.lang.Contract;
 import org.pragmatica.lang.Option;
 import org.pragmatica.lang.Result;
 import org.pragmatica.lang.Unit;
+import org.pragmatica.lang.parse.Number;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -175,10 +176,34 @@ final class DefaultSnapshotManager implements SnapshotManager {
             return Result.unitResult();
         }
 
-        return Result.allOf(snapshots.subList(0,
-                                              snapshots.size() - config.retentionCount())
-                                     .stream()
-                                     .map(DefaultSnapshotManager::deleteSnapshotFile)).mapToUnit();
+        return Result.allOf(prunableVictims(snapshots).stream().map(DefaultSnapshotManager::deleteSnapshotFile)).mapToUnit();
+    }
+
+    /// #1012: the oldest files beyond the retention count, MINUS whatever `LATEST` currently names.
+    /// The live pointer's target is off limits wherever its epoch sorts. A restart resets the
+    /// metadata epoch, so a freshly written snapshot can carry a LOWER epoch than every retained
+    /// predecessor and land in this very prefix; deleting it leaves `LATEST` dangling, which no
+    /// later boot can restore from -- self-perpetuating durable-state corruption rather than the
+    /// loss of one file. Retention is unaffected in the ordinary case, where `LATEST` names the
+    /// newest file and is therefore never inside the prefix. An unreadable `LATEST` yields the
+    /// unfiltered prefix: with no live pointer there is nothing to protect, and refusing to prune
+    /// would let the directory grow without bound. [#readLatestSnapshotPath] logs that absence.
+    private List<Path> prunableVictims(List<Path> snapshots) {
+        var victims = snapshots.subList(0,
+                                        snapshots.size() - config.retentionCount());
+
+        return readLatestSnapshotPath().map(latest -> excludingLatest(victims, latest))
+                                     .or(victims);
+    }
+
+    /// Compared by file name rather than by whole path: both sides are resolved against
+    /// [SnapshotConfig#snapshotPath], so the names identify the same file exactly, without depending
+    /// on how the directory listing spelled its entries.
+    private static List<Path> excludingLatest(List<Path> victims, Path latest) {
+        return victims.stream()
+                      .filter(path -> !path.getFileName()
+                                           .equals(latest.getFileName()))
+                      .toList();
     }
 
     private static Result<Boolean> deleteSnapshotFile(Path file) {
@@ -190,12 +215,27 @@ final class DefaultSnapshotManager implements SnapshotManager {
                    .map(DefaultSnapshotManager::sortedSnapshotFiles);
     }
 
+    /// #1012: order by the epoch the name ENCODES, never by the name itself. [#snapshotFileName]
+    /// zero-pads to six digits, so lexicographic order agrees with numeric order only while the
+    /// epoch stays below 1_000_000; past that boundary `snapshot-1000000.dat` sorts BEFORE
+    /// `snapshot-999999.dat` and pruning starts deleting the newest snapshots first.
     private static List<Path> sortedSnapshotFiles(List<Path> entries) {
         return entries.stream()
                       .filter(DefaultSnapshotManager::isSnapshotFile)
-                      .sorted(Comparator.comparing(p -> p.getFileName()
-                                                         .toString()))
+                      .sorted(Comparator.comparingLong(DefaultSnapshotManager::snapshotEpochOf))
                       .toList();
+    }
+
+    /// The epoch encoded between [#SNAPSHOT_PREFIX] and [#SNAPSHOT_SUFFIX]. A name carrying no
+    /// parsable epoch sorts oldest, so foreign files in the snapshot directory are pruned ahead of
+    /// any real snapshot -- and are still never deleted while `LATEST` names one, because
+    /// [#prunableVictims] excludes the live target regardless of where it sorts.
+    private static long snapshotEpochOf(Path path) {
+        var name = path.getFileName().toString();
+        var digits = name.substring(SNAPSHOT_PREFIX.length(),
+                                    name.length() - SNAPSHOT_SUFFIX.length());
+
+        return Number.parseLong(digits).or(Long.MIN_VALUE);
     }
 
     private static boolean isSnapshotFile(Path path) {

--- a/integrations/storage/src/main/java/org/pragmatica/storage/InMemoryMetadataStore.java
+++ b/integrations/storage/src/main/java/org/pragmatica/storage/InMemoryMetadataStore.java
@@ -157,4 +157,10 @@ final class InMemoryMetadataStore implements MetadataStore {
         refs.putAll(newRefs);
         epoch.incrementAndGet();
     }
+
+    @Override
+    @Contract
+    public void restoreEpoch(long snapshotEpoch) {
+        epoch.updateAndGet(current -> Math.max(current, snapshotEpoch));
+    }
 }

--- a/integrations/storage/src/main/java/org/pragmatica/storage/MetadataStore.java
+++ b/integrations/storage/src/main/java/org/pragmatica/storage/MetadataStore.java
@@ -71,4 +71,11 @@ public interface MetadataStore {
     /// Restore named references from a snapshot (bulk load).
     @Contract
     void restoreRefs(Map<String, BlockId> refs);
+
+    /// Restore the mutation epoch from a snapshot (bulk load), so a restarted store continues the
+    /// pre-restart sequence instead of counting up from zero (#1012). Raises the epoch to the
+    /// snapshot's value and NEVER lowers it: the epoch also names snapshot files, and a store that
+    /// has already moved past the snapshot must not be rewound into reusing names it has retired.
+    @Contract
+    void restoreEpoch(long epoch);
 }

--- a/integrations/storage/src/test/java/org/pragmatica/storage/DefaultStorageInstanceReplaceRefOrderingTest.java
+++ b/integrations/storage/src/test/java/org/pragmatica/storage/DefaultStorageInstanceReplaceRefOrderingTest.java
@@ -178,5 +178,11 @@ class DefaultStorageInstanceReplaceRefOrderingTest {
         public void restoreRefs(Map<String, BlockId> refs) {
             delegate.restoreRefs(refs);
         }
+
+        @Override
+        @Contract
+        public void restoreEpoch(long epoch) {
+            delegate.restoreEpoch(epoch);
+        }
     }
 }

--- a/integrations/storage/src/test/java/org/pragmatica/storage/SnapshotManagerTest.java
+++ b/integrations/storage/src/test/java/org/pragmatica/storage/SnapshotManagerTest.java
@@ -167,6 +167,29 @@ class SnapshotManagerTest {
             assertThat(allRefs).containsEntry("ref-beta", idB);
         }
 
+        /// #1012: a restored snapshot carries the epoch its file name was derived from. Dropping it
+        /// restarts the sequence near zero on every boot, so the next snapshot is written under
+        /// every retained predecessor and becomes the prune's first victim.
+        @Test
+        void restoreEpoch_raisesEpochToSnapshotValue() {
+            store.restoreEpoch(4_200L);
+
+            assertThat(store.currentEpoch()).isEqualTo(4_200L);
+        }
+
+        /// The epoch is a monotonic mutation counter and the snapshot file-name sequence at once, so
+        /// restoring an older snapshot over a store that has already moved on must not rewind it --
+        /// that would hand out file names the store has already retired.
+        @Test
+        void restoreEpoch_neverLowersEpoch() {
+            var id = blockIdOf(CONTENT_A);
+
+            store.createLifecycle(BlockLifecycle.blockLifecycle(id, TierLevel.MEMORY));
+            store.restoreEpoch(0L);
+
+            assertThat(store.currentEpoch()).isEqualTo(1L);
+        }
+
         @Test
         void restoreRefs_replacesExistingMappings() {
             var idA = blockIdOf(CONTENT_A);
@@ -354,6 +377,69 @@ class SnapshotManagerTest {
             freshStore.restoreLifecycles(snap.lifecycles());
 
             assertThat(freshStore.getLifecycle(idA).unwrap().orphanedAt()).isEqualTo(expectedOrphanedAt);
+        }
+
+        /// #1012 reproducer. A restart resets the in-memory metadata epoch to zero, so the first
+        /// snapshot written after the restart carries a LOWER sequence number than every retained
+        /// predecessor. Pruning picks the oldest files by that sequence number -- which is now the
+        /// file `LATEST` was pointed at moments earlier -- and deletes it. The pointer is left
+        /// dangling, so every later boot restores nothing and keeps writing low-sequence snapshots:
+        /// the corruption sustains itself rather than costing one file.
+        @Test
+        void forceSnapshot_afterEpochReset_keepsLatestTargetOnDisk() throws IOException {
+            var config = snapshotConfig(tempDir, 1, 600_000, 2, NODE_ID);
+            var beforeRestart = snapshotManager(store, config);
+
+            for (var i = 0; i < 3; i++) {
+                var content = ("pre-restart-" + i).getBytes(StandardCharsets.UTF_8);
+
+                store.createLifecycle(BlockLifecycle.blockLifecycle(blockIdOf(content), TierLevel.MEMORY));
+                beforeRestart.forceSnapshot();
+            }
+
+            var restartedStore = inMemoryMetadataStore("after-restart");
+            var afterRestart = snapshotManager(restartedStore, config);
+
+            restartedStore.createLifecycle(BlockLifecycle.blockLifecycle(blockIdOf(CONTENT_A), TierLevel.MEMORY));
+            afterRestart.forceSnapshot();
+
+            assertThat(latestTarget(tempDir)).exists();
+            assertThat(afterRestart.restoreFromLatest().isPresent()).isTrue();
+        }
+
+        /// #1012: prune order must come from the epoch the file name ENCODES, not from the name
+        /// itself. `snapshot-%06d.dat` zero-pads to six digits, so lexicographic order agrees with
+        /// numeric order only below epoch 1_000_000; above it `snapshot-1000000.dat` sorts ahead of
+        /// `snapshot-999999.dat` and the NEWEST retained snapshot becomes the first prune victim.
+        /// The LATEST-target guard cannot catch this one -- the mis-ordered file is not the file the
+        /// pointer names -- so this pins the ordering independently of that guard.
+        @Test
+        void forceSnapshot_prunesByEpochOrder_notByFileName() throws IOException {
+            var config = snapshotConfig(tempDir, 1, 600_000, 1, NODE_ID);
+            var older = tempDir.resolve("snapshot-999999.dat");
+            var newer = tempDir.resolve("snapshot-1000000.dat");
+
+            Files.writeString(older, "stale snapshot body");
+            Files.writeString(newer, "stale snapshot body");
+
+            var manager = snapshotManager(store, config);
+
+            store.createLifecycle(BlockLifecycle.blockLifecycle(blockIdOf(CONTENT_A), TierLevel.MEMORY));
+            manager.forceSnapshot();
+
+            // Deliberately says nothing about the LATEST target: that is
+            // forceSnapshot_afterEpochReset_keepsLatestTargetOnDisk's claim, and asserting it here
+            // too would make this test redden for the guard as well as for the ordering, so neither
+            // test could pin its own hunk.
+            assertThat(newer).exists();
+            assertThat(older).doesNotExist();
+        }
+
+        /// Resolves whatever `LATEST` currently names against the snapshot directory, WITHOUT
+        /// asserting the target exists -- a dangling pointer is exactly what the tests above are
+        /// looking for, so the resolution must survive it and let the assertion do the judging.
+        private static Path latestTarget(Path dir) throws IOException {
+            return dir.resolve(Files.readString(dir.resolve("LATEST")).trim());
         }
 
         private long snapshotFileCount(Path dir) throws IOException {


### PR DESCRIPTION
Fixes #1012.

> **Rebased 2026-09-11 onto `e3beb0f1d`** (the new `release-1.0.0-rc4` tip, after #1011/#1009/#1010).
> Clean rebase, no conflicts — none of the eight files this branch touches appears in the
> base-to-base diff. The rebase carried the change **byte-for-byte**: `git diff 7fa26e2ca 92fe5bf2c`
> and `git diff e3beb0f1d 2c324c99e` are identical files (409 lines each). **All evidence below was
> re-gathered on the rebased tree**; the pre-rebase results are not carried forward.

Two defects in `integrations/storage` combined into self-perpetuating durable-state corruption:
`InMemoryMetadataStore`'s epoch starts at zero and `restoreLifecycles`/`restoreRefs` only
*increment* it, while `StorageFactory.applySnapshot` read the restored snapshot's epoch and used it
for a log line only — so the epoch restarted near zero on every boot. `DefaultSnapshotManager` names
files `snapshot-%06d.dat` from that epoch, points `LATEST` at the new file, **then** prunes. From the
second boot onward the fresh low-epoch file sorted lowest and the prune deleted the target `LATEST`
had just been pointed at, which produced another low-epoch snapshot on the next boot, and so on.

### What changed

1. **`DefaultSnapshotManager.prunableVictims`** subtracts whatever `LATEST` currently names from the
   over-retention prefix, wherever that file's epoch sorts. An unreadable `LATEST` yields the
   unfiltered prefix — with no live pointer there is nothing to protect and refusing to prune would
   let the directory grow without bound.
2. **`sortedSnapshotFiles` orders by the epoch the name *encodes*** (`comparingLong(snapshotEpochOf)`),
   not by the name. The old comparator agreed with numeric order only below epoch 1,000,000.
3. **`MetadataStore.restoreEpoch(long)`**, called last by `applySnapshot`. `InMemoryMetadataStore`
   raises the epoch and never lowers it.

### The two halves are genuinely independent — and the brief's framing needed one correction

The issue describes the lexicographic sort as the ordering defect behind the corruption. It is a real
defect, but **it is not the one that caused this**: with `%06d` padding and epochs below 1,000,000,
lexicographic order *is* numeric order, so the prune correctly identified the reset file as oldest
under either comparator. The corruption comes entirely from the epoch reset. The lexicographic sort
is a separate latent defect that only bites above epoch 999,999. The mutation matrix below shows this
directly: reverting the ordering does not redden the epoch-reset reproducer, and reverting the guard
does not redden the ordering test.

### Verification

Red-before, then green. `forceSnapshot_afterEpochReset_keepsLatestTargetOnDisk` and
`forceSnapshot_prunesByEpochOrder_notByFileName` both failed on the unfixed tree with
`snapshot-000001.dat` (the `LATEST` target) missing;
`createAll_afterRestart_continuesSnapshotEpochFromDisk` failed `2L >= 6L`.

Single-hunk mutation matrix, **re-run in full on the rebased tree** (a probe's authority is bounded
by the tree it ran over). An unmutated control ran first and was green on both scopes — 274/274 and
34/34 — so the instrument is known to be able to pass. Every mutation was applied and every restore
verified **by content** (before/after `grep -c` quoted at each step, never `git diff`, which reads
zero for a staged `git checkout`), with a clean worktree confirmed after each. Results are identical
to the pre-rebase run:

| reverted hunk | storage (274 tests) | aether/node (34 tests) | red set |
|---|---|---|---|
| `comparingLong(snapshotEpochOf)` → `comparing(fileName)` | 1 | 0 | `forceSnapshot_prunesByEpochOrder_notByFileName` |
| `prunableVictims(...)` → raw `subList` | 1 | 0 | `forceSnapshot_afterEpochReset_keepsLatestTargetOnDisk` |
| `Math.max(current, snapshotEpoch)` → no-op | 1 | 1 | `restoreEpoch_raisesEpochToSnapshotValue`, `createAll_afterRestart_continuesSnapshotEpochFromDisk` |
| `Math.max(...)` → `epoch.set(...)` | 1 | 0 | `restoreEpoch_neverLowersEpoch` |
| delete `metadataStore.restoreEpoch(snapshot.epoch())` | 0 | 1 | `createAll_afterRestart_continuesSnapshotEpochFromDisk` |

The last row's set is contained in the third's: removing the implementation necessarily reddens any
test of the wiring that depends on it. Stated rather than papered over.

- **Root build** on the rebased tree: `env -u HCLOUD_TOKEN mvn clean install` from the ROOT, no
  `-pl`, no `-DskipTests` — **BUILD SUCCESS**, exit 0 (captured as `REAL_EXIT` inside the command,
  not the wrapper's status), 15:16 min, **145/145 reactor modules SUCCESS**.
- **Tests**: **13,738 `<testcase>` elements** (surefire 13,722 + failsafe 16) across 2,972 report
  files, **0 failures, 0 errors, 19 skipped**, 0 unparsable. The `testsuite@tests` attribute sums to
  11,349 — a **2,389 gap**, the known `@Nested` undercount; the element count is the total. A run
  marker dropped before the build excluded **0** stale files, so every report counted belongs to this
  run.
- **The count delta was PRE-REGISTERED before the build and scored exactly.** Predicted
  13,739 − 51 + 36 + 14 = **13,738**; actual **13,738, delta 0**. Component by component: #1011's five
  deleted `aether/aether-dht` classes were worth **51** tests on the old tree and are all absent
  (−51); the five added classes contribute exactly the predicted **+36**
  (EmberConfigBasePort 7, EmberConfigStartTimeout 5, ForgePortPreflight 7, RetryLoggingBound 5,
  QuicPeerConnectionLaneOpenDedup 12); the three modified classes net **+14**
  (ForgeServerMessage 4→13, BlueprintDeployStatus 3→3, QuicClusterNetworkStreamZombie 7→12). The old
  per-class counts were captured off disk *before* the `clean` destroyed them, so this is a
  subtraction, not a story told afterwards.
- The **19 skips are the same set** as the pre-rebase run (compared element-wise, not by count):
  9 `HetznerCloudIT` (no cloud token by design), 3 dead-surface controls, 2 `ZCstDumpTest`,
  2 `FlowCodebaseCheckTest`, 1 `FlowIdempotencyDebugTest`, 1 `ObservabilityStep0BenchTest`,
  1 `CertificateRenewalSchedulerStaleTimerTest`. None is in `integrations/storage` or `aether/node`,
  and none is one of the five tests added here.
- **JBCT gate**, re-run per module with `-Djbct.skip=false` (`integrations/` inherits
  `jbct.skip=true` from root `pom.xml:103` and declares no override — #938 — while `aether/pom.xml:93`
  sets it `false`; that pair is the positive control that the override grep finds one when it exists):
  `integrations/storage` **57 files**, `aether/node` **152 files — JBCT check passed**.
- The storage run reports one `JBCT-RET-06` error in `RemoteTierConfig.java:37`. Re-baselined against
  the **new** tip: checking `e3beb0f1d`'s storage sources out and re-running produced the **identical
  error at the identical 57-file count**. The file is touched by neither the three merges nor this
  branch, and the gate is dormant for `integrations/` in CI.
- **The lifecycle build is not gate evidence for this change** — its jbct executions cover 17
  example/slice modules, and neither `storage` nor `node` is among them. The direct runs above are.
- **#1011 does not interact with this fix.** Its `aether/node` footprint is two modified files
  (`AppHttpServer.java`, `AetherNode.java`); the `AetherNode` patch is 78 lines with **zero**
  occurrences of `Storage`, `snapshot`, `metadataStore` or `restore`.

### #1013 considered, deliberately not bundled

The argument for bundling was that a loud failed restore would make this fix self-verifying. It does
not hold on inspection, for three reasons:

1. **It is not a one-liner.** `restoreAndSignalReady` must keep signalling readiness when no snapshot
   exists — a first boot is legitimate — so the fix cannot be "only signal on success". It has to
   *distinguish absence from failure*, which means changing `SnapshotManager.restoreFromLatest()`
   from `Option<MetadataSnapshot>` to `Result<Option<MetadataSnapshot>>`: a public-API change in
   `integrations/storage` with call sites in `aether/node`.
2. **The loudness largely exists already.** A dangling `LATEST` is logged at WARN today by
   `DefaultSnapshotManager.readAndValidateSnapshot` — that is the very counter the three-arm
   experiment read as `restore-failed 5,5,5`. #1013's marginal gain is that the *readiness gate*
   learns about it, not that the failure becomes visible.
3. **This fix is verified by direct assertion, not by inference from an absent warning.** The tests
   assert the `LATEST` target survives and still restores. They would not get stronger.

Widening an API shape inside the blocking rc4 corruption fix costs blast radius for no verification
gain. #1013 is left open on its own merits.

#1014 not touched, as instructed.

### Deliberate non-change

`DefaultSnapshotManager.lastSnapshotEpoch` still starts at 0 after a restore, so `shouldSnapshot()`
sees `epochDelta = restoredEpoch` and a node whose restored epoch exceeds the mutation threshold
takes one snapshot on its first post-boot mutation. It self-corrects after that single snapshot, and
that snapshot now carries a **high** epoch, so it re-anchors the file sequence rather than corrupting
it. Changing it would suppress a snapshot that happens today — a timing concern separate from this
corruption.

Does not close #718; removes the trigger the experiment attributed 9.66× of its backpressure burst to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
