### PR TITLE
fix: scope Forge's durable data dir to the project and refuse state it cannot prove it owns (#718)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,9 @@ settings.json
 *.log
 *.log.gz
 logs/
+
+### Forge per-project durable state (#718) ###
+.aether/
 dependency-reduced-pom.xml
 pom.xml.versionsBackup
 

--- a/aether/docs/getting-started.md
+++ b/aether/docs/getting-started.md
@@ -244,6 +244,49 @@ curl http://localhost:8070/api/hello/World
 # {"greeting":"Hello, World!"}
 ```
 
+### Where Forge keeps its data
+
+Forge writes durable cluster state — the artifact disk tier and each node's
+stream write-ahead log — to a directory on disk. It prints the absolute path
+as it starts, and you should read that line rather than assume a location:
+
+```
+Forge data dir: /path/to/hello/.aether/forge-data (empty; chosen by this project ...)
+```
+
+By default that directory is **inside your project**, next to the `forge.toml`
+you passed to `--config`. Two projects on one machine therefore keep separate
+state, and running Forge in one cannot affect the other. Add `.aether/` to
+your `.gitignore` — the generated scaffold already does.
+
+Stopping and restarting Forge in the same project **reuses** that state; that
+is deliberate, and it is what makes the stream WAL crash-durable across a
+restart. Forge says so when it happens, naming how many entries it inherited:
+
+```
+Forge data dir: /path/to/hello/.aether/forge-data (REUSING 42 existing entries
+owned by this project ...). Nodes resume from this state; it is not cleared.
+```
+
+If you want a clean slate, delete the directory yourself before starting.
+Forge never deletes it for you.
+
+Two cases make Forge **refuse to start** rather than run:
+
+- the directory holds state belonging to a *different* project, or
+- it holds state with no record of which project owns it.
+
+Both refusals exit non-zero, name both projects, and tell you that nothing has
+been written or deleted yet. This is a guard, not a nuisance: an unrelated
+run that silently adopts another project's durable state is how that state
+gets destroyed.
+
+To put the directory somewhere else, set `AETHER_FORGE_DATA` to an absolute
+path. (`AETHER_HOME` also still selects it, but only for a Forge started
+*without* `--config` — it is the installer's variable, meaning the install
+directory, and scoping run data on it would re-share state across every
+project on the machine.)
+
 ### Look at the cluster
 
 Point the `aether` CLI at Forge's management port:

--- a/aether/docs/operators/runbooks/lifecycle-verification.md
+++ b/aether/docs/operators/runbooks/lifecycle-verification.md
@@ -36,13 +36,18 @@ not reach the router at all. It falls through to the static file handler, which 
    lsof -nP -iUDP:6000                 # QUIC base port; expect no output before you start
    ```
 
-4. Start from clean simulator state. Forge keeps per-node data under `$AETHER_HOME/forge-data`,
-   falling back to `~/.aether/forge-data`. Pointing Forge at a fresh directory removes inherited
-   state as a variable, and is preferable to deleting the default directory:
+4. Start from clean simulator state. Forge resolves its per-node data directory at startup and logs
+   the absolute path; with a `--config` it defaults to `<that file's directory>/.aether/forge-data`
+   (see [Data Directory](../../slice-developers/forge-guide.md#data-directory)). Pointing Forge at a
+   fresh directory removes inherited state as a variable, and is preferable to deleting the default
+   directory:
 
    ```bash
-   export AETHER_HOME="$(mktemp -d)"
+   export AETHER_FORGE_DATA="$(mktemp -d)"
    ```
+
+   Use `AETHER_FORGE_DATA`, not `AETHER_HOME`: the latter is the installer's variable (the install
+   directory) and only selects the data directory for a Forge started without `--config`.
 
    Leader election is not instantaneous, and how long it takes depends on the host, so step 1 polls
    for readiness rather than sleeping for a fixed interval.
@@ -372,7 +377,7 @@ reconciliation instead.
   - **Another Forge on the host** holding the fixed QUIC base ports `6000+` (Prerequisites step 3).
     Check first — it is the one you can rule out definitively, with `lsof`
   - **Inherited simulator state**: `Snapshot restore failed` per node on boot. Restart with a fresh
-    `AETHER_HOME` (Prerequisites step 4)
+    `AETHER_FORGE_DATA` (Prerequisites step 4)
 
 ### Slice stuck in LOAD state
 - Check if artifact exists in repository

--- a/aether/docs/slice-developers/forge-guide.md
+++ b/aether/docs/slice-developers/forge-guide.md
@@ -84,6 +84,39 @@ Environment variables override CLI arguments:
 | FORGE_PORT | Dashboard port (default: 8888) |
 | CLUSTER_SIZE | Number of nodes (default: 5) |
 | LOAD_RATE | Initial load rate (legacy support) |
+| AETHER_FORGE_DATA | Absolute path of the durable data directory (overrides the per-project default) |
+| AETHER_HOME | Data directory parent, **for config-less runs only** — see below |
+
+### Data Directory
+
+Forge writes durable cluster state (artifact disk tier, per-node stream WAL) under a directory it
+resolves at startup and logs as an absolute path. Precedence, first match wins:
+
+1. `AETHER_FORGE_DATA` — used as given.
+2. `<directory of the --config file>/.aether/forge-data` — the default for every `run-forge.sh`.
+3. `$AETHER_HOME/forge-data` — only when no `--config` was given (the container entrypoint).
+4. `~/.aether/forge-data` — final fallback.
+
+Rule 2 is what keeps two projects on one host from sharing one cluster's state. `AETHER_HOME` sits
+*below* it deliberately: `install.sh` reads that variable as the **install directory**, so scoping
+run data on it would silently re-share state across every project of anyone who exports it to put
+`$AETHER_HOME/bin` on `PATH`.
+
+Reuse is announced, never silent. Forge records the owning project in a `.forge-owner` file inside
+the data directory and, at startup:
+
+- empty or absent directory → starts fresh;
+- populated and owned by this project → **reuses** it, logging the entry count (this is what makes
+  the stream WAL survive a restart);
+- populated and owned by a different project, or populated with no owner recorded → **refuses to
+  start**, exits non-zero, and names both projects.
+
+Forge never clears the directory. Delete it yourself for a clean slate.
+
+The refusal is a check, not a lock: it inspects the directory before creating anything, so a process
+claiming the directory inside that window is not caught, and two runs of the *same* project share one
+directory by design and are not distinguished by the owner marker. Same time-of-check/time-of-use
+limitation as the QUIC port preflight, and stated for the same reason.
 
 ### Ports
 
@@ -159,8 +192,9 @@ start_timeout_seconds = 60   # How long to wait for the cluster to finish formin
 If the cluster does not finish forming inside `start_timeout_seconds`, Forge exits non-zero and
 reports what it had reached at the deadline — how many nodes were consensus-active, the leader (or
 `none`), each node with its state and QUIC port, and any per-node start failure. Raise the value if
-formation on your host is merely slow; a stale `AETHER_HOME/forge-data` directory is a common reason
-for formation to consume the whole budget.
+formation on your host is merely slow; a stale `forge-data` directory (whose path Forge logs at
+startup — see [Data Directory](#data-directory)) is a common reason for formation to consume the
+whole budget.
 
 ### Running two Forge instances on one host
 
@@ -173,6 +207,11 @@ never reaches quorum — surfacing only as `activePeerCount=1`, which is also wh
 
 Forge therefore checks the whole range at startup and refuses to start when any of it is held,
 naming the ports. If you see that message it is a collision, not stale state — no node was started.
+
+Move the **data directory** as well. Two instances launched from *different* projects already get
+separate directories by default, but two launched from the *same* project resolve to one directory
+and are not distinguished by the owner marker, so the second must be given its own with
+`AETHER_FORGE_DATA=<dir>`. See [Data Directory](#data-directory).
 
 ### Auto-Healing
 

--- a/aether/ember/src/main/java/org/pragmatica/aether/ember/EmberCluster.java
+++ b/aether/ember/src/main/java/org/pragmatica/aether/ember/EmberCluster.java
@@ -380,7 +380,8 @@ public final class EmberCluster {
     /// the same dir and the stream WAL/segments survive. Production node paths never call this (the
     /// default empty `storageConfig` keeps the read-only `/data` fallback → WAL off); Forge — a local
     /// dev simulator, not a production path — calls it at startup (`ForgeServer.applyForgeDataDir`) to
-    /// home node data under `$AETHER_HOME/forge-data`. See [#perNodeStorageConfig].
+    /// home node data under the dir `ForgeDataDir` resolves for the run, which since #718 is scoped to
+    /// the project owning the `--config` file rather than being machine-wide. See [#perNodeStorageConfig].
     ///
     /// @param baseDir writable base dir (e.g. a JUnit `@TempDir`) under which each node gets `<baseDir>/<nodeId>`
     @Contract

--- a/aether/forge/forge-core/src/main/java/org/pragmatica/aether/forge/ForgeDataDir.java
+++ b/aether/forge/forge-core/src/main/java/org/pragmatica/aether/forge/ForgeDataDir.java
@@ -62,14 +62,11 @@ import static org.pragmatica.lang.Option.option;
 public sealed interface ForgeDataDir {
     /// Single-meaning override for the data dir. Unlike `AETHER_HOME` this names one thing only.
     String DATA_DIR_ENV = "AETHER_FORGE_DATA";
-
     /// Install-directory variable, honoured for config-less runs only. See the type documentation.
     String AETHER_HOME_ENV = "AETHER_HOME";
-
     /// Records which project owns a populated data dir. Not state itself, so its presence alone never
     /// makes a directory count as populated.
     String MARKER_FILE = ".forge-owner";
-
     String PROJECT_SUBDIR = ".aether";
     String DATA_SUBDIR = "forge-data";
 
@@ -80,13 +77,10 @@ public sealed interface ForgeDataDir {
         PROJECT("this project's --config location"),
         AETHER_HOME("the " + AETHER_HOME_ENV + " environment variable (no --config given)"),
         USER_HOME("the user-home fallback (no --config and no " + AETHER_HOME_ENV + ")");
-
         private final String description;
-
         Source(String description) {
             this.description = description;
         }
-
         public String description() {
             return description;
         }
@@ -103,7 +97,6 @@ public sealed interface ForgeDataDir {
     /// [#inspect] stop a run.
     sealed interface Verdict {
         Path dataDir();
-
         /// The line an operator sees at startup, before any node exists.
         String description();
 
@@ -111,8 +104,7 @@ public sealed interface ForgeDataDir {
         record Fresh(Path dataDir, Source source) implements Verdict {
             @Override
             public String description() {
-                return "Forge data dir: " + dataDir
-                     + " (empty; chosen by " + source.description() + ")";
+                return "Forge data dir: " + dataDir + " (empty; chosen by " + source.description() + ")";
             }
         }
 
@@ -124,7 +116,9 @@ public sealed interface ForgeDataDir {
             public String description() {
                 return "Forge data dir: " + dataDir
                      + " (REUSING " + entries
-                     + " existing entr" + (entries == 1 ? "y" : "ies")
+                     + " existing entr" + (entries == 1
+                                           ? "y"
+                                           : "ies")
                      + " owned by this project; chosen by " + source.description()
                      + "). Nodes resume from this state; it is not cleared.";
             }
@@ -142,7 +136,7 @@ public sealed interface ForgeDataDir {
     /// precedence can be pinned without mutating the JVM's environment.
     static Location location(Option<Path> forgeConfig, Option<String> explicitDir, Option<String> aetherHome) {
         return explicitLocation(explicitDir, forgeConfig).orElse(() -> projectLocation(forgeConfig))
-                                                         .or(() -> homeLocation(forgeConfig, aetherHome));
+                               .or(() -> homeLocation(forgeConfig, aetherHome));
     }
 
     /// Inspect the resolved dir before anything is created.
@@ -150,15 +144,13 @@ public sealed interface ForgeDataDir {
     /// @return the verdict to announce, or a failure naming why this run must not reuse the directory
     static Result<Verdict> inspect(Location location) {
         return FileOps.isDirectory(location.dataDir())
-               ? FileOps.list(location.dataDir())
-                        .flatMap(entries -> classify(location, stateEntryCount(entries)))
+               ? FileOps.list(location.dataDir()).flatMap(entries -> classify(location, stateEntryCount(entries)))
                : Result.success(new Verdict.Fresh(location.dataDir(), location.source()));
     }
 
     /// Create the directory and record this project as its owner. Run after [#inspect] has approved.
     static Result<Path> claim(Location location) {
-        return FileOps.createDirectories(location.dataDir())
-                      .flatMap(dir -> writeMarker(dir, location.owner()));
+        return FileOps.createDirectories(location.dataDir()).flatMap(dir -> writeMarker(dir, location.owner()));
     }
 
     private static Option<Location> explicitLocation(Option<String> explicitDir, Option<Path> forgeConfig) {
@@ -170,8 +162,7 @@ public sealed interface ForgeDataDir {
 
     private static Option<Location> projectLocation(Option<Path> forgeConfig) {
         return forgeConfig.map(ForgeDataDir::configDir)
-                          .map(projectDir -> new Location(projectDir.resolve(PROJECT_SUBDIR)
-                                                                    .resolve(DATA_SUBDIR),
+                          .map(projectDir -> new Location(projectDir.resolve(PROJECT_SUBDIR).resolve(DATA_SUBDIR),
                                                           projectDir,
                                                           Source.PROJECT));
     }
@@ -228,8 +219,7 @@ public sealed interface ForgeDataDir {
     /// fresh. Without this, claiming a directory would make the very next run see it as populated.
     private static int stateEntryCount(List<Path> entries) {
         return (int) entries.stream()
-                            .filter(entry -> !MARKER_FILE.equals(entry.getFileName()
-                                                                      .toString()))
+                            .filter(entry -> !MARKER_FILE.equals(entry.getFileName().toString()))
                             .count();
     }
 
@@ -247,7 +237,8 @@ public sealed interface ForgeDataDir {
     }
 
     private static Result<Path> writeMarker(Path dataDir, Path owner) {
-        return FileOps.writeString(dataDir.resolve(MARKER_FILE), owner + System.lineSeparator())
+        return FileOps.writeString(dataDir.resolve(MARKER_FILE),
+                                   owner + System.lineSeparator())
                       .map(_ -> dataDir);
     }
 
@@ -261,7 +252,9 @@ public sealed interface ForgeDataDir {
             public String message() {
                 return "Refusing to start: the Forge data dir " + dataDir
                      + " already holds " + entries
-                     + " entr" + (entries == 1 ? "y" : "ies")
+                     + " entr" + (entries == 1
+                                  ? "y"
+                                  : "ies")
                      + " of durable state belonging to a DIFFERENT project (" + recordedOwner
                      + "), but this run belongs to " + owner
                      + ". Starting would make two projects share one cluster's durable state. "
@@ -281,13 +274,14 @@ public sealed interface ForgeDataDir {
             public String message() {
                 return "Refusing to start: the Forge data dir " + dataDir
                      + " already holds " + entries
-                     + " entr" + (entries == 1 ? "y" : "ies")
+                     + " entr" + (entries == 1
+                                  ? "y"
+                                  : "ies")
                      + " of durable state, and no " + MARKER_FILE
                      + " records which project owns it — so this run cannot tell whether the state is "
                      + "its own or something else's. This run belongs to " + owner
                      + ". Nothing has been written or deleted — no node was started. "
-                     + "If the state is yours, adopt it by writing the owning project's path into "
-                     + dataDir.resolve(MARKER_FILE)
+                     + "If the state is yours, adopt it by writing the owning project's path into " + dataDir.resolve(MARKER_FILE)
                      + "; otherwise point this run elsewhere with " + DATA_DIR_ENV
                      + "=<dir>, or move " + dataDir
                      + " aside.";

--- a/aether/forge/forge-core/src/main/java/org/pragmatica/aether/forge/ForgeDataDir.java
+++ b/aether/forge/forge-core/src/main/java/org/pragmatica/aether/forge/ForgeDataDir.java
@@ -1,0 +1,302 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2025 Pragmatica Labs - Sergiy Yevtushenko
+// Licensed under Business Source License 1.1. Change Date: 2030-01-01. Change License: Apache-2.0.
+// See LICENSE in the repository root for full terms.
+package org.pragmatica.aether.forge;
+
+import java.nio.file.Path;
+import java.util.List;
+
+import org.pragmatica.lang.Cause;
+import org.pragmatica.lang.Option;
+import org.pragmatica.lang.Result;
+import org.pragmatica.lang.Verify;
+import org.pragmatica.lang.io.FileOps;
+
+import static org.pragmatica.lang.Option.option;
+
+
+/// #718 — WHERE a Forge run keeps its durable state, and WHO is allowed to reuse it.
+///
+/// THE DEFECT THIS CLOSES. Before this, every Forge on a host wrote to one machine-wide
+/// `~/.aether/forge-data`, derived from nothing but the user's home directory. Two projects were
+/// therefore the same project as far as durable state was concerned, and the tutorial
+/// (`aether/docs/getting-started.md`) documented neither the path nor the sharing. On 2026-09-11 an
+/// agent following that tutorial verbatim in a scratch project ran `./run-forge.sh` and destroyed
+/// 32,167 files of an unrelated investigation's state; 25 survived. Nothing was done wrong — the
+/// documented procedure was followed exactly, which is why this is a code defect and not a user
+/// error.
+///
+/// TWO MECHANISMS, AND THE GUARANTEE IS DIFFERENT FOR EACH — a single "Forge runs are isolated" claim
+/// would be an overclaim, so state them separately:
+///
+///   1. SCOPE. When a run names a config file (`--config forge.toml` — every `run-forge.sh`, every
+///      example, every tutorial step), the data dir defaults to `<that file's directory>/.aether/forge-data`.
+///      Two projects then CANNOT collide, because the path is a function of the project. This is a
+///      structural guarantee, not a check.
+///   2. OWNERSHIP. A run that is about to reuse a POPULATED directory it cannot prove it owns refuses
+///      to start. This covers what scope cannot: an operator pointing two projects at one directory
+///      through [#DATA_DIR_ENV], and config-less runs, which have no project to be scoped by and so
+///      still share `AETHER_HOME`/user-home state. Here the guarantee is a check, with a
+///      time-of-check/time-of-use window, exactly as in the sibling [ForgePortPreflight].
+///
+/// WHY `AETHER_HOME` IS NOT THE SCOPING KEY, THOUGH IT ALREADY EXISTED. It is OVERLOADED: `install.sh`
+/// and `upgrade.sh` read it as the INSTALL directory (`INSTALL_DIR="${AETHER_HOME:-$HOME/.aether}"`),
+/// so a user who exports it to put `$AETHER_HOME/bin` on their `PATH` — the documented reason to set
+/// it — would silently re-share forge state across every project on the host. Scoping on a variable
+/// that means something else re-opens this defect through the back door. `AETHER_HOME` is therefore
+/// kept, honoured, and DEMOTED: it names the data dir only for config-less runs, which preserves the
+/// behaviour #515 documented for the case where it is unambiguous. [#DATA_DIR_ENV] is the new,
+/// single-meaning override for anyone who wants to place the directory by hand.
+///
+/// WHY NOT A FRESH DIRECTORY PER RUN. #515 deliberately made this base dir restart-stable so a
+/// `stop()`→`start()` reuses the same per-node dirs and the stream WAL survives — that IS the
+/// crash-durability property Forge advertises. A timestamped run dir would trade a silent collision
+/// for a silent loss of durability, so reuse stays the default and is made VISIBLE instead of
+/// prevented.
+///
+/// WHAT THIS DOES NOT DO. It never deletes, moves or adopts anything. An existing machine-wide
+/// `~/.aether/forge-data` is simply no longer read by project runs; it is left on disk untouched.
+/// Corruption of the state itself is a different layer (#1012 / the snapshot-prune path) and is not
+/// addressed here.
+public sealed interface ForgeDataDir {
+    /// Single-meaning override for the data dir. Unlike `AETHER_HOME` this names one thing only.
+    String DATA_DIR_ENV = "AETHER_FORGE_DATA";
+
+    /// Install-directory variable, honoured for config-less runs only. See the type documentation.
+    String AETHER_HOME_ENV = "AETHER_HOME";
+
+    /// Records which project owns a populated data dir. Not state itself, so its presence alone never
+    /// makes a directory count as populated.
+    String MARKER_FILE = ".forge-owner";
+
+    String PROJECT_SUBDIR = ".aether";
+    String DATA_SUBDIR = "forge-data";
+
+    /// Which rule picked the directory. Carried into the startup line so an operator reading a
+    /// surprising path learns WHY it was chosen, not merely what it is.
+    enum Source {
+        EXPLICIT("the " + DATA_DIR_ENV + " environment variable"),
+        PROJECT("this project (the directory holding the --config file)"),
+        AETHER_HOME("the " + AETHER_HOME_ENV + " environment variable (no --config given)"),
+        USER_HOME("the user-home fallback (no --config and no " + AETHER_HOME_ENV + ")");
+
+        private final String description;
+
+        Source(String description) {
+            this.description = description;
+        }
+
+        public String description() {
+            return description;
+        }
+    }
+
+    /// A resolved data dir together with the project that claims it.
+    ///
+    /// @param dataDir directory the cluster's per-node state is written under
+    /// @param owner   project this run belongs to — the `--config` file's directory, else the working directory
+    /// @param source  rule that picked `dataDir`
+    record Location(Path dataDir, Path owner, Source source) {}
+
+    /// What inspecting the resolved dir found. Both cases are reportable; only the failures of
+    /// [#inspect] stop a run.
+    sealed interface Verdict {
+        Path dataDir();
+
+        /// The line an operator sees at startup, before any node exists.
+        String description();
+
+        /// Nothing durable is present, so this run starts from empty.
+        record Fresh(Path dataDir, Source source) implements Verdict {
+            @Override
+            public String description() {
+                return "Forge data dir: " + dataDir
+                     + " (empty; chosen by " + source.description() + ")";
+            }
+        }
+
+        /// Populated state this project already owns. Announced rather than refused: restart-stable
+        /// reuse is the #515 crash-durability property, and the entry count is stated so an operator
+        /// who did not expect to inherit anything can see that they are about to.
+        record Reused(Path dataDir, Source source, int entries) implements Verdict {
+            @Override
+            public String description() {
+                return "Forge data dir: " + dataDir
+                     + " (REUSING " + entries
+                     + " existing entr" + (entries == 1 ? "y" : "ies")
+                     + " owned by this project; chosen by " + source.description()
+                     + "). Nodes resume from this state; it is not cleared.";
+            }
+        }
+    }
+
+    /// Resolve the data dir for a run, from the environment and the `--config` path.
+    ///
+    /// @param forgeConfig `--config` file, absent when the run named none
+    static Location location(Option<Path> forgeConfig) {
+        return location(forgeConfig, option(System.getenv(DATA_DIR_ENV)), option(System.getenv(AETHER_HOME_ENV)));
+    }
+
+    /// TEST SEAM — the same resolution with the two environment variables supplied directly, so the
+    /// precedence can be pinned without mutating the JVM's environment.
+    static Location location(Option<Path> forgeConfig, Option<String> explicitDir, Option<String> aetherHome) {
+        return explicitLocation(explicitDir, forgeConfig).orElse(() -> projectLocation(forgeConfig))
+                                                         .or(() -> homeLocation(forgeConfig, aetherHome));
+    }
+
+    /// Inspect the resolved dir before anything is created.
+    ///
+    /// @return the verdict to announce, or a failure naming why this run must not reuse the directory
+    static Result<Verdict> inspect(Location location) {
+        return FileOps.isDirectory(location.dataDir())
+               ? FileOps.list(location.dataDir())
+                        .flatMap(entries -> classify(location, stateEntryCount(entries)))
+               : Result.success(new Verdict.Fresh(location.dataDir(), location.source()));
+    }
+
+    /// Create the directory and record this project as its owner. Run after [#inspect] has approved.
+    static Result<Path> claim(Location location) {
+        return FileOps.createDirectories(location.dataDir())
+                      .flatMap(dir -> writeMarker(dir, location.owner()));
+    }
+
+    private static Option<Location> explicitLocation(Option<String> explicitDir, Option<Path> forgeConfig) {
+        return explicitDir.filter(Verify.Is::present)
+                          .map(dir -> new Location(absolute(Path.of(dir)),
+                                                   ownerOf(forgeConfig),
+                                                   Source.EXPLICIT));
+    }
+
+    private static Option<Location> projectLocation(Option<Path> forgeConfig) {
+        return forgeConfig.map(ForgeDataDir::configDir)
+                          .map(projectDir -> new Location(projectDir.resolve(PROJECT_SUBDIR)
+                                                                    .resolve(DATA_SUBDIR),
+                                                          projectDir,
+                                                          Source.PROJECT));
+    }
+
+    private static Location homeLocation(Option<Path> forgeConfig, Option<String> aetherHome) {
+        return aetherHome.filter(Verify.Is::present)
+                         .map(home -> new Location(absolute(Path.of(home, DATA_SUBDIR)),
+                                                   ownerOf(forgeConfig),
+                                                   Source.AETHER_HOME))
+                         .or(() -> userHomeLocation(forgeConfig));
+    }
+
+    private static Location userHomeLocation(Option<Path> forgeConfig) {
+        return new Location(absolute(Path.of(System.getProperty("user.home"), PROJECT_SUBDIR, DATA_SUBDIR)),
+                            ownerOf(forgeConfig),
+                            Source.USER_HOME);
+    }
+
+    /// The project a run belongs to: the `--config` file's directory, else the working directory. Always
+    /// defined, so a config-less run (the container entrypoint, an ad-hoc launch) still has a stable
+    /// identity to be checked against across restarts.
+    private static Path ownerOf(Option<Path> forgeConfig) {
+        return forgeConfig.map(ForgeDataDir::configDir)
+                          .or(() -> absolute(Path.of(System.getProperty("user.dir"))));
+    }
+
+    private static Path configDir(Path configFile) {
+        return option(absolute(configFile).getParent()).or(() -> absolute(configFile));
+    }
+
+    private static Path absolute(Path path) {
+        return path.toAbsolutePath()
+                   .normalize();
+    }
+
+    private static Result<Verdict> classify(Location location, int stateEntries) {
+        return stateEntries == 0
+               ? Result.success(new Verdict.Fresh(location.dataDir(), location.source()))
+               : judgeOwner(location, stateEntries, recordedOwner(location.dataDir()));
+    }
+
+    private static Result<Verdict> judgeOwner(Location location, int entries, Option<Path> recorded) {
+        return recorded.map(owner -> ownerVerdict(location, entries, owner))
+                       .or(() -> ForgeDataError.unownedState(location, entries).result());
+    }
+
+    private static Result<Verdict> ownerVerdict(Location location, int entries, Path recordedOwner) {
+        return recordedOwner.equals(location.owner())
+               ? Result.success(new Verdict.Reused(location.dataDir(), location.source(), entries))
+               : ForgeDataError.foreignState(location, recordedOwner, entries).result();
+    }
+
+    /// The marker is bookkeeping, not durable node state, so a directory holding only a marker is still
+    /// fresh. Without this, claiming a directory would make the very next run see it as populated.
+    private static int stateEntryCount(List<Path> entries) {
+        return (int) entries.stream()
+                            .filter(entry -> !MARKER_FILE.equals(entry.getFileName()
+                                                                      .toString()))
+                            .count();
+    }
+
+    private static Option<Path> recordedOwner(Path dataDir) {
+        return FileOps.readString(dataDir.resolve(MARKER_FILE))
+                      .option()
+                      .map(String::trim)
+                      .filter(Verify.Is::present)
+                      .map(Path::of);
+    }
+
+    private static Result<Path> writeMarker(Path dataDir, Path owner) {
+        return FileOps.writeString(dataDir.resolve(MARKER_FILE), owner + System.lineSeparator())
+                      .map(_ -> dataDir);
+    }
+
+    /// Refusals. Both messages state that NOTHING has been written or deleted yet, because the failure
+    /// this class exists to prevent was discovered only by noticing files were already gone.
+    sealed interface ForgeDataError extends Cause {
+        /// Populated state owned by a DIFFERENT project. Naming both projects is the point: the
+        /// operator is the only party who knows which one is the mistake.
+        record ForeignState(Path dataDir, Path recordedOwner, Path owner, int entries) implements ForgeDataError {
+            @Override
+            public String message() {
+                return "Refusing to start: the Forge data dir " + dataDir
+                     + " already holds " + entries
+                     + " entr" + (entries == 1 ? "y" : "ies")
+                     + " of durable state belonging to a DIFFERENT project (" + recordedOwner
+                     + "), but this run belongs to " + owner
+                     + ". Starting would make two projects share one cluster's durable state. "
+                     + "Nothing has been written or deleted — no node was started. "
+                     + "Either run from " + recordedOwner
+                     + ", or point this run elsewhere with " + DATA_DIR_ENV
+                     + "=<dir>, or move " + dataDir
+                     + " aside yourself if you no longer need it.";
+            }
+        }
+
+        /// Populated state with no owner recorded — state predating this check, or written by hand.
+        /// This is the exact shape that destroyed the #718 reproducer, so it refuses rather than
+        /// adopting: adopting silently is what the whole class exists to stop.
+        record UnownedState(Path dataDir, Path owner, int entries) implements ForgeDataError {
+            @Override
+            public String message() {
+                return "Refusing to start: the Forge data dir " + dataDir
+                     + " already holds " + entries
+                     + " entr" + (entries == 1 ? "y" : "ies")
+                     + " of durable state, and no " + MARKER_FILE
+                     + " records which project owns it — so this run cannot tell whether the state is "
+                     + "its own or something else's. This run belongs to " + owner
+                     + ". Nothing has been written or deleted — no node was started. "
+                     + "If the state is yours, adopt it by writing the owning project's path into "
+                     + dataDir.resolve(MARKER_FILE)
+                     + "; otherwise point this run elsewhere with " + DATA_DIR_ENV
+                     + "=<dir>, or move " + dataDir
+                     + " aside.";
+            }
+        }
+
+        static ForgeDataError foreignState(Location location, Path recordedOwner, int entries) {
+            return new ForeignState(location.dataDir(), recordedOwner, location.owner(), entries);
+        }
+
+        static ForgeDataError unownedState(Location location, int entries) {
+            return new UnownedState(location.dataDir(), location.owner(), entries);
+        }
+    }
+
+    record unused() implements ForgeDataDir {}
+}

--- a/aether/forge/forge-core/src/main/java/org/pragmatica/aether/forge/ForgeDataDir.java
+++ b/aether/forge/forge-core/src/main/java/org/pragmatica/aether/forge/ForgeDataDir.java
@@ -77,7 +77,7 @@ public sealed interface ForgeDataDir {
     /// surprising path learns WHY it was chosen, not merely what it is.
     enum Source {
         EXPLICIT("the " + DATA_DIR_ENV + " environment variable"),
-        PROJECT("this project (the directory holding the --config file)"),
+        PROJECT("this project's --config location"),
         AETHER_HOME("the " + AETHER_HOME_ENV + " environment variable (no --config given)"),
         USER_HOME("the user-home fallback (no --config and no " + AETHER_HOME_ENV + ")");
 
@@ -233,6 +233,11 @@ public sealed interface ForgeDataDir {
                             .count();
     }
 
+    /// The read failure is absorbed into `none()` deliberately — design-out rather than recovery. An
+    /// absent marker is the ordinary case, not an error, and the absorption is fail-SAFE in the one
+    /// case that is: a marker that exists but cannot be read also yields `none()`, which lands on
+    /// [ForgeDataError.UnownedState] and REFUSES the run. No path turns an unreadable marker into
+    /// permission to reuse, so nothing the absorption hides can cost data.
     private static Option<Path> recordedOwner(Path dataDir) {
         return FileOps.readString(dataDir.resolve(MARKER_FILE))
                       .option()

--- a/aether/forge/forge-core/src/main/java/org/pragmatica/aether/forge/ForgeServer.java
+++ b/aether/forge/forge-core/src/main/java/org/pragmatica/aether/forge/ForgeServer.java
@@ -150,14 +150,15 @@ public final class ForgeServer {
 
             return;
         }
-
         // #718 - resolved and checked BEFORE anything is created, so a refusal cannot have written or
         // deleted anything. A run that cannot prove it owns populated durable state stops here rather
         // than silently sharing an unrelated project's cluster state.
         var dataDirCheck = ForgeDataDir.inspect(ForgeDataDir.location(startupConfig.forgeConfig()));
 
-        dataDirCheck.onFailure(cause -> log.error("{}", cause.message()))
-                    .onSuccess(verdict -> log.info("{}", verdict.description()));
+        dataDirCheck.onFailure(cause -> log.error("{}",
+                                                  cause.message()))
+                    .onSuccess(verdict -> log.info("{}",
+                                                   verdict.description()));
         if (dataDirCheck.isFailure()) {
             System.exit(1);
 

--- a/aether/forge/forge-core/src/main/java/org/pragmatica/aether/forge/ForgeServer.java
+++ b/aether/forge/forge-core/src/main/java/org/pragmatica/aether/forge/ForgeServer.java
@@ -50,7 +50,6 @@ import org.pragmatica.lang.Cause;
 import org.pragmatica.lang.Contract;
 import org.pragmatica.lang.Option;
 import org.pragmatica.lang.Result;
-import org.pragmatica.lang.io.FileOps;
 import org.pragmatica.lang.io.TimeSpan;
 import org.pragmatica.http.HttpResult;
 
@@ -147,6 +146,19 @@ public final class ForgeServer {
 
         quicPortCheck.onFailure(cause -> log.error("{}", cause.message()));
         if (quicPortCheck.isFailure()) {
+            System.exit(1);
+
+            return;
+        }
+
+        // #718 - resolved and checked BEFORE anything is created, so a refusal cannot have written or
+        // deleted anything. A run that cannot prove it owns populated durable state stops here rather
+        // than silently sharing an unrelated project's cluster state.
+        var dataDirCheck = ForgeDataDir.inspect(ForgeDataDir.location(startupConfig.forgeConfig()));
+
+        dataDirCheck.onFailure(cause -> log.error("{}", cause.message()))
+                    .onSuccess(verdict -> log.info("{}", verdict.description()));
+        if (dataDirCheck.isFailure()) {
             System.exit(1);
 
             return;
@@ -376,32 +388,27 @@ public final class ForgeServer {
 
     /// #515 — a local-dev Forge simulator must not inherit the production `/data/aether` storage
     /// default (read-only on a laptop → a per-node "Stream WAL disabled" WARN wall + non-crash-durable
-    /// streaming). Point every embedded node at a writable, restart-stable base dir under
-    /// `$AETHER_HOME` (or the user-home `.aether/forge-data` fallback), which turns the artifact disk
-    /// tier and the per-partition stream WAL writable so Forge streaming is crash-durable by default.
-    /// Production nodes never take this path — they keep the `/data/aether` default from `StorageConfig`
-    /// / `ConfigLoader`. The single loud line (info on success, error on failure) replaces the silent
-    /// per-node WARN wall for the operator.
+    /// streaming). Point every embedded node at a writable, restart-stable base dir, which turns the
+    /// artifact disk tier and the per-partition stream WAL writable so Forge streaming is crash-durable
+    /// by default. Production nodes never take this path — they keep the `/data/aether` default from
+    /// `StorageConfig` / `ConfigLoader`. The single loud line (info on success, error on failure)
+    /// replaces the silent per-node WARN wall for the operator.
+    ///
+    /// #718 — the dir is no longer machine-wide. [ForgeDataDir] scopes it to the project owning the
+    /// `--config` file, and `claim` records this project as its owner so a later run can tell whether
+    /// state it finds is its own. [ForgeServer#main] has already refused the run if it could not.
     private void applyForgeDataDir(EmberCluster clusterInstance) {
-        var baseDir = forgeDataBaseDir();
+        var location = ForgeDataDir.location(startupConfig.forgeConfig());
+        var baseDir = location.dataDir();
 
-        FileOps.createDirectories(baseDir)
-               .onSuccess(_ -> log.info("Forge data dir: {} (stream WAL crash-durable)",
-                                        baseDir))
-               .onFailure(cause -> log.error("Forge data dir {} not writable: {} — streaming will run "
-                                            + "non-crash-durable (in-memory tail only)",
-                                             baseDir,
-                                             cause.message()));
+        ForgeDataDir.claim(location)
+                    .onSuccess(_ -> log.info("Forge data dir: {} (stream WAL crash-durable)",
+                                             baseDir))
+                    .onFailure(cause -> log.error("Forge data dir {} not writable: {} — streaming will run "
+                                                 + "non-crash-durable (in-memory tail only)",
+                                                  baseDir,
+                                                  cause.message()));
         clusterInstance.withDataBaseDir(baseDir);
-    }
-
-    private static Path forgeDataBaseDir() {
-        return Option.option(System.getenv("AETHER_HOME"))
-                     .filter(home -> !home.isBlank())
-                     .map(home -> Path.of(home, "forge-data"))
-                     .or(Path.of(System.getProperty("user.home"),
-                                 ".aether",
-                                 "forge-data"));
     }
 
     private static String serializeStatus(EmberCluster cluster,
@@ -470,7 +477,8 @@ public final class ForgeServer {
              + "-" + (config.basePort() + config.nodes() - 1)
              + " was free immediately before this start, so a QUIC port collision at that moment is "
              + "ruled out. Forge did NOT check, and any of these is consistent with what is reported "
-             + "above: stale per-node state under AETHER_HOME/forge-data (a retry/backpressure storm "
+             + "above: stale per-node state in this run's forge-data dir, whose path is logged at "
+             + "startup (a retry/backpressure storm "
              + "during formation can consume this whole budget); host load; or a genuine consensus "
              + "fault. If formation on this host is merely slow, raise cluster.start_timeout_seconds.";
     }

--- a/aether/forge/forge-core/src/test/java/org/pragmatica/aether/forge/ForgeDataDirTest.java
+++ b/aether/forge/forge-core/src/test/java/org/pragmatica/aether/forge/ForgeDataDirTest.java
@@ -1,0 +1,338 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2025 Pragmatica Labs - Sergiy Yevtushenko
+// Licensed under Business Source License 1.1. Change Date: 2030-01-01. Change License: Apache-2.0.
+// See LICENSE in the repository root for full terms.
+package org.pragmatica.aether.forge;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import org.pragmatica.lang.Option;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.pragmatica.lang.Option.none;
+import static org.pragmatica.lang.Option.some;
+
+/// #718 — two Forge runs from two different projects must not share durable state, and reuse of
+/// populated state must never be silent.
+///
+/// The defect these pin destroyed 32,167 files of an unrelated investigation's durable state on
+/// 2026-09-11. The tutorial was followed exactly; the data dir was derived from the user's home
+/// directory alone, so "a different project" and "the same project" were indistinguishable.
+///
+/// The two properties are pinned SEPARATELY because they are earned by different mechanisms and hold
+/// over different cases — scoping is structural and covers runs that name a config file, ownership is
+/// a check and covers the rest. A single "runs are isolated" assertion would overclaim.
+class ForgeDataDirTest {
+    private static Path configIn(Path projectDir) throws IOException {
+        var config = projectDir.resolve("forge.toml");
+
+        Files.writeString(config, "[cluster]\n");
+
+        return config;
+    }
+
+    private static void writeState(Path dataDir, String name) throws IOException {
+        Files.createDirectories(dataDir);
+        Files.writeString(dataDir.resolve(name), "durable\n");
+    }
+
+    /// Property 1 — scoping. Structural: the path is a function of the project, so collision is not
+    /// merely detected, it is unrepresentable.
+    @Nested
+    class Scoping {
+        /// THE test this change exists for. Against the previous implementation both projects resolved
+        /// to one machine-wide `~/.aether/forge-data` and this assertion fails.
+        @Test
+        void location_differsBetweenTwoProjects(@TempDir Path root) throws IOException {
+            var first = ForgeDataDir.location(some(configIn(Files.createDirectories(root.resolve("project-a")))),
+                                              none(),
+                                              none());
+            var second = ForgeDataDir.location(some(configIn(Files.createDirectories(root.resolve("project-b")))),
+                                               none(),
+                                               none());
+
+            assertThat(first.dataDir()).isNotEqualTo(second.dataDir());
+            assertThat(first.owner()).isNotEqualTo(second.owner());
+        }
+
+        /// #515's crash-durability property: a restart of ONE project must land on the SAME dir, or the
+        /// stream WAL it advertises cannot survive. Isolation must not be bought with a fresh dir per run.
+        @Test
+        void location_isStableAcrossRunsOfOneProject(@TempDir Path projectDir) throws IOException {
+            var config = configIn(projectDir);
+
+            assertThat(ForgeDataDir.location(some(config), none(), none())
+                                   .dataDir()).isEqualTo(ForgeDataDir.location(some(config), none(), none())
+                                                                     .dataDir());
+        }
+
+        @Test
+        void location_isUnderTheProjectDirectory(@TempDir Path projectDir) throws IOException {
+            var location = ForgeDataDir.location(some(configIn(projectDir)), none(), none());
+
+            assertThat(location.dataDir()).isEqualTo(projectDir.toAbsolutePath()
+                                                               .normalize()
+                                                               .resolve(".aether")
+                                                               .resolve("forge-data"));
+            assertThat(location.source()).isEqualTo(ForgeDataDir.Source.PROJECT);
+        }
+
+        @Test
+        void location_ownsTheProjectDirectory(@TempDir Path projectDir) throws IOException {
+            assertThat(ForgeDataDir.location(some(configIn(projectDir)), none(), none())
+                                   .owner()).isEqualTo(projectDir.toAbsolutePath()
+                                                                 .normalize());
+        }
+    }
+
+    /// Precedence. The load-bearing case is `AETHER_HOME` LOSING to the project, because that variable
+    /// is overloaded — `install.sh` reads it as the install directory, so a user who exports it for
+    /// `PATH` reasons would otherwise silently re-share state across every project on the host.
+    @Nested
+    class Precedence {
+        @Test
+        void location_prefersProjectOverAetherHome(@TempDir Path root) throws IOException {
+            var projectDir = Files.createDirectories(root.resolve("project"));
+            var aetherHome = root.resolve("aether-home");
+
+            var location = ForgeDataDir.location(some(configIn(projectDir)),
+                                                 none(),
+                                                 some(aetherHome.toString()));
+
+            assertThat(location.dataDir()).isEqualTo(projectDir.toAbsolutePath()
+                                                               .normalize()
+                                                               .resolve(".aether")
+                                                               .resolve("forge-data"));
+            assertThat(location.dataDir()).doesNotExist();
+            assertThat(aetherHome).doesNotExist();
+            assertThat(location.source()).isEqualTo(ForgeDataDir.Source.PROJECT);
+        }
+
+        @Test
+        void location_prefersExplicitOverrideOverEverything(@TempDir Path root) throws IOException {
+            var explicit = root.resolve("explicit-data");
+
+            var location = ForgeDataDir.location(some(configIn(Files.createDirectories(root.resolve("project")))),
+                                                 some(explicit.toString()),
+                                                 some(root.resolve("aether-home")
+                                                          .toString()));
+
+            assertThat(location.dataDir()).isEqualTo(explicit.toAbsolutePath()
+                                                             .normalize());
+            assertThat(location.source()).isEqualTo(ForgeDataDir.Source.EXPLICIT);
+        }
+
+        /// A config-less run has no project to be scoped by, so #515's documented `$AETHER_HOME/forge-data`
+        /// still applies — the container entrypoint takes this path.
+        @Test
+        void location_usesAetherHome_whenNoConfigGiven(@TempDir Path root) {
+            var aetherHome = root.resolve("aether-home");
+
+            var location = ForgeDataDir.location(none(), none(), some(aetherHome.toString()));
+
+            assertThat(location.dataDir()).isEqualTo(aetherHome.resolve("forge-data")
+                                                               .toAbsolutePath()
+                                                               .normalize());
+            assertThat(location.source()).isEqualTo(ForgeDataDir.Source.AETHER_HOME);
+        }
+
+        @Test
+        void location_usesUserHome_whenNoConfigAndNoAetherHome() {
+            var location = ForgeDataDir.location(none(), none(), none());
+
+            assertThat(location.dataDir()).isEqualTo(Path.of(System.getProperty("user.home"),
+                                                             ".aether",
+                                                             "forge-data")
+                                                         .toAbsolutePath()
+                                                         .normalize());
+            assertThat(location.source()).isEqualTo(ForgeDataDir.Source.USER_HOME);
+        }
+
+        /// An exported-but-empty variable is the shell's way of saying nothing, and must not resolve to
+        /// a relative `forge-data` in the working directory.
+        @Test
+        void location_ignoresBlankEnvironmentValues() {
+            var location = ForgeDataDir.location(none(), some("  "), some(""));
+
+            assertThat(location.source()).isEqualTo(ForgeDataDir.Source.USER_HOME);
+        }
+    }
+
+    /// Property 2 — ownership. Covers what scoping cannot: an explicit override aimed at one dir by two
+    /// projects, and config-less runs.
+    @Nested
+    class OwnershipGuard {
+        private ForgeDataDir.Location locationOf(Path dataDir, Path owner) {
+            return new ForgeDataDir.Location(dataDir, owner, ForgeDataDir.Source.EXPLICIT);
+        }
+
+        @Test
+        void inspect_isFresh_whenDirectoryAbsent(@TempDir Path root) {
+            ForgeDataDir.inspect(locationOf(root.resolve("absent"), root))
+                        .onFailure(cause -> fail("expected Fresh, refused: " + cause.message()))
+                        .onSuccess(verdict -> assertThat(verdict).isInstanceOf(ForgeDataDir.Verdict.Fresh.class));
+        }
+
+        @Test
+        void inspect_isFresh_whenDirectoryEmpty(@TempDir Path dataDir) {
+            ForgeDataDir.inspect(locationOf(dataDir, dataDir))
+                        .onFailure(cause -> fail("expected Fresh, refused: " + cause.message()))
+                        .onSuccess(verdict -> assertThat(verdict).isInstanceOf(ForgeDataDir.Verdict.Fresh.class));
+        }
+
+        /// The marker is bookkeeping, not durable state. Without this, claiming a directory would make
+        /// the very next run of the SAME project see it as populated.
+        @Test
+        void inspect_isFresh_whenOnlyTheMarkerIsPresent(@TempDir Path dataDir) throws IOException {
+            Files.writeString(dataDir.resolve(ForgeDataDir.MARKER_FILE), dataDir + "\n");
+
+            ForgeDataDir.inspect(locationOf(dataDir, dataDir))
+                        .onFailure(cause -> fail("expected Fresh, refused: " + cause.message()))
+                        .onSuccess(verdict -> assertThat(verdict).isInstanceOf(ForgeDataDir.Verdict.Fresh.class));
+        }
+
+        @Test
+        void inspect_announcesReuse_whenStateIsOwnedByThisProject(@TempDir Path root) throws IOException {
+            var dataDir = root.resolve("data");
+            var owner = root.resolve("project");
+
+            writeState(dataDir, "node-1");
+            Files.writeString(dataDir.resolve(ForgeDataDir.MARKER_FILE), owner + "\n");
+
+            ForgeDataDir.inspect(locationOf(dataDir, owner))
+                        .onFailure(cause -> fail("expected Reused, refused: " + cause.message()))
+                        .onSuccess(verdict -> assertThat(verdict.description()).contains("REUSING")
+                                                                               .contains("1 existing entry")
+                                                                               .contains("not cleared"));
+        }
+
+        /// The #718 shape exactly: populated state, no marker, so ownership cannot be established.
+        /// Adopting it silently is what destroyed the reproducer.
+        @Test
+        void inspect_refuses_whenStateHasNoRecordedOwner(@TempDir Path root) throws IOException {
+            var dataDir = root.resolve("data");
+
+            writeState(dataDir, "node-1");
+
+            ForgeDataDir.inspect(locationOf(dataDir, root.resolve("project")))
+                        .onSuccess(verdict -> fail("expected a refusal, got: " + verdict.description()))
+                        .onFailure(cause -> assertThat(cause).isInstanceOf(ForgeDataDir.ForgeDataError.UnownedState.class));
+        }
+
+        @Test
+        void inspect_refuses_whenStateBelongsToAnotherProject(@TempDir Path root) throws IOException {
+            var dataDir = root.resolve("data");
+
+            writeState(dataDir, "node-1");
+            Files.writeString(dataDir.resolve(ForgeDataDir.MARKER_FILE), root.resolve("other-project") + "\n");
+
+            ForgeDataDir.inspect(locationOf(dataDir, root.resolve("this-project")))
+                        .onSuccess(verdict -> fail("expected a refusal, got: " + verdict.description()))
+                        .onFailure(cause -> assertThat(cause).isInstanceOf(ForgeDataDir.ForgeDataError.ForeignState.class));
+        }
+
+        /// Honesty pin. The refusal is read by someone who is about to wonder whether their files are
+        /// already gone; it must answer that, and it must name the other project, because only the
+        /// operator knows which of the two is the mistake.
+        @Test
+        void inspect_refusalNamesBothProjectsAndStatesNothingWasDeleted(@TempDir Path root) throws IOException {
+            var dataDir = root.resolve("data");
+            var other = root.resolve("other-project");
+            var mine = root.resolve("this-project");
+
+            writeState(dataDir, "node-1");
+            Files.writeString(dataDir.resolve(ForgeDataDir.MARKER_FILE), other + "\n");
+
+            ForgeDataDir.inspect(locationOf(dataDir, mine))
+                        .onSuccess(verdict -> fail("expected a refusal, got: " + verdict.description()))
+                        .onFailure(cause -> assertThat(cause.message()).contains(other.toString())
+                                                                       .contains(mine.toString())
+                                                                       .contains("Nothing has been written or deleted")
+                                                                       .contains(ForgeDataDir.DATA_DIR_ENV));
+        }
+
+        @Test
+        void inspect_unownedRefusalStatesNothingWasDeleted(@TempDir Path root) throws IOException {
+            var dataDir = root.resolve("data");
+
+            writeState(dataDir, "node-1");
+
+            ForgeDataDir.inspect(locationOf(dataDir, root.resolve("project")))
+                        .onSuccess(verdict -> fail("expected a refusal, got: " + verdict.description()))
+                        .onFailure(cause -> assertThat(cause.message()).contains("Nothing has been written or deleted")
+                                                                       .contains(ForgeDataDir.MARKER_FILE));
+        }
+    }
+
+    /// Claiming is what makes the NEXT run's ownership check answerable.
+    @Nested
+    class Claiming {
+        @Test
+        void claim_createsTheDirectoryAndRecordsTheOwner(@TempDir Path root) {
+            var dataDir = root.resolve("data");
+            var owner = root.resolve("project");
+
+            ForgeDataDir.claim(new ForgeDataDir.Location(dataDir, owner, ForgeDataDir.Source.PROJECT))
+                        .onFailure(cause -> fail("claim failed: " + cause.message()))
+                        .onSuccess(dir -> assertThat(dir.resolve(ForgeDataDir.MARKER_FILE)).exists()
+                                                                                           .content()
+                                                                                           .contains(owner.toString()));
+        }
+
+        /// Round trip: a project that claims a dir, writes state, and comes back is allowed in — and is
+        /// told so.
+        @Test
+        void claim_makesTheNextInspectAnnounceReuse(@TempDir Path root) throws IOException {
+            var dataDir = root.resolve("data");
+            var owner = root.resolve("project");
+            var location = new ForgeDataDir.Location(dataDir, owner, ForgeDataDir.Source.PROJECT);
+
+            ForgeDataDir.claim(location)
+                        .onFailure(cause -> fail("claim failed: " + cause.message()));
+            writeState(dataDir, "node-1");
+
+            ForgeDataDir.inspect(location)
+                        .onFailure(cause -> fail("expected Reused, refused: " + cause.message()))
+                        .onSuccess(verdict -> assertThat(verdict).isInstanceOf(ForgeDataDir.Verdict.Reused.class));
+        }
+
+        /// A second project arriving at a claimed dir is refused — the guard survives a real claim, not
+        /// only a hand-written marker.
+        @Test
+        void claim_refusesASecondProjectAtTheSameDirectory(@TempDir Path root) throws IOException {
+            var dataDir = root.resolve("data");
+
+            ForgeDataDir.claim(new ForgeDataDir.Location(dataDir,
+                                                         root.resolve("first"),
+                                                         ForgeDataDir.Source.EXPLICIT))
+                        .onFailure(cause -> fail("claim failed: " + cause.message()));
+            writeState(dataDir, "node-1");
+
+            ForgeDataDir.inspect(new ForgeDataDir.Location(dataDir,
+                                                           root.resolve("second"),
+                                                           ForgeDataDir.Source.EXPLICIT))
+                        .onSuccess(verdict -> fail("expected a refusal, got: " + verdict.description()))
+                        .onFailure(cause -> assertThat(cause).isInstanceOf(ForgeDataDir.ForgeDataError.ForeignState.class));
+        }
+    }
+
+    /// The resolver reads the real environment in production; this pins that the no-argument form is
+    /// wired to the same precedence rather than a second copy of it.
+    @Test
+    void location_publicFormAgreesWithTheSeam() {
+        var viaEnv = ForgeDataDir.location(Option.<Path>none());
+        var viaSeam = ForgeDataDir.location(none(),
+                                            Option.option(System.getenv(ForgeDataDir.DATA_DIR_ENV)),
+                                            Option.option(System.getenv(ForgeDataDir.AETHER_HOME_ENV)));
+
+        assertThat(viaEnv.dataDir()).isEqualTo(viaSeam.dataDir());
+        assertThat(viaEnv.source()).isEqualTo(viaSeam.source());
+    }
+}

--- a/changelog.d/718-forge-data-isolation.md
+++ b/changelog.d/718-forge-data-isolation.md
@@ -1,0 +1,45 @@
+### Fixed (2026-09-11 — #718: every Forge on a host wrote to one machine-wide data directory, and the tutorial documented neither the path nor the sharing)
+- **`./run-forge.sh`, run exactly as `aether/docs/getting-started.md` documents it, wrote to a single
+  machine-wide `~/.aether/forge-data`.** The path was derived from the user's home directory alone, so
+  "a different project" and "the same project" were indistinguishable to Forge. On 2026-09-11 a run
+  following the tutorial verbatim in a scratch project destroyed 32,167 files of an unrelated
+  investigation's durable state; 25 survived. The documented procedure was followed exactly, which is
+  what makes this a code defect rather than a user error. The tutorial's own verification appendix
+  shows the omission was deliberate: a 2026-07-24 pass confirmed data "lands under
+  `$AETHER_HOME/forge-data`" and recorded that it was "not written into the tutorial body since it
+  wasn't a prior claim there".
+- **The data directory is now scoped to the project**, defaulting to `<directory of the --config
+  file>/.aether/forge-data`. Two projects cannot collide, because the path is a function of the
+  project rather than a check that might miss. Every `run-forge.sh` — scaffold and examples alike —
+  already passes `--config`, so this needs no change to any script.
+  `[verified: aether/forge/forge-core/src/test/java/org/pragmatica/aether/forge/ForgeDataDirTest.java`
+  → `Scoping.location_differsBetweenTwoProjects]`
+- **Restart still reuses the same directory**, so #515's crash-durable stream WAL is unaffected: the
+  isolation is not bought with a fresh directory per run.
+  `[verified: ForgeDataDirTest.Scoping.location_isStableAcrossRunsOfOneProject]`
+- **A run that cannot prove it owns populated durable state now refuses to start**, exits non-zero, and
+  names both projects. Forge records the owning project in a `.forge-owner` file and, before creating
+  anything, refuses when the directory is populated and owned by someone else or populated with no
+  owner recorded — the exact shape that destroyed the reproducer. Both refusals state that nothing has
+  been written or deleted, because the loss was discovered only by noticing files were already gone.
+  `[verified: ForgeDataDirTest.OwnershipGuard — 8 cases, incl. inspect_refuses_whenStateHasNoRecordedOwner
+  and inspect_refusalNamesBothProjectsAndStatesNothingWasDeleted]`
+- **Reuse the guard permits is announced rather than silent**, with the inherited entry count, before
+  the cluster starts. `[verified: ForgeDataDirTest.OwnershipGuard.inspect_announcesReuse_whenStateIsOwnedByThisProject]`
+- **`AETHER_HOME` is honoured but demoted to config-less runs**, and `AETHER_FORGE_DATA` is added as the
+  single-meaning override. `[mechanism: install.sh:21 and upgrade.sh:11 read AETHER_HOME as the INSTALL
+  directory (`INSTALL_DIR="${AETHER_HOME:-$HOME/.aether}"`), so scoping run data on it would silently
+  re-share state across every project of anyone who exports it to put `$AETHER_HOME/bin` on PATH.]`
+  The container entrypoint runs without `--config` and so keeps its present location unchanged.
+- **`jbct init` scaffolds `.aether/` into `.gitignore`**, and the repository ignores it for
+  `examples/*/`. `[verified: SliceProjectInitializerTest.initialize_validParams_ignoresForgeDataDir]`
+- `getting-started.md` gains a "Where Forge keeps its data" section stating the path, that it is
+  per-project, that restart reuses it, that Forge never clears it, and what the two refusals mean;
+  `forge-guide.md` gains the full precedence table.
+- **Limits, stated rather than implied.** `[unverified: no live two-project Forge run was executed —
+  the properties are pinned at the resolver and guard, not end-to-end through a started cluster.]`
+  `[unverified: the ownership check is time-of-check/time-of-use — it inspects before anything is
+  created, so a process claiming the directory inside that window is not caught. It is not a lock,
+  and the same limitation is stated on the sibling QUIC port preflight.]` An existing machine-wide
+  `~/.aether/forge-data` is never read by project runs, never adopted and never deleted; it is left on
+  disk. Corruption of the state itself is a different layer (#1012) and is untouched here.

--- a/changelog.d/718-forge-data-isolation.md
+++ b/changelog.d/718-forge-data-isolation.md
@@ -27,15 +27,25 @@
 - **Reuse the guard permits is announced rather than silent**, with the inherited entry count, before
   the cluster starts. `[verified: ForgeDataDirTest.OwnershipGuard.inspect_announcesReuse_whenStateIsOwnedByThisProject]`
 - **`AETHER_HOME` is honoured but demoted to config-less runs**, and `AETHER_FORGE_DATA` is added as the
-  single-meaning override. `[mechanism: install.sh:21 and upgrade.sh:11 read AETHER_HOME as the INSTALL
-  directory (`INSTALL_DIR="${AETHER_HOME:-$HOME/.aether}"`), so scoping run data on it would silently
-  re-share state across every project of anyone who exports it to put `$AETHER_HOME/bin` on PATH.]`
+  single-meaning override. `[mechanism: `aether/install.sh` and `aether/upgrade.sh` both read AETHER_HOME as the
+  INSTALL directory — `INSTALL_DIR="${AETHER_HOME:-$HOME/.aether}"` — so scoping run data on it would
+  silently re-share state across every project of anyone who exports it to put `$AETHER_HOME/bin` on
+  PATH.]`
   The container entrypoint runs without `--config` and so keeps its present location unchanged.
 - **`jbct init` scaffolds `.aether/` into `.gitignore`**, and the repository ignores it for
   `examples/*/`. `[verified: SliceProjectInitializerTest.initialize_validParams_ignoresForgeDataDir]`
 - `getting-started.md` gains a "Where Forge keeps its data" section stating the path, that it is
   per-project, that restart reuses it, that Forge never clears it, and what the two refusals mean;
   `forge-guide.md` gains the full precedence table.
+- **The two mechanisms are independently pinned, stated as what goes RED.** Reverting only the scoping
+  hunk (project default → the previous machine-wide resolution) reddens exactly
+  `Scoping.location_differsBetweenTwoProjects`, `Scoping.location_isUnderTheProjectDirectory` and
+  `Precedence.location_prefersProjectOverAetherHome` — 3 of 21. Reverting only the ownership guard
+  reddens exactly the 5 `OwnershipGuard` refusal/reuse cases plus
+  `Claiming.claim_makesTheNextInspectAnnounceReuse` and
+  `Claiming.claim_refusesASecondProjectAtTheSameDirectory` — 7 of 21. The two sets are disjoint;
+  neither is a superset of the other. The first probe is also the demonstration that the pre-change
+  behaviour fails the collision test.
 - **Limits, stated rather than implied.** `[unverified: no live two-project Forge run was executed —
   the properties are pinned at the resolver and guard, not end-to-end through a started cluster.]`
   `[unverified: the ownership check is time-of-check/time-of-use — it inspects before anything is

--- a/jbct/jbct-init/src/main/java/org/pragmatica/jbct/init/SliceProjectInitializer.java
+++ b/jbct/jbct-init/src/main/java/org/pragmatica/jbct/init/SliceProjectInitializer.java
@@ -567,6 +567,8 @@ public final class SliceProjectInitializer {
         .idea/
         *.iml
         .DS_Store
+        # Forge writes this project's durable cluster state here (#718).
+        .aether/
         """;
 
     private static final String SLICE_INTERFACE_TEMPLATE = """

--- a/jbct/jbct-init/src/test/java/org/pragmatica/jbct/init/SliceProjectInitializerTest.java
+++ b/jbct/jbct-init/src/test/java/org/pragmatica/jbct/init/SliceProjectInitializerTest.java
@@ -152,4 +152,18 @@ class SliceProjectInitializerTest {
         assertThat(content)
                   .contains("basePackage = \"org.example.configtest\"");
     }
+
+    /// #718 — Forge now writes this project's durable cluster state to `<project>/.aether/forge-data`,
+    /// so a scaffold that does not ignore it puts node state and stream WAL segments into the user's
+    /// first commit. The scaffold is the only place that can get this right before the user runs
+    /// `./run-forge.sh` for the first time.
+    @Test
+    void initialize_validParams_ignoresForgeDataDir() throws Exception {
+        var projectDir = tempDir.resolve("ignore-test");
+        SliceProjectInitializer.sliceProjectInitializer(projectDir, "org.example", "ignore-test")
+                                .flatMap(SliceProjectInitializer::initialize);
+        var content = Files.readString(projectDir.resolve(".gitignore"));
+        assertThat(content)
+                  .contains(".aether/");
+    }
 }


### PR DESCRIPTION
Fixes the collision half of #718. Not the corruption half — that is #1012/PR #1017, a different layer.

## What was wrong

`./run-forge.sh`, run exactly as `aether/docs/getting-started.md` documents it, wrote to a single
machine-wide `~/.aether/forge-data`. The path was derived from the user's home directory alone, so
"a different project" and "the same project" were indistinguishable to Forge, and the tutorial
documented neither the path nor the sharing.

On 2026-09-11 a run following that tutorial verbatim in a scratch project destroyed 32,167 files of
an unrelated investigation's durable state; 25 survived. The documented procedure was followed
exactly, which is what makes this a code defect rather than a user error.

The tutorial's own verification appendix shows the omission was deliberate: a 2026-07-24 pass
confirmed data "lands under `$AETHER_HOME/forge-data`" and recorded that it was "not written into the
tutorial body since it wasn't a prior claim there."

## The mechanism chosen, and what it costs

**Scoping (structural).** With a `--config` — every `run-forge.sh`, every example, every tutorial
step — the data dir defaults to `<that file's directory>/.aether/forge-data`. Two projects cannot
collide because the path is a function of the project, not a check that might miss.

**Ownership (a check).** Forge records the owning project in `.forge-owner` and, before creating
anything, refuses to start when the directory is populated and owned by someone else, or populated
with no owner recorded. That second case is the exact shape that destroyed the reproducer. Reuse the
guard permits is announced with its entry count rather than being silent.

The guarantees differ per path and are stated separately rather than as one "runs are isolated" claim.

**Why `AETHER_HOME` is not the scoping key, though it already existed.** It is overloaded:
`aether/install.sh` and `aether/upgrade.sh` read it as the *install directory*
(`INSTALL_DIR="${AETHER_HOME:-$HOME/.aether}"`). A user who exports it to put `$AETHER_HOME/bin` on
`PATH` — the documented reason to set it — would silently re-share forge state across every project
on the host. It is kept, honoured and demoted: it names the data dir only for config-less runs
(the container entrypoint, whose location is unchanged). `AETHER_FORGE_DATA` is the new
single-meaning override.

**Why not a fresh directory per run.** #515 deliberately made this dir restart-stable so the stream
WAL survives a `stop()`→`start()`. A timestamped run dir would trade a silent collision for a silent
loss of crash-durability.

**Costs, plainly.** Forge now writes inside the project (`.gitignore` updated in the repo and in the
`jbct init` scaffold). Cleaning is per-project rather than one `rm -rf`. An existing machine-wide
`~/.aether/forge-data` is orphaned — never read by project runs, never adopted, never deleted.

## Consistency with #1010

Follows `ForgePortPreflight`'s shape: checked in `main()` before anything is created, refuses with
`System.exit(1)`, message names the discriminator. Two claims #1010 shipped became stale under this
change and are corrected here rather than left to rot: `clusterStartFailureMessage` and
`forge-guide.md` both named `AETHER_HOME/forge-data` as the location. The forge-guide section on
running two instances now also says the data dir must be moved for a second instance of the *same*
project, which scoping does not cover.

## Verification

- Root `mvn clean install`, no `-pl`, no `-DskipTests`. First invocation halted at `integrations/swim`;
  resumed with `-rf :swim` → **BUILD SUCCESS**, 101 modules, 0 FAILURE, 0 SKIPPED. Union covers the
  whole reactor. `Aether Ember`, `Aether Forge Core`, `Aether Forge API`, `JBCT Init` all SUCCESS.
- **13,755 `<testcase>` elements** across surefire *and* failsafe, counted only from reports newer
  than a pre-build run marker: **0 failed**, 19 skipped. The `<testsuite tests=...>` attribute sum is
  11,370 — a 2,385 (17.3%) undercount, the known `@Nested` defect, matching the ~2,368/21% previously
  measured here. 27 pre-marker files excluded; 25 are orphans of test classes deleted by `acc9cb73d`
  (#1011) and 2 are three days old, so the marker did not land mid-build.
- **Mutation probes, stated as what goes RED.** Reverting only the scoping hunk reddens exactly 3 of
  21 (`location_differsBetweenTwoProjects`, `location_isUnderTheProjectDirectory`,
  `location_prefersProjectOverAetherHome`). Reverting only the ownership guard reddens exactly 7 of 21
  (5 × `OwnershipGuard`, 2 × `Claiming`). **Disjoint sets, neither a superset of the other.** The first
  probe is also the demonstration that the pre-change behaviour fails the collision test.
- Gate, per module, file counts quoted rather than exit status: `aether/forge/forge-core` →
  `Running JBCT check on 4 Java file(s)` … `0 format issue(s), 0 lint error(s)` … `JBCT check passed.`
  `aether/ember` → `Running JBCT check on 6 Java file(s)` … `0 format issue(s), 0 lint error(s)` …
  passed. Nothing under `integrations/` was touched.

## Limits, stated rather than implied

- No live two-project Forge run was executed. The properties are pinned at the resolver and the
  guard, not end-to-end through a started cluster.
- The ownership check is time-of-check/time-of-use — it inspects before anything is created, so a
  process claiming the directory inside that window is not caught. It is not a lock. Same limitation
  as the sibling QUIC port preflight, stated for the same reason.
- Two runs of the *same* project share one directory by design and are not distinguished by the
  marker; the forge-guide says so.
- `jbct/jbct-init` reports 7 pre-existing `JBCT-RET-06` errors under a forced direct `jbct:check`.
  They are not mine — my only change there is +2 lines inside a string constant at line 567, and the
  flagged sites are byte-identical to base. Not fixed here.

## Note for the owner

There is no dedicated issue for the collision defect; #718 is the adjacent one (stale `forge-data` is
its trigger) and PR #1010 already files a `718-` fragment, so the fragment is named `718-`. Rename if
you would rather it have its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
