### PR TITLE
fix: stop double-prefixing the api-key principal on the KV-backed auth path (#1024); diagnose #1025

### DIFF
--- a/aether/node/src/main/java/org/pragmatica/aether/http/security/KvStoreApiKeyValidator.java
+++ b/aether/node/src/main/java/org/pragmatica/aether/http/security/KvStoreApiKeyValidator.java
@@ -131,10 +131,17 @@ class KvStoreApiKeyValidator implements SecurityValidator {
                : buildContext(matched);
     }
 
+    /// #1024 — the stored `keyId` is passed BARE. The `securityContext(String, Set, AuthorizationRole)`
+    /// factory is already typed to an api-key subject: it runs the name through
+    /// `Principal.principal(name, PrincipalType.API_KEY)`, which applies the `api-key:` prefix itself.
+    /// Prepending it here too produced `api-key:api-key:ak_09e4c3ad` on `GET /api/v1/whoami` — the
+    /// prefix came from the FACTORY, not from the keyId, so the doubling was this call site's alone.
+    /// [ApiKeySecurityValidator#toSecurityContext] passes its bare `entry.name()` through the same
+    /// factory and has always been correct; this now matches it.
     private static Result<SecurityContext> buildContext(ApiKeyValue keyValue) {
         var role = parseAuthorizationRole(keyValue.authorizationRole());
 
-        return SecurityContext.securityContext("api-key:" + keyValue.keyId(), Set.of(Role.ADMIN), role);
+        return SecurityContext.securityContext(keyValue.keyId(), Set.of(Role.ADMIN), role);
     }
 
     // RET-06: `raw` is a stored ApiKeyValue field (null on legacy keys); the null/blank coalesce to a

--- a/aether/node/src/test/java/org/pragmatica/aether/http/security/KvStoreApiKeyValidatorPrincipalTest.java
+++ b/aether/node/src/test/java/org/pragmatica/aether/http/security/KvStoreApiKeyValidatorPrincipalTest.java
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (c) 2025 Pragmatica Labs - Sergiy Yevtushenko
+// Licensed under Business Source License 1.1. Change Date: 2030-01-01. Change License: Apache-2.0.
+// See LICENSE in the repository root for full terms.
+package org.pragmatica.aether.http.security;
+
+import io.netty.buffer.ByteBuf;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.pragmatica.aether.http.handler.HttpRequestContext;
+import org.pragmatica.aether.http.handler.security.AuthorizationRole;
+import org.pragmatica.aether.http.handler.security.Role;
+import org.pragmatica.aether.http.handler.security.SecurityPolicy;
+import org.pragmatica.aether.slice.kvstore.AetherKey;
+import org.pragmatica.aether.slice.kvstore.AetherKey.ApiKeyKey;
+import org.pragmatica.aether.slice.kvstore.AetherValue;
+import org.pragmatica.aether.slice.kvstore.AetherValue.ApiKeyValue;
+import org.pragmatica.cluster.state.kvstore.KVCommand;
+import org.pragmatica.cluster.state.kvstore.KVStore;
+import org.pragmatica.messaging.MessageRouter;
+import org.pragmatica.serialization.Deserializer;
+import org.pragmatica.serialization.Serializer;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/// #1024 — the PRINCIPAL STRING the KV-backed api-key path renders, pinned end-to-end through the
+/// real [KvStoreApiKeyValidator] against a real [KVStore].
+///
+/// Deliberately entered at the validator rather than at [org.pragmatica.aether.http.handler.security.Principal].
+/// `StatusRoutesWhoamiTest` already covers `/whoami`'s rendering, but it HAND-BUILDS its `Principal`
+/// via `Principal.principal(name, API_KEY)` — so it states what a correctly-prefixed principal looks
+/// like and cannot observe a validator that prefixes twice. The doubling (`api-key:api-key:ak_...`,
+/// observed live 2026-09-11) lived entirely in `buildContext`, between the stored `keyId` and the
+/// factory, which is the span this test covers and that one does not.
+///
+/// The assertion is exact equality, not `startsWith`: the defect's shape is an EXTRA correct-looking
+/// prefix, which every `startsWith("api-key:")` check in the codebase — including
+/// [org.pragmatica.aether.http.handler.security.Principal#isApiKey] — accepts.
+class KvStoreApiKeyValidatorPrincipalTest {
+    private static final String KEY_ID = "ak_09e4c3ad";
+    private static final String PLAINTEXT = "aether_bootstrap_plaintext_key";
+
+    private KVStore<AetherKey, AetherValue> kvStore;
+
+    @BeforeEach
+    void setUp() {
+        kvStore = new KVStore<>(MessageRouter.mutable(), stubSerializer(), stubDeserializer());
+    }
+
+    @Nested
+    class WhenAKvStoredKeyAuthenticates {
+        @Test
+        void validate_principalCarriesTheApiKeyPrefixExactlyOnce() {
+            registerKey(AuthorizationRole.ADMIN);
+
+            validator().validate(request(PLAINTEXT), new SecurityPolicy.RoleRequired(Role.ADMIN.value()))
+                       .onFailure(cause -> Assertions.fail("the registered key must authenticate: " + cause.message()))
+                       .onSuccess(context -> assertThat(context.principal().value())
+                                       .as("the principal an operator reads back from /whoami and an audit trail keys on")
+                                       .isEqualTo("api-key:" + KEY_ID));
+        }
+
+        /// Names the regression directly, so a reintroduction reports the defect rather than a bare
+        /// string mismatch. Redundant with the equality above BY CONSTRUCTION — that is the point:
+        /// the two cannot disagree, so this one never becomes a vacuous second assertion.
+        @Test
+        void validate_principalIsNotDoublePrefixed() {
+            registerKey(AuthorizationRole.ADMIN);
+
+            validator().validate(request(PLAINTEXT), new SecurityPolicy.RoleRequired(Role.ADMIN.value()))
+                       .onFailure(cause -> Assertions.fail("the registered key must authenticate: " + cause.message()))
+                       .onSuccess(context -> assertThat(context.principal().value())
+                                       .as("buildContext must not re-apply the prefix the factory already applies")
+                                       .doesNotContain("api-key:api-key:"));
+        }
+
+        /// The prefix is a property of the credential KIND, not of the key's authorization role, so a
+        /// non-ADMIN key renders identically. Guards against a fix applied on only one role branch.
+        @Test
+        void validate_viewerRoleKey_rendersTheSamePrincipalShape() {
+            registerKey(AuthorizationRole.VIEWER);
+
+            validator().validate(request(PLAINTEXT), SecurityPolicy.apiKeyRequired())
+                       .onFailure(cause -> Assertions.fail("the registered key must authenticate: " + cause.message()))
+                       .onSuccess(context -> assertThat(context.principal().value()).isEqualTo("api-key:" + KEY_ID));
+        }
+    }
+
+    private void registerKey(AuthorizationRole authorizationRole) {
+        var keyValue = ApiKeyValue.apiKeyValue(KEY_ID,
+                                               KvStoreApiKeyValidator.hashKey(PLAINTEXT),
+                                               0L,
+                                               authorizationRole.name());
+
+        kvStore.process(kvStore.createBatch(List.of(putKey(keyValue))));
+    }
+
+    @SuppressWarnings("unchecked")
+    private static KVCommand<AetherKey> putKey(ApiKeyValue keyValue) {
+        return (KVCommand<AetherKey>) (KVCommand<?>) new KVCommand.Put<>(ApiKeyKey.apiKeyKey(KEY_ID), keyValue);
+    }
+
+    /// The real management-plane pairing, matching `BootstrapAdminKeyValidatorAcceptanceTest`: the
+    /// deny-unless-public config validator delegating to the KV store, as `AetherNode` wires it when
+    /// no keys are configured in TOML.
+    private KvStoreApiKeyValidator validator() {
+        return new KvStoreApiKeyValidator(SecurityValidator.denyUnlessPublicValidator(), () -> kvStore);
+    }
+
+    private static HttpRequestContext request(String apiKey) {
+        return HttpRequestContext.httpRequestContext("/api/v1/whoami",
+                                                     "GET",
+                                                     Map.<String, List<String>> of(),
+                                                     Map.of("X-API-Key", List.of(apiKey)),
+                                                     "req-1024");
+    }
+
+    private static Serializer stubSerializer() {
+        return new Serializer() {
+            @Override public <T> void write(ByteBuf byteBuf, T object) {}
+        };
+    }
+
+    private static Deserializer stubDeserializer() {
+        return new Deserializer() {
+            @Override public <T> T read(ByteBuf byteBuf) {
+                return null;
+            }
+        };
+    }
+}

--- a/changelog.d/1024-whoami-double-api-key-prefix.md
+++ b/changelog.d/1024-whoami-double-api-key-prefix.md
@@ -1,0 +1,20 @@
+### Fixed (2026-09-12 — #1024: /whoami reported a double-prefixed api-key principal)
+- **`GET /api/v1/whoami` returned the principal as `api-key:api-key:ak_09e4c3ad`** for every key
+  authenticated against the KV store — the string an operator reads to answer "which credential was
+  this?", and the value `AuditLog` and `OperationalEvent.AccessDenied` key on.
+- The second prefix came from the FACTORY, not from the stored key id. `SecurityContext.securityContext(String, Set, AuthorizationRole)`
+  is already typed to an api-key subject and runs its argument through `Principal.principal(name, PrincipalType.API_KEY)`,
+  which applies `api-key:` itself; `KvStoreApiKeyValidator.buildContext` prepended it a second time.
+  The key id is stored bare, and the sibling `ApiKeySecurityValidator.toSecurityContext` has always
+  passed its bare name through the same factory — only the KV-backed path doubled.
+  `[mechanism: Principal.PrincipalType#prefixed, applied once per factory call]`
+- The KV path now passes the bare `keyId`, so the principal is `api-key:<keyId>` exactly once.
+  `[verified: aether/node/src/test/java/org/pragmatica/aether/http/security/KvStoreApiKeyValidatorPrincipalTest.java]`
+- **No consumer parsed the principal's colon arity**, so the shape change is safe: every reader
+  (`AppHttpServer`, `ManagementServer`, `WebSocketAuthenticator`, `StatusRoutes`) passes the value
+  through opaquely, and the only prefix tests in the codebase — `Principal.isApiKey`/`isUser`/`isService`
+  — are `startsWith` checks that accepted the doubled form too. That is also why no existing test
+  caught this: `StatusRoutesWhoamiTest` hand-builds its `Principal` through the same factory, so it
+  states what a correct principal looks like and never runs the validator that produced the wrong one.
+  `[mechanism: repo-wide search for colon-splitting of a principal value; the one exactly-one-colon
+  check, SliceLoadingContext#isGeneratedBaseOf, grades Maven artifact ids and never sees a principal]`


### PR DESCRIPTION
Fixes the `/whoami` principal defect in **#1024**. **#1025** is addressed as a **diagnosis with no code** — see below and the full report at `oss/internal/fix-1024-1025-2026-09-12.md`.

## #1024 — double `api-key:` prefix

`GET /api/v1/whoami` returned `api-key:api-key:ak_09e4c3ad` for any key authenticated against the KV store — the string an operator reads to answer "which credential was this?", and the value `AuditLog` and `OperationalEvent.AccessDenied` key on.

**The mechanism is not the one the ticket implies.** The stored `keyId` is **bare**; the second prefix comes from the **factory**. `SecurityContext.securityContext(String, Set, AuthorizationRole)` is already typed to an api-key subject and runs its argument through `Principal.principal(name, PrincipalType.API_KEY)`, which applies `api-key:` itself. `KvStoreApiKeyValidator.buildContext` applied it a second time. The sibling `ApiKeySecurityValidator.toSecurityContext` passes its bare name through the same factory and has always been correct — only the KV-backed path doubled.

This matters beyond pedantry: under the "keyId already carries it" model you would go looking in the key-*storage* path and could strip on write, corrupting `ApiKeyKey`/`ApiKeyValue` round-tripping while leaving the real doubling in place.

**Nothing parses the string.** Every consumer (`AppHttpServer`, `ManagementServer`, `WebSocketAuthenticator`, `StatusRoutes`) treats it opaquely. A repo-wide search for colon-splitting over `src/main/java` returned 30 hits, none on a principal. The one exactly-one-colon check in the tree, `SliceLoadingContext#isGeneratedBaseOf`, grades Maven artifact ids and never sees a principal. The only prefix tests are `Principal.isApiKey`/`isUser`/`isService` — all `startsWith`, which accepted the doubled form too, and that is also why nothing caught it.

**Why no existing test saw it, measured rather than argued.** `StatusRoutesWhoamiTest` hand-builds its `Principal` through the same factory, so it states what a correct principal looks like and never runs the validator that produced the wrong one; `BootstrapAdminKeyValidatorAcceptanceTest` does drive the real validator but asserts roles, not the principal. Under the reintroduced defect **both stayed green**.

New pin: `KvStoreApiKeyValidatorPrincipalTest` — 3 tests entered at the real `KvStoreApiKeyValidator` against a real `KVStore`. Exact equality, not `startsWith`: the defect's shape is an extra *correct-looking* prefix.

## #1025 — diagnosed, deliberately no code

- **The two anomalies do not share a cause, provable by direction.** `countedCoreMemberCount` is computed over the **same raw map** the enumeration walks, so a duplicate can only *inflate* it. The observed 4 is *below* the true member count of 5. Whatever produced the 10 did not produce the 4.
- **Raw, not deduplicated** — there is no canonicalisation anywhere in `MembershipFsm` (0 hits for `dedup|canonical|alias`; 246 for control terms in the same file).
- **The count is lagging, and lag is its specification.** `countsTowardEffective()` is true for `Member` **and `Suspect`** — "SUSPECT still counts, so a transient SWIM doubt never drops the effective size". 3 reachable + 1 still-`Suspect` = exactly 4, converging to 3. `countedCoreMemberCount` is not a reachability metric; `strictCoreObservedMemberCount` (#557) is, and exists *because* counted ≠ reachable. **There is no miscount to fix.**
- **Two id schemes coexisting is the expected steady state after auto-heal** — a CTM replacement must boot under its minted `aether-<cluster>-node-<ULID>` id, and `primary-core-N` entries are deliberately retained even when DEAD for incarnation-fenced rejoin. Both documented.
- **Eliminated:** auto-heal placeholders leaking into the enumeration (`inFlightProvisioning` is a separate map, cleared on membership arrival); and the cloud bootstrap self-minting an id (the Hetzner path threads it via `ProvisionContext.forBootstrap`).
- **Found but NOT fixed:** `CloudProviderSupport.toContext` builds its `ProvisionContext` with the overload that defaults `nodeId` to `Option.empty()`, so the provider self-mints a ULID id and labels the VM with it while the CLI records `primary-core-N` — the exact dual-identity shape. It is on the **docker** path, so it is not the cause of the Hetzner observation. Worth its own ticket; fixing provisioning identity plumbing unverified against a live provision would be a plausible fix, not a correct one.
- **Unresolved, with the discriminator named:** whether the 10 entries are 5 VMs × 2 identities or 5 originals + 5 replacements. The endpoint **already returns** the deciding fields (per-entry `state`, `incarnation`); the report captured only the totals. Since the count was 4, **all five ULID-named entries were in a non-counted state** — dispatched and announced but never promoted to `Member`, which is an auto-heal/reaping question rather than a counting one.

## Verification

- Root `mvn clean install`, no `-pl`, no `-DskipTests`: exit **0**, 15:28 min, `BUILD SUCCESS`, **0** module-level SKIPPED.
- **13763 `<testcase>` elements**, 0 failures, 0 errors, 19 skipped, across surefire **and** failsafe, parsed with `xml.etree`, filtered by a run marker dropped before the build. Attribute sum 11374 → gap **2389 (21.0%)**, matching the documented `@Nested` undercount. The 5 excluded reports are **five days old** (2026-09-07), so the marker did not land mid-build.
- Gate: `Running JBCT check on 152 Java file(s)` / `JBCT check passed.` — 152 is exactly `aether/node`'s `src/main/java` count, so the production change is inside it; the 166 test files are outside it under the repo-wide `jbct.includeTests=false`.
- Mutation probe, verified by **content** (not `git diff`): reverting only the `buildContext` hunk reddens exactly `KvStoreApiKeyValidatorPrincipalTest$WhenAKvStoredKeyAuthenticates` — 3 of 24. Restored: 24/24 green, file byte-identical to the committed base.
- Citation audit before push **caught one**: both the javadoc and the changelog cited `ApiKeySecurityValidator#buildContext`, which does not exist (it is `toSecurityContext`). Corrected, re-audited to zero, gate and tests re-run green.

Does not merge, does not close either issue.

## Verification scope — CLI-side vs node-side (checked, not assumed)

**Both issues are node-side, so no cloud run was requested.** `KvStoreApiKeyValidator` and
`ClusterTopologyRoutes` are in module **`node`**; `MembershipFsm` is in **`aether-deployment`**.
`aether/cli`'s 17 dependencies include **neither**. A cloud VM boots the published node jar, so a
cloud run would produce a confident result about a binary that cannot contain this fix.

**Live-cluster confirmation is therefore outstanding and is stated as unverified.** The
`[verified:]` tag in the changelog fragment is scoped to what the test asserts — the principal the
KV auth path produces — not to an end-to-end `/whoami` response from a cluster.

One qualification: the local docker harness **does** build the node image from source
(`docker build --no-cache -f docker/aether-node/Dockerfile -t aether-node:local`,
`run-tests.sh:631`; `env/docker.toml:41` sets `image = "aether-node:local"`), so a local docker
cluster — not cloud — is the available live-path option for #1024. Not run here: multi-container
state on a shared box, low marginal value over an exact-equality pin through the real validator plus
a mutation probe.

## Why a local repro would NOT settle #1025

A local docker cluster would likely reproduce the 10-for-5 shape — **through a defect that provably
cannot exist on the Hetzner path.** The two bootstrap paths diverge at `BootstrapPhaseProvision:376-377`:

- **DOCKER** → `provisionRoleGroup` → `CloudProviderSupport.provisionVia` → `toContext(group)`,
  which uses the 4-arg `provisionContext` overload defaulting `nodeId` to `Option.empty()`.
  `DockerComputeProvider.resolveIdentity` then mints `aether-<cluster>-node-<ULID>`, and
  `buildRunCommand` sets `var nodeId = containerName` ("NodeId == container name") — **the container
  boots under the minted ULID while the CLI recorded `primary-core-N`.**
- **CLOUD** → `provisionCloudRoleGroup` → `buildCloudProvisionSpec` →
  `ProvisionContext.forBootstrap(..., nodeId)` — **the id is threaded.**

Right shape, wrong cause. Treating that as confirmation would be the fixture-provenance error, so no
such instrument was built.

**This upgrades the unfixed finding:** `CloudProviderSupport.toContext` is not a latent
inconsistency but a **live defect on the docker path that produces #1025's exact symptom**, with the
docker source in active use locally (`tests/integration/cluster-config.toml`, `env/docker*.toml`,
`env/remote*.toml`). It lives in module **`environment-integration`** (not `aether/cli` — grep the
module name, not the label), which is shaded into the CLI, so it is testable — unlike the assigned
issues. **Filed as #1027**; not fixed here, since it needs a signature change to thread the index
and #1025 is diagnose-before-fix.
