### PR TITLE
fix: destroy falls back to recorded node addresses and trusts the cluster CA (#1023)

### DIFF
--- a/aether/cli/src/main/java/org/pragmatica/aether/cli/cluster/ClusterDestroyCommand.java
+++ b/aether/cli/src/main/java/org/pragmatica/aether/cli/cluster/ClusterDestroyCommand.java
@@ -257,9 +257,12 @@ class ClusterDestroyCommand implements Callable<Integer> {
 
         prepareClusterTrust(endpoint, state);
 
-        return fetchNodeIds(endpoint, siblingEndpoints(endpoint, state))
-                   .fold(_ -> onEnumerationFailed(registry, clusterName, endpoint),
-                         nodeIds -> destroyEnumerated(registry, clusterName, nodeIds));
+        return fetchNodeIds(endpoint, siblingEndpoints(endpoint, state)).fold(_ -> onEnumerationFailed(registry,
+                                                                                                       clusterName,
+                                                                                                       endpoint),
+                                                                              nodeIds -> destroyEnumerated(registry,
+                                                                                                           clusterName,
+                                                                                                           nodeIds));
     }
 
     /// An unreadable ledger arrives here as ABSENT, which is deliberate and is NOT a softening of #994's
@@ -516,7 +519,7 @@ class ClusterDestroyCommand implements Callable<Integer> {
     @Contract
     private static void installTrustForHttps(org.pragmatica.lang.Option<BootstrapState> state) {
         recordedClusterSecret(state).onPresent(ClusterDestroyCommand::installDerivedTrust)
-                                    .onEmpty(ClusterDestroyCommand::warnNoRecordedClusterSecret);
+                             .onEmpty(ClusterDestroyCommand::warnNoRecordedClusterSecret);
     }
 
     private static org.pragmatica.lang.Option<String> recordedClusterSecret(org.pragmatica.lang.Option<BootstrapState> state) {
@@ -562,10 +565,10 @@ class ClusterDestroyCommand implements Callable<Integer> {
     /// `ManagementServer.tryForwardIfNotLeader` FORWARDS the request when the receiving node is not the
     /// leader. `NODE_DRAIN` and `NODE_SHUTDOWN` forward the same way, which is why the endpoint that
     /// answers is kept as the override for the rest of the destroy.
-    static List<String> siblingEndpoints(Result<String> endpoint,
-                                         org.pragmatica.lang.Option<BootstrapState> state) {
+    static List<String> siblingEndpoints(Result<String> endpoint, org.pragmatica.lang.Option<BootstrapState> state) {
         return endpoint.option()
-                       .map(primary -> hostSubstitutedEndpoints(primary, collectedAddresses(state)))
+                       .map(primary -> hostSubstitutedEndpoints(primary,
+                                                                collectedAddresses(state)))
                        .or(List.of());
     }
 
@@ -576,8 +579,8 @@ class ClusterDestroyCommand implements Callable<Integer> {
 
     private static List<String> hostSubstitutedEndpoints(String primary, List<String> addresses) {
         return parseEndpoint(primary).filter(ClusterDestroyCommand::hasHttpScheme)
-                                     .map(uri -> substituteHosts(uri, primary, addresses))
-                                     .or(List.of());
+                            .map(uri -> substituteHosts(uri, primary, addresses))
+                            .or(List.of());
     }
 
     private static org.pragmatica.lang.Option<URI> parseEndpoint(String endpoint) {
@@ -622,8 +625,9 @@ class ClusterDestroyCommand implements Callable<Integer> {
     Result<List<String>> fetchNodeIds(Result<String> endpoint, List<String> siblings) {
         logPhase(DestroyPhase.ENUMERATE_NODES, enumerationAnnouncement(endpoint, siblings));
 
-        return firstSuccessfulEnumeration(endpoint, siblings).onFailure(cause -> warnNodeEnumerationFailed(cause, endpoint))
-                                                             .onSuccess(ClusterDestroyCommand::reportNodesFound);
+        return firstSuccessfulEnumeration(endpoint, siblings).onFailure(cause -> warnNodeEnumerationFailed(cause,
+                                                                                                           endpoint))
+                                         .onSuccess(ClusterDestroyCommand::reportNodesFound);
     }
 
     /// The first candidate that answers KEEPS the endpoint override, so DRAIN and SHUTDOWN follow the node
@@ -646,7 +650,6 @@ class ClusterDestroyCommand implements Callable<Integer> {
                                                               Result<String> endpoint,
                                                               List<String> siblings) {
         announceSiblingFallback(primary, siblings);
-
         for (var candidate : siblings) {
             var attempt = enumerateFrom(candidate);
 
@@ -665,7 +668,7 @@ class ClusterDestroyCommand implements Callable<Integer> {
         ClusterHttpClient.setEndpointOverride(candidate);
 
         return listNodes().onSuccess(_ -> reportSiblingSucceeded(candidate))
-                          .onFailure(cause -> reportSiblingFailed(candidate, cause));
+                        .onFailure(cause -> reportSiblingFailed(candidate, cause));
     }
 
     @Contract

--- a/aether/cli/src/main/java/org/pragmatica/aether/cli/cluster/ClusterDestroyCommand.java
+++ b/aether/cli/src/main/java/org/pragmatica/aether/cli/cluster/ClusterDestroyCommand.java
@@ -247,11 +247,29 @@ class ClusterDestroyCommand implements Callable<Integer> {
     /// [#onEnumerationFailed] instead of being flattened into an empty node list, because the two states it
     /// used to merge have opposite consequences: a cluster that genuinely has no nodes needs no drain, and a
     /// cluster that cannot be reached needs one it cannot get.
+    /// #1023 — the bootstrap ledger is read HERE, before the first management request, because both of the
+    /// two observed failures are answered by data it already holds: every node's address (the endpoint
+    /// SPOF) and the cluster secret (the trust anchor). Neither is new state; destroy already loaded this
+    /// same ledger, but only in [#cleanupCloudResources], three phases too late to reach the cluster with.
     Result<Integer> performDestruction(ClusterRegistry registry, ClusterName clusterName, Result<String> endpoint) {
         announceDestroyPlan(clusterName);
+        var state = recordedState(clusterName);
 
-        return fetchNodeIds(endpoint).fold(_ -> onEnumerationFailed(registry, clusterName, endpoint),
-                                           nodeIds -> destroyEnumerated(registry, clusterName, nodeIds));
+        prepareClusterTrust(endpoint, state);
+
+        return fetchNodeIds(endpoint, siblingEndpoints(endpoint, state))
+                   .fold(_ -> onEnumerationFailed(registry, clusterName, endpoint),
+                         nodeIds -> destroyEnumerated(registry, clusterName, nodeIds));
+    }
+
+    /// An unreadable ledger arrives here as ABSENT, which is deliberate and is NOT a softening of #994's
+    /// SF-1: [#cleanupCloudResources] re-reads the same file and still refuses to report cleanup done when
+    /// it cannot be read. The two decisions are different. "I cannot derive a trust anchor or a fallback
+    /// address" costs an enumeration attempt and ends in the #998 refusal; "I cannot tell which resources
+    /// are still billing" must never end in a removed registry entry.
+    private static org.pragmatica.lang.Option<BootstrapState> recordedState(ClusterName clusterName) {
+        return stateLoader.apply(clusterName)
+                          .or(org.pragmatica.lang.Option.none());
     }
 
     private Result<Integer> destroyEnumerated(ClusterRegistry registry, ClusterName clusterName, List<String> nodeIds) {
@@ -466,6 +484,127 @@ class ClusterDestroyCommand implements Callable<Integer> {
                           .equals(input);
     }
 
+    /// #1023 failure 2 — `SSLHandshakeException … PKIX path building failed`, observed live on a
+    /// `[operations.tls] auto_generate = true` cluster, so drain and shutdown could not run at all.
+    ///
+    /// TRACED, not inferred: [ClusterHttpClient#enableClusterTrust] had exactly ONE caller,
+    /// [ClusterBootstrapOrchestrator#configureClusterHttpClient], on the bootstrap path. Destroy never
+    /// installed any `SSLContext`, so every request it made used the JDK default trust store — and the
+    /// cluster's leaf certificates are signed by a CA derived from `cluster_secret` via HKDF
+    /// ([ClusterTrust], [SelfSignedCertificateProvider]), which is not an anchor in that store. The thing
+    /// that REFUSES the connection is the default `X509TrustManager`, not the cluster: there is no path
+    /// from the presented leaf to any anchor it holds.
+    ///
+    /// The fix installs the SAME anchor bootstrap installs — the cluster's own CA and nothing else. This is
+    /// not a relaxation: verification is strictly narrower than the JDK default, not wider, and
+    /// [ClusterHttpClient#enableTlsSkipVerify] (trust-all) is deliberately NOT used here. #209 removed that
+    /// shortcut from the bootstrap path for the same reason it must not reappear on this one — destroy
+    /// presents the operator API key and issues shutdown commands over this channel.
+    @Contract
+    static void prepareClusterTrust(Result<String> endpoint, org.pragmatica.lang.Option<BootstrapState> state) {
+        httpsEndpoint(endpoint).onPresent(_ -> installTrustForHttps(state));
+    }
+
+    /// `https` is the signal, and it is the one bootstrap itself writes:
+    /// [BootstrapPhasePost#managementScheme] returns `https` exactly when `auto_generate` is true. An
+    /// `http` endpoint needs no anchor, so the whole decision is skipped rather than guessed at.
+    private static org.pragmatica.lang.Option<String> httpsEndpoint(Result<String> endpoint) {
+        return endpoint.option()
+                       .filter(value -> "https".equals(ClusterHttpClient.schemeOf(value)));
+    }
+
+    @Contract
+    private static void installTrustForHttps(org.pragmatica.lang.Option<BootstrapState> state) {
+        recordedClusterSecret(state).onPresent(ClusterDestroyCommand::installDerivedTrust)
+                                    .onEmpty(ClusterDestroyCommand::warnNoRecordedClusterSecret);
+    }
+
+    private static org.pragmatica.lang.Option<String> recordedClusterSecret(org.pragmatica.lang.Option<BootstrapState> state) {
+        return state.map(BootstrapState::clusterSecret)
+                    .filter(secret -> !secret.isBlank());
+    }
+
+    @Contract
+    private static void installDerivedTrust(String clusterSecret) {
+        System.out.println("  Trusting this cluster's own CA, derived from the cluster_secret recorded at"
+                          + " bootstrap — the same derivation the nodes used to sign their certificates."
+                          + " No other issuer is trusted for this connection.");
+        ClusterHttpClient.enableClusterTrust(clusterSecret);
+    }
+
+    /// The honest half, and the reason this is a NOTE rather than a silent fallback: with no recorded
+    /// secret there is no anchor to derive, and the alternative — trusting whatever certificate is
+    /// presented — is what #209 removed. An operator reading a bare `PKIX path building failed` cannot
+    /// tell those two states apart, so this names which one they are in BEFORE the request fails.
+    @Contract
+    private static void warnNoRecordedClusterSecret() {
+        System.err.println("  NOTE: this cluster's endpoint is https, but no cluster_secret is recorded in its"
+                          + " bootstrap state, so the CA that signed its certificates cannot be derived. If"
+                          + " TLS was auto-generated, the next request will fail to build a trust path"
+                          + " (PKIX). Certificate verification is deliberately NOT disabled to work around"
+                          + " this.");
+    }
+
+    /// #1023 failure 1 — the registry records ONE node's address as the cluster endpoint
+    /// ([BootstrapPhasePost#managementEndpoint] takes `addresses().getFirst()`), and teardown is exactly
+    /// when that node is most likely to be the one that is already gone. Observed live on 2026-09-11: the
+    /// entry named a node the operator had deliberately killed, enumeration got a `ConnectException`, and
+    /// destroy refused — while three healthy nodes were serving the very same route.
+    ///
+    /// The addresses are NOT a new field. [BootstrapPhaseCollect] already records every provisioned node's
+    /// public IP in `BootstrapState.collectedAddresses`, and destroy already loads that ledger. Only the
+    /// scheme and port are borrowed from the recorded endpoint, so a deliberately port-less or proxied
+    /// entry is REPRODUCED rather than second-guessed — #998's reason for refusing to default a port
+    /// applies unchanged to the siblings built from it.
+    ///
+    /// Any live node can answer, and this is checked at the code that enforces it rather than at a
+    /// docstring: [ManagementRoute#NODE_LIFECYCLE_LIST] is `LEADER`-targeted, and
+    /// `ManagementServer.tryForwardIfNotLeader` FORWARDS the request when the receiving node is not the
+    /// leader. `NODE_DRAIN` and `NODE_SHUTDOWN` forward the same way, which is why the endpoint that
+    /// answers is kept as the override for the rest of the destroy.
+    static List<String> siblingEndpoints(Result<String> endpoint,
+                                         org.pragmatica.lang.Option<BootstrapState> state) {
+        return endpoint.option()
+                       .map(primary -> hostSubstitutedEndpoints(primary, collectedAddresses(state)))
+                       .or(List.of());
+    }
+
+    private static List<String> collectedAddresses(org.pragmatica.lang.Option<BootstrapState> state) {
+        return state.map(BootstrapState::collectedAddresses)
+                    .or(List.of());
+    }
+
+    private static List<String> hostSubstitutedEndpoints(String primary, List<String> addresses) {
+        return parseEndpoint(primary).filter(ClusterDestroyCommand::hasHttpScheme)
+                                     .map(uri -> substituteHosts(uri, primary, addresses))
+                                     .or(List.of());
+    }
+
+    private static org.pragmatica.lang.Option<URI> parseEndpoint(String endpoint) {
+        return Result.lift(Causes::fromThrowable,
+                           () -> URI.create(endpoint))
+                     .option();
+    }
+
+    private static boolean hasHttpScheme(URI uri) {
+        return "http".equals(uri.getScheme()) || "https".equals(uri.getScheme());
+    }
+
+    private static List<String> substituteHosts(URI uri, String primary, List<String> addresses) {
+        return addresses.stream()
+                        .filter(address -> !address.isBlank())
+                        .map(address -> endpointForHost(uri, address))
+                        .filter(candidate -> !candidate.equals(primary))
+                        .distinct()
+                        .toList();
+    }
+
+    private static String endpointForHost(URI uri, String address) {
+        return uri.getPort() < 0
+               ? uri.getScheme() + "://" + address
+               : uri.getScheme() + "://" + address + ":" + uri.getPort();
+    }
+
     /// #995 — this is the call that produced the observed silence: one management request, up to
     /// [#requestTimeoutSeconds] before it gives up, and its failure was swallowed by `.or(List.of())`
     /// with no message at all. It now says what it is about to wait for and for how long, and reports a
@@ -476,14 +615,96 @@ class ClusterDestroyCommand implements Callable<Integer> {
     /// cluster. The `Result` is returned rather than flattened by `.or(List.of())`: that flattening is what
     /// made an unreachable cluster indistinguishable from an empty one.
     Result<List<String>> fetchNodeIds(Result<String> endpoint) {
-        logPhase(DestroyPhase.ENUMERATE_NODES,
-                 String.format("Listing cluster nodes from %s (one request, timeout %ds)",
-                               endpoint.or("<no endpoint resolved>"),
-                               requestTimeoutSeconds()));
+        return fetchNodeIds(endpoint, List.of());
+    }
 
-        return endpoint.flatMap(_ -> listNodes())
-                       .onFailure(cause -> warnNodeEnumerationFailed(cause, endpoint))
-                       .onSuccess(ClusterDestroyCommand::reportNodesFound);
+    /// #1023 — the recorded endpoint first, then each sibling address in turn.
+    Result<List<String>> fetchNodeIds(Result<String> endpoint, List<String> siblings) {
+        logPhase(DestroyPhase.ENUMERATE_NODES, enumerationAnnouncement(endpoint, siblings));
+
+        return firstSuccessfulEnumeration(endpoint, siblings).onFailure(cause -> warnNodeEnumerationFailed(cause, endpoint))
+                                                             .onSuccess(ClusterDestroyCommand::reportNodesFound);
+    }
+
+    /// The first candidate that answers KEEPS the endpoint override, so DRAIN and SHUTDOWN follow the node
+    /// that proved reachable instead of the one the registry happens to name. Enumerating from a live node
+    /// and then draining against a dead one would be a fix in name only.
+    ///
+    /// When every candidate fails, the PRIMARY endpoint's failure is the one returned and reported: it is
+    /// the endpoint the operator recorded, and the siblings are a recovery path, not a redefinition of the
+    /// target. This is also what keeps the #998 diagnostics — the port-less note, and the refusal itself —
+    /// attached to the endpoint they are about.
+    private static Result<List<String>> firstSuccessfulEnumeration(Result<String> endpoint, List<String> siblings) {
+        var primary = endpoint.flatMap(_ -> listNodes());
+
+        return primary.isSuccess() || siblings.isEmpty()
+               ? primary
+               : enumerateFromSiblings(primary, endpoint, siblings);
+    }
+
+    private static Result<List<String>> enumerateFromSiblings(Result<List<String>> primary,
+                                                              Result<String> endpoint,
+                                                              List<String> siblings) {
+        announceSiblingFallback(primary, siblings);
+
+        for (var candidate : siblings) {
+            var attempt = enumerateFrom(candidate);
+
+            if (attempt.isSuccess()) {
+                return attempt;
+            }
+        }
+
+        restorePrimaryEndpoint(endpoint);
+
+        return primary;
+    }
+
+    private static Result<List<String>> enumerateFrom(String candidate) {
+        System.out.printf("  Trying recorded node address %s...%n", candidate);
+        ClusterHttpClient.setEndpointOverride(candidate);
+
+        return listNodes().onSuccess(_ -> reportSiblingSucceeded(candidate))
+                          .onFailure(cause -> reportSiblingFailed(candidate, cause));
+    }
+
+    @Contract
+    private static void announceSiblingFallback(Result<List<String>> primary, List<String> siblings) {
+        System.out.printf("  The recorded endpoint did not answer (%s). Trying %d other node address(es)"
+                         + " recorded at bootstrap — any live node forwards this request to the leader.%n",
+                          primary.fold(Cause::message, _ -> "no failure"),
+                          siblings.size());
+    }
+
+    @Contract
+    private static void reportSiblingSucceeded(String candidate) {
+        System.out.printf("  %s answered. The rest of this destroy — drain and shutdown — will use it"
+                         + " instead of the recorded endpoint.%n",
+                          candidate);
+    }
+
+    @Contract
+    private static void reportSiblingFailed(String candidate, Cause cause) {
+        System.err.printf("  %s did not answer: %s%n", candidate, cause.message());
+    }
+
+    /// Every sibling failed, so the target goes back to what the operator recorded. Leaving the override
+    /// pointing at the last address tried would make the refusal describe an endpoint nobody chose.
+    @Contract
+    private static void restorePrimaryEndpoint(Result<String> endpoint) {
+        endpoint.onSuccess(ClusterHttpClient::setEndpointOverride);
+    }
+
+    private static String enumerationAnnouncement(Result<String> endpoint, List<String> siblings) {
+        return siblings.isEmpty()
+               ? String.format("Listing cluster nodes from %s (one request, timeout %ds)",
+                               endpoint.or("<no endpoint resolved>"),
+                               requestTimeoutSeconds())
+               : String.format("Listing cluster nodes from %s (timeout %ds), falling back to %d other node"
+                              + " address(es) recorded at bootstrap if it does not answer",
+                               endpoint.or("<no endpoint resolved>"),
+                               requestTimeoutSeconds(),
+                               siblings.size());
     }
 
     private static Result<List<String>> listNodes() {
@@ -668,8 +889,14 @@ class ClusterDestroyCommand implements Callable<Integer> {
         System.out.println();
         System.out.printf("Cluster '%s' destruction summary:%n", clusterName);
         System.out.printf("  Nodes processed: %d%n", nodeIds.size());
-        System.out.printf("  Drains succeeded: %d/%d%n", countSuccesses(drainResults), drainResults.size());
-        System.out.printf("  Shutdowns succeeded: %d/%d%n", countSuccesses(shutdownResults), shutdownResults.size());
+        System.out.printf("  Drains succeeded: %d/%d%s%n",
+                          countSuccesses(drainResults),
+                          drainResults.size(),
+                          skippedNote(nodeIds));
+        System.out.printf("  Shutdowns succeeded: %d/%d%s%n",
+                          countSuccesses(shutdownResults),
+                          shutdownResults.size(),
+                          skippedNote(nodeIds));
         System.out.printf("  Cloud resource cleanup: %s%n",
                           cleanupSucceeded
                           ? "ok"
@@ -698,6 +925,16 @@ class ClusterDestroyCommand implements Callable<Integer> {
         System.out.printf("Cluster '%s' destroyed successfully.%n", clusterName);
 
         return ExitCode.SUCCESS;
+    }
+
+    /// #1023 — `Drains succeeded: 0/0` was the ENTIRE observable outcome of a destroy that drained nothing,
+    /// and a ratio whose denominator is zero reads like a pass. It is a SKIP. The number is unchanged and
+    /// still honest; what was missing is which of the two it describes, so the summary now says so rather
+    /// than leaving the reader to notice that `0/0` is not `3/3`.
+    private static String skippedNote(List<String> nodeIds) {
+        return nodeIds.isEmpty()
+               ? "  (SKIPPED — no nodes were enumerated, so nothing was drained or shut down)"
+               : "";
     }
 
     private static long countSuccesses(List<NodeResult> results) {

--- a/aether/cli/src/test/java/org/pragmatica/aether/cli/cluster/ClusterDestroyCommandTest.java
+++ b/aether/cli/src/test/java/org/pragmatica/aether/cli/cluster/ClusterDestroyCommandTest.java
@@ -1315,6 +1315,61 @@ class ClusterDestroyCommandTest {
                         () -> "nothing was skipped, so the note must be absent; got:\n" + stdout());
         }
 
+        /// **Wiring, not behaviour** — and it is a separate test for a reason. Every assertion above drives
+        /// `siblingEndpoints` / `fetchNodeIds` directly, so deleting the CALL to them from
+        /// [ClusterDestroyCommand#performDestruction] would restore the whole defect with all of them still
+        /// green. This one enters through `performDestruction` and asserts on the hosts the requests
+        /// carried: the siblings must be derived from the ledger and threaded into the enumeration.
+        @Test
+        void performDestruction_derivesSiblingsFromTheLedgerAndUsesThem_whenTheRecordedEndpointIsDead() {
+            var attempted = new ArrayList<String>();
+            var originalRemover = ClusterDestroyCommand.registryRemover;
+
+            ClusterHttpClient.HTTP_OPS_REF.set(new HostSelectiveHttpOperations("10.0.0.3", "[]", attempted));
+            ClusterDestroyCommand.stateLoader = name -> Result.success(some(stateWithAddresses("10.255.255.1",
+                                                                                               "10.0.0.3")));
+            ClusterDestroyCommand.vmSweeper = (state, name) -> Result.unitResult();
+            ClusterDestroyCommand.registryRemover = (registry, name) -> Result.success(registry);
+            try {
+                var exitCode = new ClusterDestroyCommand().performDestruction(registryWithNoEntries(),
+                                                                             CLUSTER_NAME,
+                                                                             TARGET_ENDPOINT);
+
+                assertEquals(List.of("10.255.255.1", "10.0.0.3"), attempted,
+                             "the dead recorded endpoint is tried first, then the sibling the LEDGER supplied — "
+                             + "if this reads as one host, performDestruction is not passing the siblings on");
+                exitCode.onFailure(cause -> fail("the destroy must produce a summary: " + cause.message()))
+                        .onSuccess(code -> assertEquals(ExitCode.SUCCESS, (int) code,
+                                                        "a cluster reachable through a sibling is NOT an "
+                                                        + "unreachable cluster, so #998 must not refuse it"));
+                assertFalse(stderr().contains("REFUSING to destroy"),
+                            () -> "the refusal is for a cluster that cannot be reached at all; got:\n" + stderr());
+            } finally {
+                ClusterDestroyCommand.registryRemover = originalRemover;
+            }
+        }
+
+        /// The same wiring check for the trust half, and it needs no network: the NO-SECRET branch leaves the
+        /// stubbed client in place, so the note reaching stderr proves `performDestruction` called
+        /// `prepareClusterTrust` before enumerating. Without this, deleting that call would leave every
+        /// trust test above green.
+        @Test
+        void performDestruction_prepareTheTrustAnchor_beforeEnumerating() {
+            var attempted = new ArrayList<String>();
+
+            ClusterHttpClient.HTTP_OPS_REF.set(new HostSelectiveHttpOperations("no-host-answers", "[]", attempted));
+            ClusterDestroyCommand.stateLoader = name -> Result.success(some(stateWithVms(1)));
+
+            new ClusterDestroyCommand().performDestruction(registryWithNoEntries(), CLUSTER_NAME, TARGET_ENDPOINT);
+
+            assertTrue(stderr().contains("no cluster_secret is recorded"),
+                       () -> "performDestruction must take the trust decision for its https target; got:\n"
+                             + stderr());
+            assertTrue(stderr().indexOf("no cluster_secret is recorded") < stderr().indexOf("could not list cluster nodes"),
+                       () -> "and it must take it BEFORE the request it governs — an anchor installed after the "
+                             + "handshake governs nothing; got:\n" + stderr());
+        }
+
         private static ClusterRegistry registryWithNoEntries() {
             return ClusterRegistry.clusterRegistry(Path.of("unused-registry.toml"), none(), List.of());
         }

--- a/aether/cli/src/test/java/org/pragmatica/aether/cli/cluster/ClusterDestroyCommandTest.java
+++ b/aether/cli/src/test/java/org/pragmatica/aether/cli/cluster/ClusterDestroyCommandTest.java
@@ -46,6 +46,8 @@ import picocli.CommandLine.Command;
 import static org.pragmatica.aether.environment.ClusterName.clusterName;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.pragmatica.lang.Option.none;
@@ -109,6 +111,19 @@ class ClusterDestroyCommandTest {
 
     private static BootstrapState emptyState() {
         return BootstrapState.initialState(CLUSTER_NAME, "hash-1", "2026-05-01T00:00:00Z");
+    }
+
+    /// #1023 — a ledger carrying the addresses [BootstrapPhaseCollect] records for EVERY provisioned node,
+    /// which is the data the endpoint SPOF is repaired from. It is not a new field; `stateWithVms` simply
+    /// never populated it, which is why no test could have caught the single-address endpoint.
+    private static BootstrapState stateWithAddresses(String... addresses) {
+        return BootstrapState.initialState(CLUSTER_NAME, "hash-1", "2026-05-01T00:00:00Z")
+                             .withCollectedAddresses(List.of(addresses));
+    }
+
+    private static BootstrapState stateWithSecret(String secret) {
+        return BootstrapState.initialState(CLUSTER_NAME, "hash-1", "2026-05-01T00:00:00Z")
+                             .withClusterSecret(secret);
     }
 
     @Nested
@@ -1035,6 +1050,289 @@ class ClusterDestroyCommandTest {
 
         private static ClusterRegistry registryWithNoEntries() {
             return ClusterRegistry.clusterRegistry(Path.of("unused-registry.toml"), none(), List.of());
+        }
+    }
+
+    /// #1023 — `cluster destroy` could not drain AT ALL on a TLS-auto_generate cloud cluster. Observed
+    /// live on a 5-node Hetzner cluster on 2026-09-11; the final summary read
+    /// `Drains succeeded: 0/0, Shutdowns succeeded: 0/0`, which is a SKIP wearing the shape of a pass.
+    ///
+    /// Two independent failures, pinned separately here because they have different fixes and different
+    /// risk: the registry's endpoint names ONE node and cannot survive it, and the CLI holds no trust
+    /// anchor for the CA the cluster generated for itself.
+    @Nested
+    class SingleEndpointSpofAndClusterTrust {
+
+        private final ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+        private final ByteArrayOutputStream err = new ByteArrayOutputStream();
+
+        private PrintStream originalOut;
+
+        private PrintStream originalErr;
+
+        private HttpOperations originalHttpOps;
+
+        private String originalEndpoint;
+
+        @BeforeEach
+        void captureStreamsAndStubHttp() {
+            originalOut = System.out;
+            originalErr = System.err;
+            originalHttpOps = ClusterHttpClient.HTTP_OPS_REF.get();
+            originalEndpoint = ClusterHttpClient.ENDPOINT_OVERRIDE.get();
+            System.setOut(new PrintStream(out, true, StandardCharsets.UTF_8));
+            System.setErr(new PrintStream(err, true, StandardCharsets.UTF_8));
+            ClusterHttpClient.setEndpointOverride("https://10.255.255.1:8080");
+        }
+
+        @AfterEach
+        void restoreStreamsAndHttp() {
+            System.setOut(originalOut);
+            System.setErr(originalErr);
+            ClusterHttpClient.HTTP_OPS_REF.set(originalHttpOps);
+            ClusterHttpClient.ENDPOINT_OVERRIDE.set(originalEndpoint);
+        }
+
+        private String stdout() {
+            return out.toString(StandardCharsets.UTF_8);
+        }
+
+        private String stderr() {
+            return err.toString(StandardCharsets.UTF_8);
+        }
+
+        /// Failure 1, the defect itself: the node the registry names is DEAD and three healthy nodes are
+        /// serving the same route. Asserted on the HOSTS the requests actually carried, in order — a call
+        /// count cannot distinguish "tried the sibling" from "retried the primary twice".
+        @Test
+        void fetchNodeIds_fallsThroughToALiveSibling_whenTheRecordedEndpointIsDead() {
+            var attempted = new ArrayList<String>();
+
+            ClusterHttpClient.HTTP_OPS_REF.set(new HostSelectiveHttpOperations("10.0.0.3",
+                                                                               """
+                                                                               [{"nodeId":"core-2"}]
+                                                                               """,
+                                                                               attempted));
+
+            var nodeIds = new ClusterDestroyCommand().fetchNodeIds(TARGET_ENDPOINT,
+                                                                   List.of("https://10.0.0.2:8080",
+                                                                           "https://10.0.0.3:8080"));
+
+            assertEquals(Result.success(List.of("core-2")), nodeIds,
+                         "a live sibling answers the enumeration the dead recorded endpoint could not");
+            assertEquals(List.of("10.255.255.1", "10.0.0.2", "10.0.0.3"), attempted,
+                         "the recorded endpoint must be tried FIRST and each sibling in turn — the operator's "
+                         + "recorded target is not silently replaced");
+        }
+
+        /// The half that makes the fallthrough worth having. Enumerating from a live node and then draining
+        /// against the dead one would be a fix in name only, so the endpoint that answered must become the
+        /// target for the REST of the destroy.
+        @Test
+        void fetchNodeIds_retargetsSubsequentRequests_ontoTheSiblingThatAnswered() {
+            var attempted = new ArrayList<String>();
+
+            ClusterHttpClient.HTTP_OPS_REF.set(new HostSelectiveHttpOperations("10.0.0.3", "[]", attempted));
+
+            new ClusterDestroyCommand().fetchNodeIds(TARGET_ENDPOINT, List.of("https://10.0.0.3:8080"));
+
+            assertEquals("https://10.0.0.3:8080", ClusterHttpClient.ENDPOINT_OVERRIDE.get(),
+                         "DRAIN and SHUTDOWN resolve this override, so it must name the node that proved "
+                         + "reachable rather than the one the registry happens to record");
+            assertTrue(stdout().contains("will use it"),
+                       () -> "and the transcript must record the retarget; got:\n" + stdout());
+        }
+
+        /// Negative control, and it guards #998: when every candidate fails, the endpoint override goes back
+        /// to what the operator recorded, the PRIMARY failure is the one reported, and the refusal stands.
+        /// Leaving the override on the last address tried would make the refusal describe a target nobody
+        /// chose.
+        @Test
+        void fetchNodeIds_restoresTheRecordedEndpointAndStillFails_whenEverySiblingAlsoFails() {
+            var attempted = new ArrayList<String>();
+
+            ClusterHttpClient.HTTP_OPS_REF.set(new HostSelectiveHttpOperations("no-host-answers", "[]", attempted));
+
+            var nodeIds = new ClusterDestroyCommand().fetchNodeIds(TARGET_ENDPOINT, List.of("https://10.0.0.2:8080"));
+
+            assertTrue(nodeIds.isFailure(),
+                       () -> "an unreachable cluster is still an unreachable cluster: " + nodeIds);
+            assertEquals(List.of("10.255.255.1", "10.0.0.2"), attempted, "both candidates were tried");
+            assertEquals("https://10.255.255.1:8080", ClusterHttpClient.ENDPOINT_OVERRIDE.get(),
+                         "the target returns to the recorded endpoint once the recovery path is exhausted");
+            assertTrue(stderr().contains("could not list cluster nodes"),
+                       () -> "#998's refusal must survive the fallback; got:\n" + stderr());
+        }
+
+        /// Positive control for the two above: with NO siblings recorded the behaviour is exactly what it
+        /// was before #1023 — one request, no fallback announcement. Without this, "tried 3 hosts" is
+        /// equally consistent with a loop that always runs.
+        @Test
+        void fetchNodeIds_issuesOneRequestAndAnnouncesNoFallback_whenNoSiblingsAreRecorded() {
+            var attempted = new ArrayList<String>();
+
+            ClusterHttpClient.HTTP_OPS_REF.set(new HostSelectiveHttpOperations("no-host-answers", "[]", attempted));
+
+            new ClusterDestroyCommand().fetchNodeIds(TARGET_ENDPOINT, List.of());
+
+            assertEquals(List.of("10.255.255.1"), attempted, "exactly one request, to the recorded endpoint");
+            assertFalse(stdout().contains("Trying recorded node address"),
+                        () -> "there is nothing to fall back to, so nothing may be announced; got:\n" + stdout());
+            assertTrue(stdout().contains("one request"),
+                       () -> "and the announcement still describes a single request; got:\n" + stdout());
+        }
+
+        /// The construction itself, against #1023's OBSERVED registry entry. Scheme and port are borrowed
+        /// from the recorded endpoint rather than defaulted — #998's reason for refusing to invent a port
+        /// applies unchanged to the siblings built from it — and the primary's own address is not retried.
+        @Test
+        void siblingEndpoints_borrowTheRecordedSchemeAndPort_andExcludeThePrimary() {
+            var state = stateWithAddresses("138.199.236.244", "10.0.0.2", "10.0.0.3");
+
+            var siblings = ClusterDestroyCommand.siblingEndpoints(Result.success("https://138.199.236.244:8080"),
+                                                                  some(state));
+
+            assertEquals(List.of("https://10.0.0.2:8080", "https://10.0.0.3:8080"), siblings,
+                         "https and 8080 come from the recorded entry, and the node it already names is not "
+                         + "tried twice");
+        }
+
+        /// #998's property, preserved: a target with NO recorded endpoint must produce no candidates at all.
+        /// The siblings are a recovery path for a known target, never a way to guess one — draining a
+        /// different cluster's nodes is worse than not draining this one's.
+        @Test
+        void siblingEndpoints_areEmpty_whenTheTargetHasNoRecordedEndpoint() {
+            var noEndpoint = ClusterDestroyCommand.DestroyError.General.NO_TARGET_ENDPOINT.<String> result();
+
+            var siblings = ClusterDestroyCommand.siblingEndpoints(noEndpoint, some(stateWithAddresses("10.0.0.2")));
+
+            assertEquals(List.of(), siblings,
+                         "no recorded endpoint means no scheme and no port, so there is nothing to build a "
+                         + "candidate from — and nothing may be invented");
+        }
+
+        @Test
+        void siblingEndpoints_areEmpty_whenTheLedgerRecordsNoAddresses() {
+            var siblings = ClusterDestroyCommand.siblingEndpoints(TARGET_ENDPOINT, some(stateWithVms(3)));
+
+            assertEquals(List.of(), siblings, "a ledger with no collected addresses offers no fallback");
+        }
+
+        /// Failure 2: the CLI must hold a trust anchor for the CA the cluster generated for itself. The
+        /// observable is that the HTTP client is REPLACED — `enableClusterTrust` installs a new client
+        /// carrying an `SSLContext` whose trust store holds the derived CA and nothing else.
+        @Test
+        void prepareClusterTrust_installsTheDerivedClusterCa_whenHttpsAndASecretIsRecorded() {
+            var before = ClusterHttpClient.HTTP_OPS_REF.get();
+
+            ClusterDestroyCommand.prepareClusterTrust(TARGET_ENDPOINT, some(stateWithSecret("cluster-secret-for-test")));
+
+            assertNotSame(before, ClusterHttpClient.HTTP_OPS_REF.get(),
+                          "an SSLContext trusting the cluster's own CA must actually be installed — without it "
+                          + "every request fails PKIX path building and nothing can be drained");
+            assertTrue(stdout().contains("Trusting this cluster's own CA"),
+                       () -> "and the anchor being used must be stated; got:\n" + stdout());
+        }
+
+        /// Negative control: a plain-http cluster needs no anchor, so the client must be left alone. Without
+        /// this, "the client changed" would also be satisfied by an unconditional replacement.
+        @Test
+        void prepareClusterTrust_leavesTheClientUntouched_whenTheEndpointIsPlainHttp() {
+            var before = ClusterHttpClient.HTTP_OPS_REF.get();
+
+            ClusterDestroyCommand.prepareClusterTrust(Result.success("http://10.0.0.2:8080"),
+                                                      some(stateWithSecret("cluster-secret-for-test")));
+
+            assertSame(before, ClusterHttpClient.HTTP_OPS_REF.get(),
+                       "an http endpoint has no certificate to verify, so no trust decision is taken");
+            assertFalse(stdout().contains("Trusting this cluster's own CA"),
+                        () -> "and nothing is announced; got:\n" + stdout());
+        }
+
+        /// The honest half. With no recorded secret there is no anchor to derive, and the tempting
+        /// workaround — trusting whatever certificate is presented — is exactly what #209 removed. The
+        /// client must be left VERIFYING, and the operator must be told which of the two states they are in
+        /// before the request fails with a bare PKIX error.
+        @Test
+        void prepareClusterTrust_saysSoAndDisablesNothing_whenHttpsButNoSecretIsRecorded() {
+            var before = ClusterHttpClient.HTTP_OPS_REF.get();
+
+            ClusterDestroyCommand.prepareClusterTrust(TARGET_ENDPOINT, some(stateWithVms(1)));
+
+            assertSame(before, ClusterHttpClient.HTTP_OPS_REF.get(),
+                       "certificate verification must NOT be disabled as a workaround: a destroy that "
+                       + "trusts any certificate is worse than one that refuses");
+            assertTrue(stderr().contains("no cluster_secret is recorded"),
+                       () -> "the reason must be named; got:\n" + stderr());
+            assertTrue(stderr().contains("NOT disabled"),
+                       () -> "and the refusal to work around it must be explicit; got:\n" + stderr());
+        }
+
+        @Test
+        void prepareClusterTrust_leavesTheClientUntouched_whenThereIsNoLedgerAtAll() {
+            var before = ClusterHttpClient.HTTP_OPS_REF.get();
+
+            ClusterDestroyCommand.prepareClusterTrust(TARGET_ENDPOINT, none());
+
+            assertSame(before, ClusterHttpClient.HTTP_OPS_REF.get(),
+                       "no ledger means no secret to derive an anchor from");
+            assertTrue(stderr().contains("no cluster_secret is recorded"),
+                       () -> "and it is reported rather than passed over; got:\n" + stderr());
+        }
+
+        /// #1023's summary line. `0/0` is a ratio over an empty set — a SKIP — and it reads like a pass.
+        /// The count is unchanged and was always honest; what was missing is which of the two it describes.
+        @Test
+        void printSummary_marksTheDrainAndShutdownCountsAsSkipped_whenNoNodesWereEnumerated() {
+            ClusterDestroyCommand.finalizeDestruction(registryWithNoEntries(),
+                                                      CLUSTER_NAME,
+                                                      true,
+                                                      List.of(),
+                                                      List.of(),
+                                                      List.of());
+
+            assertTrue(stdout().contains("Drains succeeded: 0/0  (SKIPPED"),
+                       () -> "a zero-denominator ratio must say it is a skip; got:\n" + stdout());
+            assertTrue(stdout().contains("Shutdowns succeeded: 0/0  (SKIPPED"),
+                       () -> "and both counts carry it; got:\n" + stdout());
+        }
+
+        /// Negative control: with nodes actually processed the note must NOT appear, or it is an always-on
+        /// line that says nothing about this destroy.
+        @Test
+        void printSummary_omitsTheSkippedNote_whenNodesWereProcessed() {
+            ClusterDestroyCommand.finalizeDestruction(registryWithNoEntries(),
+                                                      CLUSTER_NAME,
+                                                      true,
+                                                      List.of("core-0"),
+                                                      List.of(new ClusterDestroyCommand.NodeResult("core-0", true)),
+                                                      List.of(new ClusterDestroyCommand.NodeResult("core-0", true)));
+
+            assertTrue(stdout().contains("Drains succeeded: 1/1"),
+                       () -> "precondition: a real drain was counted; got:\n" + stdout());
+            assertFalse(stdout().contains("SKIPPED"),
+                        () -> "nothing was skipped, so the note must be absent; got:\n" + stdout());
+        }
+
+        private static ClusterRegistry registryWithNoEntries() {
+            return ClusterRegistry.clusterRegistry(Path.of("unused-registry.toml"), none(), List.of());
+        }
+    }
+
+    /// Answers for exactly one host and fails for every other, recording the host of each request in order.
+    /// The ORDER is the assertion that matters: a call count cannot tell "fell through to the sibling" from
+    /// "retried the primary", and those are the two behaviours #1023 turns on.
+    private record HostSelectiveHttpOperations(String liveHost, String body, List<String> attempted)
+            implements HttpOperations {
+        @Override
+        @SuppressWarnings("unchecked")
+        public <T> Promise<HttpResult<T>> send(HttpRequest request, BodyHandler<T> handler) {
+            attempted.add(request.uri().getHost());
+
+            return liveHost.equals(request.uri().getHost())
+                   ? Promise.success(new HttpResult<>(200, HttpHeaders.of(Map.of(), (a, b) -> true), (T) body))
+                   : Causes.cause("connection refused").promise();
         }
     }
 

--- a/changelog.d/1023-destroy-drain-endpoint-spof-and-cluster-trust.md
+++ b/changelog.d/1023-destroy-drain-endpoint-spof-and-cluster-trust.md
@@ -48,8 +48,20 @@ persists** — no new field was added to the registry or the bootstrap state.
   count was always honest, but nothing said which of the two it described. Both the drain and shutdown
   lines now carry `(SKIPPED — no nodes were enumerated…)` when the node list was empty.
 
-**Not verified without a live cloud run.** The original failure was only reproducible on a live
-TLS-auto_generate cloud cluster. What is pinned above is unit-level: endpoint-candidate construction and
-fallthrough, the retarget, the restore-and-refuse path, and which trust anchor is installed. That a
-drain **completes** end-to-end against a real cluster whose first recorded node is dead is
-**[design intent — unverified]** — it requires a cloud bootstrap this change was not able to run.
+- **Certificate validation is enforced, and that is demonstrated rather than asserted.** With a
+  cluster-CA-signed certificate served by a stub node, the **correct** recorded secret completes the
+  handshake and drains (`Drains succeeded: 3/3`); a **wrong** secret, everything else identical, is
+  rejected with `PKIX path validation failed … signature check failed` and refuses. Had this been
+  "fixed" by disabling validation, that control would have passed.
+  [mechanism: the installed anchor is the derived cluster CA and nothing else, so a certificate from a
+  different cluster's secret has no path to it — #209's MITM property, preserved on the destroy path]
+
+**Verification scope — read this before quoting the above.** The CLI path is exercised end-to-end on the
+built `aether.jar` (isolated `-Duser.home`) against a **stub node**, over real TLS, with request-level
+attribution (11 requests, none addressed to the dead endpoint) and a negative control that fails for the
+right reason. It is **not** the feature catalog's *Integration-verified* bar: the certificate was issued
+by the same provider class rather than by a real node at first leadership, the stub answers
+`NODE_LIFECYCLE_LIST` directly so a real **leader-forwarding hop is read but never exercised**, and no
+multi-node cloud cluster was involved. So the drain claim is **[design intent — unverified]** at the
+multi-node-with-failure-injection bar, and verified at the CLI-behaviour bar. Do not read "the tests
+pass" as "drain works on a real cluster" — that conflation is what let `0/0` read as success.

--- a/changelog.d/1023-destroy-drain-endpoint-spof-and-cluster-trust.md
+++ b/changelog.d/1023-destroy-drain-endpoint-spof-and-cluster-trust.md
@@ -1,0 +1,55 @@
+### Fixed (2026-09-12 — #1023: `cluster destroy` could not drain at all on a TLS-auto_generate cloud cluster)
+
+Observed live on a 5-node Hetzner cluster on 2026-09-11, final summary
+`Drains succeeded: 0/0, Shutdowns succeeded: 0/0`. Two independent failures, fixed separately because
+they have different mechanisms and different risk. Both are repaired from data bootstrap **already
+persists** — no new field was added to the registry or the bootstrap state.
+
+- **The registry stores ONE node's address as the cluster endpoint, and teardown is exactly when that
+  node is most likely to be gone.** `BootstrapPhasePost.managementEndpoint` builds the persisted entry
+  from `addresses().getFirst()`, so the single recorded endpoint is a single point of failure: the
+  observed entry named a node the operator had deliberately killed, enumeration got a `ConnectException`,
+  and destroy refused — while three healthy nodes were serving the same route. `destroy` now falls back
+  to the other node addresses `BootstrapPhaseCollect` already records in
+  `BootstrapState.collectedAddresses`, trying the recorded endpoint first and each sibling in turn.
+  Scheme and port are borrowed from the recorded entry rather than defaulted, so #998's refusal to invent
+  a port applies unchanged to the candidates built from it.
+  [mechanism: `NODE_LIFECYCLE_LIST` is `LEADER`-targeted and `ManagementServer.tryForwardIfNotLeader`
+  forwards it, so any live node serves the same cluster-wide list; `NODE_DRAIN` and `NODE_SHUTDOWN`
+  forward the same way]
+  [verified: `aether/cli` `ClusterDestroyCommandTest.SingleEndpointSpofAndClusterTrust` — asserted on the
+  ordered hosts the requests carried, not on a call count]
+- **The endpoint that answers becomes the target for the rest of the destroy.** Enumerating from a live
+  node and then draining against the dead one would be a fix in name only. When every candidate fails the
+  override is restored to the recorded endpoint, the PRIMARY failure is the one reported, and #998's
+  refusal stands — nothing is deleted.
+- **The CLI held no trust anchor for the CA the cluster generated for itself, so TLS failed before drain
+  could run.** `SSLHandshakeException … PKIX path building failed`. Traced rather than inferred:
+  `ClusterHttpClient.enableClusterTrust` had exactly ONE caller,
+  `ClusterBootstrapOrchestrator.configureClusterHttpClient`, on the bootstrap path. `destroy` installed no
+  `SSLContext` at all, so it used the JDK default trust store, and the cluster's leaf certificates are
+  signed by a CA derived from `cluster_secret` via HKDF. What refuses the connection is the default
+  `X509TrustManager`: there is no path from the presented leaf to any anchor it holds. `destroy` now
+  installs the same anchor bootstrap installs, derived from the `cluster_secret` its bootstrap state
+  already records.
+  [mechanism: verification is made strictly NARROWER than the JDK default — the cluster's own CA and
+  nothing else. `enableTlsSkipVerify` (trust-all) is deliberately not used; #209 removed it from the
+  bootstrap path and it must not reappear on a path that presents the operator API key and issues
+  shutdown commands]
+  [verified: `ClusterDestroyCommandTest` — the client is replaced for an https endpoint with a recorded
+  secret, and left untouched for plain http]
+- **When the secret is absent, destroy says so instead of failing with a bare PKIX error — and disables
+  nothing.** An https endpoint whose bootstrap state records no `cluster_secret` gets an explicit note
+  naming what cannot be derived and stating that certificate verification is deliberately not disabled to
+  work around it.
+  [verified: `prepareClusterTrust_saysSoAndDisablesNothing_whenHttpsButNoSecretIsRecorded` asserts the
+  HTTP client is the SAME instance afterwards]
+- **`Drains succeeded: 0/0` now says it is a SKIP.** A ratio over an empty set reads like a pass; the
+  count was always honest, but nothing said which of the two it described. Both the drain and shutdown
+  lines now carry `(SKIPPED — no nodes were enumerated…)` when the node list was empty.
+
+**Not verified without a live cloud run.** The original failure was only reproducible on a live
+TLS-auto_generate cloud cluster. What is pinned above is unit-level: endpoint-candidate construction and
+fallthrough, the retarget, the restore-and-refuse path, and which trust anchor is installed. That a
+drain **completes** end-to-end against a real cluster whose first recorded node is dead is
+**[design intent — unverified]** — it requires a cloud bootstrap this change was not able to run.


### PR DESCRIPTION
**DO NOT MERGE without the maintainer's word.** Refs #1023 — **fixes the two named mechanisms; the
drained-teardown goal remains blocked by #1032.** This PR does **not** make drain work. Read the live
cluster section before reading it as such.

`cluster destroy` could not drain **at all** on a TLS-`auto_generate` cloud cluster (observed live
2026-09-11; summary `Drains succeeded: 0/0, Shutdowns succeeded: 0/0`). Two independent failures, fixed
separately, both from data bootstrap **already persists** — no field added to the registry or the
bootstrap state. Branched from `release-1.0.0-rc4` @ `be160be01`.

## 1. The registry stores ONE node's address as the cluster endpoint

`BootstrapPhasePost.managementEndpoint` builds the persisted entry from `addresses().getFirst()`. That
entry cannot survive the node it names, and teardown is when that node is most likely gone.

`destroy` now falls back to the other addresses `BootstrapPhaseCollect` already records in
`BootstrapState.collectedAddresses` — a ledger `destroy` **already loaded**, three phases too late to
reach the cluster with. Scheme and port are **borrowed from the recorded entry**, never defaulted, so
#998's refusal to invent a port applies to the candidates built from it. The endpoint that answers
**keeps the override**, so drain and shutdown follow the node that proved reachable.

*Mechanism, at the enforcing code rather than a docstring:* `NODE_LIFECYCLE_LIST` is `LEADER`-targeted
and `ManagementServer` dispatches `RouteTarget.LeaderNode` to `tryForwardIfNotLeader`, which **forwards**
when the receiver is not the leader. `NODE_DRAIN` / `NODE_SHUTDOWN` forward the same way.

## 2. The CLI held no trust anchor for the CA the cluster generated for itself

`SSLHandshakeException … PKIX path building failed`. **Traced, not inferred:**
`ClusterHttpClient.enableClusterTrust` had exactly ONE caller —
`ClusterBootstrapOrchestrator.configureClusterHttpClient`, on the bootstrap path. `destroy` installed no
`SSLContext` at all, so it used the JDK default trust store, while the cluster's leaves are signed by a
CA derived from `cluster_secret` via HKDF. What refuses the connection is the default
`X509TrustManager` — no path from the presented leaf to any anchor it holds.

`destroy` now installs the same anchor bootstrap installs. **Verification is made strictly NARROWER than
the JDK default — the cluster's own CA and nothing else.** `enableTlsSkipVerify` (trust-all) is
deliberately **not** used; #209 removed it from the bootstrap path and it must not reappear on a path
that presents the operator API key and issues shutdown commands. This half needed no design ruling: #209
had already answered the question; `destroy` simply never called it.

With no recorded secret, `destroy` says so explicitly and **disables nothing**.

## The centrepiece: validation is ENFORCED, demonstrated rather than asserted

`SelfSignedCertificateProvider` issued a leaf from a cluster secret (`openssl`: `SAN: IP Address:…`,
ECDSA, signed by the derived CA); a stub node served HTTPS with it, bound so the recorded endpoint
refuses on the same port. **Same server, same certificate, same code path — only the recorded secret
differs:**

| recorded secret | outcome |
|---|---|
| **correct** | fallthrough → handshake completes → `Drains succeeded: 3/3`, `Shutdowns succeeded: 3/3`, exit 0 |
| **wrong** | `SSLHandshakeException: (bad_certificate) PKIX path validation failed … signature check failed` → `REFUSING`, exit 1, nothing deleted |

Mutually exclusive by construction. It settles two things usually argued separately: the anchor is
**load-bearing** (drain runs iff the derived CA matches), and **validation is genuinely enforced, not
disabled** — had this been "fixed" with trust-all, the second row would have **passed**. #209's MITM
property is preserved on the destroy path. The stub logged **11 requests, 0 addressed anywhere but the
sibling**, drain + shutdown hitting `core-0/1/2` exactly once each.

## On a LIVE 5-node Hetzner cluster (TLS `auto_generate = true`)

The registry entry bootstrap wrote was `https://138.199.236.244:8080` — **the same address #1023 cites**
— one node's address chosen by position. That node was **deleted at the provider**, recreating the
incident. Controls run *inside* that configuration first: the registry-named endpoint `http_code=000`
(genuinely gone); all survivors `401 / ssl_verify=0` (alive, TLS validating).

**A CA derived from the recorded secret validates a certificate issued by a REAL node at first
leadership** — the last self-referential link, since the local arms proved the mechanism using the same
provider class that generates it:

    without derived CA → http_code=000  ssl_verify=20   (unable to get local issuer certificate)
    with    derived CA → http_code=401  ssl_verify=0    (TLS VALIDATED; 401 = no key sent)

`ssl_verify=20` on the same endpoint is the control **inside** the failing configuration: #1023's PKIX
condition was demonstrably live, not historical. The `401` is the *right* failure — TLS validated,
authorization refused — distinguishing "trust works, credential absent" from "trust broken".

Then `destroy` against the deleted endpoint (surviving population **four**, not five):

    Trusting this cluster's own CA, derived from the cluster_secret …
    The recorded endpoint did not answer (… ConnectException). Trying 4 other node address(es) …
    https://91.98.86.221:8080 answered. The rest of this destroy … will use it …
    3 node(s) reported by the cluster.

`91.98.86.221` is `primary-core-1`. **Both halves of #1023 are fixed and confirmed live.**

### The live run REFUTED my own prediction — reported, not smoothed

    Drains succeeded: 0/3        Shutdowns succeeded: 3/3

I pre-registered a non-zero named drain count. It was **zero**: `primary-core-4` and `primary-core-1`
were **refused by the cluster with HTTP 409** — *"Disruption budget exceeded: draining … would leave 2
core-scoped operational nodes, minimum is 3"*; `primary-core-3` accepted the drain but never reached
`DECOMMISSIONED` within 120 s.

**A 409 is an application-level answer, so TLS, authentication, routing and leader-forwarding all
worked.** The refusal is evidence about the layers beneath it. The obstacle is **not** in anything this
PR touches, and it was **invisible before** because destroy never got far enough to meet it.

**→ tracked as #1032.** `cluster destroy` cannot perform a graceful drained teardown, because draining
every node necessarily violates the cluster's own disruption budget — a guard with no way to distinguish
"operator draining below quorum" from "full teardown". **This PR deliberately does not lower that
guard**; the guard is correct, and lowering it would produce a green result and a real regression.

**So, precisely: this fixes the two named mechanisms. The drained-teardown goal remains blocked by
#1032, and #1023 stays open.**

### The honest diagnostic found a real defect on its first live run

This run printed `0/3`, an explicit *"Warning: some drain/shutdown operations failed"*, and **no**
"destroyed successfully". The old path printed `0/0` **under a success line**. The disruption-budget
defect has presumably existed all along and was unfindable because the failure rendered as a benign
zero. That is the argument for fixing diagnostics, stated as data rather than as principle.

Teardown verified by the AFTER listing: all six resource classes **0**, matching the pre-run baseline;
ssh-key `aether-test` and snapshot `aether-1.0.0-rc2-jvm` preserved.

## Verification

**Unit** (`ClusterDestroyCommandTest`, **56 `<testcase>` elements, 0 failures**; 15 new): candidate
construction (scheme/port borrowed, primary excluded), fallthrough order asserted on the **hosts the
requests carried**, the retarget, restore-and-still-refuse, which anchor is installed, the no-secret
branch, and the `SKIPPED` note with its negative control.

**On the real `aether.jar`** (isolated `-Duser.home`): the trust line precedes enumeration and performs
genuine HKDF/CA derivation; 3 collected addresses yield 2 candidates; exhaustion still refuses with
registry and ledger byte-intact, exit 1.

**Mutation probe:** 6 mutations, each reverted and content-verified, every one red. P2/P3 redden the
*identical* set — two mutations of one hunk, **not** independently pinned. P1/P4 exist because every
other test drives the new methods *directly*, so deleting the **calls** from `performDestruction` would
have restored the whole defect with all of them green.

**Gate:** `mvn jbct:check -pl aether/cli -Djbct.skip=false` → `Running JBCT check on 106 Java file(s)` →
`JBCT check passed.` (106 = every main source; test sources are outside the gate repo-wide via
`jbct.includeTests=false`.)

**Root build** (ROOT, no `-pl`, no `-DskipTests`): **13,723 `<testcase>` elements** (the `tests=`
attribute sum reads 11,334 — the known `@Nested` undercount), **1 failure — `ember`'s
`EmberBootstrapAdminKeyAuthTest`, not this change.** Two agreeing reasons: `dependency:tree -pl
aether/ember` shows `:node:jar` present (positive control) and `cli` **absent**; and CI is green on this
branch, where `build-and-test` is `mvn install -B -pl '!examples'` — the full reactor, ember included.

## Scope and costs, stated

**This fixes the reader, not the writer.** The registry still records one endpoint, and
`ClusterHttpClient.resolveEndpoint()` is shared by every registry-based command — so every *other*
command keeps the same single point of failure and none installs the trust anchor. Confirmed live:
`aether nodes live` printed an empty table and **exited 0** while the same endpoint gave `curl`
`ssl_verify=20` (pre-existing; **#1033**).

**The fallback list is a bootstrap-time snapshot.** `collectedAddresses` is written once by
`BootstrapPhaseCollect` and never updated, so a node that auto-heal replaces *later* at a new address is
not a fallback candidate. It happened to be covered on this run, but the bound is real.

**Operator-facing cost this introduces:** a fully unreachable N-node cluster now takes roughly
**(N−1) × 130 s** before refusing — about 17 minutes for a dead 9-node cluster, in an outage, which is
when destroy is actually run. Bounded, and the announcement names how many candidates will be tried
before the wait begins. A bounded overall deadline is design work deserving its own round, filed
separately rather than bundled here.

**A hand-edited entry pointing at a reverse proxy with a publicly-signed certificate would now be
refused** on the https path, because the installed anchor is the cluster CA only. No shipped code path
produces such an entry; the alternative (a union trust store) would accept any publicly-valid
certificate for that host, weaker than what #209 chose for this channel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
